### PR TITLE
Fix Docker build issues on Windows and non-ARM architectures

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -42,9 +42,10 @@ RUN mkdir -p /workspace /home/node/.claude && \
 
 WORKDIR /workspace
 
-RUN wget https://github.com/dandavison/delta/releases/download/0.18.2/git-delta_0.18.2_arm64.deb && \
-  sudo dpkg -i git-delta_0.18.2_arm64.deb && \
-  rm git-delta_0.18.2_arm64.deb
+RUN ARCH=$(dpkg --print-architecture) && \
+  wget "https://github.com/dandavison/delta/releases/download/0.18.2/git-delta_0.18.2_${ARCH}.deb" && \
+  sudo dpkg -i "git-delta_0.18.2_${ARCH}.deb" && \
+  rm "git-delta_0.18.2_${ARCH}.deb"
 
 # Set up non-root user
 USER node

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+*.sh text eol=lf


### PR DESCRIPTION

## Problem
The current .devcontainer setup encounters two major issues when building on Windows or non-ARM architectures:
The Dockerfile attempts to install git-delta specifically for ARM64 architecture, causing build failures on x86_64 systems.
Windows line endings (CRLF) in shell scripts cause script execution failures within the Linux container.

## Changes
Modified the Dockerfile to detect system architecture and install the appropriate version of git-delta (ARM64 vs AMD64), and incorporated the great suggestions by @w-duffy.
Added a .gitattributes file to enforce LF line endings for all text files, with special attention to shell scripts
Ensured script files have proper executable permissions


## Testing
Successfully built and ran the dev container on Windows 11 with Docker Desktop.
These changes maintain compatibility with ARM-based systems while adding support for the more common x86_64 architecture, making Claude Code more accessible to developers using standard hardware.
nb. unfortunately claude-code is at capacity so i cant test the actual application
