### PR TITLE
Add GitHub issue template for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Environment
+- Platform (select one):
+  - [ ] Anthropic API
+  - [ ] AWS Bedrock
+  - [ ] Google Vertex AI
+  - [ ] Other: <!-- specify -->
+- Claude CLI version: <!-- output of `claude --version` -->
+- Operating System: <!-- e.g. macOS 14.3, Windows 11, Ubuntu 22.04 -->
+
+## Bug Description
+<!-- A clear and concise description of the bug -->
+
+## Steps to Reproduce
+1. <!-- First step -->
+2. <!-- Second step -->
+3. <!-- And so on... -->
+
+## Expected Behavior
+<!-- What you expected to happen -->
+
+## Actual Behavior
+<!-- What actually happened -->
+
+## Additional Context
+<!-- Add any other context about the problem here, such as screenshots, logs, etc. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,6 +14,7 @@ assignees: ''
   - [ ] Other: <!-- specify -->
 - Claude CLI version: <!-- output of `claude --version` -->
 - Operating System: <!-- e.g. macOS 14.3, Windows 11, Ubuntu 22.04 -->
+- Terminal:  <!-- e.g. iTerm2, Terminal App -->
 
 ## Bug Description
 <!-- A clear and concise description of the bug -->


### PR DESCRIPTION
## Summary
- Add a structured GitHub issue template for bug reports
- Include fields for platform selection, CLI version, OS info, and reproduction steps

## Test plan
- Verify the template appears when creating a new issue

🤖 Generated with [Claude Code](https://claude.ai/code)