### PR TITLE
Release Claude Code 1.0.0 with general availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
+## 1.0.0
+
+- Claude Code is now generally available
+- Introducing Sonnet 4 and Opus 4 models
+
 ## 0.2.125
+
 - Breaking change: Bedrock ARN passed to `ANTHROPIC_MODEL` or `ANTHROPIC_SMALL_FAST_MODEL` should no longer contain an escaped slash (specify `/` instead of `%2F`)
 - Removed `DEBUG=true` in favor of `ANTHROPIC_LOG=debug`, to log all requests
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,1 @@
-Claude Code is a Beta research preview per our [Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms). If Customer chooses to send us feedback about Claude Code, such as transcripts of Customer Claude Code usage, Anthropic may use that feedback to debug related issues or to improve Claude Code’s functionality (e.g., to reduce the risk of similar bugs occurring in the future). Anthropic will not train models using feedback from Claude Code.
-
 © Anthropic PBC. All rights reserved. Use is subject to Anthropic's [Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Claude Code (Research Preview)
+# Claude Code
 
 ![](https://img.shields.io/badge/Node.js-18%2B-brightgreen?style=flat-square) [![npm]](https://www.npmjs.com/package/@anthropic-ai/claude-code)
 
@@ -20,11 +20,11 @@ Some of its key capabilities include:
 1. If you are new to Node.js and Node Package Manager (`npm`), then it is recommended that you configure an NPM prefix for your user.
    Instructions on how to do this can be found [here](https://docs.anthropic.com/en/docs/claude-code/troubleshooting#recommended-solution-create-a-user-writable-npm-prefix).
 
-   *Important* We recommend installing this package as a non-privileged user, not as an administrative user like `root`.
+   _Important_ We recommend installing this package as a non-privileged user, not as an administrative user like `root`.
    Installing as a non-privileged user helps maintain your system's security and stability.
 
 2. Install Claude Code:
-   
+
    ```sh
    npm install -g @anthropic-ai/claude-code
    ```
@@ -32,12 +32,6 @@ Some of its key capabilities include:
 3. Navigate to your project directory and run <code>claude</code>.
 
 4. Complete the one-time OAuth process with your Anthropic Console account.
-
-### Research Preview
-
-We're launching Claude Code as a beta product in research preview to learn directly from developers about their experiences collaborating with AI agents. Our aim is to learn more about how developers prefer to collaborate with AI tools, which development workflows benefit most from working with the agent, and how we can make the agent experience more intuitive.
-
-This is an early version of the product experience, and it's likely to evolve as we learn more about developer preferences. Claude Code is an early look into what's possible with agentic coding, and we know there are areas to improve. We plan to enhance tool execution reliability, support for long-running commands, terminal rendering, and Claude's self-knowledge of its capabilities -- as well as many other product experiences -- over the coming weeks.
 
 ### Reporting Bugs
 


### PR DESCRIPTION
## Summary
- Announce Claude Code 1.0.0 general availability release in CHANGELOG.md
- Remove beta/research preview language from LICENSE.md and README.md to reflect GA status

## Test plan
- [ ] Verify CHANGELOG.md contains new 1.0.0 section with GA announcement
- [ ] Confirm LICENSE.md no longer references beta preview terms
- [ ] Check README.md title updated and research preview section removed

🤖 Generated with [Claude Code](https://claude.ai/code)