### PR TITLE
fix: remove duplicate comment

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -89,7 +89,6 @@ iptables -A INPUT -s "$HOST_NETWORK" -j ACCEPT
 iptables -A OUTPUT -d "$HOST_NETWORK" -j ACCEPT
 
 # Set default policies to DROP first
-# Set default policies to DROP first
 iptables -P INPUT DROP
 iptables -P FORWARD DROP
 iptables -P OUTPUT DROP


### PR DESCRIPTION
Hello,

this pull request removes a duplicate comment in `.devcontainer/init-firewall.sh`.

Thank you.