### PR TITLE
pinned GitHub Actions

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -14,7 +14,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
 
       - name: Run Claude Issue Triage
         uses: ./.github/actions/claude-issue-triage-action

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,13 +25,13 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@8e84799f37d42f24e0ebae41205346879bdcab5a  # beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@8e84799f37d42f24e0ebae41205346879bdcab5a  # beta
+        uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 


### PR DESCRIPTION
This PR implements pinning for GitHub Actions as used in this repository. Pinning GitHub Actions [is a best practice](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) recommended by GitHub as _pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release_.

Not pinning your GitHub Actions exposes you to supply chain attacks, as was recently the case with the [tj-actions/changed-files](https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-tj-actionschanged-files-cve-2025-30066-and-reviewdogaction) action.

The versions that I've pinned is the same versions that is currently in use by the repository.