### PR TITLE
Add AutoPR workflow file

### DIFF
--- a/.github/workflows/autopr.yml
+++ b/.github/workflows/autopr.yml
@@ -1,0 +1,14 @@
+name: AutoPR
+
+on:
+    merge_group:
+    pull_request:
+        types: [opened, synchronize, edited]
+
+permissions: {}
+
+jobs:
+    autopr:
+        uses: anthropics/actions/.github/workflows/trigger-autopr.yml@main
+        secrets: inherit
+


### PR DESCRIPTION
This PR adds the AutoPR workflow, which is required for L3 Branch Protections.<br><br>The added workflow is manually disabled and will [need to be enabled](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/disabling-and-enabling-a-workflow?tool=cli) to fully 'turn on' when L3 branch protections go live (this should be handled by DevProd/SecEng)