### PR TITLE
fix: Add nano and vim editors to devcontainer with default editor config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -19,7 +19,9 @@ RUN apt update && apt install -y less \
   iproute2 \
   dnsutils \
   aggregate \
-  jq
+  jq \
+  nano \
+  vim
 
 # Ensure default node user has access to /usr/local/share
 RUN mkdir -p /usr/local/share/npm-global && \
@@ -56,6 +58,10 @@ ENV PATH=$PATH:/usr/local/share/npm-global/bin
 
 # Set the default shell to zsh rather than sh
 ENV SHELL=/bin/zsh
+
+# Set the default editor and visual
+ENV EDITOR nano
+ENV VISUAL nano
 
 # Default powerline10k theme
 RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/v1.2.0/zsh-in-docker.sh)" -- \


### PR DESCRIPTION
## Description
This PR enhances the devcontainer editor support to fix the `/memory` command functionality and improve the overall developer experience.

## Related Issue
Fixes #2098

## Changes
- Added `nano` editor to fix the `/memory` command
- Added `vim` editor to provide an alternative for users who prefer it
- Set `EDITOR` and `VISUAL` environment variables to `nano` as the default editor
  - This ensures consistent editor behavior across various CLI tools
  - Users can still override these in their shell configuration

## Why these changes?
1. **nano**: Required for the `/memory` command to work (fixes the reported issue)
2. **vim**: Many developers prefer vim, so including both editors provides flexibility
3. **EDITOR/VISUAL**: These standard environment variables ensure that:
   - Git commits open the correct editor
   - Other CLI tools that need an editor work out of the box
   - The behavior is predictable and consistent

## Testing
- Built the devcontainer with the updated Dockerfile
- Verified that the `/memory` command now works correctly
- Confirmed both nano and vim are available
- Tested that `git commit` and other tools use the configured editor

## Impact
This is a non-breaking change that adds two lightweight packages and sets sensible defaults while maintaining flexibility for user preferences.