### PR TITLE
Update claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,4 +34,6 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: ${{ github.event.comment.body }}
 


### PR DESCRIPTION
The most recent commit updates .github/workflows/claude.yml by supplying the missing inputs required by the anthropics/claude-code-action step. The workflow now sets the following parameters in the with: block:

These lines ensure the action has an API key, a GitHub token for authentication, and the comment body as the prompt. They close out the job definition properly so the YAML parses correctly. The commit shows only two additions to complete the workflow configuration:

With these changes, the workflow now runs the Claude Code action with all required inputs whenever a comment mentions @claude, or a review or issue includes that tag.