### PR TITLE
Add checkout step to issue triage workflow

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -13,6 +13,9 @@ jobs:
       issues: write
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Create triage prompt
         run: |
           mkdir -p /tmp/claude-prompts


### PR DESCRIPTION
Added a checkout step to the GitHub Actions workflow for issue triage to ensure the repository is available during the triage process. Otherwise `gh labels list` doesn't work. I shouldn't have removed this in https://github.com/anthropics/claude-code/pull/2779, but Claude has been doing mostly okay without it thankfully.

🤖 Generated with [Claude Code](https://claude.ai/code)