### PR TITLE
Example Hook 

### DIFF
--- a/examples/hooks/bash_command_validator_example.py
+++ b/examples/hooks/bash_command_validator_example.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Claude Code Hook: Bash Command Validator
+=========================================
+This hook runs as a PreToolUse hook for the Bash tool.
+It validates bash commands against a set of rules before execution.
+In this case it changes grep calls to using rg.
+
+Read more about hooks here: https://docs.anthropic.com/en/docs/claude-code/hooks
+
+Make sure to change your path to your actual script.
+
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python -m ./bash_command_validator_example"
+          }
+        ]
+      }
+    ]
+  }
+}
+
+"""
+
+import json
+import re
+import sys
+
+# Define validation rules as a list of (regex pattern, message) tuples
+VALIDATION_RULES = [
+    (
+        r"\bgrep\b(?!.*\|)",
+        "Use 'rg' (ripgrep) instead of 'grep' for better performance and features",
+    ),
+    (
+        r"\bfind\s+\S+\s+-name\b",
+        "Use 'rg --files | rg pattern' or 'rg --files -g pattern' instead of 'find -name' for better performance",
+    ),
+]
+
+
+def validate_command(command: str) -> list[str]:
+    issues = []
+    for pattern, message in VALIDATION_RULES:
+        if re.search(pattern, command):
+            issues.append(message)
+    return issues
+
+
+def main():
+    try:
+        input_data = json.load(sys.stdin)
+    except json.JSONDecodeError as e:
+        print(f"Error: Invalid JSON input: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    tool_input = input_data.get("tool_input", {})
+    command = tool_input.get("command", "")
+
+    if not command:
+        sys.exit(0)
+
+    # Validate the command
+    issues = validate_command(command)
+
+    if issues:
+        for message in issues:
+            print(f"• {message}", file=sys.stderr)
+        # Exit code 2 blocks tool call and shows stderr to Claude
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hooks/bash_command_validator_example.py
+++ b/examples/hooks/bash_command_validator_example.py
@@ -18,7 +18,7 @@ Make sure to change your path to your actual script.
         "hooks": [
           {
             "type": "command",
-            "command": "python -m ./bash_command_validator_example"
+            "command": "python3 /path/to/claude-code/examples/hooks/bash_command_validator_example.py"
           }
         ]
       }
@@ -33,21 +33,21 @@ import re
 import sys
 
 # Define validation rules as a list of (regex pattern, message) tuples
-VALIDATION_RULES = [
+_VALIDATION_RULES = [
     (
-        r"\bgrep\b(?!.*\|)",
+        r"^grep\b(?!.*\|)",
         "Use 'rg' (ripgrep) instead of 'grep' for better performance and features",
     ),
     (
-        r"\bfind\s+\S+\s+-name\b",
+        r"^find\s+\S+\s+-name\b",
         "Use 'rg --files | rg pattern' or 'rg --files -g pattern' instead of 'find -name' for better performance",
     ),
 ]
 
 
-def validate_command(command: str) -> list[str]:
+def _validate_command(command: str) -> list[str]:
     issues = []
-    for pattern, message in VALIDATION_RULES:
+    for pattern, message in _VALIDATION_RULES:
         if re.search(pattern, command):
             issues.append(message)
     return issues
@@ -58,6 +58,7 @@ def main():
         input_data = json.load(sys.stdin)
     except json.JSONDecodeError as e:
         print(f"Error: Invalid JSON input: {e}", file=sys.stderr)
+        # Exit code 1 shows stderr to the user but not to Claude
         sys.exit(1)
 
     tool_name = input_data.get("tool_name", "")
@@ -70,9 +71,7 @@ def main():
     if not command:
         sys.exit(0)
 
-    # Validate the command
-    issues = validate_command(command)
-
+    issues = _validate_command(command)
     if issues:
         for message in issues:
             print(f"• {message}", file=sys.stderr)


### PR DESCRIPTION
This PR adds a comprehensive example hook (bash_command_validator_example.py) that demonstrates how to validate bash commands before execution using Claude Code's PreToolUse hook system.

  The hook validates commands against configurable rules and currently includes:
  - Suggesting rg (ripgrep) instead of grep for better performance
  - Recommending rg --files patterns instead of find -name commands

A user would put the config into their settings.json and execute the fill from there.