### PR TITLE
Enhancement Proposal: Expand STDOUT via MCP tool name suffix

### DIFF
--- a/docs/enhancement-proposal-expand-stdout-suffix.md
+++ b/docs/enhancement-proposal-expand-stdout-suffix.md
@@ -1,0 +1,30 @@
+# Enhancement Proposal: Expand STDOUT via MCP tool name suffix
+
+## Summary
+Add mode namespace support (e.g., **`__expand`**) to MCP tool names.  
+
+Example use case: **`mcp__acme__get_help__expand`**
+
+## Motivation
+- Enable tools to indicate behavior/mode directly in their name.
+- Facilitate zero-configuration, self-documenting, and minimal implementation for new tool modes.
+- Maintain backward compatibility and avoid changes to the MCP specification.
+
+## Proposed Solution
+
+- Allow tool names to include a mode namespace suffix such as `__expand`.
+
+Example usage:
+
+  ```js
+  server.registerTool(
+    "help__expand",  // ← mode namespace
+    {
+      title: "Help",
+      description: "Display help information (always expanded)",
+      inputSchema: zodToJsonSchema(z.object({})),
+    }
+    // ...
+  )
+  ```
+  


### PR DESCRIPTION
### Summary

This pull request adds an enhancement proposal document outlining a method for supporting mode namespaces (e.g., **`__expand`**) in MCP tool names (e.g., **`mcp__acme__get_help__expand`**). 

### Problem 
Claude Code does not support automatic STDOUT expansion for specific MCP tools

Adjacent Issue: #2638 

### Solution
Allow tool names to include a mode namespace suffix such as **`__expand`**

Example usage:

```js
server.registerTool(
  "help__expand",  // ← mode namespace
  {
    title: "Help",
    description: "Display help information (always expanded)",
    inputSchema: zodToJsonSchema(z.object({})),
  }
  // ...
)
```

### Why This Works
- Allows MCP tools to indicate their behavior directly in their name
- Provides a pragmatic solution that is zero-config, self-documenting, and backward compatible
- Keeps tool registration simple and flexible, while providing deeper MCP integration
- Elevates the combined capability of Claude Code and MCP, and overall user experience
- Minimal footprint and implementation lift
