### PR TITLE
Fix typo in CHANGELOG.md for custom slash commands path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Fixed config file corruption issue by enforcing atomic writes
 - Updated prompt input undo to Ctrl+\_ to avoid breaking existing Ctrl+U behavior, matching zsh's undo shortcut
 - Stop Hooks: Fixed transcript path after /clear and fixed triggering when loop ends with tool call
-- Custom slash commands: Restored namespacing in command names based on subdirectories. For example, .claude/frontend/component.md is now /frontend:component, not /component.
+- Custom slash commands: Restored namespacing in command names based on subdirectories. For example, .claude/commands/frontend/component.md is now /frontend:component, not /component.
 
 ## 1.0.44
 


### PR DESCRIPTION
## Summary
- Fixed incorrect example path in CHANGELOG.md for custom slash commands
- Changed `.claude/frontend/component.md` to `.claude/commands/frontend/component.md`
- This matches the correct path structure documented at https://docs.anthropic.com/en/docs/claude-code/slash-commands#namespacing

## Details
The CHANGELOG.md entry for v1.0.45 contained an incorrect example path for custom slash commands. The path was missing the `commands/` directory, which could confuse users trying to set up custom slash commands.

## Test plan
- [x] Verified the corrected path matches the official documentation
- [x] No code changes, only documentation update