### PR TITLE
Isolate devcontainer mounts using ${devcontainerId}

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,8 +38,8 @@
   },
   "remoteUser": "node",
   "mounts": [
-    "source=claude-code-bashhistory,target=/commandhistory,type=volume",
-    "source=claude-code-config,target=/home/node/.claude,type=volume"
+    "source=claude-code-bashhistory-${devcontainerId},target=/commandhistory,type=volume",
+    "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume"
   ],
   "remoteEnv": {
     "NODE_OPTIONS": "--max-old-space-size=4096",


### PR DESCRIPTION
Use ${devcontainerId} variable to create project-specific volumes, preventing cross-container data access. This addresses a potential security issue where multiple containers could share sensitive data through named volumes.

🤖 Generated with [Claude Code](https://claude.ai/code)