### PR TITLE
fix: Add check to run_devcontainer_claude_code.ps1 for the presence of required command

### DIFF
--- a/Script/run_devcontainer_claude_code.ps1
+++ b/Script/run_devcontainer_claude_code.ps1
@@ -37,6 +37,21 @@ param(
 Write-Host "--- DevContainer Startup & Connection Script ---"
 Write-Host "Using backend: $($Backend)"
 
+# --- Prerequisite Check ---
+Write-Host "Checking for required commands..."
+try {
+    Get-Command $Backend -ErrorAction Stop | Out-Null
+    Write-Host "- $($Backend) command found."
+    Get-Command devcontainer -ErrorAction Stop | Out-Null
+    Write-Host "- devcontainer command found."
+}
+catch {
+    Write-Error "A required command is not installed or not in your PATH."
+    Write-Error "Please ensure '$($_.Exception.Message.Split(':')[0])' and 'devcontainer' are installed and accessible."
+    exit 1
+}
+
+
 # --- Backend-Specific Initialization ---
 if ($Backend -eq 'podman') {
     Write-Host "--- Podman Backend Initialization ---"


### PR DESCRIPTION
## Proposal: Addition of check for presence of required commands
This change adds an early check to ensure that required commands such as devcontainer and either podman or docker are installed before the script proceeds.
If any are missing, the script will exit with a clear and user-friendly error message.

This helps users identify missing dependencies early, avoiding obscure errors during execution.