### PR TITLE
fix: Use containerEnv for environment variables in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,7 +41,7 @@
     "source=claude-code-bashhistory-${devcontainerId},target=/commandhistory,type=volume",
     "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume"
   ],
-  "remoteEnv": {
+  "containerEnv": {
     "NODE_OPTIONS": "--max-old-space-size=4096",
     "CLAUDE_CONFIG_DIR": "/home/node/.claude",
     "POWERLEVEL9K_DISABLE_GITSTATUS": "true"


### PR DESCRIPTION
When launching dev containers via scripts (not through VS Code), remoteEnv does not properly set environment variables. This causes NODE_OPTIONS, CLAUDE_CONFIG_DIR, and POWERLEVEL9K_DISABLE_GITSTATUS to be undefined.

Changed remoteEnv to containerEnv to ensure environment variables are correctly set regardless of how the container is launched.

🤖 Generated with [Claude Code](https://claude.ai/code)