### PR TITLE
Update Dockerfile to use Node v22

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:22
 
 ARG TZ
 ENV TZ="$TZ"


### PR DESCRIPTION
Our projects have an engine requirement on Node 22, so Claude fails to run our local npm scripts due to this limitation.

Given that Node 22 is LTS, are you happy to upgrade the version on the dev container?