### PR TITLE
Add GitHub workflow to lock stale issues

### DIFF
--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -1,9 +1,9 @@
-name: 'Lock Stale Issues'
+name: "Lock Stale Issues"
 
 on:
   schedule:
-    # 7am Pacific = 2pm UTC (3pm UTC during DST)
-    - cron: '0 14 * * *'
+    # 8am Pacific = 1pm UTC (2pm UTC during DST)
+    - cron: "0 14 * * *"
   workflow_dispatch:
 
 permissions:
@@ -16,16 +16,15 @@ jobs:
   lock-threads:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771  # v5.0.1
+      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5.0.1
         with:
-          issue-inactive-days: '7'
-          pr-inactive-days: '36500'  # ~100 years (effectively disabled)
-          discussion-inactive-days: '36500'  # ~100 years (effectively disabled)
-          process-only: 'issues'
-          issue-lock-reason: 'resolved'
+          issue-inactive-days: "7"
+          pr-inactive-days: "36500" # ~100 years (effectively disabled)
+          discussion-inactive-days: "36500" # ~100 years (effectively disabled)
+          process-only: "issues"
           issue-comment: >
             This issue has been automatically locked since it was
             closed and has not had any activity for 7 days.
-            
+
             If you're experiencing a similar issue, please file a new issue
             and reference this one if it's relevant: #${{ github.event.issue.number }}

--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -1,0 +1,31 @@
+name: 'Lock Stale Issues'
+
+on:
+  schedule:
+    # 7am Pacific = 2pm UTC (3pm UTC during DST)
+    - cron: '0 14 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+concurrency:
+  group: lock-threads
+
+jobs:
+  lock-threads:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771  # v5.0.1
+        with:
+          issue-inactive-days: '7'
+          pr-inactive-days: '36500'  # ~100 years (effectively disabled)
+          discussion-inactive-days: '36500'  # ~100 years (effectively disabled)
+          process-only: 'issues'
+          issue-lock-reason: 'resolved'
+          issue-comment: >
+            This issue has been automatically locked since it was
+            closed and has not had any activity for 7 days.
+            
+            If you're experiencing a similar issue, please file a new issue
+            and reference this one if it's relevant: #${{ github.event.issue.number }}

--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -19,12 +19,9 @@ jobs:
       - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5.0.1
         with:
           issue-inactive-days: "7"
-          pr-inactive-days: "36500" # ~100 years (effectively disabled)
-          discussion-inactive-days: "36500" # ~100 years (effectively disabled)
           process-only: "issues"
           issue-comment: >
             This issue has been automatically locked since it was
             closed and has not had any activity for 7 days.
-
             If you're experiencing a similar issue, please file a new issue
-            and reference this one if it's relevant: #${{ github.event.issue.number }}
+            and reference this one if it's relevant.


### PR DESCRIPTION
- Locks issues closed for 7+ days without activity
- Runs daily at 7am Pacific (2pm UTC)
- Includes manual workflow dispatch trigger
- Posts helpful comment before locking with guidance for new issues

🤖 Generated with [Claude Code](https://claude.ai/code)