### PR TITLE
Improvement: Prevent continuous execution in a short period of time.

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -23,6 +23,9 @@ jobs:
       pull-requests: read
       issues: read
       id-token: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4


### PR DESCRIPTION
## Problem:
If a user edits or posts a series of comments in a short period of time, each time a workflow is triggered,
multiple Claude's may start running at the same time. This is a waste of resources and can cause confusion.

Fix:
add a concurrency setting so that for the same Issue or PR, only one latest job is always run (old jobs are automatically cancelled).