### PR TITLE
Replace lock-threads action with GitHub Script

### DIFF
--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -13,16 +13,81 @@ concurrency:
   group: lock-threads
 
 jobs:
-  lock-threads:
+  lock-closed-issues:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5.0.1
+      - name: Lock closed issues after 7 days of inactivity
+        uses: actions/github-script@v7
         with:
-          issue-inactive-days: "7"
-          process-only: "issues"
-          log-output: true
-          issue-comment: >
-            This issue has been automatically locked since it was
-            closed and has not had any activity for 7 days.
-            If you're experiencing a similar issue, please file a new issue
-            and reference this one if it's relevant.
+          script: |
+            const sevenDaysAgo = new Date();
+            sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+            
+            const lockComment = `This issue has been automatically locked since it was closed and has not had any activity for 7 days. If you're experiencing a similar issue, please file a new issue and reference this one if it's relevant.`;
+            
+            let page = 1;
+            let hasMore = true;
+            let totalLocked = 0;
+            
+            while (hasMore) {
+              // Get closed issues (pagination)
+              const { data: issues } = await github.rest.issues.listForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'closed',
+                sort: 'updated',
+                direction: 'asc',
+                per_page: 100,
+                page: page
+              });
+              
+              if (issues.length === 0) {
+                hasMore = false;
+                break;
+              }
+              
+              for (const issue of issues) {
+                // Skip if already locked
+                if (issue.locked) continue;
+                
+                // Skip pull requests
+                if (issue.pull_request) continue;
+                
+                // Check if updated more than 7 days ago
+                const updatedAt = new Date(issue.updated_at);
+                if (updatedAt > sevenDaysAgo) {
+                  // Since issues are sorted by updated_at ascending, 
+                  // once we hit a recent issue, all remaining will be recent too
+                  hasMore = false;
+                  break;
+                }
+                
+                try {
+                  // Add comment before locking
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    body: lockComment
+                  });
+                  
+                  // Lock the issue
+                  await github.rest.issues.lock({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    lock_reason: 'resolved'
+                  });
+                  
+                  totalLocked++;
+                  console.log(`Locked issue #${issue.number}: ${issue.title}`);
+                } catch (error) {
+                  console.error(`Failed to lock issue #${issue.number}: ${error.message}`);
+                }
+              }
+              
+              page++;
+            }
+            
+            console.log(`Total issues locked: ${totalLocked}`);


### PR DESCRIPTION
Replaces the dessant/lock-threads action with a direct GitHub Script implementation to avoid the deprecated search/issues API endpoint warning. The new implementation:
- Uses github.rest.issues.listForRepo() instead of the deprecated search API
- Maintains the same 7-day inactivity threshold
- Adds the same comment before locking
- Uses 'resolved' as the lock reason
- Handles pagination properly for large repositories

Replacing with custom implementation because we're [seeing](https://github.com/anthropics/claude-code/actions/runs/16806860705/job/47601485245) this deprecation warning:

```
[@octokit/request] "GET https://api.github.com/search/issues?q=repo%3Aanthropics%2Fclaude-code%20updated%3A%3C2025-07-31T14%3A07%3A44Z%20is%3Aclosed%20is%3Aunlocked%20is%3Aissue&sort=updated&order=desc&per_page=50" is deprecated. It is scheduled to be removed on Thu, 04 Sep 2025 00:00:00 GMT. See https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more/
```

The lock-threads repo seems unmaintained: https://github.com/dessant/lock-threads

🤖 Generated with [Claude Code](https://claude.ai/code)