### PR TITLE
Update auto-close-duplicates script to actually close issues

### DIFF
--- a/.claude/commands/dedupe.md
+++ b/.claude/commands/dedupe.md
@@ -28,9 +28,10 @@ Found 3 possible duplicate issues:
 2. <link to issue>
 3. <link to issue>
 
-If your issue is a duplicate, please close it and 👍 the existing issue instead.
+This issue will be automatically closed as a duplicate in 3 days.
 
-<sub>This issue will be automatically closed as a duplicate in 3 days if there are no additional comments. To prevent auto-closure, please 👎 this comment.</sub>
+- If your issue is a duplicate, please close it and 👍 the existing issue instead
+- To prevent auto-closure, add a comment or 👎 this comment
 
 🤖 Generated with [Claude Code](https://claude.ai/code)
 


### PR DESCRIPTION
## Summary
- Remove dry run mode from auto-close-duplicates script and implement actual issue closing functionality
- Extract duplicate issue number from bot comments using regex parsing
- Close issues via GitHub API with proper state (`closed` with `not_planned` reason) and add explanatory comments
- Add comprehensive error handling for API failures
- Use consistent Claude Code comment format with instructions for reopening if incorrect

## Test plan
- [ ] Verify script can parse duplicate issue numbers from bot comments
- [ ] Test API calls for closing issues and adding comments
- [ ] Confirm error handling works for failed API requests
- [ ] Review comment format matches Claude Code style guide

🤖 Generated with [Claude Code](https://claude.ai/code)