### PR TITLE
Fix workflow failure by adding workflow_dispatch trigger

### DIFF
--- a/.github/workflows/claude-dedupe-issues.yml
+++ b/.github/workflows/claude-dedupe-issues.yml
@@ -3,6 +3,12 @@ description: Automatically dedupe GitHub issues using Claude Code
 on:
   issues:
     types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue number to process for duplicate detection'
+        required: true
+        type: string
 
 jobs:
   claude-dedupe-issues:
@@ -19,7 +25,7 @@ jobs:
       - name: Run Claude Code slash command
         uses: anthropics/claude-code-base-action@beta
         with:
-          prompt: "/dedupe ${{ github.repository }}/issues/${{ github.event.issue.number }}"
+          prompt: "/dedupe ${{ github.repository }}/issues/${{ github.event.issue.number || inputs.issue_number }}"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_env: |
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Fixed the failing backfill-duplicate-comments workflow by adding missing `workflow_dispatch` trigger to claude-dedupe-issues.yml
- Added `issue_number` input parameter for manual workflow triggers
- Updated prompt to use either `github.event.issue.number` or `inputs.issue_number`

## Test plan
- [ ] Verify backfill-duplicate-comments workflow can now successfully trigger claude-dedupe-issues.yml
- [ ] Test manual workflow dispatch with issue number input
- [ ] Confirm existing automatic triggers on issue creation still work

🤖 Generated with [Claude Code](https://claude.ai/code)