### PR TITLE
Add Statsig event logging to GitHub issue workflows

### DIFF
--- a/.github/workflows/auto-close-duplicates.yml
+++ b/.github/workflows/auto-close-duplicates.yml
@@ -28,3 +28,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
           GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}
+          STATSIG_API_KEY: ${{ secrets.STATSIG_API_KEY }}

--- a/.github/workflows/claude-dedupe-issues.yml
+++ b/.github/workflows/claude-dedupe-issues.yml
@@ -29,3 +29,52 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_env: |
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log duplicate comment event to Statsig
+        if: always()
+        env:
+          STATSIG_API_KEY: ${{ secrets.STATSIG_API_KEY }}
+        run: |
+          ISSUE_NUMBER=${{ github.event.issue.number || inputs.issue_number }}
+          REPO=${{ github.repository }}
+          
+          if [ -z "$STATSIG_API_KEY" ]; then
+            echo "STATSIG_API_KEY not found, skipping Statsig logging"
+            exit 0
+          fi
+          
+          # Prepare the event payload
+          EVENT_PAYLOAD=$(jq -n \
+            --arg issue_number "$ISSUE_NUMBER" \
+            --arg repo "$REPO" \
+            --arg triggered_by "${{ github.event_name }}" \
+            '{
+              events: [{
+                eventName: "github_duplicate_comment_added",
+                value: 1,
+                metadata: {
+                  repository: $repo,
+                  issue_number: ($issue_number | tonumber),
+                  triggered_by: $triggered_by,
+                  workflow_run_id: "${{ github.run_id }}"
+                },
+                time: (now | floor | tostring)
+              }]
+            }')
+          
+          # Send to Statsig API
+          echo "Logging duplicate comment event to Statsig for issue #${ISSUE_NUMBER}"
+          
+          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://events.statsigapi.net/v1/log_event \
+            -H "Content-Type: application/json" \
+            -H "STATSIG-API-KEY: ${STATSIG_API_KEY}" \
+            -d "$EVENT_PAYLOAD")
+          
+          HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+          BODY=$(echo "$RESPONSE" | head -n-1)
+          
+          if [ "$HTTP_CODE" -eq 200 ] || [ "$HTTP_CODE" -eq 202 ]; then
+            echo "Successfully logged duplicate comment event for issue #${ISSUE_NUMBER}"
+          else
+            echo "Failed to log duplicate comment event for issue #${ISSUE_NUMBER}. HTTP ${HTTP_CODE}: ${BODY}"
+          fi

--- a/.github/workflows/log-issue-events.yml
+++ b/.github/workflows/log-issue-events.yml
@@ -1,0 +1,68 @@
+name: Log GitHub Issue Events
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  log-issue-created:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: read
+
+    steps:
+      - name: Log issue creation to Statsig
+        env:
+          STATSIG_API_KEY: ${{ secrets.STATSIG_API_KEY }}
+        run: |
+          ISSUE_NUMBER=${{ github.event.issue.number }}
+          REPO=${{ github.repository }}
+          ISSUE_TITLE="${{ github.event.issue.title }}"
+          AUTHOR="${{ github.event.issue.user.login }}"
+          CREATED_AT="${{ github.event.issue.created_at }}"
+          
+          if [ -z "$STATSIG_API_KEY" ]; then
+            echo "STATSIG_API_KEY not found, skipping Statsig logging"
+            exit 0
+          fi
+          
+          # Prepare the event payload
+          EVENT_PAYLOAD=$(jq -n \
+            --arg issue_number "$ISSUE_NUMBER" \
+            --arg repo "$REPO" \
+            --arg title "$ISSUE_TITLE" \
+            --arg author "$AUTHOR" \
+            --arg created_at "$CREATED_AT" \
+            '{
+              events: [{
+                eventName: "github_issue_created",
+                value: 1,
+                metadata: {
+                  repository: $repo,
+                  issue_number: ($issue_number | tonumber),
+                  issue_title: $title,
+                  issue_author: $author,
+                  created_at: $created_at
+                },
+                time: (now | floor | tostring)
+              }]
+            }')
+          
+          # Send to Statsig API
+          echo "Logging issue creation to Statsig for issue #${ISSUE_NUMBER}"
+          
+          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://events.statsigapi.net/v1/log_event \
+            -H "Content-Type: application/json" \
+            -H "STATSIG-API-KEY: ${STATSIG_API_KEY}" \
+            -d "$EVENT_PAYLOAD")
+          
+          HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+          BODY=$(echo "$RESPONSE" | head -n-1)
+          
+          if [ "$HTTP_CODE" -eq 200 ] || [ "$HTTP_CODE" -eq 202 ]; then
+            echo "Successfully logged issue creation for issue #${ISSUE_NUMBER}"
+          else
+            echo "Failed to log issue creation for issue #${ISSUE_NUMBER}. HTTP ${HTTP_CODE}: ${BODY}"
+          fi

--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -51,6 +51,42 @@ function extractDuplicateIssueNumber(commentBody: string): number | null {
   return match ? parseInt(match[1], 10) : null;
 }
 
+async function logStatsigEvent(eventName: string, value: number, metadata: Record<string, any>): Promise<void> {
+  const statsigApiKey = process.env.STATSIG_API_KEY;
+  if (!statsigApiKey) {
+    console.log("[DEBUG] STATSIG_API_KEY not found, skipping Statsig logging");
+    return;
+  }
+
+  const eventPayload = {
+    events: [{
+      eventName,
+      value,
+      metadata,
+      time: Math.floor(Date.now()).toString()
+    }]
+  };
+
+  try {
+    const response = await fetch('https://events.statsigapi.net/v1/log_event', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'STATSIG-API-KEY': statsigApiKey
+      },
+      body: JSON.stringify(eventPayload)
+    });
+
+    if (response.ok) {
+      console.log(`[DEBUG] Successfully logged Statsig event: ${eventName}`);
+    } else {
+      console.log(`[DEBUG] Failed to log Statsig event: ${response.status} ${response.statusText}`);
+    }
+  } catch (error) {
+    console.log(`[DEBUG] Error logging to Statsig: ${error}`);
+  }
+}
+
 async function closeIssueAsDuplicate(
   owner: string,
   repo: string,
@@ -80,6 +116,14 @@ If this is incorrect, please re-open this issue or create a new one.
 🤖 Generated with [Claude Code](https://claude.ai/code)`
     }
   );
+
+  // Log to Statsig
+  await logStatsigEvent('github_issue_closed_as_duplicate', 1, {
+    repository: `${owner}/${repo}`,
+    issue_number: issueNumber,
+    duplicate_of_issue: duplicateOfNumber,
+    closed_by: 'auto-close-script'
+  });
 }
 
 async function autoCloseDuplicates(): Promise<void> {


### PR DESCRIPTION
## Summary
- Added Statsig event logging when GitHub issues are closed as duplicates
- Added Statsig event logging when duplicate comments are added to issues
- Added Statsig event logging when new issues are created
- Updated workflows to pass STATSIG_API_KEY environment variable

## Changes
- **`scripts/auto-close-duplicates.ts`**: Added `logStatsigEvent()` function and integrated logging into duplicate closure process
- **`.github/workflows/auto-close-duplicates.yml`**: Added STATSIG_API_KEY environment variable
- **`.github/workflows/claude-dedupe-issues.yml`**: Added step to log duplicate comment events
- **`.github/workflows/log-issue-events.yml`**: New workflow to log issue creation events

## Test plan
- [ ] Verify workflows run without errors when STATSIG_API_KEY is available
- [ ] Verify workflows gracefully skip logging when STATSIG_API_KEY is missing
- [ ] Monitor Statsig dashboard for incoming events after deployment

🤖 Generated with [Claude Code](https://claude.ai/code)