### PR TITLE
Add containerized Claude Code script with host credential proxy

### DIFF
--- a/.devcontainer/scripts/README.md
+++ b/.devcontainer/scripts/README.md
@@ -1,0 +1,105 @@
+# claudebox - Run Claude Code in Docker with auth proxy
+
+Run Claude Code in Docker containers such that your API credentials stay on your host machine and are injected via proxy.
+
+## Quick Start
+
+```bash
+# Add to PATH
+export PATH="$PATH:/path/to/claude-code/.devcontainer/scripts"
+
+# Run from your project directory
+cd /path/to/your/project
+claudebox
+
+# With your CLAUDE.md
+claudebox --mount-claude-md
+```
+
+Claude Code runs in a container with access to your current directory. API credentials stay on the host.
+
+## How It Works
+
+```
+Host Machine                 Container                    Anthropic API
+┌─────────────┐             ┌─────────────┐             ┌─────────────┐
+│ Real Creds  │             │ Dummy Creds │             │             │
+│ (Keychain)  │             │ (Dummy)     │             │             │
+│             │             │             │             │             │
+│  ┌───────┐  │             │  ┌───────┐  │             │             │
+│  │ Proxy │◄─┼─────────────┼──┤Claude │  │             │             │
+│  │       │  │ Intercept   │  │ Code  │  │             │             │
+│  └───┬───┘  │ & Replace   │  └───────┘  │             │             │
+│      │      │             │             │             │             │
+│      └──────┼─────────────┼─────────────┼─────────────┤             │
+│             │             │             │             │             │
+└─────────────┘             └─────────────┘             └─────────────┘
+```
+
+### The Process
+
+1. **Setup**: `claudebox` starts an authentication proxy on your host machine
+2. **Container**: Docker container gets dummy credentials and proxy URL
+3. **Interception**: When Claude Code makes API calls, they go to the proxy first
+4. **Injection**: Proxy retrieves real credentials via `get-claude-credentials.sh` and replaces dummy access tokens in API requests
+5. **Forwarding**: Proxy sends the request to Anthropic with real credentials
+6. **Response**: API response flows back through proxy to Claude Code
+
+### Components
+
+- `claudebox` - Main script that manages Docker container and proxy
+- `claude-auth-proxy.py` - Authentication proxy that injects real credentials
+- `get-claude-credentials.sh` - Shared credential retrieval script (supports macOS Keychain, Linux config files)
+
+## Prerequisites
+
+- Docker Desktop running
+- macOS (uses Keychain) or Linux (uses config files) with Claude Code credentials
+- Python 3.6+
+
+Your existing Claude Code setup should already have credentials configured. The container gets minimal config (just `hasCompletedOnboarding`) to skip setup screens.
+
+## Options
+
+```bash
+claudebox --help
+
+Options:
+  --mount-claude-md Mount your real CLAUDE.md file (default: none)
+  --help            Show help
+```
+
+## Security
+
+**What goes into the container:**
+- Dummy credentials (both access and refresh tokens replaced with dummy values)
+- Minimal config (`hasCompletedOnboarding` only)
+- Your current directory mounted as `/workspace`
+- Your `CLAUDE.md` file if `--mount-claude-md` is used
+
+**What stays on the host:**
+- Real API credentials (retrieved from macOS Keychain or Linux config files)
+- Your personal config and usage history
+- File paths and user identifiers
+
+**Limitations:**
+- Windows credential retrieval not implemented
+- Proxy traffic is unencrypted (localhost only)
+
+## Troubleshooting
+
+### Proxy fails to start
+```bash
+# Check if Docker is running
+docker info
+
+# Run with debug output to see all commands
+bash -x claudebox
+```
+
+### No credentials found
+```bash
+# Verify keychain access
+security find-generic-password -s "Claude Code-credentials" -a "$(whoami)" -w
+```
+

--- a/.devcontainer/scripts/claude-auth-proxy.py
+++ b/.devcontainer/scripts/claude-auth-proxy.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import urllib.request
+import urllib.error
+
+ANTHROPIC_API_BASE = 'https://api.anthropic.com'
+DUMMY_TOKENS = [
+    'sk-ant-oat01-dummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDQ-DummyAA'
+]
+
+class ClaudeAuthProxyHandler(BaseHTTPRequestHandler):
+    def log_message(self, format, *args):
+        pass
+    
+    def get_real_oauth_token(self):
+        try:
+            script_dir = os.path.dirname(os.path.abspath(__file__))
+            cred_script = os.path.join(script_dir, 'get-claude-credentials.sh')
+            
+            result = subprocess.run([cred_script], capture_output=True, text=True, timeout=10)
+            
+            if result.returncode == 0 and result.stdout:
+                creds = json.loads(result.stdout.strip())
+                
+                if 'claudeAiOauth' in creds:
+                    oauth_data = creds['claudeAiOauth']
+                    
+                    if 'accessToken' in oauth_data:
+                        return oauth_data['accessToken']
+                    
+        except json.JSONDecodeError:
+            pass
+        except Exception:
+            pass
+        
+        return None
+    
+    def do_POST(self): self.handle_request('POST')
+    def do_GET(self): self.handle_request('GET')  
+    def do_PUT(self): self.handle_request('PUT')
+    def do_DELETE(self): self.handle_request('DELETE')
+    
+    def handle_request(self, method):
+        content_length = int(self.headers.get('Content-Length', 0))
+        body = self.rfile.read(content_length) if content_length > 0 else b''
+        real_token = self.get_real_oauth_token()
+        
+        if not real_token:
+            self.send_error(500, "No credentials found")
+            return
+        
+        url = f"{ANTHROPIC_API_BASE}{self.path}"
+        headers = dict(self.headers)
+        
+        # Inject real credentials
+        token_replaced = False
+        for name, value in headers.items():
+            if isinstance(value, str):
+                for dummy in DUMMY_TOKENS:
+                    if dummy in value:
+                        value = value.replace(dummy, real_token)
+                        token_replaced = True
+                headers[name] = value
+        
+        if not token_replaced:
+            self.send_error(500, "No dummy tokens found to replace")
+            return
+        
+        # Fix headers
+        headers.pop('Content-Length', None)
+        headers.pop('Connection', None) 
+        headers['Host'] = 'api.anthropic.com'
+        
+        try:
+            req = urllib.request.Request(url, data=body, headers=headers, method=method)
+            with urllib.request.urlopen(req, timeout=600) as resp:
+                self.send_response(resp.code)
+                for key, value in resp.headers.items():
+                    if key.lower() not in ['connection', 'transfer-encoding']:
+                        self.send_header(key, value)
+                self.end_headers()
+                self.wfile.write(resp.read())
+                
+        except urllib.error.HTTPError as e:
+            error_body = e.read()
+            error_headers = dict(e.headers) if hasattr(e, 'headers') else {}
+            
+            self.send_response(e.code)
+            for key, value in error_headers.items():
+                if key.lower() not in ['connection', 'transfer-encoding']:
+                    self.send_header(key, value)
+            self.end_headers()
+            self.wfile.write(error_body)
+            
+        except Exception as e:
+            self.send_error(502, f"Bad Gateway: {str(e)}")
+
+def main():
+    parser = argparse.ArgumentParser(description='Claude Authentication Proxy')
+    parser.add_argument('--port', type=int, required=True)
+    args = parser.parse_args()
+    
+    try:
+        server = HTTPServer(('0.0.0.0', args.port), ClaudeAuthProxyHandler)
+        server.serve_forever()
+    except KeyboardInterrupt:
+        server.shutdown()
+    except OSError:
+        # Port likely in use - exit with error
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/.devcontainer/scripts/claude-auth-proxy.py
+++ b/.devcontainer/scripts/claude-auth-proxy.py
@@ -5,59 +5,69 @@ import json
 import os
 import subprocess
 import sys
-from http.server import HTTPServer, BaseHTTPRequestHandler
-import urllib.request
 import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
-ANTHROPIC_API_BASE = 'https://api.anthropic.com'
+ANTHROPIC_API_BASE = "https://api.anthropic.com"
 DUMMY_TOKENS = [
-    'sk-ant-oat01-dummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDQ-DummyAA'
+    "sk-ant-oat01-dummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDQ-DummyAA"
 ]
+
 
 class ClaudeAuthProxyHandler(BaseHTTPRequestHandler):
     def log_message(self, format, *args):
         pass
-    
+
     def get_real_oauth_token(self):
         try:
             script_dir = os.path.dirname(os.path.abspath(__file__))
-            cred_script = os.path.join(script_dir, 'get-claude-credentials.sh')
-            
-            result = subprocess.run([cred_script], capture_output=True, text=True, timeout=10)
-            
+            cred_script = os.path.join(script_dir, "get-claude-credentials.sh")
+
+            result = subprocess.run(
+                [cred_script], capture_output=True, text=True, timeout=10
+            )
+
             if result.returncode == 0 and result.stdout:
                 creds = json.loads(result.stdout.strip())
-                
-                if 'claudeAiOauth' in creds:
-                    oauth_data = creds['claudeAiOauth']
-                    
-                    if 'accessToken' in oauth_data:
-                        return oauth_data['accessToken']
-                    
+
+                if "claudeAiOauth" in creds:
+                    oauth_data = creds["claudeAiOauth"]
+
+                    if "accessToken" in oauth_data:
+                        return oauth_data["accessToken"]
+
         except json.JSONDecodeError:
             pass
         except Exception:
             pass
-        
+
         return None
-    
-    def do_POST(self): self.handle_request('POST')
-    def do_GET(self): self.handle_request('GET')  
-    def do_PUT(self): self.handle_request('PUT')
-    def do_DELETE(self): self.handle_request('DELETE')
-    
+
+    def do_POST(self):
+        self.handle_request("POST")
+
+    def do_GET(self):
+        self.handle_request("GET")
+
+    def do_PUT(self):
+        self.handle_request("PUT")
+
+    def do_DELETE(self):
+        self.handle_request("DELETE")
+
     def handle_request(self, method):
-        content_length = int(self.headers.get('Content-Length', 0))
-        body = self.rfile.read(content_length) if content_length > 0 else b''
+        content_length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(content_length) if content_length > 0 else b""
         real_token = self.get_real_oauth_token()
-        
+
         if not real_token:
             self.send_error(500, "No credentials found")
             return
-        
+
         url = f"{ANTHROPIC_API_BASE}{self.path}"
         headers = dict(self.headers)
-        
+
         # Inject real credentials
         token_replaced = False
         for name, value in headers.items():
@@ -67,47 +77,90 @@ class ClaudeAuthProxyHandler(BaseHTTPRequestHandler):
                         value = value.replace(dummy, real_token)
                         token_replaced = True
                 headers[name] = value
-        
+
         if not token_replaced:
             self.send_error(500, "No dummy tokens found to replace")
             return
-        
+
         # Fix headers
-        headers.pop('Content-Length', None)
-        headers.pop('Connection', None) 
-        headers['Host'] = 'api.anthropic.com'
-        
+        headers.pop("Content-Length", None)
+        headers.pop("Connection", None)
+        headers["Host"] = "api.anthropic.com"
+
         try:
             req = urllib.request.Request(url, data=body, headers=headers, method=method)
             with urllib.request.urlopen(req, timeout=600) as resp:
                 self.send_response(resp.code)
                 for key, value in resp.headers.items():
-                    if key.lower() not in ['connection', 'transfer-encoding']:
+                    if key.lower() not in ["connection", "transfer-encoding"]:
                         self.send_header(key, value)
                 self.end_headers()
                 self.wfile.write(resp.read())
-                
+
         except urllib.error.HTTPError as e:
+            # If we get a 401, try to refresh token with claude -p and retry once
+            if e.code == 401:
+                try:
+                    subprocess.run(
+                        ["claude", "-p", "hi claude, may you be happy"],
+                        capture_output=True,
+                        timeout=30,
+                    )
+
+                    # Get fresh token after refresh
+                    fresh_token = self.get_real_oauth_token()
+                    if fresh_token and fresh_token != real_token:
+                        # Update headers with fresh token
+                        for name, value in headers.items():
+                            if isinstance(value, str):
+                                for dummy in DUMMY_TOKENS:
+                                    if real_token in value:
+                                        value = value.replace(real_token, fresh_token)
+                                headers[name] = value
+
+                        # Retry request with fresh token
+                        retry_req = urllib.request.Request(
+                            url, data=body, headers=headers, method=method
+                        )
+                        with urllib.request.urlopen(
+                            retry_req, timeout=600
+                        ) as retry_resp:
+                            self.send_response(retry_resp.code)
+                            for key, value in retry_resp.headers.items():
+                                if key.lower() not in [
+                                    "connection",
+                                    "transfer-encoding",
+                                ]:
+                                    self.send_header(key, value)
+                            self.end_headers()
+                            self.wfile.write(retry_resp.read())
+                        return
+
+                except Exception:
+                    pass  # Fall through to original error handling
+
+            # Original error handling for non-401 or failed retry
             error_body = e.read()
-            error_headers = dict(e.headers) if hasattr(e, 'headers') else {}
-            
+            error_headers = dict(e.headers) if hasattr(e, "headers") else {}
+
             self.send_response(e.code)
             for key, value in error_headers.items():
-                if key.lower() not in ['connection', 'transfer-encoding']:
+                if key.lower() not in ["connection", "transfer-encoding"]:
                     self.send_header(key, value)
             self.end_headers()
             self.wfile.write(error_body)
-            
+
         except Exception as e:
             self.send_error(502, f"Bad Gateway: {str(e)}")
 
+
 def main():
-    parser = argparse.ArgumentParser(description='Claude Authentication Proxy')
-    parser.add_argument('--port', type=int, required=True)
+    parser = argparse.ArgumentParser(description="Claude Authentication Proxy")
+    parser.add_argument("--port", type=int, required=True)
     args = parser.parse_args()
-    
+
     try:
-        server = HTTPServer(('0.0.0.0', args.port), ClaudeAuthProxyHandler)
+        server = HTTPServer(("0.0.0.0", args.port), ClaudeAuthProxyHandler)
         server.serve_forever()
     except KeyboardInterrupt:
         server.shutdown()
@@ -115,5 +168,6 @@ def main():
         # Port likely in use - exit with error
         sys.exit(1)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/.devcontainer/scripts/claudebox
+++ b/.devcontainer/scripts/claudebox
@@ -1,0 +1,167 @@
+#!/bin/bash
+set -euo pipefail
+
+DOCKER_IMAGE="claude-code-devcontainer"
+CONTAINER_NAME="claude-code-auth-$$-$(date +%s)"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEVCONTAINER_DIR="$(dirname "$SCRIPT_DIR")"
+PROXY_SCRIPT="$SCRIPT_DIR/claude-auth-proxy.py"
+
+# Initialize variables
+CLAUDE_ARGS=()
+MOUNT_CLAUDE_MD=false
+TEMP_CREDS=""
+PROXY_PID=""
+MAX_ATTEMPTS=30
+ATTEMPT=0
+while [[ $# -gt 0 ]]; do
+    case $1 in
+    --mount-claude-md)
+        MOUNT_CLAUDE_MD=true
+        shift
+        ;;
+    --help)
+        cat <<'EOF'
+Run Claude Code in a Docker container with credential isolation.
+
+Real API credentials stay on the host and are injected via proxy.
+
+USAGE:
+    Run this script from your project directory:
+    
+    cd /path/to/your/project
+    claudebox [OPTIONS] [CLAUDE_OPTIONS]
+
+OPTIONS:
+    --mount-claude-md Mount your real CLAUDE.md file (default: none)
+    --help            Show this help
+
+WORKSPACE:
+    The current directory becomes /workspace in the container.
+    Claude Code will have access to all files in the current directory.
+
+EXAMPLES:
+    cd ~/my-project && claudebox
+    cd ~/my-project && claudebox --mount-claude-md -p "hello world"
+    cd ~/my-project && claudebox --continue
+EOF
+        exit 0
+        ;;
+    *)
+        # Pass unknown arguments to Claude
+        CLAUDE_ARGS+=("$1")
+        shift
+        ;;
+    esac
+done
+
+docker info >/dev/null 2>&1 || {
+    echo "Docker not running"
+    exit 1
+}
+
+# Build image if needed
+if ! docker image inspect "$DOCKER_IMAGE" >/dev/null 2>&1; then
+    [[ "$VERBOSE" == "true" ]] && echo "🔨 Building devcontainer image..."
+    docker build -t "$DOCKER_IMAGE" -f "$DEVCONTAINER_DIR/Dockerfile" "$DEVCONTAINER_DIR" || exit 1
+fi
+
+# Find an available port
+find_available_port() {
+    local port=$1
+    local max_port=65535
+    for ((i = 0; i <= $((max_port - port)); i++)); do
+        if ! nc -z localhost $((port + i)) 2>/dev/null; then
+            echo $((port + i))
+            return 0
+        fi
+    done
+    echo "❌ No available ports found in range $port-$max_port" >&2
+    return 1
+}
+
+# Find available port in ephemeral range (58080-65535) to avoid conflicts with registered services
+ACTUAL_PORT=$(find_available_port 58080) || exit 1
+
+# Start proxy in background on the available port
+python3 "$PROXY_SCRIPT" --port "$ACTUAL_PORT" &
+PROXY_PID=$!
+
+# Health check polling - wait for proxy to be ready
+while [[ $ATTEMPT -lt $MAX_ATTEMPTS ]]; do
+    if ! ps -p $PROXY_PID >/dev/null 2>&1; then
+        echo "❌ Proxy process died unexpectedly"
+        exit 1
+    fi
+
+    # Try to connect to the proxy port
+    if nc -z localhost "$ACTUAL_PORT" 2>/dev/null; then
+        break
+    fi
+
+    ATTEMPT=$((ATTEMPT + 1))
+    if [[ $ATTEMPT -eq $MAX_ATTEMPTS ]]; then
+        echo "❌ Proxy failed to start after ${MAX_ATTEMPTS} attempts"
+        kill $PROXY_PID 2>/dev/null || true
+        exit 1
+    fi
+
+    sleep 0.2
+done
+
+# Cleanup on exit
+cleanup() {
+    local exit_code=$?
+
+    # Kill proxy process and remove container
+    kill $PROXY_PID 2>/dev/null || true
+    docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+
+    # Clean up temporary files
+    rm -f "$TEMP_CREDS" 2>/dev/null || true
+
+    exit $exit_code
+}
+trap cleanup INT TERM EXIT
+
+# Create dummy credentials (pipe directly, never write real creds to disk)
+TEMP_CREDS=$(mktemp) || {
+    echo "Failed to create temporary credentials file" >&2
+    exit 1
+}
+
+# Try to get credentials and replace with dummy tokens in one operation
+if ! "$SCRIPT_DIR/get-claude-credentials.sh" 2>/dev/null | jq '
+        .claudeAiOauth.accessToken = "sk-ant-oat01-dummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDQ-DummyAA" |
+        .claudeAiOauth.refreshToken = "sk-ant-ort01-dummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDummyDQ-DummyAA"
+    ' >"$TEMP_CREDS" 2>/dev/null; then
+    # Failed to get credentials or process them, clean up
+    rm -f "$TEMP_CREDS"
+    TEMP_CREDS=""
+fi
+
+# Build docker command
+docker_cmd=(
+    docker run --rm --name "$CONTAINER_NAME" -it
+    -v "$(pwd):/workspace" -w /workspace
+    -e "ANTHROPIC_BASE_URL=http://host.docker.internal:$ACTUAL_PORT"
+)
+
+# Mount dummy credentials directly to Claude's location if they exist
+[[ -n "$TEMP_CREDS" ]] && docker_cmd+=(-v "$TEMP_CREDS:/home/node/.claude/.credentials.json:ro")
+[[ "$MOUNT_CLAUDE_MD" == true && -f "$HOME/.claude/CLAUDE.md" ]] && docker_cmd+=(-v "$HOME/.claude/CLAUDE.md:/tmp/host-claude-md:ro")
+
+docker_cmd+=("$DOCKER_IMAGE")
+
+# Run container with setup script
+"${docker_cmd[@]}" bash -c "
+    # Copy CLAUDE.md if provided
+    [[ -f /tmp/host-claude-md ]] && cp /tmp/host-claude-md /home/node/.claude/CLAUDE.md
+    
+    # Create minimal config to skip setup screen
+    echo '{\"hasCompletedOnboarding\": true}' > /home/node/.claude.json
+
+    # Start Claude with passed arguments
+    claude \"\$@\"
+" -- "${CLAUDE_ARGS[@]+"${CLAUDE_ARGS[@]}"}"

--- a/.devcontainer/scripts/get-claude-credentials.sh
+++ b/.devcontainer/scripts/get-claude-credentials.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Shared credential retrieval script
+# Outputs JSON credentials or exits with error
+
+# From https://github.com/textcortex/claude-code-sandbox/blob/main/src/credentials.ts
+case "$(uname)" in
+Darwin)
+    # macOS: Use Keychain
+    security find-generic-password \
+        -s "Claude Code-credentials" \
+        -a "$(whoami)" \
+        -w 2>/dev/null || exit 1
+    ;;
+Linux)
+    # Try ~/.claude/.credentials.json first (Claude Code standard location)
+    if [[ -f "$HOME/.claude/.credentials.json" ]]; then
+        cat "$HOME/.claude/.credentials.json" 2>/dev/null || exit 1
+    # Try ~/.config/claude/auth.json (XDG config location)
+    elif [[ -f "$HOME/.config/claude/auth.json" ]]; then
+        cat "$HOME/.config/claude/auth.json" 2>/dev/null || exit 1
+    else
+        exit 1
+    fi
+    ;;
+MINGW* | CYGWIN* | MSYS*)
+    # TODO: Windows credential retrieval
+    exit 1
+    ;;
+*)
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
**Status:** This appears to work -- no credentials enter the container, but the containerized Claude starts up and works as if they were there because of the proxy on the host that adds them. However I'm still learning about software engineering, so please scrutinize it before use! I would also love feedback before *I* start using it too much. :) 

Claude and I worked out how to adjust the packets by writing this transparent proxy first: https://gist.github.com/ElleNajt/04db039b7721b82b2a8224e1a2ccc81d

**Description:** 

This runs Claude Code in a Docker container with dummy OAuth tokens. Host proxy intercepts API calls and replaces dummy tokens with real credentials.

This addresses [this issue](https://github.com/anthropics/claude-code/issues/5082) that I opened.

Components:
- claudebox: Starts proxy and container, mounts working directory as /workspace
- claude-auth-proxy.py: HTTP proxy that swaps dummy tokens for real ones
- get-claude-credentials.sh: Retrieves credentials from macOS keychain
- Container config: .claude.json only hasCompletedOnboarding flag, ~/.claude/.credentials.json only has dummy tokens, CLAUDE.md only optionally passed through

Currently tested on macOS only (using security command for keychain access).

🤖 Generated with [Claude Code](https://claude.ai/code)