### PR TITLE
Add GitHub workflow logging for issue closure events

### DIFF
--- a/.github/workflows/log-issue-events.yml
+++ b/.github/workflows/log-issue-events.yml
@@ -2,10 +2,11 @@ name: Log GitHub Issue Events
 
 on:
   issues:
-    types: [opened]
+    types: [opened, closed]
 
 jobs:
   log-issue-created:
+    if: github.event.action == 'opened'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -65,4 +66,115 @@ jobs:
             echo "Successfully logged issue creation for issue #${ISSUE_NUMBER}"
           else
             echo "Failed to log issue creation for issue #${ISSUE_NUMBER}. HTTP ${HTTP_CODE}: ${BODY}"
+          fi
+
+  log-issue-closed:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: read
+
+    steps:
+      - name: Log issue closure to Statsig
+        env:
+          STATSIG_API_KEY: ${{ secrets.STATSIG_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUE_NUMBER=${{ github.event.issue.number }}
+          REPO=${{ github.repository }}
+          ISSUE_TITLE="${{ github.event.issue.title }}"
+          CLOSED_BY="${{ github.event.issue.closed_by.login }}"
+          CLOSED_AT="${{ github.event.issue.closed_at }}"
+          STATE_REASON="${{ github.event.issue.state_reason }}"
+          
+          if [ -z "$STATSIG_API_KEY" ]; then
+            echo "STATSIG_API_KEY not found, skipping Statsig logging"
+            exit 0
+          fi
+          
+          # Get additional issue data via GitHub API
+          echo "Fetching additional issue data for #${ISSUE_NUMBER}"
+          ISSUE_DATA=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${REPO}/issues/${ISSUE_NUMBER}")
+          
+          COMMENTS_COUNT=$(echo "$ISSUE_DATA" | jq -r '.comments')
+          
+          # Get reactions data
+          REACTIONS_DATA=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${REPO}/issues/${ISSUE_NUMBER}/reactions")
+          
+          REACTIONS_COUNT=$(echo "$REACTIONS_DATA" | jq '. | length')
+          
+          # Check if issue was closed automatically (by checking if closed_by is a bot)
+          CLOSED_AUTOMATICALLY="false"
+          if [[ "$CLOSED_BY" == *"[bot]"* ]]; then
+            CLOSED_AUTOMATICALLY="true"
+          fi
+          
+          # Check if closed as duplicate by looking for duplicate label or state_reason
+          CLOSED_AS_DUPLICATE="false"
+          if [ "$STATE_REASON" = "not_planned" ]; then
+            # Check if issue has duplicate label
+            LABELS=$(echo "$ISSUE_DATA" | jq -r '.labels[] | select(.name | test("duplicate"; "i")) | .name')
+            if [ -n "$LABELS" ]; then
+              CLOSED_AS_DUPLICATE="true"
+            fi
+          fi
+          
+          # Prepare the event payload
+          EVENT_PAYLOAD=$(jq -n \
+            --arg issue_number "$ISSUE_NUMBER" \
+            --arg repo "$REPO" \
+            --arg title "$ISSUE_TITLE" \
+            --arg closed_by "$CLOSED_BY" \
+            --arg closed_at "$CLOSED_AT" \
+            --arg state_reason "$STATE_REASON" \
+            --arg comments_count "$COMMENTS_COUNT" \
+            --arg reactions_count "$REACTIONS_COUNT" \
+            --arg closed_automatically "$CLOSED_AUTOMATICALLY" \
+            --arg closed_as_duplicate "$CLOSED_AS_DUPLICATE" \
+            '{
+              events: [{
+                eventName: "github_issue_closed",
+                value: 1,
+                metadata: {
+                  repository: $repo,
+                  issue_number: ($issue_number | tonumber),
+                  issue_title: $title,
+                  closed_by: $closed_by,
+                  closed_at: $closed_at,
+                  state_reason: $state_reason,
+                  comments_count: ($comments_count | tonumber),
+                  reactions_count: ($reactions_count | tonumber),
+                  closed_automatically: ($closed_automatically | test("true")),
+                  closed_as_duplicate: ($closed_as_duplicate | test("true"))
+                },
+                time: (now | floor | tostring)
+              }]
+            }')
+          
+          # Send to Statsig API
+          echo "Logging issue closure to Statsig for issue #${ISSUE_NUMBER}"
+          
+          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://events.statsigapi.net/v1/log_event \
+            -H "Content-Type: application/json" \
+            -H "STATSIG-API-KEY: ${STATSIG_API_KEY}" \
+            -d "$EVENT_PAYLOAD")
+          
+          HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+          BODY=$(echo "$RESPONSE" | head -n-1)
+          
+          if [ "$HTTP_CODE" -eq 200 ] || [ "$HTTP_CODE" -eq 202 ]; then
+            echo "Successfully logged issue closure for issue #${ISSUE_NUMBER}"
+            echo "Closed by: $CLOSED_BY"
+            echo "Comments: $COMMENTS_COUNT"
+            echo "Reactions: $REACTIONS_COUNT"
+            echo "Closed automatically: $CLOSED_AUTOMATICALLY"
+            echo "Closed as duplicate: $CLOSED_AS_DUPLICATE"
+          else
+            echo "Failed to log issue closure for issue #${ISSUE_NUMBER}. HTTP ${HTTP_CODE}: ${BODY}"
           fi


### PR DESCRIPTION
## Summary
- Extends the existing `log-issue-events` workflow to capture detailed metrics when issues are closed
- Logs closure data to Statsig including who closed the issue, whether it was automatic/duplicate, and engagement metrics
- Follows the same pattern as the existing issue creation logging

## Key Features
- **Closure tracking**: Captures who closed the issue and when
- **Automation detection**: Identifies if the issue was closed by a bot
- **Duplicate detection**: Checks for duplicate labels when state_reason is "not_planned"  
- **Engagement metrics**: Records comment and reaction counts at time of closure
- **State reason**: Captures GitHub's issue state_reason field

## Test plan
- [ ] Verify workflow syntax is valid (already validated with yq)
- [ ] Test on a closed issue to ensure proper data collection
- [ ] Confirm Statsig logging works with the new `github_issue_closed` event
- [ ] Validate that both opened and closed events work independently

🤖 Generated with [Claude Code](https://claude.ai/code)