### PR TITLE
Fix GitHub Actions workflow to properly escape issue titles

### DIFF
--- a/.github/workflows/log-issue-events.yml
+++ b/.github/workflows/log-issue-events.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           ISSUE_NUMBER=${{ github.event.issue.number }}
           REPO=${{ github.repository }}
-          ISSUE_TITLE="${{ github.event.issue.title }}"
+          ISSUE_TITLE=$(echo '${{ github.event.issue.title }}' | sed "s/'/'\\\\''/g")
           AUTHOR="${{ github.event.issue.user.login }}"
           CREATED_AT="${{ github.event.issue.created_at }}"
           
@@ -84,7 +84,7 @@ jobs:
         run: |
           ISSUE_NUMBER=${{ github.event.issue.number }}
           REPO=${{ github.repository }}
-          ISSUE_TITLE="${{ github.event.issue.title }}"
+          ISSUE_TITLE=$(echo '${{ github.event.issue.title }}' | sed "s/'/'\\\\''/g")
           CLOSED_BY="${{ github.event.issue.closed_by.login }}"
           CLOSED_AT="${{ github.event.issue.closed_at }}"
           STATE_REASON="${{ github.event.issue.state_reason }}"


### PR DESCRIPTION
Fixes this run failure: https://github.com/anthropics/claude-code/actions/runs/16891126187/job/47850902613

## Summary
- Fix shell execution vulnerability in log-issue-events workflow
- Issue titles containing backticks were being executed as shell commands
- Properly escape titles using single quotes and sed

## Test plan
- [ ] Verify workflow runs successfully with issue titles containing backticks
- [ ] Confirm no command injection occurs

🤖 Generated with [Claude Code](https://claude.ai/code)