### PR TITLE
Consolidate GitHub issue closure events

### DIFF
--- a/.github/workflows/log-issue-events.yml
+++ b/.github/workflows/log-issue-events.yml
@@ -115,14 +115,10 @@ jobs:
             CLOSED_AUTOMATICALLY="true"
           fi
           
-          # Check if closed as duplicate by looking for duplicate label or state_reason
+          # Check if closed as duplicate by state_reason
           CLOSED_AS_DUPLICATE="false"
-          if [ "$STATE_REASON" = "not_planned" ]; then
-            # Check if issue has duplicate label
-            LABELS=$(echo "$ISSUE_DATA" | jq -r '.labels[] | select(.name | test("duplicate"; "i")) | .name')
-            if [ -n "$LABELS" ]; then
-              CLOSED_AS_DUPLICATE="true"
-            fi
+          if [ "$STATE_REASON" = "duplicate" ]; then
+            CLOSED_AS_DUPLICATE="true"
           fi
           
           # Prepare the event payload

--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -65,7 +65,7 @@ async function closeIssueAsDuplicate(
     'PATCH',
     {
       state: 'closed',
-      state_reason: 'not_planned',
+      state_reason: 'duplicate',
       labels: ['duplicate']
     }
   );

--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -51,41 +51,6 @@ function extractDuplicateIssueNumber(commentBody: string): number | null {
   return match ? parseInt(match[1], 10) : null;
 }
 
-async function logStatsigEvent(eventName: string, value: number, metadata: Record<string, any>): Promise<void> {
-  const statsigApiKey = process.env.STATSIG_API_KEY;
-  if (!statsigApiKey) {
-    console.log("[DEBUG] STATSIG_API_KEY not found, skipping Statsig logging");
-    return;
-  }
-
-  const eventPayload = {
-    events: [{
-      eventName,
-      value,
-      metadata,
-      time: Math.floor(Date.now()).toString()
-    }]
-  };
-
-  try {
-    const response = await fetch('https://events.statsigapi.net/v1/log_event', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'STATSIG-API-KEY': statsigApiKey
-      },
-      body: JSON.stringify(eventPayload)
-    });
-
-    if (response.ok) {
-      console.log(`[DEBUG] Successfully logged Statsig event: ${eventName}`);
-    } else {
-      console.log(`[DEBUG] Failed to log Statsig event: ${response.status} ${response.statusText}`);
-    }
-  } catch (error) {
-    console.log(`[DEBUG] Error logging to Statsig: ${error}`);
-  }
-}
 
 async function closeIssueAsDuplicate(
   owner: string,
@@ -100,7 +65,8 @@ async function closeIssueAsDuplicate(
     'PATCH',
     {
       state: 'closed',
-      state_reason: 'not_planned'
+      state_reason: 'not_planned',
+      labels: ['duplicate']
     }
   );
 
@@ -117,13 +83,6 @@ If this is incorrect, please re-open this issue or create a new one.
     }
   );
 
-  // Log to Statsig
-  await logStatsigEvent('github_issue_closed_as_duplicate', 1, {
-    repository: `${owner}/${repo}`,
-    issue_number: issueNumber,
-    duplicate_of_issue: duplicateOfNumber,
-    closed_by: 'auto-close-script'
-  });
 }
 
 async function autoCloseDuplicates(): Promise<void> {


### PR DESCRIPTION
## Summary
- Removed duplicate Statsig event logging from auto-close script to prevent double-logging
- GitHub workflow now uniformly handles all issue closures with proper metadata detection
- Added duplicate label to script closures for consistent workflow detection

## Test plan
- [ ] Verify auto-close script still functions correctly
- [ ] Confirm only one github_issue_closed event fires per closure
- [ ] Check duplicate detection works properly in workflow

🤖 Generated with [Claude Code](https://claude.ai/code)