### PR TITLE
fix: improve duplicate issue number extraction in auto-close script

### DIFF
--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -47,8 +47,19 @@ async function githubRequest<T>(endpoint: string, token: string, method: string 
 }
 
 function extractDuplicateIssueNumber(commentBody: string): number | null {
-  const match = commentBody.match(/#(\d+)/);
-  return match ? parseInt(match[1], 10) : null;
+  // Try to match #123 format first
+  let match = commentBody.match(/#(\d+)/);
+  if (match) {
+    return parseInt(match[1], 10);
+  }
+  
+  // Try to match GitHub issue URL format: https://github.com/owner/repo/issues/123
+  match = commentBody.match(/github\.com\/[^\/]+\/[^\/]+\/issues\/(\d+)/);
+  if (match) {
+    return parseInt(match[1], 10);
+  }
+  
+  return null;
 }
 
 


### PR DESCRIPTION
## Summary
- Fixed the `extractDuplicateIssueNumber` function to handle both `#123` format and full GitHub issue URLs
- Resolves "could not extract duplicate issue number from comment" errors in the auto-close-duplicates script

## Test plan
- [x] Tested extraction logic with real GitHub comment containing URL format
- [x] Verified both `#123` and `https://github.com/owner/repo/issues/123` formats work
- [x] Confirmed null return for comments without issue numbers

🤖 Generated with [Claude Code](https://claude.ai/code)