### PR TITLE
fix: update auto-close-duplicates workflow permissions to write

### DIFF
--- a/.github/workflows/auto-close-duplicates.yml
+++ b/.github/workflows/auto-close-duplicates.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-      issues: read
+      issues: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Fix 403 Forbidden errors in the auto-close-duplicates workflow by updating the issues permission from `read` to `write`
- This allows the workflow to successfully close duplicate issues instead of failing with permission errors

## Test plan
- [ ] Verify the workflow runs successfully on the next scheduled execution
- [ ] Check that duplicate issues can be closed without 403 errors

🤖 Generated with [Claude Code](https://claude.ai/code)