### PR TITLE
fix: improve DNS resolution in firewall script to filter CNAME records

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -71,7 +71,7 @@ for domain in \
     "statsig.anthropic.com" \
     "statsig.com"; do
     echo "Resolving $domain..."
-    ips=$(dig +short A "$domain")
+    ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}')
     if [ -z "$ips" ]; then
         echo "ERROR: Failed to resolve $domain"
         exit 1


### PR DESCRIPTION
## Summary

This PR improves the DNS resolution logic in the firewall initialization script to properly filter out CNAME records and only extract A record IP addresses.

## Changes

- Modified `.devcontainer/init-firewall.sh:74` to use `dig +noall +answer A` with `awk` filtering instead of `dig +short A`
- The new approach ensures only A records are processed by checking `$4 == "A"` and extracting the IP from `$5`
- This prevents CNAME records from being incorrectly processed as IP addresses

## Why this change is needed

The previous implementation using `dig +short A` could return CNAME records in addition to A records, which would cause issues when trying to process non-IP values as IP addresses in the firewall configuration.

### Example with marketplace.visualstudio.com

**Before (problematic output):**
```bash
$ dig +short A marketplace.visualstudio.com
marketplace-visualstudio-com.bx-0007.bx-msedge.net.
bx-0007.bx-msedge.net.
150.171.74.16
150.171.73.16
```

**After (clean IP-only output):**
```bash
$ dig +noall +answer A marketplace.visualstudio.com | awk '$4 == "A" {print $5}'
150.171.74.16
150.171.73.16
```