### PR TITLE
Re-add log-issue-events workflow with security fix

### DIFF
--- a/.github/workflows/log-issue-events.yml
+++ b/.github/workflows/log-issue-events.yml
@@ -1,0 +1,40 @@
+name: Log Issue Events to Statsig
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  log-to-statsig:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+    steps:
+      - name: Log issue creation to Statsig
+        env:
+          STATSIG_API_KEY: ${{ secrets.STATSIG_API_KEY }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          AUTHOR: ${{ github.event.issue.user.login }}
+          CREATED_AT: ${{ github.event.issue.created_at }}
+        run: |
+          # All values are now safely passed via environment variables
+          # No direct templating in the shell script to prevent injection attacks
+          
+          curl -X POST "https://events.statsigapi.net/v1/log_event" \
+            -H "Content-Type: application/json" \
+            -H "statsig-api-key: $STATSIG_API_KEY" \
+            -d '{
+              "events": [{
+                "eventName": "github_issue_created",
+                "metadata": {
+                  "issue_number": "'"$ISSUE_NUMBER"'",
+                  "repository": "'"$REPO"'",
+                  "title": "'"$(echo "$ISSUE_TITLE" | sed "s/\"/\\\\\"/g")"'",
+                  "author": "'"$AUTHOR"'",
+                  "created_at": "'"$CREATED_AT"'"
+                },
+                "time": '"$(date +%s)000"'
+              }]
+            }'


### PR DESCRIPTION
## Summary
- Re-implements the workflow removed in #5919, but with proper security fixes
- All GitHub event data is now passed via environment variables instead of direct templating
- Prevents remote code execution vulnerability through malicious issue titles

## Test plan
- [ ] Create test issues with various special characters in titles
- [ ] Verify Statsig events are logged correctly
- [ ] Confirm no shell injection is possible with malicious titles

🤖 Generated with [Claude Code](https://claude.ai/code)