### PR TITLE
fix: ensure firewall rules are re-applied on every DevContainer start

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -51,5 +51,6 @@
   },
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",
-  "postCreateCommand": "sudo /usr/local/bin/init-firewall.sh"
+  "postStartCommand": "sudo /usr/local/bin/init-firewall.sh",
+  "waitFor": "postStartCommand"
 }


### PR DESCRIPTION
## Summary
This PR fixes a DevContainer security issue where firewall rules were not persisting after container restarts, potentially exposing the development environment to unrestricted network access.


## Problem
Previously, the firewall rules configured within the DevContainer are reset after restarting the container.

This is because `init-firewall.sh` is executed via `postCreateCommand`, which only runs once when the container is created, while the `iptables` rules are reset whenever the container is restarted.

### Environment
- DevContainer config version: d2f8882
- Operating System: Windows 11
- Docker Desktop: 4.43.2
- VSCode: 1.103.1
- Dev Containers extension: 0.422.1

### Steps to Reproduce the Problem
1. Open a workspace with .devcontainer configuration in VSCode DevContainer.
2. Check access to a non-allowed domain (`curl -s --connect-timeout 5 https://example.com >/dev/null && echo allowed || echo blocked`).
3. Close VSCode and wait for the container to be stopped.
4. Reopen the workspace in VSCode DevContainer (which restarts the container).
5. Check access to the non-allowed domain again.

### Expected Behavior
Before restart: blocked
After restart: blocked

### Actual Behavior
Before restart: blocked
After restart: **allowed**


## Changes
- Use `postStartCommand` instead of `postCreateCommand` to apply the firewall rules every time the container starts.
- Added `"waitFor": "postStartCommand"` to ensure the container becomes accessible only after firewall initialization successfully completes, preventing access to an unsecured container state.


## Test Plan
- [ ] Verify firewall blocks unauthorized domains after fresh container creation
- [ ] Confirm firewall rules persist after container restart
- [ ] Test that allowed domains (GitHub, npm, etc.) remain accessible
- [ ] Ensure container startup fails gracefully if firewall script encounters errors


## Technical Notes
This change aligns with container restart behavior where iptables rules are typically reset. The current robust initialization approach (lines 5-25 in `init-firewall.sh`) could potentially be simplified by preserving environment-specific configurations (such as Docker DNS rules) rather than extracting and restoring them.


## See Also
- [Development Container Specification: Lifecycle](https://containers.dev/implementors/spec/#lifecycle)
- [Dev Container metadata reference: Lifecycle scripts](https://containers.dev/implementors/json_reference/#lifecycle-scripts)