### PR TITLE
feat(devcontainer): Use firewall reject rule for immediate feedback instead of +2min timeouts

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -113,6 +113,9 @@ iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 # Then allow only specific outbound traffic to allowed domains
 iptables -A OUTPUT -m set --match-set allowed-domains dst -j ACCEPT
 
+# Explicitly REJECT all other outbound traffic for immediate feedback
+iptables -A OUTPUT -j REJECT --reject-with icmp-port-unreachable
+
 echo "Firewall configuration complete"
 echo "Verifying firewall rules..."
 if curl --connect-timeout 5 https://example.com >/dev/null 2>&1; then

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -114,7 +114,7 @@ iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 iptables -A OUTPUT -m set --match-set allowed-domains dst -j ACCEPT
 
 # Explicitly REJECT all other outbound traffic for immediate feedback
-iptables -A OUTPUT -j REJECT --reject-with icmp-port-unreachable
+iptables -A OUTPUT -j REJECT --reject-with icmp-admin-prohibited
 
 echo "Firewall configuration complete"
 echo "Verifying firewall rules..."


### PR DESCRIPTION
## Problem

Inside the container, any request to the blocked addresses will block for a reasonable time until timeout, which is not a great developer/troubleshooting experience.

<img width="776" height="70" alt="image" src="https://github.com/user-attachments/assets/cf6e0794-f333-4429-b8b0-0897055857eb" />

## Fix

Use REJECT with icmp-admin-prohibited (seemed the better fit) for immediate fail for outbound connections. Resulting in connection error in ~200ms vs 20-120 seconds timeout.

<img width="757" height="96" alt="image" src="https://github.com/user-attachments/assets/5cecd509-da9f-4f8a-b6db-d1f6111872d6" />


## Security considerations (analysis with Claude)

 No security vulnerabilities identified. All shell scripts use proper input validation, controlled environments, and appropriate
  privilege boundaries for development containers.


  Recommended change:
  iptables -A OUTPUT -j REJECT --reject-with icmp-admin-prohibited

  Rationale: The script blocks based on IP policy, not port availability. icmp-admin-prohibited correctly indicates administrative policy blocking rather than port unavailability, providing semantically accurate error messages to applications.

  Impact: Applications will receive "Operation not permitted" instead of "Connection refused" - better reflecting the actual blocking reason while maintaining fast failure behavior.

  🛡️ Security Design Validation

  - Asymmetric firewall behavior: INPUT drops silently (stealth), OUTPUT rejects with feedback (UX)


## Test Plan

- [x] Claude Code Sec. Review
- [x] Test and benchmark previous and new behavior
- [x] Security implications and research
- [x] Check we can access allowed addresses (github, anthropic)