### PR TITLE
Add issue close event trigger to log-issue-events workflow

### DIFF
--- a/.github/workflows/log-issue-events.yml
+++ b/.github/workflows/log-issue-events.yml
@@ -2,7 +2,7 @@ name: Log Issue Events to Statsig
 
 on:
   issues:
-    types: [opened]
+    types: [opened, closed]
 
 jobs:
   log-to-statsig:


### PR DESCRIPTION
## Summary
- Updates the GitHub workflow to trigger on both issue `opened` and `closed` events
- Expands event tracking beyond just issue creation to include issue closure

## Test plan
- [ ] Verify workflow triggers on issue close events
- [ ] Confirm existing issue open functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)