### PR TITLE
chore: Update Dockerfile deprecated ENV usage

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -65,8 +65,8 @@ ENV PATH=$PATH:/usr/local/share/npm-global/bin
 ENV SHELL=/bin/zsh
 
 # Set the default editor and visual
-ENV EDITOR nano
-ENV VISUAL nano
+ENV EDITOR=nano
+ENV VISUAL=nano
 
 # Default powerline10k theme
 ARG ZSH_IN_DOCKER_VERSION=1.2.0


### PR DESCRIPTION
[Source](https://docs.docker.com/reference/build-checks/legacy-key-value-format/#description)
The correct format for declaring environment variables and build arguments in a Dockerfile is ENV key=value and ARG key=value, where the variable name (key) and value (value) are separated by an equals sign (=). Historically, Dockerfiles have also supported a space separator between the key and the value (for example, ARG key value). This legacy format is deprecated, and you should only use the format with the equals sign.

## See Reference
[Docker Documentation](https://docs.docker.com/reference/build-checks/legacy-key-value-format/)

## As shown in Docker destop
<img width="939" height="370" alt="Screenshot 2025-08-25 at 12 24 30 PM" src="https://github.com/user-attachments/assets/2056c37b-fe87-4b1d-9810-55390025bc5b" />
