### PR TITLE
feat(devcontainer): add Claude Code extension and VS Code marketplace URLs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,6 +16,7 @@
   "customizations": {
     "vscode": {
       "extensions": [
+        "anthropic.claude-code",
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
         "eamodio.gitlens"

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -69,7 +69,10 @@ for domain in \
     "api.anthropic.com" \
     "sentry.io" \
     "statsig.anthropic.com" \
-    "statsig.com"; do
+    "statsig.com" \
+    "marketplace.visualstudio.com" \
+    "vscode.blob.core.windows.net" \
+    "update.code.visualstudio.com"; do
     echo "Resolving $domain..."
     ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}')
     if [ -z "$ips" ]; then


### PR DESCRIPTION
- Add anthropic.claude-code extension to default extensions list
- Allow VS Code marketplace URLs in firewall configuration:
  - marketplace.visualstudio.com (marketplace API)
  - vscode.blob.core.windows.net (extension downloads)
  - update.code.visualstudio.com (VS Code updates/metadata)

🤖 Generated with [Claude Code](https://claude.ai/code)