### PR TITLE
fix: broken links in issue template configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,14 +4,11 @@ contact_links:
     url: https://anthropic.com/discord
     about: Get help, ask questions, and chat with other Claude Code users
   - name: 📖 Documentation
-    url: https://docs.anthropic.com/en/docs/claude-code
+    url: https://docs.claude.com/en/docs/claude-code
     about: Read the official documentation and guides
   - name: 🎓 Getting Started Guide
-    url: https://docs.anthropic.com/en/docs/claude-code/getting-started
+    url: https://docs.claude.com/en/docs/claude-code/quickstart
     about: New to Claude Code? Start here
   - name: 🔧 Troubleshooting Guide
-    url: https://docs.anthropic.com/en/docs/claude-code/troubleshooting
+    url: https://docs.claude.com/en/docs/claude-code/troubleshooting
     about: Common issues and how to fix them
-  - name: 💡 Discussions
-    url: https://github.com/anthropics/claude-code/discussions
-    about: Share ideas, tips, and chat with maintainers


### PR DESCRIPTION
## Summary
Fixes broken links in the GitHub issue template configuration that were reported in issue #7730.

## Changes Made
- Updated all documentation URLs from `docs.anthropic.com` to `docs.claude.com` to avoid unnecessary redirects
- Changed Getting Started Guide URL from `/getting-started` to `/quickstart` path (the correct current path)
- Removed the "Discussions" link entirely since GitHub Discussions are not enabled for this repository

## Test Plan
- [x] Verified all new URLs return HTTP 200 status codes
- [x] Confirmed GitHub Discussions are disabled for this repository (`has_discussions: false`)
- [x] Tested that redirects from old URLs point to the correct new URLs

## Links
Fixes #7730

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update