### PR TITLE
Remove model specification from new-sdk-app command

### DIFF
--- a/plugins/agent-sdk-dev/commands/new-sdk-app.md
+++ b/plugins/agent-sdk-dev/commands/new-sdk-app.md
@@ -1,7 +1,6 @@
 ---
 description: Create and setup a new Claude Agent SDK application
 argument-hint: [project-name]
-model: sonnet
 ---
 
 You are tasked with helping the user create a new Claude Agent SDK application. Follow these steps carefully:


### PR DESCRIPTION
## Summary
- Removed the `model: sonnet` field from the new-sdk-app command frontmatter

## Context
The model field is no longer needed in the command frontmatter as model selection is now handled at a different level in the system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)