### PR TITLE
docs: enforce task tool and model metadata

### DIFF
--- a/plugins/commit-commands/commands/clean_gone.md
+++ b/plugins/commit-commands/commands/clean_gone.md
@@ -1,8 +1,12 @@
 ---
+allowed-tools: Bash(git:*), Task
 description: Cleans up all git branches marked as [gone] (branches that have been deleted on the remote but still exist locally), including removing associated worktrees.
+model: claude-3-5-haiku-latest
 ---
 
 ## Your Task
+
+**IMPORTANT: You MUST use the Task tool to complete ALL tasks.**
 
 You need to execute the following bash commands to clean up stale local branches that have been deleted from the remote repository.
 
@@ -13,7 +17,7 @@ You need to execute the following bash commands to clean up stale local branches
    ```bash
    git branch -v
    ```
-   
+
    Note: Branches with a '+' prefix have associated worktrees and must have their worktrees removed before deletion.
 
 2. **Next, identify worktrees that need to be removed for [gone] branches**
@@ -50,4 +54,3 @@ After executing these commands, you will:
 - Provide feedback on which worktrees and branches were removed
 
 If no branches are marked as [gone], report that no cleanup was needed.
-

--- a/plugins/commit-commands/commands/commit-push-pr.md
+++ b/plugins/commit-commands/commands/commit-push-pr.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*)
+allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*), Task
 description: Commit, push, and open a PR
 ---
 
@@ -10,6 +10,8 @@ description: Commit, push, and open a PR
 - Current branch: !`git branch --show-current`
 
 ## Your task
+
+**IMPORTANT: You MUST use the Task tool to complete ALL tasks.**
 
 Based on the above changes:
 

--- a/plugins/commit-commands/commands/commit.md
+++ b/plugins/commit-commands/commands/commit.md
@@ -1,6 +1,7 @@
 ---
-allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*), Task
 description: Create a git commit
+model: claude-3-5-haiku-latest
 ---
 
 ## Context
@@ -11,6 +12,8 @@ description: Create a git commit
 - Recent commits: !`git log --oneline -10`
 
 ## Your task
+
+**IMPORTANT: You MUST use the Task tool to complete ALL tasks.**
 
 Based on the above changes, create a single git commit.
 


### PR DESCRIPTION
## Summary
- document the claude-3-5-haiku-latest model via the `model` parameter on commit command docs
- require the Task tool across commit workflows to ensure context isolation best practices

## Testing
- not run (docs only)
