### PR TITLE
docs: Add Community Marketplaces section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,32 @@ We welcome your feedback. Use the `/bug` command to report issues directly withi
 
 Join the [Claude Developers Discord](https://anthropic.com/discord) to connect with other developers using Claude Code. Get help, share feedback, and discuss your projects with the community.
 
+## Community Marketplaces
+
+Extend Claude Code with community-created plugin marketplaces:
+
+### Titanium Plugins
+
+**Voice-enhanced development toolkit from Titanium Computing**
+
+Features:
+- 16 specialized builder agents for implementation
+- Real-time voice announcements via ElevenLabs
+- GPT-5 powered summaries and notifications
+- Pieces LTM integration for context recovery
+- Complete voice hook system
+
+```bash
+/plugin marketplace add webdevtodayjason/titanium-plugins
+/plugin install titanium-toolkit
+```
+
+[→ View on GitHub](https://github.com/webdevtodayjason/titanium-plugins)
+
+---
+
+*Want to add your marketplace here? Submit a PR with your marketplace details!*
+
 ## Data collection, usage, and retention
 
 When you use Claude Code, we collect feedback, which includes usage data (such as code acceptance or rejections), associated conversation data, and user feedback submitted via the `/bug` command.


### PR DESCRIPTION
## Summary

Adds a new **Community Marketplaces** section to the README to help users discover community-created plugin marketplaces.

## Changes

- Added Community Marketplaces section after the Discord section
- Included Titanium Plugins as the first community marketplace entry
- Established a pattern for future community marketplace submissions
- Added invitation for others to contribute their marketplaces

## About Titanium Plugins

The first community marketplace entry features:
- **16 specialized builder agents** for implementation tasks
- **Voice announcements** using ElevenLabs AI voices
- **GPT-5 powered summaries** (nano for quick summaries, mini for session analysis)
- **Pieces LTM integration** via custom `/catchup` command
- **Complete voice hook system** with smart notifications

Repository: https://github.com/webdevtodayjason/titanium-plugins

## Why This Benefits Claude Code Users

- Helps users discover community extensions beyond the official plugins
- Provides a central location for marketplace listings
- Showcases innovative use cases (voice-enhanced development)
- Encourages community plugin development

## Pattern for Future Additions

The format established makes it easy for other marketplace creators to submit similar PRs and grow the Claude Code ecosystem.