### PR TITLE
fix: correct YAML frontmatter in pr-review-toolkit agent files

### DIFF
--- a/plugins/pr-review-toolkit/agents/code-reviewer.md
+++ b/plugins/pr-review-toolkit/agents/code-reviewer.md
@@ -1,9 +1,38 @@
 ---
 name: code-reviewer
-description: Use this agent when you need to review code for adherence to project guidelines, style guides, and best practices. This agent should be used proactively after writing or modifying code, especially before committing changes or creating pull requests. It will check for style violations, potential issues, and ensure code follows the established patterns in CLAUDE.md. Also the agent needs to know which files to focus on for the review. In most cases this will recently completed work which is unstaged in git (can be retrieved by doing a git diff). However there can be cases where this is different, make sure to specify this as the agent input when calling the agent. \n\nExamples:\n<example>\nContext: The user has just implemented a new feature with several TypeScript files.\nuser: "I've added the new authentication feature. Can you check if everything looks good?"\nassistant: "I'll use the Task tool to launch the code-reviewer agent to review your recent changes."\n<commentary>\nSince the user has completed a feature and wants validation, use the code-reviewer agent to ensure the code meets project standards.\n</commentary>\n</example>\n<example>\nContext: The assistant has just written a new utility function.\nuser: "Please create a function to validate email addresses"\nassistant: "Here's the email validation function:"\n<function call omitted for brevity>\nassistant: "Now I'll use the Task tool to launch the code-reviewer agent to review this implementation."\n<commentary>\nProactively use the code-reviewer agent after writing new code to catch issues early.\n</commentary>\n</example>\n<example>\nContext: The user is about to create a PR.\nuser: "I think I'm ready to create a PR for this feature"\nassistant: "Before creating the PR, I'll use the Task tool to launch the code-reviewer agent to ensure all code meets our standards."\n<commentary>\nProactively review code before PR creation to avoid review comments and iterations.\n</commentary>\n</example>
+description: Use this agent when you need to review code for adherence to project guidelines, style guides, and best practices. This agent should be used proactively after writing or modifying code, especially before committing changes or creating pull requests. It will check for style violations, potential issues, and ensure code follows the established patterns in CLAUDE.md. Also the agent needs to know which files to focus on for the review. In most cases this will recently completed work which is unstaged in git (can be retrieved by doing a git diff). However there can be cases where this is different, make sure to specify this as the agent input when calling the agent.
 model: opus
 color: green
 ---
+
+Examples:
+<example>
+Context: The user has just implemented a new feature with several TypeScript files.
+user: "I've added the new authentication feature. Can you check if everything looks good?"
+assistant: "I'll use the Task tool to launch the code-reviewer agent to review your recent changes."
+<commentary>
+Since the user has completed a feature and wants validation, use the code-reviewer agent to ensure the code meets project standards.
+</commentary>
+</example>
+<example>
+Context: The assistant has just written a new utility function.
+user: "Please create a function to validate email addresses"
+assistant: "Here's the email validation function:"
+<function call omitted for brevity>
+assistant: "Now I'll use the Task tool to launch the code-reviewer agent to review this implementation."
+<commentary>
+Proactively use the code-reviewer agent after writing new code to catch issues early.
+</commentary>
+</example>
+<example>
+Context: The user is about to create a PR.
+user: "I think I'm ready to create a PR for this feature"
+assistant: "Before creating the PR, I'll use the Task tool to launch the code-reviewer agent to ensure all code meets our standards."
+<commentary>
+Proactively review code before PR creation to avoid review comments and iterations.
+</commentary>
+</example>
+
 
 You are an expert code reviewer specializing in modern software development across multiple languages and frameworks. Your primary responsibility is to review code against project guidelines in CLAUDE.md with high precision to minimize false positives.
 

--- a/plugins/pr-review-toolkit/agents/code-simplifier.md
+++ b/plugins/pr-review-toolkit/agents/code-simplifier.md
@@ -1,6 +1,12 @@
 ---
 name: code-simplifier
-description: Use this agent when code has been written or modified and needs to be simplified for clarity, consistency, and maintainability while preserving all functionality. This agent should be triggered automatically after completing a coding task or writing a logical chunk of code. It simplifies code by following project best practices while retaining all functionality. The agent focuses only on recently modified code unless instructed otherwise.\n\nExamples:\n\n<example>
+description: Use this agent when code has been written or modified and needs to be simplified for clarity, consistency, and maintainability while preserving all functionality. This agent should be triggered automatically after completing a coding task or writing a logical chunk of code. It simplifies code by following project best practices while retaining all functionality. The agent focuses only on recently modified code unless instructed otherwise.
+model: opus
+---
+
+Examples:
+
+<example>
 Context: The assistant has just implemented a new feature that adds user authentication to an API endpoint.
 user: "Please add authentication to the /api/users endpoint"
 assistant: "I've implemented the authentication for the /api/users endpoint. Here's the code:"

--- a/plugins/pr-review-toolkit/agents/comment-analyzer.md
+++ b/plugins/pr-review-toolkit/agents/comment-analyzer.md
@@ -1,9 +1,36 @@
 ---
 name: comment-analyzer
-description: Use this agent when you need to analyze code comments for accuracy, completeness, and long-term maintainability. This includes: (1) After generating large documentation comments or docstrings, (2) Before finalizing a pull request that adds or modifies comments, (3) When reviewing existing comments for potential technical debt or comment rot, (4) When you need to verify that comments accurately reflect the code they describe.\n\n<example>\nContext: The user is working on a pull request that adds several documentation comments to functions.\nuser: "I've added documentation to these functions. Can you check if the comments are accurate?"\nassistant: "I'll use the comment-analyzer agent to thoroughly review all the comments in this pull request for accuracy and completeness."\n<commentary>\nSince the user has added documentation comments and wants them checked, use the comment-analyzer agent to verify their accuracy against the actual code.\n</commentary>\n</example>\n\n<example>\nContext: The user just asked to generate comprehensive documentation for a complex function.\nuser: "Add detailed documentation for this authentication handler function"\nassistant: "I've added the documentation. Now let me use the comment-analyzer agent to verify that the comments are accurate and helpful for long-term maintenance."\n<commentary>\nAfter generating large documentation comments, proactively use the comment-analyzer to ensure quality.\n</commentary>\n</example>\n\n<example>\nContext: The user is preparing to create a pull request with multiple code changes and comments.\nuser: "I think we're ready to create the PR now"\nassistant: "Before creating the pull request, let me use the comment-analyzer agent to review all the comments we've added or modified to ensure they're accurate and won't create technical debt."\n<commentary>\nBefore finalizing a PR, use the comment-analyzer to review all comment changes.\n</commentary>\n</example>
+description: Use this agent when you need to analyze code comments for accuracy, completeness, and long-term maintainability. This includes: (1) After generating large documentation comments or docstrings, (2) Before finalizing a pull request that adds or modifies comments, (3) When reviewing existing comments for potential technical debt or comment rot, (4) When you need to verify that comments accurately reflect the code they describe.
 model: inherit
 color: green
 ---
+
+<example>
+Context: The user is working on a pull request that adds several documentation comments to functions.
+user: "I've added documentation to these functions. Can you check if the comments are accurate?"
+assistant: "I'll use the comment-analyzer agent to thoroughly review all the comments in this pull request for accuracy and completeness."
+<commentary>
+Since the user has added documentation comments and wants them checked, use the comment-analyzer agent to verify their accuracy against the actual code.
+</commentary>
+</example>
+
+<example>
+Context: The user just asked to generate comprehensive documentation for a complex function.
+user: "Add detailed documentation for this authentication handler function"
+assistant: "I've added the documentation. Now let me use the comment-analyzer agent to verify that the comments are accurate and helpful for long-term maintenance."
+<commentary>
+After generating large documentation comments, proactively use the comment-analyzer to ensure quality.
+</commentary>
+</example>
+
+<example>
+Context: The user is preparing to create a pull request with multiple code changes and comments.
+user: "I think we're ready to create the PR now"
+assistant: "Before creating the pull request, let me use the comment-analyzer agent to review all the comments we've added or modified to ensure they're accurate and won't create technical debt."
+<commentary>
+Before finalizing a PR, use the comment-analyzer to review all comment changes.
+</commentary>
+</example>
 
 You are a meticulous code comment analyzer with deep expertise in technical documentation and long-term code maintainability. You approach every comment with healthy skepticism, understanding that inaccurate or outdated comments create technical debt that compounds over time.
 

--- a/plugins/pr-review-toolkit/agents/pr-test-analyzer.md
+++ b/plugins/pr-review-toolkit/agents/pr-test-analyzer.md
@@ -1,9 +1,36 @@
 ---
 name: pr-test-analyzer
-description: Use this agent when you need to review a pull request for test coverage quality and completeness. This agent should be invoked after a PR is created or updated to ensure tests adequately cover new functionality and edge cases. Examples:\n\n<example>\nContext: Daisy has just created a pull request with new functionality.\nuser: "I've created the PR. Can you check if the tests are thorough?"\nassistant: "I'll use the pr-test-analyzer agent to review the test coverage and identify any critical gaps."\n<commentary>\nSince Daisy is asking about test thoroughness in a PR, use the Task tool to launch the pr-test-analyzer agent.\n</commentary>\n</example>\n\n<example>\nContext: A pull request has been updated with new code changes.\nuser: "The PR is ready for review - I added the new validation logic we discussed"\nassistant: "Let me analyze the PR to ensure the tests adequately cover the new validation logic and edge cases."\n<commentary>\nThe PR has new functionality that needs test coverage analysis, so use the pr-test-analyzer agent.\n</commentary>\n</example>\n\n<example>\nContext: Reviewing PR feedback before marking as ready.\nuser: "Before I mark this PR as ready, can you double-check the test coverage?"\nassistant: "I'll use the pr-test-analyzer agent to thoroughly review the test coverage and identify any critical gaps before you mark it ready."\n<commentary>\nDaisy wants a final test coverage check before marking PR ready, use the pr-test-analyzer agent.\n</commentary>\n</example>
+description: Use this agent when you need to review a pull request for test coverage quality and completeness. This agent should be invoked after a PR is created or updated to ensure tests adequately cover new functionality and edge cases.
 model: inherit
 color: cyan
 ---
+
+<example>
+Context: Daisy has just created a pull request with new functionality.
+user: "I've created the PR. Can you check if the tests are thorough?"
+assistant: "I'll use the pr-test-analyzer agent to review the test coverage and identify any critical gaps."
+<commentary>
+Since Daisy is asking about test thoroughness in a PR, use the Task tool to launch the pr-test-analyzer agent.
+</commentary>
+</example>
+
+<example>
+Context: A pull request has been updated with new code changes.
+user: "The PR is ready for review - I added the new validation logic we discussed"
+assistant: "Let me analyze the PR to ensure the tests adequately cover the new validation logic and edge cases."
+<commentary>
+The PR has new functionality that needs test coverage analysis, so use the pr-test-analyzer agent.
+</commentary>
+</example>
+
+<example>
+Context: Reviewing PR feedback before marking as ready.
+user: "Before I mark this PR as ready, can you double-check the test coverage?"
+assistant: "I'll use the pr-test-analyzer agent to thoroughly review the test coverage and identify any critical gaps before you mark it ready."
+<commentary>
+Daisy wants a final test coverage check before marking PR ready, use the pr-test-analyzer agent.
+</commentary>
+</example>
 
 You are an expert test coverage analyst specializing in pull request review. Your primary responsibility is to ensure that PRs have adequate test coverage for critical functionality without being overly pedantic about 100% coverage.
 

--- a/plugins/pr-review-toolkit/agents/silent-failure-hunter.md
+++ b/plugins/pr-review-toolkit/agents/silent-failure-hunter.md
@@ -1,9 +1,30 @@
 ---
 name: silent-failure-hunter
-description: Use this agent when reviewing code changes in a pull request to identify silent failures, inadequate error handling, and inappropriate fallback behavior. This agent should be invoked proactively after completing a logical chunk of work that involves error handling, catch blocks, fallback logic, or any code that could potentially suppress errors. Examples:\n\n<example>\nContext: Daisy has just finished implementing a new feature that fetches data from an API with fallback behavior.\nDaisy: "I've added error handling to the API client. Can you review it?"\nAssistant: "Let me use the silent-failure-hunter agent to thoroughly examine the error handling in your changes."\n<Task tool invocation to launch silent-failure-hunter agent>\n</example>\n\n<example>\nContext: Daisy has created a PR with changes that include try-catch blocks.\nDaisy: "Please review PR #1234"\nAssistant: "I'll use the silent-failure-hunter agent to check for any silent failures or inadequate error handling in this PR."\n<Task tool invocation to launch silent-failure-hunter agent>\n</example>\n\n<example>\nContext: Daisy has just refactored error handling code.\nDaisy: "I've updated the error handling in the authentication module"\nAssistant: "Let me proactively use the silent-failure-hunter agent to ensure the error handling changes don't introduce silent failures."\n<Task tool invocation to launch silent-failure-hunter agent>\n</example>
+description: Use this agent when reviewing code changes in a pull request to identify silent failures, inadequate error handling, and inappropriate fallback behavior. This agent should be invoked proactively after completing a logical chunk of work that involves error handling, catch blocks, fallback logic, or any code that could potentially suppress errors.
 model: inherit
 color: yellow
 ---
+
+<example>
+Context: Daisy has just finished implementing a new feature that fetches data from an API with fallback behavior.
+Daisy: "I've added error handling to the API client. Can you review it?"
+Assistant: "Let me use the silent-failure-hunter agent to thoroughly examine the error handling in your changes."
+<Task tool invocation to launch silent-failure-hunter agent>
+</example>
+
+<example>
+Context: Daisy has created a PR with changes that include try-catch blocks.
+Daisy: "Please review PR #1234"
+Assistant: "I'll use the silent-failure-hunter agent to check for any silent failures or inadequate error handling in this PR."
+<Task tool invocation to launch silent-failure-hunter agent>
+</example>
+
+<example>
+Context: Daisy has just refactored error handling code.
+Daisy: "I've updated the error handling in the authentication module"
+Assistant: "Let me proactively use the silent-failure-hunter agent to ensure the error handling changes don't introduce silent failures."
+<Task tool invocation to launch silent-failure-hunter agent>
+</example>
 
 You are an elite error handling auditor with zero tolerance for silent failures and inadequate error handling. Your mission is to protect users from obscure, hard-to-debug issues by ensuring every error is properly surfaced, logged, and actionable.
 

--- a/plugins/pr-review-toolkit/agents/type-design-analyzer.md
+++ b/plugins/pr-review-toolkit/agents/type-design-analyzer.md
@@ -1,9 +1,27 @@
 ---
 name: type-design-analyzer
-description: Use this agent when you need expert analysis of type design in your codebase. Specifically use it: (1) when introducing a new type to ensure it follows best practices for encapsulation and invariant expression, (2) during pull request creation to review all types being added, (3) when refactoring existing types to improve their design quality. The agent will provide both qualitative feedback and quantitative ratings on encapsulation, invariant expression, usefulness, and enforcement.\n\n<example>\nContext: Daisy is writing code that introduces a new UserAccount type and wants to ensure it has well-designed invariants.\nuser: "I've just created a new UserAccount type that handles user authentication and permissions"\nassistant: "I'll use the type-design-analyzer agent to review the UserAccount type design"\n<commentary>\nSince a new type is being introduced, use the type-design-analyzer to ensure it has strong invariants and proper encapsulation.\n</commentary>\n</example>\n\n<example>\nContext: Daisy is creating a pull request and wants to review all newly added types.\nuser: "I'm about to create a PR with several new data model types"\nassistant: "Let me use the type-design-analyzer agent to review all the types being added in this PR"\n<commentary>\nDuring PR creation with new types, use the type-design-analyzer to review their design quality.\n</commentary>\n</example>
+description: Use this agent when you need expert analysis of type design in your codebase. Specifically use it: (1) when introducing a new type to ensure it follows best practices for encapsulation and invariant expression, (2) during pull request creation to review all types being added, (3) when refactoring existing types to improve their design quality. The agent will provide both qualitative feedback and quantitative ratings on encapsulation, invariant expression, usefulness, and enforcement.
 model: inherit
 color: pink
 ---
+
+<example>
+Context: Daisy is writing code that introduces a new UserAccount type and wants to ensure it has well-designed invariants.
+user: "I've just created a new UserAccount type that handles user authentication and permissions"
+assistant: "I'll use the type-design-analyzer agent to review the UserAccount type design"
+<commentary>
+Since a new type is being introduced, use the type-design-analyzer to ensure it has strong invariants and proper encapsulation.
+</commentary>
+</example>
+
+<example>
+Context: Daisy is creating a pull request and wants to review all newly added types.
+user: "I'm about to create a PR with several new data model types"
+assistant: "Let me use the type-design-analyzer agent to review all the types being added in this PR"
+<commentary>
+During PR creation with new types, use the type-design-analyzer to review their design quality.
+</commentary>
+</example>
 
 You are a type design expert with extensive experience in large-scale software architecture. Your specialty is analyzing and improving type designs to ensure they have strong, clearly expressed, and well-encapsulated invariants.
 


### PR DESCRIPTION
## Summary
- Fixed YAML parsing errors in all agent markdown files under plugins/pr-review-toolkit/agents/
- Moved description field content to a single line (removed embedded newlines)
- Relocated Examples section outside of YAML frontmatter to markdown body

## Context
The description fields contained literal `\n\n` characters and example blocks, causing YAML parser errors: "could not find expected ':' while scanning a simple key at line 6 column 1". This prevented the files from being properly parsed and displayed on GitHub.

## Files Modified
- code-simplifier.md
- code-reviewer.md
- comment-analyzer.md
- pr-test-analyzer.md
- silent-failure-hunter.md
- type-design-analyzer.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)