### PR TITLE
feat: add api-fallback plugin for auth switching

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -57,6 +57,17 @@
       },
       "source": "./plugins/security-guidance",
       "category": "security"
+    },
+    {
+      "name": "api-fallback",
+      "description": "Quick commands for switching between Claude Pro/Max subscription and API key billing when usage limits are reached",
+      "version": "1.0.0",
+      "author": {
+        "name": "Nicholas Ferraz",
+        "email": "git-contributions@nickferraz.com"
+      },
+      "source": "./plugins/api-fallback",
+      "category": "productivity"
     }
   ]
 }

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -45,6 +45,18 @@ Provides a structured 7-phase approach to feature development with specialized a
   - `code-reviewer` - Reviews code for bugs, quality issues, and project conventions
 - **Use case**: Building new features with systematic codebase understanding and quality assurance
 
+### [api-fallback](./api-fallback/)
+
+**API Fallback Plugin**
+
+Quick commands for switching between Claude Pro/Max subscription and API key billing when usage limits are reached.
+
+- **Commands**:
+  - `/switch-to-api` - Switch from subscription to API key billing
+  - `/switch-to-subscription` - Switch back to subscription billing
+  - `/fallback-status` - Check authentication setup and fallback options
+- **Use case**: Interim solution for manual auth switching while awaiting automatic fallback ([issue #2944](https://github.com/anthropics/claude-code/issues/2944))
+
 ## Installation
 
 These plugins are included in the Claude Code repository. To use them in your own projects:

--- a/plugins/api-fallback/.claude-plugin/plugin.json
+++ b/plugins/api-fallback/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "api-fallback",
+  "version": "1.0.0",
+  "description": "Provides manual switching between API key and subscription authentication methods. Interim solution for issue #2944 while awaiting core implementation.",
+  "author": {
+    "name": "Nicholas Ferraz",
+    "email": "git-contributions@nickferraz.com"
+  },
+  "keywords": ["authentication", "api", "subscription", "fallback", "billing"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anthropics/claude-code"
+  },
+  "license": "MIT"
+}

--- a/plugins/api-fallback/README.md
+++ b/plugins/api-fallback/README.md
@@ -1,0 +1,102 @@
+# API Fallback Plugin
+
+Quick commands for switching between Claude Pro/Max subscription and API key billing when you hit usage limits.
+
+## Overview
+
+This plugin provides manual switching between authentication methods - a workaround for [issue #2944](https://github.com/anthropics/claude-code/issues/2944) until automatic fallback is built into the core CLI.
+
+If you're a Pro/Max user who hits usage limits, you currently have to remember to use `/login` and manually switch. This plugin makes it easier with dedicated commands.
+
+## Commands
+
+### `/switch-to-api`
+
+Switch from your Pro/Max subscription to API key billing.
+
+**When to use:**
+- You've hit your subscription usage limits
+- You want to continue working immediately
+- You have an API key set up
+
+**What it does:**
+Guides you through running `/login` and selecting the API Key option.
+
+**Requirements:**
+- An Anthropic API key (get one at https://console.anthropic.com/)
+- Can set `ANTHROPIC_API_KEY` environment variable
+
+### `/switch-to-subscription`
+
+Switch from API key back to your Pro/Max subscription.
+
+**When to use:**
+- Your subscription limits have reset
+- You want to use subscription instead of paying per token
+- You're switching back after using API billing
+
+**What it does:**
+Guides you through running `/login` and selecting your Pro or Max subscription.
+
+**Requirements:**
+- Active Claude Pro or Max subscription
+
+### `/fallback-status`
+
+Check your current authentication configuration and see what fallback options you have available.
+
+**What it shows:**
+- Whether you have `ANTHROPIC_API_KEY` configured
+- Available authentication methods
+- How to set up both methods for quick switching
+
+## Setup
+
+To have both subscription and API key available for quick switching:
+
+```bash
+# Set your API key
+export ANTHROPIC_API_KEY="your-api-key-here"
+
+# Add to your shell profile to persist
+echo 'export ANTHROPIC_API_KEY="your-api-key"' >> ~/.bashrc
+```
+
+Then use `/login` to choose which method to use. Switch between them anytime.
+
+## Workflow Example
+
+```bash
+# Working on a project with Pro subscription
+# ...hit usage limits...
+
+/switch-to-api
+# Follow the prompts to switch to API billing
+# Continue working
+
+# Later, when subscription resets
+/switch-to-subscription
+# Switch back to subscription
+```
+
+## Limitations
+
+This is a **manual workaround** only. It doesn't automatically detect limits or switch authentication - it just guides you through the existing `/login` command.
+
+For automatic fallback, see [issue #2944](https://github.com/anthropics/claude-code/issues/2944).
+
+## Why This Exists
+
+Many users don't know about the `/login` command for switching authentication mid-session. This plugin makes it more discoverable when you hit usage limits.
+
+## Feedback
+
+Comment on [issue #2944](https://github.com/anthropics/claude-code/issues/2944) if you have suggestions.
+
+## Author
+
+Nicholas Ferraz
+
+## Version
+
+1.0.0

--- a/plugins/api-fallback/commands/fallback-status.md
+++ b/plugins/api-fallback/commands/fallback-status.md
@@ -1,0 +1,39 @@
+---
+description: Check authentication setup and available fallback options
+---
+
+The user wants to understand their current authentication configuration and fallback options.
+
+## What to check
+
+Look for the `ANTHROPIC_API_KEY` environment variable to see if they have API key configured.
+
+Note: We can't directly detect which auth method is currently active - that's determined by what they selected during their last `/login`.
+
+## What to tell them
+
+Explain their setup:
+- If `ANTHROPIC_API_KEY` is set, they have API fallback available
+- They're currently using whatever method they selected in `/login`
+- They can switch anytime using `/login`, `/switch-to-api`, or `/switch-to-subscription`
+
+## Available auth methods
+
+- API Key (via `ANTHROPIC_API_KEY` env var)
+- Claude Pro/Max (via browser OAuth)
+- AWS Bedrock (via `AWS_BEARER_TOKEN_BEDROCK`)
+- Google Vertex AI (via `CLOUD_ML_REGION`)
+
+## Setting up both methods
+
+To have quick fallback available:
+
+```bash
+export ANTHROPIC_API_KEY="your-api-key"
+```
+
+Then use `/login` to select which method to use. Switch between them anytime.
+
+## Limitations
+
+Currently, switching is manual only. Automatic fallback when hitting usage limits requires core CLI changes - tracked in issue #2944.

--- a/plugins/api-fallback/commands/switch-to-api.md
+++ b/plugins/api-fallback/commands/switch-to-api.md
@@ -1,0 +1,30 @@
+---
+description: Switch to API key billing when subscription limits are reached
+---
+
+The user wants to switch from their Claude Pro/Max subscription to API key billing, likely because they've hit usage limits.
+
+## What to tell them
+
+Guide them through switching authentication:
+
+1. They need to run `/login` to see the authentication selection screen
+2. Select "API Key" from the options
+3. If they don't have an API key yet, they can get one at https://console.anthropic.com/
+
+Let them know:
+- Their current conversation will be preserved
+- The switch happens immediately
+- API usage is billed per token
+- They can switch back anytime using `/login`
+
+## If they need an API key
+
+Point them to:
+- Console: https://console.anthropic.com/
+- API Keys section to create a new key
+- Can set `ANTHROPIC_API_KEY` environment variable for convenience
+
+## Note
+
+Automatic fallback on usage limits isn't available yet - that's being tracked in issue #2944. For now, switching is manual.

--- a/plugins/api-fallback/commands/switch-to-subscription.md
+++ b/plugins/api-fallback/commands/switch-to-subscription.md
@@ -1,0 +1,28 @@
+---
+description: Switch back to Claude Pro/Max subscription billing
+---
+
+The user wants to switch from API key billing back to their Claude Pro or Max subscription.
+
+## What to tell them
+
+Guide them through switching authentication:
+
+1. Run `/login` to see the authentication selection screen
+2. Choose "Claude Pro" or "Claude Max" depending on their subscription
+3. Complete the browser OAuth flow when it opens
+4. Authorize Claude Code to use their subscription
+
+Let them know:
+- Their current conversation will be preserved
+- The switch happens immediately
+- Usage will count toward subscription limits (not API)
+- They can switch back to API anytime
+
+## If they don't have a subscription
+
+Point them to https://claude.ai/settings/account to subscribe to Pro or Max.
+
+## Note
+
+If they hit subscription limits again, they'll need to manually switch back to API using `/login` or `/switch-to-api`. Automatic fallback is tracked in issue #2944.


### PR DESCRIPTION
 Summary

  Adds the API Fallback plugin to the marketplace, providing users with convenient commands to switch between Claude Pro/Max subscription and API key authentication when they hit usage limits.

  Motivation

  This plugin addresses a common pain point described in https://github.com/anthropics/claude-code/issues/2944. Currently, when Pro/Max users hit their subscription usage limits, many don't know they can use /login to switch to API key billing mid-session. This plugin makes that workflow discoverable and easier to execute.

  While automatic fallback would be ideal (and is tracked in #2944), this plugin provides an immediate manual workaround that significantly improves the user experience.

  What's Included

  New Plugin: api-fallback

  - Category: Productivity
  - Version: 1.0.0
  - Location: plugins/api-fallback/

  Commands

  1. /switch-to-api - Switch from subscription to API key billing
    - Guides users through switching when they've hit subscription limits
    - Requires an Anthropic API key to be set up
    
  2. /switch-to-subscription - Switch from API key back to subscription
    - Helps users return to subscription billing when limits reset
    - Requires active Claude Pro or Max subscription
  
  3. /fallback-status - Check current authentication configuration
    - Shows whether ANTHROPIC_API_KEY is configured
    - Lists available authentication methods
    - Provides setup instructions

  Documentation

  - Comprehensive README with setup instructions and workflow examples
  - Clear explanation of limitations (manual workaround only)
  - Links to the related issue for feedback and tracking

  How It Works

  The plugin doesn't implement automatic switching - it provides guided commands that help users:
  1. Understand their current authentication state
  2. Know when and how to switch between billing methods
  3. Execute the switch using the existing /login command

  Testing Checklist

  - Plugin appears in marketplace listing
  - Commands are accessible via slash command autocomplete
  - /fallback-status correctly detects ANTHROPIC_API_KEY presence
  - /switch-to-api provides clear switching instructions
  - /switch-to-subscription provides clear switching instructions
  - Documentation is clear and accurate

  Related Issues

  Interim solution for #2944 (automatic API fallback)