### PR TITLE
feat: upgrade GitHub workflows to use Claude Sonnet 4.5

### DIFF
--- a/.github/workflows/claude-dedupe-issues.yml
+++ b/.github/workflows/claude-dedupe-issues.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           prompt: "/dedupe ${{ github.repository }}/issues/${{ github.event.issue.number || inputs.issue_number }}"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--model claude-sonnet-4-5-20250929"
           claude_env: |
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -102,5 +102,6 @@ jobs:
           timeout_minutes: "5"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           mcp_config: /tmp/mcp-config/mcp-servers.json
+          claude_args: "--model claude-sonnet-4-5-20250929"
           claude_env: |
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,4 +34,5 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--model claude-sonnet-4-5-20250929"
 


### PR DESCRIPTION
Update all Claude Code GitHub Action workflows to use the latest Sonnet 4.5 model (claude-sonnet-4-5-20250929) instead of the default Sonnet 4.0 model. This provides improved performance and capabilities for:
- Issue commenting and PR reviews (claude.yml)
- Automated issue triage (claude-issue-triage.yml)
- Duplicate issue detection (claude-dedupe-issues.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)