### PR TITLE
Add oncall triage slash command for issue management

### DIFF
--- a/.claude/commands/oncall-triage.md
+++ b/.claude/commands/oncall-triage.md
@@ -1,0 +1,40 @@
+---
+allowed-tools: Bash(gh issue list:*), Bash(gh issue view:*), Bash(gh issue edit:*), TodoWrite
+description: Triage GitHub issues and label critical ones for oncall
+---
+
+You're an oncall triage assistant for GitHub issues. Your task is to identify critical issues that require immediate oncall attention and apply the "oncall" label.
+
+Repository: anthropics/claude-code
+
+Task overview:
+
+1. First, get all open bugs updated in the last 3 days with at least 5 engagements:
+   ```bash
+   gh issue list --repo anthropics/claude-code --state open --label bug --limit 1000 --json number,title,updatedAt,comments,reactions | jq -r '.[] | select((.updatedAt >= (now - 259200 | strftime("%Y-%m-%dT%H:%M:%SZ"))) and ((.comments | length) + ([.reactions[].content] | length) >= 5)) | "\(.number)"'
+   ```
+
+2. Save the list of issue numbers and create a TODO list with ALL of them. This ensures you process every single one.
+
+3. For each issue in your TODO list:
+   - Use `gh issue view <number> --repo anthropics/claude-code --json title,body,labels,comments` to get full details
+   - Read and understand the full issue content and comments to determine actual user impact
+   - Evaluate: Is this truly blocking users from using Claude Code?
+     - Consider: "crash", "stuck", "frozen", "hang", "unresponsive", "cannot use", "blocked", "broken"
+     - Does it prevent core functionality? Can users work around it?
+   - Be conservative - only flag issues that truly prevent users from getting work done
+
+4. For issues that are truly blocking and don't already have the "oncall" label:
+   - Use `gh issue edit <number> --repo anthropics/claude-code --add-label "oncall"`
+   - Mark the issue as complete in your TODO list
+
+5. After processing all issues, provide a summary:
+   - List each issue number that received the "oncall" label
+   - Include the issue title and brief reason why it qualified
+   - If no issues qualified, state that clearly
+
+Important:
+- Process ALL issues in your TODO list systematically
+- Don't post any comments to issues
+- Only add the "oncall" label, never remove it
+- Use individual `gh issue view` commands instead of bash for loops to avoid approval prompts

--- a/.claude/commands/oncall-triage.md
+++ b/.claude/commands/oncall-triage.md
@@ -9,9 +9,9 @@ Repository: anthropics/claude-code
 
 Task overview:
 
-1. First, get all open bugs updated in the last 3 days with at least 5 engagements:
+1. First, get all open bugs updated in the last 3 days with at least 50 engagements:
    ```bash
-   gh issue list --repo anthropics/claude-code --state open --label bug --limit 1000 --json number,title,updatedAt,comments,reactions | jq -r '.[] | select((.updatedAt >= (now - 259200 | strftime("%Y-%m-%dT%H:%M:%SZ"))) and ((.comments | length) + ([.reactions[].content] | length) >= 5)) | "\(.number)"'
+   gh issue list --repo anthropics/claude-code --state open --label bug --limit 1000 --json number,title,updatedAt,comments,reactions | jq -r '.[] | select((.updatedAt >= (now - 259200 | strftime("%Y-%m-%dT%H:%M:%SZ"))) and ((.comments | length) + ([.reactions[].content] | length) >= 50)) | "\(.number)"'
    ```
 
 2. Save the list of issue numbers and create a TODO list with ALL of them. This ensures you process every single one.

--- a/.github/workflows/oncall-triage.yml
+++ b/.github/workflows/oncall-triage.yml
@@ -54,7 +54,7 @@ jobs:
              - Use mcp__github__get_issue_comments to read all comments
              - Evaluate whether this issue needs the oncall label:
                a) Is it a bug? (has "bug" label or describes bug behavior)
-               b) Does it have at least 5 engagements? (count comments + reactions)
+               b) Does it have at least 50 engagements? (count comments + reactions)
                c) Is it truly blocking? Read and understand the full content to determine:
                   - Does this prevent core functionality from working?
                   - Can users work around it?


### PR DESCRIPTION
Creates a new /oncall-triage command that automates the process of triaging GitHub issues and labeling critical ones for oncall attention.

The command:
- Fetches open bugs updated in last 3 days with 5+ engagements
- Systematically evaluates each issue for blocking severity
- Adds "oncall" label to truly blocking issues
- Provides summary of all issues that received the label

Includes guidance to use individual gh commands instead of bash loops to avoid approval prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)