### PR TITLE
Add hooks subdirectory reproduction test for debugging Issue #10367

### DIFF
--- a/examples/hooks/HOOKS_SUBDIRECTORY_TEST_README.md
+++ b/examples/hooks/HOOKS_SUBDIRECTORY_TEST_README.md
@@ -1,0 +1,165 @@
+# Hooks Subdirectory Reproduction Test
+
+## Purpose
+
+This script helps reproduce and debug Issue #10367 and related hook execution problems when Claude Code runs from subdirectories.
+
+## What It Tests
+
+The script creates an isolated test environment to verify whether hooks execute correctly when Claude Code is launched from nested subdirectories vs. the home directory.
+
+**Hook Types Tested:**
+- `UserPromptSubmit` - Fires when user submits a prompt
+- `PreToolUse` - Fires before tool execution (e.g., before Bash commands)
+- `SessionStart` - Fires when Claude Code session starts
+- `Stop` - Fires when Claude completes a response
+
+## Usage
+
+### Quick Test
+
+```bash
+curl -fsSL https://gist.github.com/dcversus/e18f1566a1c5515c8da56288b4975507/raw/claude-hooks-reproduction-test.sh | bash
+```
+
+### Manual Test
+
+```bash
+# Make script executable
+chmod +x hooks_subdirectory_reproduction_test.sh
+
+# Run the test
+./hooks_subdirectory_reproduction_test.sh
+
+# Follow the printed instructions
+```
+
+## What the Script Does
+
+1. **Creates test environment** in `/tmp/claude-hooks-test-XXXXX/workspace/subdir`
+2. **Generates hook scripts** that log execution to `/tmp/claude-hook-test.log`
+3. **Configures both local and global settings**:
+   - Local: `.claude/settings.json` in working directory
+   - Global: `~/.claude/settings.json` (backs up existing)
+4. **Verifies hooks work manually** before testing with Claude Code
+5. **Provides step-by-step instructions** for manual verification
+
+## Expected Results
+
+### If Hooks Work Correctly ✅
+
+After following the test steps, `/tmp/claude-hook-test.log` should contain entries like:
+
+```
+SessionStart: 2025-10-26 08:30:15
+2025-10-26 08:30:16 - Hook executed! (UserPromptSubmit)
+2025-10-26 08:30:18 - Hook executed! (PreToolUse on Bash)
+Stop: 2025-10-26 08:30:19
+```
+
+### If Hooks Are Broken ❌
+
+```bash
+$ cat /tmp/claude-hook-test.log
+cat: /tmp/claude-hook-test.log: No such file or directory
+```
+
+This indicates hooks never fired despite proper configuration.
+
+## Related Issues
+
+- **Issue #10367**: Hooks completely non-functional in subdirectories (v2.0.27)
+- **Issue #8810**: UserPromptSubmit hooks not working when started from subdirectories
+- **Issue #6305**: PreToolUse/PostToolUse hooks not executing
+
+## Cleanup
+
+The script provides cleanup instructions at the end of execution:
+
+```bash
+# Remove test environment
+rm -rf /tmp/claude-hooks-test-XXXXX
+rm -f /tmp/claude-hook-test.log
+
+# Restore original settings
+BACKUP=$(ls -t ~/.claude/settings.json.backup-* 2>/dev/null | head -1)
+if [ -n "$BACKUP" ]; then
+  mv "$BACKUP" ~/.claude/settings.json
+fi
+```
+
+## Technical Details
+
+### Hook Configuration Format
+
+**Local Settings** (`.claude/settings.json`):
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/absolute/path/to/hook-script.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Global Settings** (`~/.claude/settings.json`):
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/absolute/path/to/hook-script.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Hook Script Format
+
+Hooks must:
+1. Read JSON from stdin
+2. Write output to stdout/stderr
+3. Exit with appropriate code:
+   - `0` = Success
+   - `2` = Blocking error (for PreToolUse)
+   - Other = Non-blocking error
+
+**Example Hook:**
+```bash
+#!/usr/bin/env bash
+read -r input_json
+timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+echo "$timestamp - Hook executed!" >> /tmp/claude-hook-test.log
+echo "🎬 Hook fired at $timestamp" >&2
+exit 0
+```
+
+## Contributing
+
+If you discover hooks work correctly in your environment when running this test:
+
+1. Note your Claude Code version (`claude --version`)
+2. Note your OS and platform
+3. Share your configuration that works
+4. Comment on Issue #10367 with details
+
+This helps the community identify working configurations and potential fixes.
+
+## License
+
+This test script is provided as-is for debugging and community support purposes.

--- a/examples/hooks/hooks_subdirectory_reproduction_test.sh
+++ b/examples/hooks/hooks_subdirectory_reproduction_test.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Claude Code Hooks Bug Reproduction Test
+# Tests hooks functionality in subdirectories (Issue #8810 + #6305)
+
+set -e
+
+echo "🧪 Claude Code Hooks Bug Reproduction Test"
+echo "=========================================="
+echo ""
+
+# Setup test directory structure
+TEST_DIR="/tmp/claude-hooks-test-$$"
+mkdir -p "$TEST_DIR/workspace/subdir"
+cd "$TEST_DIR"
+
+# Create hook script
+mkdir -p "$TEST_DIR/workspace/subdir/.claude/hooks"
+cat > "$TEST_DIR/workspace/subdir/.claude/hooks/test-hook.sh" <<'HOOK_EOF'
+#!/usr/bin/env bash
+read -r input_json
+timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+echo "$timestamp - Hook executed!" >> /tmp/claude-hook-test.log
+echo "🎬 Hook fired at $timestamp" >&2
+exit 0
+HOOK_EOF
+
+chmod +x "$TEST_DIR/workspace/subdir/.claude/hooks/test-hook.sh"
+
+# Test 1: Local settings.json (working directory)
+echo "📝 Creating local .claude/settings.json..."
+cat > "$TEST_DIR/workspace/subdir/.claude/settings.json" <<SETTINGS_EOF
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$TEST_DIR/workspace/subdir/.claude/hooks/test-hook.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+SETTINGS_EOF
+
+# Test 2: Global settings.json (backup existing)
+echo "📝 Updating global ~/.claude/settings.json..."
+mkdir -p ~/.claude
+
+if [ -f ~/.claude/settings.json ]; then
+  cp ~/.claude/settings.json ~/.claude/settings.json.backup-$(date +%s)
+  echo "   ✅ Backed up existing settings to ~/.claude/settings.json.backup-$(date +%s)"
+fi
+
+cat > ~/.claude/settings.json <<GLOBAL_EOF
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$TEST_DIR/workspace/subdir/.claude/hooks/test-hook.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cat > /dev/null && date '+SessionStart: %Y-%m-%d %H:%M:%S' >> /tmp/claude-hook-test.log"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cat > /dev/null && date '+Stop: %Y-%m-%d %H:%M:%S' >> /tmp/claude-hook-test.log"
+          }
+        ]
+      }
+    ]
+  }
+}
+GLOBAL_EOF
+
+# Clear test log
+rm -f /tmp/claude-hook-test.log
+
+echo ""
+echo "✅ Test environment created!"
+echo ""
+echo "📁 Directories:"
+echo "   Test root: $TEST_DIR"
+echo "   Working dir (Claude launch from here): $TEST_DIR/workspace/subdir"
+echo ""
+echo "📄 Files:"
+echo "   Hook script: $TEST_DIR/workspace/subdir/.claude/hooks/test-hook.sh"
+echo "   Local settings: $TEST_DIR/workspace/subdir/.claude/settings.json"
+echo "   Global settings: ~/.claude/settings.json (original backed up)"
+echo "   Test log: /tmp/claude-hook-test.log"
+echo ""
+echo "🧪 Manual Hook Test:"
+echo '   {"test": true}' | "$TEST_DIR/workspace/subdir/.claude/hooks/test-hook.sh" 2>&1
+
+if [ -f /tmp/claude-hook-test.log ]; then
+  echo "   ✅ Script works when run manually!"
+  echo "   Log contents:"
+  cat /tmp/claude-hook-test.log | sed 's/^/      /'
+  rm -f /tmp/claude-hook-test.log  # Clear for actual test
+else
+  echo "   ❌ Script failed to create log"
+  exit 1
+fi
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "🚀 REPRODUCTION STEPS"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "1. Launch Claude Code from the subdirectory:"
+echo ""
+echo "   cd $TEST_DIR/workspace/subdir"
+echo "   claude --dangerously-skip-permissions"
+echo ""
+echo "2. Send any message to Claude (e.g., \"hello\")"
+echo ""
+echo "3. Ask Claude to check the hook log:"
+echo ""
+echo "   Check if hooks fired: cat /tmp/claude-hook-test.log"
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "📊 EXPECTED VS ACTUAL"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "Expected (hooks working):"
+echo "   SessionStart: 2025-10-26 08:30:15"
+echo "   2025-10-26 08:30:16 - Hook executed! (UserPromptSubmit)"
+echo "   2025-10-26 08:30:18 - Hook executed! (PreToolUse on Bash)"
+echo "   Stop: 2025-10-26 08:30:19"
+echo ""
+echo "Actual (hooks broken in subdirectories):"
+echo "   cat: /tmp/claude-hook-test.log: No such file or directory"
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "🧹 CLEANUP"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "After testing, restore your original settings:"
+echo ""
+echo "   # Remove test environment"
+echo "   rm -rf $TEST_DIR"
+echo "   rm -f /tmp/claude-hook-test.log"
+echo ""
+echo "   # Restore original settings (if you had any)"
+echo "   BACKUP=\$(ls -t ~/.claude/settings.json.backup-* 2>/dev/null | head -1)"
+echo "   if [ -n \"\$BACKUP\" ]; then"
+echo "     mv \"\$BACKUP\" ~/.claude/settings.json"
+echo "     echo \"Restored: \$BACKUP\""
+echo "   else"
+echo "     rm ~/.claude/settings.json"
+echo "     echo \"No backup found, removed test settings\""
+echo "   fi"
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "✅ Setup complete! Follow the reproduction steps above."
+echo ""


### PR DESCRIPTION
## Overview

This PR contributes a comprehensive reproduction test to help debug and verify hook execution problems when Claude Code runs from subdirectories (Issues #10367, #8810, #6305).

## Changes

### New Files

1. **`examples/hooks/hooks_subdirectory_reproduction_test.sh`**
   - Automated test script that creates isolated environment
   - Tests UserPromptSubmit, PreToolUse, SessionStart, and Stop hooks
   - Verifies manual execution before testing with Claude Code
   - Backs up existing `~/.claude/settings.json` automatically
   - Provides clear cleanup instructions

2. **`examples/hooks/HOOKS_SUBDIRECTORY_TEST_README.md`**
   - Complete usage documentation
   - Technical details about hook configuration
   - Expected vs actual behavior comparison
   - Cleanup and contribution guidelines

## Problem Being Addressed

Many users report hooks completely fail to execute when Claude Code is launched from subdirectories (Issue #10367). This affects:
- CI/CD pipeline development
- Multi-agent workflows
- Context injection
- Security validation
- Progress tracking

## How This Helps

**For Users:**
- Quick verification if hooks work in their environment
- Reproducible test case for bug reports
- Clear documentation of expected behavior

**For Maintainers:**
- Standardized reproduction steps
- Community-validated test cases
- Platform/version comparison data

## Usage

### Quick Test
```bash
curl -fsSL https://gist.github.com/dcversus/e18f1566a1c5515c8da56288b4975507/raw/claude-hooks-reproduction-test.sh | bash
```

### Manual Test
```bash
chmod +x examples/hooks/hooks_subdirectory_reproduction_test.sh
./examples/hooks/hooks_subdirectory_reproduction_test.sh
# Follow printed instructions
```

## Testing

- ✅ Tested on macOS Darwin 23.5.0
- ✅ Verified hooks work manually but fail with Claude Code from subdirs
- ✅ Script creates clean isolated environment
- ✅ Backs up existing settings safely
- ✅ Public gist available: https://gist.github.com/dcversus/e18f1566a1c5515c8da56288b4975507

## Related Issues

- #10367 - Hooks completely non-functional in subdirectories (v2.0.27)
- #8810 - UserPromptSubmit hooks not working when started from subdirectories
- #6305 - PreToolUse/PostToolUse hooks not executing

## Impact

This addition provides a standard, reproducible way for the community to:
1. Verify hook functionality in their environments
2. Report bugs with consistent reproduction steps
3. Identify working configurations across platforms
4. Help maintainers debug and fix hook issues

## Checklist

- [x] Added comprehensive reproduction test script
- [x] Included detailed documentation
- [x] Tested on local environment
- [x] Follows existing examples structure
- [x] Public gist available for community testing
- [x] Related issues documented

## Contribution Motivation

We're building open-source game engine pipelines that rely on hooks for:
- Parallel agent orchestration
- Automated PRP (Phase Requirement Proposal) updates
- Quality gates and validation
- CI/CD workflow automation

Hooks being broken blocks our entire development workflow. This test helps the community debug the issue together.

Thank you for considering this contribution! 🙏