### PR TITLE
Add missing plugin.json files to fix claudelint errors

### DIFF
--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "code-review",
+  "description": "Automated code review for pull requests using multiple specialized agents with confidence-based scoring",
+  "version": "1.0.0",
+  "author": {
+    "name": "Boris Cherny",
+    "email": "boris@anthropic.com"
+  }
+}
+

--- a/plugins/commit-commands/.claude-plugin/plugin.json
+++ b/plugins/commit-commands/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "commit-commands",
+  "description": "Streamline your git workflow with simple commands for committing, pushing, and creating pull requests",
+  "version": "1.0.0",
+  "author": {
+    "name": "Anthropic",
+    "email": "support@anthropic.com"
+  }
+}
+


### PR DESCRIPTION
Added plugin metadata files for code-review and commit-commands plugins to comply with Claude plugin structure requirements. These files were identified as missing by the [claudelint](https://github.com/stbenjam/claudelint) tool, which validates plugin structure and format according to the Claude Code plugin conventions.