### PR TITLE
Implement Explanatory output style as a plugin

### DIFF
--- a/plugins/explanatory-output-style/.claude-plugin/plugin.json
+++ b/plugins/explanatory-output-style/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "explanatory-output-style",
+  "version": "1.0.0",
+  "description": "Adds educational insights about implementation choices and codebase patterns (mimics the deprecated Explanatory output style)",
+  "author": {
+    "name": "Anthropic",
+    "email": "support@anthropic.com"
+  }
+}

--- a/plugins/explanatory-output-style/.claude-plugin/plugin.json
+++ b/plugins/explanatory-output-style/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Adds educational insights about implementation choices and codebase patterns (mimics the deprecated Explanatory output style)",
   "author": {
-    "name": "Anthropic",
-    "email": "support@anthropic.com"
+    "name": "Dickson Tsai",
+    "email": "dickson@anthropic.com"
   }
 }

--- a/plugins/explanatory-output-style/README.md
+++ b/plugins/explanatory-output-style/README.md
@@ -1,10 +1,15 @@
 # Explanatory Output Style Plugin
 
-This plugin recreates the deprecated Explanatory output style as a SessionStart hook.
+This plugin recreates the deprecated Explanatory output style as a SessionStart
+hook.
+
+WARNING: Do not install this plugin unless you are fine with incurring the token
+cost of this plugin's additional instructions and output.
 
 ## What it does
 
-When enabled, this plugin automatically adds instructions at the start of each session that encourage Claude to:
+When enabled, this plugin automatically adds instructions at the start of each
+session that encourage Claude to:
 
 1. Provide educational insights about implementation choices
 2. Explain codebase patterns and decisions
@@ -12,7 +17,9 @@ When enabled, this plugin automatically adds instructions at the start of each s
 
 ## How it works
 
-The plugin uses a SessionStart hook to inject additional context into every session. This context instructs Claude to provide brief educational explanations before and after writing code, formatted as:
+The plugin uses a SessionStart hook to inject additional context into every
+session. This context instructs Claude to provide brief educational explanations
+before and after writing code, formatted as:
 
 ```
 `★ Insight ─────────────────────────────────────`
@@ -20,15 +27,13 @@ The plugin uses a SessionStart hook to inject additional context into every sess
 `─────────────────────────────────────────────────`
 ```
 
-## Installation
-
-Install this plugin from the Claude Code marketplace, or manually by placing it in your `.claude/plugins` directory.
-
 ## Usage
 
-Once installed, the plugin activates automatically at the start of every session. No additional configuration is needed.
+Once installed, the plugin activates automatically at the start of every
+session. No additional configuration is needed.
 
 The insights focus on:
+
 - Specific implementation choices for your codebase
 - Patterns and conventions in your code
 - Trade-offs and design decisions
@@ -36,7 +41,8 @@ The insights focus on:
 
 ## Migration from Output Styles
 
-This plugin replaces the deprecated "Explanatory" output style setting. If you previously used:
+This plugin replaces the deprecated "Explanatory" output style setting. If you
+previously used:
 
 ```json
 {
@@ -46,11 +52,21 @@ This plugin replaces the deprecated "Explanatory" output style setting. If you p
 
 You can now achieve the same behavior by installing this plugin instead.
 
+More generally, this SessionStart hook pattern is roughly equivalent to
+CLAUDE.md, but it is more flexible and allows for distribution through plugins.
+
+Note: Output styles that involve tasks besides software development, are better
+expressed as
+[subagents](https://docs.claude.com/en/docs/claude-code/sub-agents), not as
+SessionStart hooks. Subagents change the system prompt while SessionStart hooks
+add to the default system prompt.
+
 ## Managing changes
 
-* Disable the plugin - keep the code installed on your device
-* Uninstall the plugin - remove the code from your device
-* Update the plugin - create a local copy of this plugin to personalize this plugin
-    - Hint: Ask Claude to read https://docs.claude.com/en/docs/claude-code/plugins.md and set it up for you!
-
-
+- Disable the plugin - keep the code installed on your device
+- Uninstall the plugin - remove the code from your device
+- Update the plugin - create a local copy of this plugin to personalize this
+  plugin
+  - Hint: Ask Claude to read
+    https://docs.claude.com/en/docs/claude-code/plugins.md and set it up for
+    you!

--- a/plugins/explanatory-output-style/README.md
+++ b/plugins/explanatory-output-style/README.md
@@ -1,0 +1,56 @@
+# Explanatory Output Style Plugin
+
+This plugin recreates the deprecated Explanatory output style as a SessionStart hook.
+
+## What it does
+
+When enabled, this plugin automatically adds instructions at the start of each session that encourage Claude to:
+
+1. Provide educational insights about implementation choices
+2. Explain codebase patterns and decisions
+3. Balance task completion with learning opportunities
+
+## How it works
+
+The plugin uses a SessionStart hook to inject additional context into every session. This context instructs Claude to provide brief educational explanations before and after writing code, formatted as:
+
+```
+`★ Insight ─────────────────────────────────────`
+[2-3 key educational points]
+`─────────────────────────────────────────────────`
+```
+
+## Installation
+
+Install this plugin from the Claude Code marketplace, or manually by placing it in your `.claude/plugins` directory.
+
+## Usage
+
+Once installed, the plugin activates automatically at the start of every session. No additional configuration is needed.
+
+The insights focus on:
+- Specific implementation choices for your codebase
+- Patterns and conventions in your code
+- Trade-offs and design decisions
+- Codebase-specific details rather than general programming concepts
+
+## Migration from Output Styles
+
+This plugin replaces the deprecated "Explanatory" output style setting. If you previously used:
+
+```json
+{
+  "outputStyle": "Explanatory"
+}
+```
+
+You can now achieve the same behavior by installing this plugin instead.
+
+## Managing changes
+
+* Disable the plugin - keep the code installed on your device
+* Uninstall the plugin - remove the code from your device
+* Update the plugin - create a local copy of this plugin to personalize this plugin
+    - Hint: Ask Claude to read https://docs.claude.com/en/docs/claude-code/plugins.md and set it up for you!
+
+

--- a/plugins/explanatory-output-style/hooks-handlers/session-start.sh
+++ b/plugins/explanatory-output-style/hooks-handlers/session-start.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Output the explanatory mode instructions as additionalContext
+# This mimics the deprecated Explanatory output style
+
+cat << 'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "You are in 'explanatory' output style mode, where you should provide educational insights about the codebase as you help with the user's task.\n\nYou should be clear and educational, providing helpful explanations while remaining focused on the task. Balance educational content with task completion. When providing insights, you may exceed typical length constraints, but remain focused and relevant.\n\n## Insights\nIn order to encourage learning, before and after writing code, always provide brief educational explanations about implementation choices using (with backticks):\n\"`★ Insight ─────────────────────────────────────`\n[2-3 key educational points]\n`─────────────────────────────────────────────────`\"\n\nThese insights should be included in the conversation, not in the codebase. You should generally focus on interesting insights that are specific to the codebase or the code you just wrote, rather than general programming concepts. Do not wait until the end to provide insights. Provide them as you write code."
+  }
+}
+EOF
+
+exit 0

--- a/plugins/explanatory-output-style/hooks/hooks.json
+++ b/plugins/explanatory-output-style/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "description": "Explanatory mode hook that adds educational insights instructions",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks-handlers/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

This PR implements the deprecated Explanatory output style as a plugin, providing a migration path for users who want to continue using this functionality.

**Implementation approach:**
- Created a new plugin `explanatory-output-style` that uses a SessionStart hook to inject instructions
- The hook adds `additionalContext` that instructs Claude to provide educational insights about implementation choices
- Insights are formatted with a distinctive header: `★ Insight ─────────────────────────────────────`
- The plugin automatically activates at the start of every session when installed

**Key files:**
- `plugins/explanatory-output-style/.claude-plugin/plugin.json` - Plugin metadata
- `plugins/explanatory-output-style/hooks/hooks.json` - Hook configuration for SessionStart event
- `plugins/explanatory-output-style/hooks-handlers/session-start.sh` - Bash script that outputs the instructions as JSON
- `plugins/explanatory-output-style/README.md` - Documentation on usage and migration

This implementation was created by reading the plugins and hooks documentation on docs.claude.com to understand how to properly structure a plugin with hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>