### PR TITLE
Add explanatory-output-style metadata to marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -37,6 +37,17 @@
       "category": "productivity"
     },
     {
+      "name": "explanatory-output-style",
+      "version": "1.0.0",
+      "description": "Adds educational insights about implementation choices and codebase patterns (mimics the deprecated Explanatory output style)",
+      "author": {
+        "name": "Dickson Tsai",
+        "email": "dickson@anthropic.com"
+      },
+      "source": "./plugins/explanatory-output-style",
+      "category": "development"
+    },
+    {
       "name": "feature-dev",
       "description": "Comprehensive feature development workflow with specialized agents for codebase exploration, architecture design, and quality review",
       "version": "1.0.0",


### PR DESCRIPTION
For those who want to use this plugin immediately

<img width="916" height="332" alt="image" src="https://github.com/user-attachments/assets/1b905045-5c1d-4f04-8ea9-1c4cfe97878a" />
<img width="921" height="939" alt="image" src="https://github.com/user-attachments/assets/efb18bd2-cee6-4498-95e8-d07e33ae3993" />

Please feel free to close this PR if there is any problem publishing it.