### PR TITLE
Add Explanatory Output Style plugin to plugins marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -68,6 +68,17 @@
       },
       "source": "./plugins/code-review",
       "category": "productivity"
+    },
+    {
+      "name": "Explanatory Output Style",
+      "description": "Recreates the deprecated Explanatory output style as a SessionStart hook",
+      "version": "1.0.0",
+      "author": {
+        "name": "Dickson Tsai",
+        "email": "dickson.tsai@gmail.com"
+      },
+      "source": "./plugins/code-review",
+      "category": "productivity"
     }
   ]
 }


### PR DESCRIPTION
Issue: Explanatory Output Style plugin was not present in plugins marketplace

Fix: Add entry to .claude-plugin/marketplace.json for Explanatory Output Style plugin.

Notes: Cited @dicksontsai as creator.

Possible improvements: Revise version number. Place in "correct position" among other plugins in marketplace.json

Discussion: Given this is only an example plugin meant to replace a deprecated feature, it is possible it is undesirable to have the plugin available in the market for perpetuity. Recommend removing Explanatory plugin from plugins/ immediately, or keeping entry in marketplace.json until aforementioned plugin is removed.