### PR TITLE
Add explanatory-output-style and learning-output-style plugins to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -68,6 +68,28 @@
       },
       "source": "./plugins/code-review",
       "category": "productivity"
+    },
+    {
+      "name": "explanatory-output-style",
+      "description": "Adds educational insights about implementation choices and codebase patterns (mimics the deprecated Explanatory output style)",
+      "version": "1.0.0",
+      "author": {
+        "name": "Dickson Tsai",
+        "email": "dickson@anthropic.com"
+      },
+      "source": "./plugins/explanatory-output-style",
+      "category": "learning"
+    },
+    {
+      "name": "learning-output-style",
+      "description": "Interactive learning mode that requests meaningful code contributions at decision points (mimics the unshipped Learning output style)",
+      "version": "1.0.0",
+      "author": {
+        "name": "Boris Cherny",
+        "email": "boris@anthropic.com"
+      },
+      "source": "./plugins/learning-output-style",
+      "category": "learning"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Added `explanatory-output-style` plugin to marketplace.json
- Added `learning-output-style` plugin to marketplace.json
- Both plugins categorized as "learning" to improve discoverability

## Test plan
- [ ] Verify marketplace.json is valid JSON
- [ ] Confirm both plugins load correctly from the marketplace
- [ ] Check that plugin metadata matches the actual plugin.json files

🤖 Generated with [Claude Code](https://claude.com/claude-code)