### PR TITLE
docs: Update README installation options to match official docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,26 @@ Claude Code is an agentic coding tool that lives in your terminal, understands y
 
 1. Install Claude Code:
 
-```sh
+**macOS/Linux:**
+```bash
+curl -fsSL https://claude.ai/install.sh | bash
+```
+
+**Homebrew:**
+```bash
+brew install --cask claude-code
+```
+
+**Windows:**
+```powershell
+irm https://claude.ai/install.ps1 | iex
+```
+
+**NPM:**
+```bash
 npm install -g @anthropic-ai/claude-code
 ```
+Requires [Node.js 18+](https://nodejs.org/en/download/)
 
 2. Navigate to your project directory and run `claude`.
 


### PR DESCRIPTION
## Summary

Updates the README installation section to include all available installation methods, bringing it in line with the official documentation at https://docs.claude.com/en/docs/claude-code/overview

## Changes

- Added macOS/Linux curl installer
- Added Homebrew installation method
- Added Windows PowerShell installer
- Retained NPM installation method with Node.js requirement note

All options are presented in the same order as the official documentation.