### PR TITLE
Add Otter.AI to Notion automation integration guide via Zapier MCP

### DIFF
--- a/examples/integrations/otter-zapier-notion/QUICKSTART.md
+++ b/examples/integrations/otter-zapier-notion/QUICKSTART.md
@@ -1,0 +1,223 @@
+# Quick Start Guide: Otter.AI → Notion Automation
+
+Get your Otter.AI transcriptions automatically saved to Notion in under 30 minutes.
+
+## Overview
+
+This automation will:
+✅ Monitor Otter.AI for new meeting transcripts
+✅ Process them with Claude for summaries and insights
+✅ Save everything to your Notion database
+✅ Run automatically after each meeting
+
+## What You'll Need
+
+- [ ] Otter.AI account
+- [ ] Notion workspace
+- [ ] Zapier account (free tier works)
+- [ ] Claude Desktop installed
+- [ ] 30 minutes setup time
+
+## 5-Step Setup
+
+### Step 1: Set Up Notion (5 minutes)
+
+1. **Create a new database** in Notion
+2. **Add these properties**:
+   - Title (text)
+   - Date (date)
+   - Summary (text)
+   - Transcript (text)
+   - Participants (multi-select)
+   - Status (select: New, Reviewed, Archived)
+
+3. **Create integration**:
+   - Go to [notion.so/my-integrations](https://www.notion.so/my-integrations)
+   - Click "New integration"
+   - Name: "Otter Sync"
+   - Copy the **integration token**
+
+4. **Share database**:
+   - In your database, click "Share"
+   - Invite your "Otter Sync" integration
+
+📖 **Detailed guide**: [notion-database-template.md](./notion-database-template.md)
+
+### Step 2: Configure Claude Desktop (5 minutes)
+
+1. **Open Claude Desktop**
+2. **Go to Settings** → Developer → Edit Config
+3. **Add this code** to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "zapier-mcp": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://actions.zapier.com/mcp/<YOUR_ENDPOINT>/sse"
+      ]
+    }
+  }
+}
+```
+
+4. **Restart Claude Desktop**
+
+You'll get the `<YOUR_ENDPOINT>` in the next step.
+
+### Step 3: Create Zapier MCP Server (5 minutes)
+
+1. **Log in to Zapier**: [zapier.com](https://zapier.com)
+2. **Navigate to**: Actions → MCP Servers
+3. **Click**: "Create MCP Server"
+4. **Select**: Claude Desktop
+5. **Copy the endpoint URL** (looks like: `https://actions.zapier.com/mcp/abc123/sse`)
+6. **Go back to Claude Desktop** and paste this URL in your config (see Step 2)
+
+### Step 4: Create Zapier Workflow (10 minutes)
+
+#### A. Set Up Trigger
+
+1. **Create new Zap**: [zapier.com/app/editor](https://zapier.com/app/editor)
+2. **Trigger**: Otter.ai → "New Transcript Created"
+3. **Connect** your Otter.AI account
+4. **Test trigger** to confirm it works
+
+#### B. Add Claude Processing
+
+1. **Action**: Webhooks by Zapier → POST
+2. **URL**: Your MCP endpoint from Step 3
+3. **Body**:
+```json
+{
+  "transcript_text": "{{trigger.transcript}}",
+  "title": "{{trigger.title}}",
+  "date": "{{trigger.created_at}}"
+}
+```
+
+**OR** use direct Claude API:
+
+1. **Action**: Anthropic (Claude) → Send Prompt
+2. **Prompt**:
+```
+Summarize this meeting transcript in 2-3 sentences, then list key points:
+
+{{trigger.transcript}}
+```
+
+#### C. Add Notion Action
+
+1. **Action**: Notion → Create Database Item
+2. **Database**: Select your Transcripts database
+3. **Map fields**:
+   - Title: `{{trigger.title}}`
+   - Date: `{{trigger.created_at}}`
+   - Summary: `{{claude.response}}` (from previous step)
+   - Transcript: `{{trigger.transcript}}`
+   - Status: `New`
+
+4. **Test** the action
+
+### Step 5: Test & Activate (5 minutes)
+
+1. **Record a test meeting** in Otter.AI (even just 30 seconds)
+2. **Wait 5-10 minutes** for Otter to process
+3. **Check Zapier** task history
+4. **Verify entry** appears in Notion
+5. **Turn on your Zap** ✅
+
+## You're Done! 🎉
+
+From now on:
+- Record a meeting in Otter.AI
+- Wait for transcription (usually 5-15 minutes)
+- Find it automatically in your Notion database
+
+## Customization Ideas
+
+Once the basic setup works, enhance it:
+
+### Extract Action Items
+
+Update your Claude prompt to include:
+```
+Also extract any action items mentioned, formatted as:
+- [ ] Task description (Owner: Name)
+```
+
+### Add Tags
+
+Have Claude suggest tags:
+```
+Suggest 3-5 relevant tags for this meeting (e.g., Sales, Engineering, Strategy)
+```
+
+### Filter by Duration
+
+In Zapier trigger, add filter:
+- Only continue if Duration > 5 minutes
+
+### Send Notifications
+
+Add Slack or Email step:
+- Notify team when important meetings are transcribed
+
+## Troubleshooting
+
+### "Zapier can't find my Notion database"
+- ✅ Ensure database is shared with your integration
+- ✅ Refresh database list in Zapier
+- ✅ Check integration has "Can edit" permissions
+
+### "MCP connection failed"
+- ✅ Verify endpoint URL is correct in config
+- ✅ Restart Claude Desktop
+- ✅ Check Claude Desktop logs
+
+### "Transcript not appearing in Notion"
+- ✅ Check Zapier task history for errors
+- ✅ Verify all required Notion fields are mapped
+- ✅ Test each Zap step individually
+
+### "Claude processing is slow"
+- ⚠️ Long transcripts take more time
+- ⚠️ Consider using Claude 3 Haiku for faster (cheaper) processing
+- ⚠️ Simplify your prompt
+
+## Get Full Details
+
+- **Complete setup**: [README.md](./README.md)
+- **Zapier workflow**: [zapier-workflow.md](./zapier-workflow.md)
+- **Notion database**: [notion-database-template.md](./notion-database-template.md)
+- **Config examples**: [claude_desktop_config.json](./claude_desktop_config.json)
+
+## Support
+
+Need help?
+- 📖 Read the detailed guides above
+- 💬 Check [Zapier MCP Guide](https://zapier.com/blog/zapier-mcp-guide/)
+- 🔧 Review [Claude Desktop Docs](https://docs.anthropic.com/en/docs/claude-code/overview)
+
+## What's Next?
+
+Now that you have automatic transcription saving:
+
+1. **Create views** in Notion:
+   - Recent meetings
+   - Needs review
+   - By participant
+
+2. **Add automations**:
+   - Auto-archive old transcripts
+   - Create tasks from action items
+   - Send weekly digest emails
+
+3. **Integrate more tools**:
+   - Link to project management (Asana, Jira)
+   - Connect to CRM (Salesforce, HubSpot)
+   - Sync with calendar (Google, Outlook)
+
+Happy automating! 🚀

--- a/examples/integrations/otter-zapier-notion/README.md
+++ b/examples/integrations/otter-zapier-notion/README.md
@@ -1,0 +1,313 @@
+# Otter.AI to Notion Automation via Zapier MCP
+
+This guide shows you how to automatically download and save Otter.AI transcriptions to Notion using Claude Desktop with Zapier MCP integration. After each call or meeting ends in Otter.AI, the transcript will be automatically processed and saved to your Notion workspace.
+
+## Overview
+
+This automation workflow:
+1. Monitors Otter.AI for new transcriptions
+2. Triggers when a call/meeting ends and transcription is complete
+3. Uses Zapier MCP to connect Otter.AI with Claude Desktop
+4. Processes and formats the transcript
+5. Automatically saves it to your Notion database
+
+## Prerequisites
+
+- **Claude Desktop** installed on your machine
+- **Otter.AI** account with active transcriptions
+- **Notion** account with API access
+- **Zapier** account (free or paid plan)
+- **Node.js** 18+ installed (for MCP)
+
+## Architecture
+
+```
+Otter.AI (New Transcript)
+    ↓
+Zapier Trigger
+    ↓
+Zapier MCP Server
+    ↓
+Claude Desktop (Process & Format)
+    ↓
+Notion API (Save to Database)
+```
+
+## Quick Start
+
+### 1. Set Up Zapier MCP Integration
+
+#### Create Zapier MCP Server
+
+1. Log in to [Zapier](https://zapier.com)
+2. Navigate to **Actions** → **MCP Servers**
+3. Click **Create MCP Server**
+4. Select **Claude Desktop** as the client
+5. Copy your unique MCP endpoint URL (format: `https://actions.zapier.com/mcp/<your-id>/sse`)
+
+### 2. Configure Claude Desktop
+
+#### Edit Configuration File
+
+1. Open Claude Desktop
+2. Go to **Settings** → **Developer** (or **Integrations**)
+3. Click **Edit Config** to open `claude_desktop_config.json`
+
+#### Add MCP Server Configuration
+
+Add the following to your configuration file:
+
+```json
+{
+  "mcpServers": {
+    "zapier-mcp": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://actions.zapier.com/mcp/<your-endpoint-id>/sse"
+      ]
+    }
+  }
+}
+```
+
+Replace `<your-endpoint-id>` with your actual Zapier MCP endpoint ID.
+
+#### Restart Claude Desktop
+
+Close and reopen Claude Desktop to load the new MCP configuration.
+
+### 3. Create Zapier Workflow (Zap)
+
+#### Set Up Trigger
+
+1. In Zapier, create a new **Zap**
+2. **Trigger**: Choose **Otter.ai**
+3. **Event**: Select **New Transcript Created** or **Transcript Completed**
+4. Connect your Otter.AI account
+5. Test the trigger to ensure it can access your transcripts
+
+#### Configure Action
+
+1. **Action**: Choose **Anthropic (Claude)** or **Webhooks** (to send to MCP)
+2. **Event**: Select **Send Prompt** or **POST Request**
+3. Configure the action to:
+   - Extract transcript text from Otter.AI
+   - Send to Claude Desktop via MCP
+   - Format for Notion
+
+#### Add Notion Integration
+
+1. Add another **Action** step
+2. **Action**: Choose **Notion**
+3. **Event**: Select **Create Database Item** or **Create Page**
+4. Map fields:
+   - **Title**: Meeting name or transcript title
+   - **Content**: Formatted transcript text
+   - **Date**: Transcript date
+   - **Participants**: Meeting attendees (if available)
+   - **Tags**: Custom tags or categories
+
+5. Test the complete workflow
+
+### 4. Set Up Notion Database
+
+#### Create Transcripts Database
+
+1. Open Notion
+2. Create a new database with these properties:
+   - **Title** (Title field) - Meeting/transcript name
+   - **Date** (Date field) - When the meeting occurred
+   - **Transcript** (Text field) - Full transcript content
+   - **Summary** (Text field) - AI-generated summary
+   - **Participants** (Multi-select) - Meeting attendees
+   - **Duration** (Number) - Meeting length in minutes
+   - **Source** (Select) - "Otter.AI"
+   - **Status** (Select) - "New", "Reviewed", "Archived"
+
+#### Get Notion Integration Token
+
+1. Go to [Notion Integrations](https://www.notion.so/my-integrations)
+2. Click **New Integration**
+3. Name it "Otter Transcript Sync"
+4. Select your workspace
+5. Copy the **Internal Integration Token**
+6. Share your Transcripts database with this integration
+
+## Configuration Examples
+
+See the following files for detailed configuration examples:
+
+- [`claude_desktop_config.json`](./claude_desktop_config.json) - Complete Claude Desktop configuration
+- [`zapier-workflow.md`](./zapier-workflow.md) - Detailed Zapier workflow setup
+- [`notion-database-template.md`](./notion-database-template.md) - Notion database structure
+
+## Usage
+
+Once configured, the automation works automatically:
+
+1. **Record a meeting** in Otter.AI
+2. **End the call** - Otter.AI processes the transcription
+3. **Zapier detects** the new transcript (usually within 1-15 minutes)
+4. **Claude Desktop receives** the transcript via MCP
+5. **Transcript is formatted** and enhanced with:
+   - Summary
+   - Key points
+   - Action items
+   - Speaker identification
+6. **Saved to Notion** in your Transcripts database
+
+## Advanced Features
+
+### Custom Transcript Processing
+
+You can enhance the transcript processing by configuring Claude to:
+
+- **Extract action items** automatically
+- **Generate meeting summaries** with key takeaways
+- **Identify decisions made** during the meeting
+- **Tag topics** discussed
+- **Create follow-up tasks** in Notion
+
+### Example Prompt Template
+
+In your Zapier action, use this prompt template:
+
+```
+Process this Otter.AI transcript and format it for Notion:
+
+Transcript:
+{{transcript_text}}
+
+Meeting Info:
+- Title: {{meeting_title}}
+- Date: {{meeting_date}}
+- Duration: {{duration}} minutes
+- Participants: {{participants}}
+
+Please provide:
+1. A concise summary (2-3 sentences)
+2. Key discussion points (bullet list)
+3. Decisions made
+4. Action items with owners (if mentioned)
+5. Topics/tags for categorization
+
+Format the output as JSON for Notion database import.
+```
+
+### Filtering Transcripts
+
+Configure your Zapier trigger to only process specific transcripts:
+
+- **By duration**: Only meetings longer than X minutes
+- **By participants**: Only meetings with specific attendees
+- **By keywords**: Only transcripts containing certain terms
+- **By folder**: Only transcripts in specific Otter.AI folders
+
+## Troubleshooting
+
+### MCP Connection Issues
+
+If Claude Desktop cannot connect to Zapier MCP:
+
+1. **Check logs**:
+   ```bash
+   # macOS
+   tail -n 20 -F ~/Library/Logs/Claude/mcp*.log
+
+   # Windows
+   type %APPDATA%\Claude\logs\mcp*.log
+
+   # Linux
+   tail -n 20 -F ~/.config/Claude/logs/mcp*.log
+   ```
+
+2. **Clear MCP cache**:
+   ```bash
+   rm -rf ~/.mcp-auth
+   ```
+
+3. **Verify endpoint URL** in your configuration
+4. **Restart Claude Desktop**
+
+### Zapier Trigger Not Firing
+
+- Verify Otter.AI account connection in Zapier
+- Check if test transcripts are being created
+- Review Zapier task history for errors
+- Ensure Zap is turned ON
+
+### Notion Integration Failures
+
+- Verify integration token is correct
+- Check that database is shared with the integration
+- Ensure all required fields exist in the database
+- Review Zapier error logs for specific field issues
+
+### Transcript Formatting Issues
+
+- Check Claude Desktop MCP connection status
+- Verify the prompt template in Zapier
+- Test with a shorter transcript first
+- Review Claude Desktop logs for processing errors
+
+## Security Considerations
+
+- **API Keys**: Store Notion and Zapier API keys securely
+- **Transcript Privacy**: Ensure your Otter.AI and Notion workspaces have appropriate access controls
+- **MCP Authentication**: The MCP endpoint includes authentication tokens - keep them private
+- **Data Retention**: Configure Notion retention policies per your organization's requirements
+
+## Cost Considerations
+
+- **Otter.AI**: Check your plan's transcription limits
+- **Zapier**: Free plan includes 100 tasks/month; paid plans for more volume
+- **Claude API**: MCP usage may consume API credits depending on your plan
+- **Notion**: Most plans support unlimited pages and databases
+
+## Support and Resources
+
+- [Zapier MCP Documentation](https://zapier.com/blog/zapier-mcp-guide/)
+- [Claude Desktop MCP Guide](https://docs.anthropic.com/en/docs/claude-code/overview)
+- [Otter.AI API Documentation](https://otter.ai/developer)
+- [Notion API Documentation](https://developers.notion.com/)
+
+## Example Workflow Results
+
+After setup, each Otter.AI transcript will appear in Notion like this:
+
+**Example Notion Page**:
+```
+Title: Weekly Team Sync - Nov 4, 2025
+Date: November 4, 2025
+Duration: 45 minutes
+Participants: Alice, Bob, Carol
+Status: New
+Source: Otter.AI
+
+Summary:
+Team discussed Q4 roadmap priorities, resolved blocker on API integration,
+and aligned on sprint goals for next two weeks.
+
+Key Points:
+• Q4 focus: Complete API v2 migration
+• Blocker resolved: Database connection issue fixed
+• Sprint goals: 3 features for next iteration
+
+Decisions:
+• Approved moving forward with new architecture
+• Agreed to weekly sync schedule
+
+Action Items:
+• Alice: Review API documentation by Friday
+• Bob: Deploy hotfix by EOD
+• Carol: Schedule design review for next week
+
+[Full Transcript]
+Speaker 1 (Alice): Good morning everyone...
+[...]
+```
+
+## License
+
+This integration guide is provided as-is for educational and automation purposes. Ensure compliance with each service's terms of service.

--- a/examples/integrations/otter-zapier-notion/claude_desktop_config.json
+++ b/examples/integrations/otter-zapier-notion/claude_desktop_config.json
@@ -1,0 +1,24 @@
+{
+  "mcpServers": {
+    "zapier-mcp": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://actions.zapier.com/mcp/<YOUR_ENDPOINT_ID>/sse"
+      ],
+      "env": {
+        "ZAPIER_API_KEY": "<YOUR_ZAPIER_API_KEY>"
+      }
+    },
+    "notion-mcp": {
+      "command": "npx",
+      "args": [
+        "@notionhq/client"
+      ],
+      "env": {
+        "NOTION_API_KEY": "<YOUR_NOTION_INTEGRATION_TOKEN>"
+      }
+    }
+  },
+  "globalShortcut": "CommandOrControl+Shift+Space"
+}

--- a/examples/integrations/otter-zapier-notion/notion-database-template.md
+++ b/examples/integrations/otter-zapier-notion/notion-database-template.md
@@ -1,0 +1,464 @@
+# Notion Database Template for Otter.AI Transcripts
+
+This guide shows you how to create a properly structured Notion database to store and organize your Otter.AI transcriptions.
+
+## Quick Setup
+
+### Option 1: Create from Scratch
+
+Follow the [Detailed Setup](#detailed-setup) section below.
+
+### Option 2: Duplicate Template
+
+If you have access to a Notion template link (coming soon), you can duplicate the pre-built database.
+
+## Detailed Setup
+
+### Step 1: Create New Database
+
+1. Open your Notion workspace
+2. Navigate to the page where you want to store transcripts
+3. Type `/database` and select **Database - Full page** or **Database - Inline**
+4. Name the database: **"Meeting Transcripts"** or **"Otter Transcriptions"**
+
+### Step 2: Configure Database Properties
+
+Click **+** or the **•••** menu to add the following properties:
+
+#### Core Properties
+
+| Property Name | Type | Description | Configuration |
+|--------------|------|-------------|---------------|
+| **Title** | Title | Meeting or transcript name | Default property, rename if needed |
+| **Date** | Date | When the meeting occurred | Include time if needed |
+| **Status** | Select | Processing status | Options: New, Reviewed, Archived, Action Required |
+| **Source** | Select | Where transcript came from | Options: Otter.AI, Manual, Other |
+
+#### Content Properties
+
+| Property Name | Type | Description | Configuration |
+|--------------|------|-------------|---------------|
+| **Summary** | Text | AI-generated meeting summary | Use regular text (not rich text for Zapier compatibility) |
+| **Transcript** | Text | Full transcript text | Large text field |
+| **Key Points** | Text | Main discussion points | Bulleted list format |
+| **Decisions** | Text | Decisions made | Bulleted list format |
+| **Action Items** | Text | Tasks and next steps | Formatted as checklist |
+
+#### Metadata Properties
+
+| Property Name | Type | Description | Configuration |
+|--------------|------|-------------|---------------|
+| **Duration** | Number | Meeting length in minutes | Format: Number |
+| **Participants** | Multi-select | Meeting attendees | Add names as you process transcripts |
+| **Tags** | Multi-select | Topics or categories | Examples: Sales, Engineering, HR, Strategy |
+| **Sentiment** | Select | Overall meeting tone | Options: Positive, Neutral, Negative, Mixed |
+
+#### Reference Properties
+
+| Property Name | Type | Description | Configuration |
+|--------------|------|-------------|---------------|
+| **Otter Link** | URL | Link to original Otter.AI transcript | Direct link |
+| **Recording Link** | URL | Link to audio/video recording | If available |
+| **Related Docs** | Relation | Link to related Notion pages | Create relation to other databases |
+| **Meeting Series** | Select | Recurring meeting identifier | Examples: Weekly Standup, Monthly Review |
+
+#### Advanced Properties (Optional)
+
+| Property Name | Type | Description | Configuration |
+|--------------|------|-------------|---------------|
+| **Priority** | Select | Importance level | Options: High, Medium, Low |
+| **Follow-up Date** | Date | When to review action items | Date only |
+| **Owner** | Person | Person responsible for follow-up | Select workspace members |
+| **Project** | Relation | Related project | Link to Projects database |
+| **Transcript ID** | Text | Otter.AI unique identifier | For reference/debugging |
+| **Word Count** | Number | Total words in transcript | Auto-calculated via Zapier |
+| **Created At** | Created time | When Notion entry was created | Auto-populated |
+| **Last Edited** | Last edited time | Last modification time | Auto-populated |
+
+### Step 3: Configure Property Settings
+
+#### Status Options (Select)
+
+1. Click on **Status** property
+2. Add these options with colors:
+   - **New** (Blue) - Just imported, not yet reviewed
+   - **Reviewed** (Green) - Reviewed and processed
+   - **Action Required** (Red) - Has pending action items
+   - **Archived** (Gray) - Completed and archived
+
+3. Set **New** as the default
+
+#### Source Options (Select)
+
+1. Click on **Source** property
+2. Add options:
+   - **Otter.AI** (Purple) - From Otter.AI automation
+   - **Manual Upload** (Yellow) - Manually added
+   - **Other** (Gray) - Other sources
+
+3. Set **Otter.AI** as default
+
+#### Sentiment Options (Select)
+
+1. Click on **Sentiment** property
+2. Add options:
+   - **Positive** (Green) - Positive tone
+   - **Neutral** (Gray) - Neutral tone
+   - **Negative** (Red) - Negative tone
+   - **Mixed** (Orange) - Mixed sentiments
+
+#### Priority Options (Select)
+
+1. Click on **Priority** property
+2. Add options:
+   - **High** (Red)
+   - **Medium** (Yellow)
+   - **Low** (Gray)
+
+### Step 4: Create Database Views
+
+Create multiple views to organize your transcripts:
+
+#### View 1: All Transcripts (Table)
+
+- **Default view**
+- **Sort**: Date (descending) - newest first
+- **Filter**: None
+- **Properties visible**: All
+
+#### View 2: Recent Meetings (Gallery)
+
+1. Click **+ Add a view** → **Gallery**
+2. Name: "Recent Meetings"
+3. **Card Preview**: Summary or Transcript
+4. **Card Size**: Medium
+5. **Sort**: Date (descending)
+6. **Filter**: Date is within the past 1 month
+7. **Properties shown**: Title, Date, Participants, Tags
+
+#### View 3: Needs Review (List)
+
+1. Click **+ Add a view** → **List**
+2. Name: "Needs Review"
+3. **Sort**: Date (ascending) - oldest first
+4. **Filter**: Status is "New" OR Status is "Action Required"
+5. **Properties shown**: Title, Date, Status, Priority, Participants
+
+#### View 4: By Tag (Board)
+
+1. Click **+ Add a view** → **Board**
+2. Name: "By Tag"
+3. **Group by**: Tags
+4. **Sort**: Date (descending)
+5. **Properties shown**: Title, Date, Summary
+
+#### View 5: Calendar View (Calendar)
+
+1. Click **+ Add a view** → **Calendar**
+2. Name: "Calendar"
+3. **Date Property**: Date
+4. **Show**: Title, Participants
+5. Useful for seeing meeting distribution over time
+
+#### View 6: Action Items (Table)
+
+1. Click **+ Add a view** → **Table**
+2. Name: "Action Items"
+3. **Filter**:
+   - Action Items is not empty
+   - Status is not "Archived"
+4. **Sort**: Follow-up Date (ascending)
+5. **Properties shown**: Title, Action Items, Owner, Follow-up Date, Status
+
+### Step 5: Set Up Templates
+
+Create templates for different meeting types:
+
+#### Template 1: Team Standup
+
+1. In database, click **⌄** next to **New** button
+2. Select **+ New template**
+3. Name: "Team Standup Template"
+4. Pre-fill properties:
+   - **Meeting Series**: Weekly Standup
+   - **Tags**: Team, Standup
+   - **Status**: New
+5. Add template content:
+   ```
+   ## Agenda
+   - Yesterday's accomplishments
+   - Today's plans
+   - Blockers
+
+   ## Summary
+   [Auto-populated by Zapier]
+
+   ## Action Items
+   [Auto-populated by Zapier]
+   ```
+
+#### Template 2: Client Meeting
+
+1. Create another template
+2. Name: "Client Meeting Template"
+3. Pre-fill properties:
+   - **Tags**: Client, Sales
+   - **Priority**: High
+   - **Status**: Action Required
+4. Add template content:
+   ```
+   ## Client Information
+   - Company:
+   - Contact:
+
+   ## Meeting Purpose
+   [Auto-populated by Zapier]
+
+   ## Next Steps
+   [Auto-populated by Zapier]
+   ```
+
+#### Template 3: Project Review
+
+1. Create template: "Project Review Template"
+2. Pre-fill:
+   - **Tags**: Project, Review
+   - **Meeting Series**: Project Review
+3. Content:
+   ```
+   ## Project Status
+   [Auto-populated]
+
+   ## Milestones Discussed
+   [Auto-populated]
+
+   ## Decisions & Action Items
+   [Auto-populated]
+   ```
+
+### Step 6: Share Database with Integration
+
+For Zapier to write to your database:
+
+1. Click **Share** button (top-right)
+2. Click **Invite**
+3. Search for your Notion integration (e.g., "Otter Transcript Sync")
+4. Select the integration
+5. Set permissions: **Can edit**
+6. Click **Invite**
+
+### Step 7: Get Database ID
+
+You'll need the database ID for Zapier configuration:
+
+1. Open your database in Notion
+2. Copy the page URL
+3. The database ID is the string between the workspace name and the "?v=":
+   ```
+   https://www.notion.so/workspace/[DATABASE_ID]?v=...
+   ```
+4. Example: `3a2b1c4d5e6f7g8h9i0j1k2l`
+5. Save this ID for Zapier setup
+
+## Database Formula Examples
+
+### Auto-calculate Properties
+
+Add calculated fields to enhance your database:
+
+#### Formula 1: Days Since Meeting
+
+Add a **Formula** property named "Days Ago":
+
+```
+dateBetween(now(), prop("Date"), "days")
+```
+
+Shows how many days ago the meeting occurred.
+
+#### Formula 2: Needs Follow-up
+
+Add a **Formula** property named "Needs Follow-up":
+
+```
+if(prop("Follow-up Date") < now() and prop("Status") != "Archived", "⚠️ Overdue", if(prop("Action Items") != "", "📋 Has Items", "✓ Complete"))
+```
+
+Flags transcripts that need attention.
+
+#### Formula 3: Meeting Length Category
+
+Add a **Formula** property named "Length Category":
+
+```
+if(prop("Duration") > 60, "🔴 Long", if(prop("Duration") > 30, "🟡 Medium", "🟢 Short"))
+```
+
+Categorizes meetings by duration.
+
+#### Formula 4: Has Recording
+
+Add a **Formula** property named "Has Recording":
+
+```
+if(empty(prop("Recording Link")), "❌ No", "✅ Yes")
+```
+
+Indicates if recording link exists.
+
+## Automation Rules (Notion Built-in)
+
+Set up Notion automations for additional workflows:
+
+### Automation 1: Auto-archive Old Transcripts
+
+1. In database, click **⚙️** → **Automations** → **New automation**
+2. **Trigger**: Property edited
+3. **Property**: Status
+4. **When**: Status is "Reviewed"
+5. **Action**: Edit property
+6. **Wait**: 30 days
+7. **Then**: Set Status to "Archived"
+
+### Automation 2: Assign Owner for Action Items
+
+1. **Trigger**: Database entry created
+2. **When**: Action Items is not empty
+3. **Action**: Edit property
+4. **Property**: Status → "Action Required"
+5. **And**: Send notification to workspace
+
+### Automation 3: Reminder for Follow-ups
+
+1. **Trigger**: Property edited
+2. **Property**: Follow-up Date
+3. **When**: Follow-up Date is today
+4. **Action**: Send notification
+5. **To**: Property "Owner"
+6. **Message**: "Follow-up needed: {Title}"
+
+## Sample Database Entry
+
+Here's what a completed entry looks like:
+
+```
+Title: Q4 Planning Session - Engineering Team
+Date: November 4, 2025, 2:00 PM
+Status: Reviewed
+Source: Otter.AI
+Priority: High
+
+Duration: 45 minutes
+Participants: Alice Johnson, Bob Smith, Carol Williams
+Tags: Engineering, Planning, Q4, Strategy
+Sentiment: Positive
+
+Summary:
+Team discussed Q4 roadmap priorities, focusing on API v2 migration
+and mobile app enhancements. Agreed on sprint allocation and timeline.
+All major blockers have been resolved.
+
+Key Points:
+• Q4 focus: Complete API v2 migration by end of November
+• Mobile app beta launch scheduled for mid-December
+• Infrastructure upgrades approved for January
+• Hiring: 2 senior engineers to join in Q4
+
+Decisions:
+• Approved API v2 architecture proposal
+• Decided to delay feature X to Q1 2026
+• Agreed on bi-weekly sprint cycles
+
+Action Items:
+☐ Alice: Finalize API v2 technical spec (Due: Nov 10)
+☐ Bob: Review infrastructure costs and present options (Due: Nov 15)
+☐ Carol: Schedule interviews for engineering positions (Due: Nov 8)
+
+Otter Link: https://otter.ai/u/abc123xyz
+Meeting Series: Quarterly Planning
+Follow-up Date: November 15, 2025
+Owner: Alice Johnson
+Project: [Link to API v2 Migration project]
+```
+
+## Tips for Organization
+
+### Tagging Strategy
+
+Create consistent tags:
+- **By Team**: Engineering, Sales, Marketing, HR, Finance
+- **By Type**: Standup, Review, Planning, Client Meeting, Interview
+- **By Priority**: Urgent, Important, Routine
+- **By Project**: Project names or codes
+
+### Naming Conventions
+
+Use consistent naming for meetings:
+```
+[Type] - [Topic] - [Date]
+```
+
+Examples:
+- `Weekly Standup - Engineering - Nov 4, 2025`
+- `Client Meeting - Acme Corp - Q4 Review`
+- `Project Review - Mobile App - Sprint 12`
+
+### Regular Maintenance
+
+- **Weekly**: Review "Needs Review" view and process new transcripts
+- **Monthly**: Archive completed transcripts older than 30 days
+- **Quarterly**: Review tagging system and update as needed
+
+## Integration with Other Notion Databases
+
+### Link to Projects Database
+
+1. Create a **Projects** database
+2. Add **Relation** property in Transcripts database
+3. Link each transcript to its related project
+
+### Link to Tasks Database
+
+1. Create a **Tasks** database
+2. Use **Relation** to link action items from transcripts to tasks
+3. Automate task creation from action items
+
+### Link to Contacts Database
+
+1. Create a **Contacts** database
+2. Replace **Participants** multi-select with **Relation** to Contacts
+3. Track all meetings per person
+
+## Troubleshooting
+
+### Zapier Can't Find Database
+
+- Ensure database is shared with your Notion integration
+- Check that integration has "Can edit" permissions
+- Try refreshing the database list in Zapier
+
+### Fields Not Populating
+
+- Verify property names match exactly (case-sensitive)
+- Check property types match Zapier output
+- Ensure text fields are not rich text (use plain text)
+
+### Multi-select Not Working
+
+- Format Zapier output as comma-separated text
+- Pre-create all possible values in Notion
+- Values are case-sensitive
+
+## Resources
+
+- [Notion API Documentation](https://developers.notion.com/)
+- [Notion Database Guide](https://www.notion.so/help/guides/creating-a-database)
+- [Notion Formulas Reference](https://www.notion.so/help/formulas)
+
+## Next Steps
+
+After setting up your database:
+1. Complete the Zapier integration ([see zapier-workflow.md](./zapier-workflow.md))
+2. Test with a sample transcript
+3. Customize views and properties for your needs
+4. Share with your team and gather feedback

--- a/examples/integrations/otter-zapier-notion/zapier-workflow.md
+++ b/examples/integrations/otter-zapier-notion/zapier-workflow.md
@@ -1,0 +1,447 @@
+# Zapier Workflow Configuration Guide
+
+This guide provides detailed step-by-step instructions for creating a Zapier workflow (Zap) that automatically transfers Otter.AI transcriptions to Notion via Claude Desktop.
+
+## Table of Contents
+
+1. [Prerequisites](#prerequisites)
+2. [Step 1: Create MCP Server in Zapier](#step-1-create-mcp-server-in-zapier)
+3. [Step 2: Set Up Otter.AI Trigger](#step-2-set-up-otterai-trigger)
+4. [Step 3: Configure Claude Processing](#step-3-configure-claude-processing)
+5. [Step 4: Add Notion Action](#step-4-add-notion-action)
+6. [Step 5: Testing and Activation](#step-5-testing-and-activation)
+7. [Advanced Configurations](#advanced-configurations)
+
+## Prerequisites
+
+Before starting, ensure you have:
+
+- Active Zapier account (free or paid)
+- Otter.AI account with transcription access
+- Notion workspace with admin permissions
+- Claude Desktop installed and configured
+- API keys and tokens ready
+
+## Step 1: Create MCP Server in Zapier
+
+### 1.1 Navigate to MCP Servers
+
+1. Log in to [Zapier](https://zapier.com)
+2. Click on **Actions** in the left sidebar
+3. Select **MCP Servers** from the dropdown
+4. Click **Create MCP Server** button
+
+### 1.2 Configure MCP Server
+
+1. **Server Name**: Enter "Claude Desktop - Otter Transcripts"
+2. **Client Type**: Select **Claude Desktop**
+3. **Description**: "Processes Otter.AI transcriptions and saves to Notion"
+4. Click **Create Server**
+
+### 1.3 Get Endpoint URL
+
+After creation, you'll see:
+- **Endpoint URL**: `https://actions.zapier.com/mcp/<unique-id>/sse`
+- **API Key**: (automatically generated)
+
+**Important**: Copy both the endpoint URL and API key. You'll need these for Claude Desktop configuration.
+
+## Step 2: Set Up Otter.AI Trigger
+
+### 2.1 Create New Zap
+
+1. Go to [Zapier Dashboard](https://zapier.com/app/dashboard)
+2. Click **Create Zap**
+3. Name your Zap: "Otter.AI → Claude → Notion"
+
+### 2.2 Configure Trigger
+
+1. **Choose App**: Search for and select **Otter.ai**
+2. **Choose Trigger Event**: Select one of:
+   - **New Transcript Created** (triggers when transcript is ready)
+   - **Transcript Updated** (triggers when transcript is edited)
+   - Recommended: **New Transcript Created**
+
+3. **Connect Account**:
+   - Click **Sign in to Otter.ai**
+   - Enter your Otter.AI credentials
+   - Authorize Zapier to access your transcripts
+
+4. **Configure Trigger Settings**:
+   - **Folder Filter** (optional): Select specific Otter.AI folders
+   - **Minimum Duration** (optional): Only trigger for meetings longer than X minutes
+   - Example: Set to 5 to skip very short recordings
+
+### 2.3 Test Trigger
+
+1. Click **Test Trigger**
+2. Zapier will fetch a recent transcript from your Otter.AI account
+3. Review the sample data to ensure it contains:
+   - Transcript ID
+   - Title
+   - Transcript text
+   - Date/time
+   - Duration
+   - Participants (if available)
+
+4. Click **Continue** if test is successful
+
+## Step 3: Configure Claude Processing
+
+### 3.1 Add Claude Action
+
+1. Click **+** to add a new action step
+2. **Choose App**: Search for **Webhooks by Zapier** or **HTTP** module
+3. **Action Event**: Select **POST Request**
+
+### 3.2 Configure Webhook to MCP
+
+1. **URL**: Enter your MCP endpoint from Step 1.3
+2. **Method**: POST
+3. **Headers**:
+   ```
+   Content-Type: application/json
+   Authorization: Bearer <YOUR_ZAPIER_API_KEY>
+   ```
+
+4. **Body** (JSON format):
+   ```json
+   {
+     "action": "process_transcript",
+     "transcript": {
+       "id": "{{trigger.transcript_id}}",
+       "title": "{{trigger.title}}",
+       "text": "{{trigger.transcript}}",
+       "date": "{{trigger.created_at}}",
+       "duration": "{{trigger.duration}}",
+       "participants": "{{trigger.participants}}"
+     },
+     "processing_instructions": {
+       "generate_summary": true,
+       "extract_action_items": true,
+       "identify_key_points": true,
+       "detect_speakers": true,
+       "create_tags": true
+     },
+     "output_format": "notion"
+   }
+   ```
+
+5. **Data Passthrough**: Enable this to receive Claude's processed output
+
+### 3.3 Alternative: Direct Claude API Integration
+
+If you prefer using Claude API directly:
+
+1. **Choose App**: Search for **Anthropic (Claude)**
+2. **Action Event**: Select **Send Prompt**
+3. **Connect Account**: Enter your Anthropic API key
+4. **Configure Prompt**:
+
+   ```
+   Process this Otter.AI meeting transcript for Notion database entry:
+
+   Meeting Title: {{trigger.title}}
+   Date: {{trigger.created_at}}
+   Duration: {{trigger.duration}} minutes
+   Participants: {{trigger.participants}}
+
+   Full Transcript:
+   {{trigger.transcript}}
+
+   Please analyze and provide:
+   1. A concise 2-3 sentence summary
+   2. 5-7 key discussion points as bullet points
+   3. All decisions made during the meeting
+   4. Action items with responsible parties (if mentioned)
+   5. 3-5 relevant tags for categorization
+   6. Sentiment analysis (positive, neutral, negative)
+
+   Format your response as JSON with this structure:
+   {
+     "summary": "...",
+     "key_points": ["...", "..."],
+     "decisions": ["...", "..."],
+     "action_items": [
+       {"task": "...", "owner": "...", "deadline": "..."}
+     ],
+     "tags": ["...", "...", "..."],
+     "sentiment": "positive|neutral|negative"
+   }
+   ```
+
+5. **Model**: Select **Claude 3.5 Sonnet** or **Claude 3 Opus**
+6. **Max Tokens**: 4000 (sufficient for most transcripts)
+
+### 3.4 Test Action
+
+1. Click **Test Action**
+2. Verify Claude processes the sample transcript
+3. Check that the output includes all requested fields
+4. Click **Continue**
+
+## Step 4: Add Notion Action
+
+### 4.1 Add Notion Step
+
+1. Click **+** to add another action
+2. **Choose App**: Search for and select **Notion**
+3. **Action Event**: Select **Create Database Item**
+
+### 4.2 Connect Notion Account
+
+1. Click **Sign in to Notion**
+2. Select your Notion workspace
+3. Authorize Zapier to access your databases
+
+### 4.3 Select Database
+
+1. **Database**: Choose your "Transcripts" database
+   - If not visible, ensure the database is shared with your Notion integration
+   - You may need to refresh the database list
+
+### 4.4 Map Fields
+
+Map the Zapier data to your Notion database properties:
+
+#### Basic Fields
+
+- **Title** (Title property):
+  ```
+  {{trigger.title}} - {{trigger.created_at_formatted}}
+  ```
+
+- **Date** (Date property):
+  ```
+  {{trigger.created_at}}
+  ```
+
+- **Duration** (Number property):
+  ```
+  {{trigger.duration}}
+  ```
+
+#### Processed Content (from Claude)
+
+If using Webhooks/MCP:
+- **Summary** (Text property):
+  ```
+  {{action.summary}}
+  ```
+
+- **Key Points** (Text property):
+  ```
+  {{action.key_points}}
+  ```
+
+- **Decisions** (Text property):
+  ```
+  {{action.decisions}}
+  ```
+
+- **Action Items** (Text property):
+  ```
+  {{action.action_items}}
+  ```
+
+If using direct Claude API:
+- Parse the JSON response and map each field
+- Use **Format** step if needed to extract JSON fields
+
+#### Additional Fields
+
+- **Participants** (Multi-select):
+  ```
+  {{trigger.participants}}
+  ```
+  Note: Format as comma-separated values
+
+- **Source** (Select):
+  ```
+  Otter.AI
+  ```
+
+- **Status** (Select):
+  ```
+  New
+  ```
+
+- **Tags** (Multi-select):
+  ```
+  {{action.tags}}
+  ```
+
+- **Transcript** (Text property):
+  ```
+  {{trigger.transcript}}
+  ```
+
+- **Otter Link** (URL property):
+  ```
+  {{trigger.url}}
+  ```
+
+### 4.5 Advanced Field Mapping
+
+For complex fields, you may need to add a **Formatter** step:
+
+1. Add **Format** step between Claude and Notion
+2. **Action**: **Text → Split Text** or **Utilities → Line-item to Text**
+3. Configure to split arrays into comma-separated text
+4. Use formatted output in Notion fields
+
+### 4.6 Test Notion Action
+
+1. Click **Test Action**
+2. Check your Notion database for the new test entry
+3. Verify all fields are populated correctly
+4. Make adjustments if needed
+
+## Step 5: Testing and Activation
+
+### 5.1 Complete End-to-End Test
+
+1. Create a test recording in Otter.AI
+   - Record a short 1-2 minute meeting
+   - Add a clear title
+   - Wait for transcription to complete
+
+2. Monitor Zapier Task History
+   - Go to **Zap History** in Zapier
+   - Wait for the Zap to trigger (may take 1-15 minutes)
+   - Click on the task to see details
+
+3. Verify each step:
+   - ✓ Otter.AI trigger captured transcript
+   - ✓ Claude processed the content
+   - ✓ Notion entry was created
+
+4. Check Notion database for the new entry
+
+### 5.2 Activate Zap
+
+If everything works correctly:
+
+1. Return to Zap editor
+2. Click **Publish** or **Turn on Zap**
+3. Confirm activation
+
+Your Zap is now live and will automatically process new Otter.AI transcripts!
+
+## Advanced Configurations
+
+### Multi-Path Workflows
+
+Create conditional logic based on transcript content:
+
+1. Add **Filter** step after Otter.AI trigger
+2. Configure conditions:
+   - **Duration > 10 minutes**: Process fully
+   - **Duration < 10 minutes**: Simple save without Claude processing
+   - **Contains keyword**: Tag as "Important"
+
+### Custom Notion Templates
+
+Create different Notion pages based on meeting type:
+
+1. Add **Paths by Zapier** after Claude processing
+2. Configure paths:
+   - **Path A**: Sales calls → Sales database
+   - **Path B**: Team meetings → Team database
+   - **Path C**: Interviews → HR database
+
+### Email Notifications
+
+Add email alerts for important transcripts:
+
+1. Add **Email by Zapier** action
+2. **To**: Your email or team distribution list
+3. **Subject**: `New Transcript: {{trigger.title}}`
+4. **Body**: Include summary and action items
+5. **Condition**: Only send if action items exist
+
+### Slack Integration
+
+Post summaries to Slack channels:
+
+1. Add **Slack** action after Notion
+2. **Channel**: Select target channel
+3. **Message**:
+   ```
+   📝 New Meeting Transcript: *{{trigger.title}}*
+
+   Summary: {{action.summary}}
+
+   View in Notion: {{notion.page_url}}
+   ```
+
+### Batch Processing
+
+Process multiple transcripts at once:
+
+1. Use **Schedule by Zapier** as trigger
+2. Set to run hourly or daily
+3. Fetch all new Otter transcripts since last run
+4. Use **Looping by Zapier** to process each one
+
+### Error Handling
+
+Add error recovery mechanisms:
+
+1. After each action, add **Filter** step
+2. Check for successful completion
+3. If error, add **Paths**:
+   - **Path A**: Retry action
+   - **Path B**: Log error to Google Sheets
+   - **Path C**: Send error notification
+
+## Monitoring and Optimization
+
+### Task History
+
+Regularly check Zapier Task History:
+- Monitor success/failure rates
+- Identify bottlenecks
+- Track processing times
+
+### Adjust Trigger Frequency
+
+For faster processing:
+- Upgrade Zapier plan for shorter polling intervals
+- Use webhook triggers if available
+
+### Optimize Prompts
+
+Refine Claude prompts based on results:
+- Add more specific instructions
+- Adjust output format
+- Include examples of desired output
+
+## Troubleshooting
+
+See [README.md](./README.md#troubleshooting) for common issues and solutions.
+
+## Cost Optimization
+
+- **Zapier Tasks**: Each Zap run counts as 1-3 tasks (depending on steps)
+- **Claude API**: Each transcript costs ~$0.01-0.10 (depending on length)
+- **Notion API**: Free for most use cases
+
+**Tips**:
+- Filter short/unimportant transcripts to save tasks
+- Use scheduled processing instead of instant triggers
+- Batch process during off-peak hours
+
+## Next Steps
+
+- Customize the Claude prompt for your specific needs
+- Add additional processing steps (e.g., task creation in project management tools)
+- Integrate with calendar apps to link meetings with transcripts
+- Create dashboards in Notion to visualize transcript data
+
+## Resources
+
+- [Zapier Webhooks Documentation](https://zapier.com/apps/webhook/integrations)
+- [Otter.AI Zapier Integration](https://zapier.com/apps/otterai/integrations)
+- [Notion API Documentation](https://developers.notion.com/)
+- [Claude API Documentation](https://docs.anthropic.com/)


### PR DESCRIPTION
This integration enables automatic downloading and saving of Otter.AI transcriptions to Notion using Claude Desktop with Zapier MCP.

Includes:
- Complete setup guide (README.md)
- Quick start guide for 30-minute setup
- Detailed Zapier workflow configuration
- Notion database template with properties and views
- Claude Desktop configuration examples
- Step-by-step instructions with troubleshooting

Features:
- Automatic transcript monitoring from Otter.AI
- Claude-powered processing for summaries and insights
- Structured Notion database with metadata
- Action item extraction
- Customizable tags and categorization
- Multiple database views and templates

Usage: Users can follow the guides to set up end-to-end automation that processes meeting transcripts and saves them to Notion after each Otter.AI call/meeting ends.