### PR TITLE
fix: use portable shebang in plugin hooks

### DIFF
--- a/plugins/explanatory-output-style/hooks-handlers/session-start.sh
+++ b/plugins/explanatory-output-style/hooks-handlers/session-start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Output the explanatory mode instructions as additionalContext
 # This mimics the deprecated Explanatory output style

--- a/plugins/learning-output-style/hooks-handlers/session-start.sh
+++ b/plugins/learning-output-style/hooks-handlers/session-start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Output the learning mode instructions as additionalContext
 # This combines the unshipped Learning output style with explanatory functionality


### PR DESCRIPTION
## Summary
- Use portable shebang in plugin hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)