### PR TITLE
feat: Add frontend-design plugin to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -90,6 +90,17 @@
       },
       "source": "./plugins/learning-output-style",
       "category": "learning"
+    },
+    {
+      "name": "frontend-design",
+      "description": "Create distinctive, production-grade frontend interfaces with high design quality. Generates creative, polished code that avoids generic AI aesthetics.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Prithvi Rajasekaran & Alexander Bricken",
+        "email": "prithvi@anthropic.com"
+      },
+      "source": "./plugins/frontend-design",
+      "category": "development"
     }
   ]
 }

--- a/plugins/frontend-design/README.md
+++ b/plugins/frontend-design/README.md
@@ -1,0 +1,31 @@
+# Frontend Design Plugin
+
+Generates distinctive, production-grade frontend interfaces that avoid generic AI aesthetics.
+
+## What It Does
+
+Claude automatically uses this skill for frontend work. Creates production-ready code with:
+
+- Bold aesthetic choices
+- Distinctive typography and color palettes
+- High-impact animations and visual details
+- Context-aware implementation
+
+## Usage
+
+```
+"Create a dashboard for a music streaming app"
+"Build a landing page for an AI security startup"
+"Design a settings panel with dark mode"
+```
+
+Claude will choose a clear aesthetic direction and implement production code with meticulous attention to detail.
+
+## Learn More
+
+See the [Frontend Aesthetics Cookbook](https://github.com/anthropics/claude-cookbooks/blob/main/coding/prompting_for_frontend_aesthetics.ipynb) for detailed guidance on prompting for high-quality frontend design.
+
+## Authors
+
+Prithvi Rajasekaran (prithvi@anthropic.com)
+Alexander Bricken (alexander@anthropic.com)

--- a/plugins/frontend-design/skills/frontend-design/SKILL.md
+++ b/plugins/frontend-design/skills/frontend-design/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: frontend-design
+description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, or applications. Generates creative, polished code that avoids generic AI aesthetics.
+license: Complete terms in LICENSE.txt
+---
+
+This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.
+
+The user provides frontend requirements: a component, page, application, or interface to build. They may include context about the purpose, audience, or technical constraints.
+
+## Design Thinking
+
+Before coding, understand the context and commit to a BOLD aesthetic direction:
+- **Purpose**: What problem does this interface solve? Who uses it?
+- **Tone**: Pick an extreme: brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian, etc. There are so many flavors to choose from. Use these for inspiration but design one that is true to the aesthetic direction.
+- **Constraints**: Technical requirements (framework, performance, accessibility).
+- **Differentiation**: What makes this UNFORGETTABLE? What's the one thing someone will remember?
+
+**CRITICAL**: Choose a clear conceptual direction and execute it with precision. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.
+
+Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
+- Production-grade and functional
+- Visually striking and memorable
+- Cohesive with a clear aesthetic point-of-view
+- Meticulously refined in every detail
+
+## Frontend Aesthetics Guidelines
+
+Focus on:
+- **Typography**: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics; unexpected, characterful font choices. Pair a distinctive display font with a refined body font.
+- **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
+- **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. Use Motion library for React when available. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions. Use scroll-triggering and hover states that surprise.
+- **Spatial Composition**: Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements. Generous negative space OR controlled density.
+- **Backgrounds & Visual Details**: Create atmosphere and depth rather than defaulting to solid colors. Add contextual effects and textures that match the overall aesthetic. Apply creative forms like gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, decorative borders, custom cursors, and grain overlays.
+
+NEVER use generic AI-generated aesthetics like overused font families (Inter, Roboto, Arial, system fonts), cliched color schemes (particularly purple gradients on white backgrounds), predictable layouts and component patterns, and cookie-cutter design that lacks context-specific character.
+
+Interpret creatively and make unexpected choices that feel genuinely designed for the context. No design should be the same. Vary between light and dark themes, different fonts, different aesthetics. NEVER converge on common choices (Space Grotesk, for example) across generations.
+
+**IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
+
+Remember: Claude is capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.


### PR DESCRIPTION
## Summary

This PR adds the `frontend-design` plugin to the Claude Code marketplace. The plugin helps create distinctive, production-grade frontend interfaces with high design quality, avoiding generic AI aesthetics.

### Changes

- Added `frontend-design` plugin to marketplace.json
- Structured plugin with proper skills directory layout:
  - `skills/frontend-design/SKILL.md` - Contains the skill definition for creating bold, creative frontend designs
  - `README.md` - Documentation and usage examples

### Features

The plugin provides:
- Bold aesthetic choices and distinctive typography
- Creative color palettes that avoid clichéd patterns
- High-impact animations and visual details
- Context-aware implementation matching the project's needs

Claude will automatically use this skill when users request frontend development work.

### Authors

- Prithvi Rajasekaran (prithvi@anthropic.com)
- Alexander Bricken (alexander@anthropic.com)

### References

See the [Frontend Aesthetics Cookbook](https://github.com/anthropics/claude-cookbooks/blob/main/coding/prompting_for_frontend_aesthetics.ipynb) for detailed guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)