### PR TITLE
docs: Update README with skills and hooks sections

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -85,6 +85,7 @@ plugin-name/
 ├── agents/                  # Specialized agents (optional)
 ├── skills/                  # Agent Skills (optional)
 ├── hooks/                   # Event handlers (optional)
+├── .mcp.json                # External tool configuration (optional)
 └── README.md                # Plugin documentation
 ```
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -81,8 +81,10 @@ Each plugin follows the standard Claude Code plugin structure:
 plugin-name/
 ├── .claude-plugin/
 │   └── plugin.json          # Plugin metadata
-├── commands/                 # Slash commands (optional)
-├── agents/                   # Specialized agents (optional)
+├── commands/                # Slash commands (optional)
+├── agents/                  # Specialized agents (optional)
+├── skills/                  # Agent Skills (optional)
+├── hooks/                   # Event handlers (optional)
 └── README.md                # Plugin documentation
 ```
 


### PR DESCRIPTION
Added sections for skills and hooks to the plugin structure per the [official documentation](https://code.claude.com/docs/en/plugins#plugin-structure-overview).