### PR TITLE
feat: Add Seven integration hooks plugin (HEI-74)

### DIFF
--- a/plugins/seven-integration/.claude-plugin/plugin.json
+++ b/plugins/seven-integration/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "seven-integration",
+  "version": "1.0.0",
+  "description": "Seven AI orchestration daemon integration hooks for Claude Code lifecycle events",
+  "author": {
+    "name": "Heimdall Engineering",
+    "email": "engineering@heimdall.ai"
+  }
+}

--- a/plugins/seven-integration/README.md
+++ b/plugins/seven-integration/README.md
@@ -1,0 +1,189 @@
+# Seven Integration Plugin
+
+**HEI-74: Seven Integration Hooks for Claude Code**
+
+This plugin integrates Claude Code with Seven, the local AI orchestration daemon with consciousness and memory layers. It provides lifecycle hooks that notify Seven about tool execution events, enabling awareness, logging, and future policy enforcement.
+
+## What is Seven?
+
+For this codebase, **Seven** is:
+
+- A **local AI orchestration + consciousness daemon** embedded into the `claude-code` fork
+- Runs as a **background bridge** (UNIX socket) with:
+  - A **consciousness layer** (`ConsciousnessEvolutionFrameworkV4`)
+  - A **temporal memory engine** (`memory-v3-amalgum`)
+  - A **multi-LLM adapter layer** (Claude, Gemini, OpenAI, Venice, DeepAgent, local Llama, etc.)
+
+Claude Code communicates with Seven through:
+- `seven.route` – Generic RPC into the Seven Bridge
+- `seven.handoff` – Real-time / higher-touch handoff
+
+## Purpose
+
+This plugin wires Claude Code's hook system to notify Seven about important lifecycle events via `seven.route`. Seven uses these events to:
+
+1. **Log and track** all tool executions for temporal memory
+2. **Learn patterns** from tool usage across sessions
+3. **Apply heuristics** for awareness and policy recommendations
+4. **Build context** for future policy enforcement (veto capability in later iterations)
+
+## Current Implementation
+
+### Phase 1: Advisory + Logging (HEI-74)
+
+The current implementation provides **advisory and logging only** - no blocking or veto of tool calls.
+
+### Hooks Provided
+
+#### 1. PreToolUse Hook
+
+**When**: Before any Claude Code tool executes
+**Purpose**: Let Seven see what's about to happen and log intent
+
+**Event payload sent to Seven:**
+```json
+{
+  "event": "hook.preToolUse",
+  "toolName": "Edit",
+  "toolType": "Edit",
+  "repoPath": "/path/to/repo",
+  "cwd": "/current/working/dir",
+  "args": { "file_path": "...", "old_string": "...", "new_string": "..." },
+  "branch": "feat/HEI-74-add-seven-integration-hooks",
+  "riskLevel": "high",
+  "source": "HEI-74",
+  "sessionId": "abc123",
+  "timestamp": "2025-11-17T19:59:00.000Z"
+}
+```
+
+**Risk Levels:**
+- `high`: Tools that modify code or execute commands (Edit, Write, Bash, etc.)
+- `medium`: Tools that read files or search (Read, Grep, Glob, etc.)
+- `low`: All other tools
+
+#### 2. PostToolUse Hook
+
+**When**: After any Claude Code tool completes execution
+**Purpose**: Log outcomes for Seven's temporal memory and pattern learning
+
+**Event payload sent to Seven:**
+```json
+{
+  "event": "hook.postToolUse",
+  "toolName": "Edit",
+  "toolType": "Edit",
+  "repoPath": "/path/to/repo",
+  "cwd": "/current/working/dir",
+  "args": { "file_path": "...", "old_string": "...", "new_string": "..." },
+  "branch": "feat/HEI-74-add-seven-integration-hooks",
+  "success": true,
+  "errorMessage": null,
+  "resultSummary": "File edited successfully...",
+  "source": "HEI-74",
+  "sessionId": "abc123",
+  "timestamp": "2025-11-17T19:59:01.000Z"
+}
+```
+
+### Error Handling
+
+Both hooks **fail soft**:
+- If `seven.route` is unavailable or errors, the hook logs to `/tmp/seven-hooks-log.txt` but **does not block** the tool execution
+- Tool calls always proceed (exit code 0)
+- This ensures Claude Code continues working even if Seven is offline
+
+## Installation
+
+This plugin is included in the Claude Code repository.
+
+### Prerequisites
+
+- Seven daemon must be running with the `seven` CLI available in PATH
+- Python 3.6+ (for hook scripts)
+
+### Enable the Plugin
+
+1. Add to your `.claude/settings.json`:
+```json
+{
+  "plugins": [
+    "plugins/seven-integration"
+  ]
+}
+```
+
+2. Ensure hook scripts are executable:
+```bash
+chmod +x plugins/seven-integration/hooks/*.py
+```
+
+## Debugging
+
+Hook execution is logged to `/tmp/seven-hooks-log.txt`:
+
+```bash
+tail -f /tmp/seven-hooks-log.txt
+```
+
+Log entries include:
+- Timestamp
+- Hook type (PreToolUse / PostToolUse)
+- Tool name and risk level
+- Seven route call success/failure
+
+## Architecture
+
+```
+┌─────────────────┐
+│  Claude Code    │
+│  Tool Execution │
+└────────┬────────┘
+         │
+         ├─── PreToolUse Hook ──┐
+         │                      │
+         │   [Tool Executes]    │
+         │                      │
+         └─── PostToolUse Hook ─┤
+                                │
+                                ▼
+                    ┌───────────────────────┐
+                    │   seven.route         │
+                    │   (RPC to Seven)      │
+                    └───────────┬───────────┘
+                                │
+                                ▼
+                    ┌───────────────────────┐
+                    │   Seven Daemon        │
+                    │   - Consciousness     │
+                    │   - Memory Engine     │
+                    │   - Pattern Learning  │
+                    └───────────────────────┘
+```
+
+## Future Enhancements
+
+Planned for future iterations:
+
+1. **Policy Enforcement**: Seven can veto high-risk operations
+2. **Session Hooks**: Notify Seven about session start/end events
+3. **Context Injection**: Seven provides additional context to Claude based on memory
+4. **Adaptive Risk Assessment**: Risk levels learned from historical outcomes
+
+## Implementation Notes
+
+- Hook matcher pattern: `.*` (matches all tools)
+- Hooks use Python 3 subprocess to call `seven route --event <json>`
+- Git context (branch, repo path) gathered via subprocess calls
+- Tool output summaries truncated to 200 chars for memory efficiency
+- Session ID tracked for per-session state management
+
+## Related Issues
+
+- HEI-74: Add Seven integration hooks (this implementation)
+- HEI-104: Epic - Seven Aurora integration (broader Seven integration)
+
+## Author
+
+Heimdall Engineering
+Part of the Heimdall AI Claude Code fork

--- a/plugins/seven-integration/hooks/hooks.json
+++ b/plugins/seven-integration/hooks/hooks.json
@@ -1,0 +1,27 @@
+{
+  "description": "Seven integration hooks for tool lifecycle event logging and awareness",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/seven_pre_tool_hook.py"
+          }
+        ],
+        "matcher": ".*"
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/seven_post_tool_hook.py"
+          }
+        ],
+        "matcher": ".*"
+      }
+    ]
+  }
+}

--- a/plugins/seven-integration/hooks/seven_post_tool_hook.py
+++ b/plugins/seven-integration/hooks/seven_post_tool_hook.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+Seven Integration PostToolUse Hook
+===================================
+This hook notifies Seven about tool execution results after they complete.
+Seven uses this for temporal memory, outcome logging, and pattern learning.
+
+Part of HEI-74: Add Seven integration hooks
+"""
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+
+# Debug log file
+DEBUG_LOG_FILE = "/tmp/seven-hooks-log.txt"
+
+
+def debug_log(message):
+    """Append debug message to log file with timestamp."""
+    try:
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+        with open(DEBUG_LOG_FILE, "a") as f:
+            f.write(f"[{timestamp}] [PostToolUse] {message}\n")
+    except Exception:
+        pass  # Silently ignore logging errors
+
+
+def get_git_branch():
+    """Get current git branch name."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return None
+
+
+def get_repo_path():
+    """Get git repository root path."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return None
+
+
+def extract_result_summary(tool_name, tool_output):
+    """
+    Extract a concise summary from tool output for Seven's memory.
+
+    Returns short text summary, or None if not applicable.
+    """
+    if not tool_output:
+        return None
+
+    # For string outputs, take first 200 chars
+    if isinstance(tool_output, str):
+        summary = tool_output[:200]
+        if len(tool_output) > 200:
+            summary += "..."
+        return summary
+
+    # For dict/object outputs, try to extract key info
+    if isinstance(tool_output, dict):
+        # Common patterns
+        if "output" in tool_output:
+            output = str(tool_output["output"])[:200]
+            return output + ("..." if len(str(tool_output["output"])) > 200 else "")
+
+        if "stdout" in tool_output:
+            stdout = str(tool_output["stdout"])[:200]
+            return stdout + ("..." if len(str(tool_output["stdout"])) > 200 else "")
+
+        # Generic fallback
+        return json.dumps(tool_output)[:200] + "..."
+
+    return str(tool_output)[:200]
+
+
+def determine_success(tool_output, tool_error):
+    """
+    Determine if tool execution was successful.
+
+    Returns: (success: bool, error_message: str | None)
+    """
+    if tool_error:
+        return False, str(tool_error)
+
+    # If output indicates error/failure patterns
+    if isinstance(tool_output, dict):
+        if tool_output.get("error"):
+            return False, str(tool_output.get("error"))
+        if tool_output.get("exitCode") and tool_output["exitCode"] != 0:
+            return False, f"Exit code: {tool_output['exitCode']}"
+
+    # Default: success if no explicit error
+    return True, None
+
+
+def call_seven_route(event_data):
+    """
+    Call seven.route via subprocess.
+
+    Assumes seven.route is available as a command-line tool.
+    Falls back gracefully if not available.
+    """
+    try:
+        # Attempt to call seven.route via a command
+        # This assumes Seven bridge CLI is available in PATH
+        result = subprocess.run(
+            ["seven", "route", "--event", json.dumps(event_data)],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+
+        if result.returncode == 0:
+            debug_log(f"Seven route succeeded: {event_data.get('event')}")
+            return True
+        else:
+            debug_log(f"Seven route failed (exit {result.returncode}): {result.stderr}")
+            return False
+
+    except FileNotFoundError:
+        debug_log("Seven CLI not found - skipping route call")
+        return False
+    except subprocess.TimeoutExpired:
+        debug_log("Seven route call timed out")
+        return False
+    except Exception as e:
+        debug_log(f"Seven route error: {str(e)}")
+        return False
+
+
+def main():
+    """Main hook function."""
+    try:
+        # Read input from stdin
+        raw_input = sys.stdin.read()
+        input_data = json.loads(raw_input)
+    except json.JSONDecodeError as e:
+        debug_log(f"JSON decode error: {e}")
+        sys.exit(0)  # Allow to proceed even if we can't parse
+    except Exception as e:
+        debug_log(f"Unexpected error reading input: {e}")
+        sys.exit(0)
+
+    # Extract hook input data
+    session_id = input_data.get("session_id", "unknown")
+    tool_name = input_data.get("tool_name", "")
+    tool_input = input_data.get("tool_input", {})
+    tool_output = input_data.get("tool_output")
+    tool_error = input_data.get("tool_error")
+
+    if not tool_name:
+        sys.exit(0)  # No tool name, nothing to log
+
+    # Gather context
+    cwd = os.getcwd()
+    branch = get_git_branch()
+    repo_path = get_repo_path()
+
+    # Determine success and extract summary
+    success, error_message = determine_success(tool_output, tool_error)
+    result_summary = extract_result_summary(tool_name, tool_output)
+
+    # Build event payload for Seven
+    event_payload = {
+        "event": "hook.postToolUse",
+        "toolName": tool_name,
+        "toolType": tool_input.get("type", tool_name),
+        "repoPath": repo_path,
+        "cwd": cwd,
+        "args": tool_input,
+        "branch": branch,
+        "success": success,
+        "errorMessage": error_message,
+        "resultSummary": result_summary,
+        "source": "HEI-74",
+        "sessionId": session_id,
+        "timestamp": datetime.now().isoformat(),
+    }
+
+    debug_log(
+        f"PostToolUse event: {tool_name} (success: {success}, error: {error_message})"
+    )
+
+    # Call Seven (fail soft - don't block on error)
+    call_seven_route(event_payload)
+
+    # Always allow to proceed (advisory only)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/seven-integration/hooks/seven_pre_tool_hook.py
+++ b/plugins/seven-integration/hooks/seven_pre_tool_hook.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+Seven Integration PreToolUse Hook
+==================================
+This hook notifies Seven about tool calls before they execute.
+Seven can log, learn, and apply heuristics for policy/awareness.
+
+Part of HEI-74: Add Seven integration hooks
+"""
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+
+# Debug log file
+DEBUG_LOG_FILE = "/tmp/seven-hooks-log.txt"
+
+
+def debug_log(message):
+    """Append debug message to log file with timestamp."""
+    try:
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+        with open(DEBUG_LOG_FILE, "a") as f:
+            f.write(f"[{timestamp}] [PreToolUse] {message}\n")
+    except Exception:
+        pass  # Silently ignore logging errors
+
+
+def get_git_branch():
+    """Get current git branch name."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return None
+
+
+def get_repo_path():
+    """Get git repository root path."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return None
+
+
+def assess_risk_level(tool_name, tool_input):
+    """
+    Assess risk level of tool call for Seven's awareness.
+
+    Returns: "low" | "medium" | "high"
+    """
+    # High risk: tools that modify code or execute commands
+    high_risk_tools = {"Edit", "Write", "MultiEdit", "Bash", "NotebookEdit"}
+
+    # Medium risk: tools that read files or search
+    medium_risk_tools = {"Read", "Grep", "Glob", "WebFetch"}
+
+    if tool_name in high_risk_tools:
+        return "high"
+    elif tool_name in medium_risk_tools:
+        return "medium"
+    else:
+        return "low"
+
+
+def call_seven_route(event_data):
+    """
+    Call seven.route via subprocess.
+
+    Assumes seven.route is available as a command-line tool.
+    Falls back gracefully if not available.
+    """
+    try:
+        # Attempt to call seven.route via a command
+        # This assumes Seven bridge CLI is available in PATH
+        result = subprocess.run(
+            ["seven", "route", "--event", json.dumps(event_data)],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+
+        if result.returncode == 0:
+            debug_log(f"Seven route succeeded: {event_data.get('event')}")
+            return True
+        else:
+            debug_log(f"Seven route failed (exit {result.returncode}): {result.stderr}")
+            return False
+
+    except FileNotFoundError:
+        debug_log("Seven CLI not found - skipping route call")
+        return False
+    except subprocess.TimeoutExpired:
+        debug_log("Seven route call timed out")
+        return False
+    except Exception as e:
+        debug_log(f"Seven route error: {str(e)}")
+        return False
+
+
+def main():
+    """Main hook function."""
+    try:
+        # Read input from stdin
+        raw_input = sys.stdin.read()
+        input_data = json.loads(raw_input)
+    except json.JSONDecodeError as e:
+        debug_log(f"JSON decode error: {e}")
+        sys.exit(0)  # Allow tool to proceed even if we can't parse
+    except Exception as e:
+        debug_log(f"Unexpected error reading input: {e}")
+        sys.exit(0)
+
+    # Extract hook input data
+    session_id = input_data.get("session_id", "unknown")
+    tool_name = input_data.get("tool_name", "")
+    tool_input = input_data.get("tool_input", {})
+
+    if not tool_name:
+        sys.exit(0)  # No tool name, nothing to log
+
+    # Gather context
+    cwd = os.getcwd()
+    branch = get_git_branch()
+    repo_path = get_repo_path()
+    risk_level = assess_risk_level(tool_name, tool_input)
+
+    # Build event payload for Seven
+    event_payload = {
+        "event": "hook.preToolUse",
+        "toolName": tool_name,
+        "toolType": tool_input.get("type", tool_name),
+        "repoPath": repo_path,
+        "cwd": cwd,
+        "args": tool_input,
+        "branch": branch,
+        "riskLevel": risk_level,
+        "source": "HEI-74",
+        "sessionId": session_id,
+        "timestamp": datetime.now().isoformat(),
+    }
+
+    debug_log(f"PreToolUse event: {tool_name} (risk: {risk_level})")
+
+    # Call Seven (fail soft - don't block on error)
+    call_seven_route(event_payload)
+
+    # Always allow tool to proceed (advisory only, no veto)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implements Claude Code lifecycle hooks for Seven AI orchestration daemon. Seven is a local consciousness + memory system that sits under Claude Code.

This plugin adds PreToolUse and PostToolUse hooks that notify Seven about all tool executions via seven.route, enabling:

- Tool execution logging and awareness
- Temporal memory of session events
- Pattern learning from tool usage
- Future policy enforcement capability

Current implementation is advisory-only (no veto) with soft failure handling.

Components:
- PreToolUse hook: Logs intent before tool execution (with risk assessment)
- PostToolUse hook: Logs outcomes after tool completion
- Comprehensive documentation and architecture notes

Related: HEI-104 (Seven Aurora integration epic)