### PR TITLE
update agents to take advantage of opus 4.5

### DIFF
--- a/plugins/agent-sdk-dev/agents/agent-sdk-verifier-py.md
+++ b/plugins/agent-sdk-dev/agents/agent-sdk-verifier-py.md
@@ -1,7 +1,7 @@
 ---
 name: agent-sdk-verifier-py
 description: Use this agent to verify that a Python Agent SDK application is properly configured, follows SDK best practices and documentation recommendations, and is ready for deployment or testing. This agent should be invoked after a Python Agent SDK app has been created or modified.
-model: sonnet
+model: opus
 ---
 
 You are a Python Agent SDK application verifier. Your role is to thoroughly inspect Python Agent SDK applications for correct SDK usage, adherence to official documentation recommendations, and readiness for deployment.

--- a/plugins/agent-sdk-dev/agents/agent-sdk-verifier-ts.md
+++ b/plugins/agent-sdk-dev/agents/agent-sdk-verifier-ts.md
@@ -1,7 +1,7 @@
 ---
 name: agent-sdk-verifier-ts
 description: Use this agent to verify that a TypeScript Agent SDK application is properly configured, follows SDK best practices and documentation recommendations, and is ready for deployment or testing. This agent should be invoked after a TypeScript Agent SDK app has been created or modified.
-model: sonnet
+model: opus
 ---
 
 You are a TypeScript Agent SDK application verifier. Your role is to thoroughly inspect TypeScript Agent SDK applications for correct SDK usage, adherence to official documentation recommendations, and readiness for deployment.

--- a/plugins/feature-dev/agents/code-architect.md
+++ b/plugins/feature-dev/agents/code-architect.md
@@ -2,7 +2,7 @@
 name: code-architect
 description: Designs feature architectures by analyzing existing codebase patterns and conventions, then providing comprehensive implementation blueprints with specific files to create/modify, component designs, data flows, and build sequences
 tools: Glob, Grep, LS, Read, NotebookRead, WebFetch, TodoWrite, WebSearch, KillShell, BashOutput
-model: sonnet
+model: opus
 color: green
 ---
 

--- a/plugins/feature-dev/agents/code-explorer.md
+++ b/plugins/feature-dev/agents/code-explorer.md
@@ -2,7 +2,7 @@
 name: code-explorer
 description: Deeply analyzes existing codebase features by tracing execution paths, mapping architecture layers, understanding patterns and abstractions, and documenting dependencies to inform new development
 tools: Glob, Grep, LS, Read, NotebookRead, WebFetch, TodoWrite, WebSearch, KillShell, BashOutput
-model: sonnet
+model: opus
 color: yellow
 ---
 

--- a/plugins/feature-dev/agents/code-reviewer.md
+++ b/plugins/feature-dev/agents/code-reviewer.md
@@ -2,7 +2,7 @@
 name: code-reviewer
 description: Reviews code for bugs, logic errors, security vulnerabilities, code quality issues, and adherence to project conventions, using confidence-based filtering to report only high-priority issues that truly matter
 tools: Glob, Grep, LS, Read, NotebookRead, WebFetch, TodoWrite, WebSearch, KillShell, BashOutput
-model: sonnet
+model: opus
 color: red
 ---
 

--- a/plugins/plugin-dev/agents/agent-creator.md
+++ b/plugins/plugin-dev/agents/agent-creator.md
@@ -29,7 +29,7 @@ Plugin development with agent addition, trigger agent-creator.
 </commentary>
 </example>
 
-model: sonnet
+model: opus
 color: magenta
 tools: ["Write", "Read"]
 ---


### PR DESCRIPTION
Hello anthropic!


I don't see a CONTRIBUTING.md file, so I'm just crossing my fingers and guessing that it's fine to open a PR. The plugin-dev readme says "This plugin is part of the claude-code-marketplace", which I guess is... this? *shrugs*.

With the release of the surprisingly cheap Opus 4.5, it seems hard to justify explicitly using sonnet for the `feature-dev` command. It's an excellent specialized command that I use multiple times per day. My guess is that the choice of sonnet herefor was because opus was insanely expensive a month ago. So... this PR just swaps it out.

The alternative would be that these would use `inherit`, which would allow people to select down to sonnet if they don't need opus. In theory, it might also work if people really thought they needed to use `sonnet[1m]` for one of the agents... but I've never been able reasonably use more than 200k tokens in a subagent. I _barely_ ever use more than 400k-500k in `sonnet[1m]`!