### PR TITLE
fix: Add missing hookEventName to PreToolUse hook documentation

### DIFF
--- a/plugins/plugin-dev/skills/hook-development/SKILL.md
+++ b/plugins/plugin-dev/skills/hook-development/SKILL.md
@@ -145,7 +145,9 @@ Execute before any tool runs. Use to approve, deny, or modify tool calls.
 ```json
 {
   "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
     "permissionDecision": "allow|deny|ask",
+    "permissionDecisionReason": "Explanation for decision",
     "updatedInput": {"field": "modified_value"}
   },
   "systemMessage": "Explanation for Claude"

--- a/plugins/plugin-dev/skills/hook-development/examples/validate-bash.sh
+++ b/plugins/plugin-dev/skills/hook-development/examples/validate-bash.sh
@@ -23,19 +23,19 @@ fi
 
 # Check for destructive operations
 if [[ "$command" == *"rm -rf"* ]] || [[ "$command" == *"rm -fr"* ]]; then
-  echo '{"hookSpecificOutput": {"permissionDecision": "deny"}, "systemMessage": "Dangerous command detected: rm -rf"}' >&2
+  echo '{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": "Dangerous command detected: rm -rf"}}' >&2
   exit 2
 fi
 
 # Check for other dangerous commands
 if [[ "$command" == *"dd if="* ]] || [[ "$command" == *"mkfs"* ]] || [[ "$command" == *"> /dev/"* ]]; then
-  echo '{"hookSpecificOutput": {"permissionDecision": "deny"}, "systemMessage": "Dangerous system operation detected"}' >&2
+  echo '{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": "Dangerous system operation detected"}}' >&2
   exit 2
 fi
 
 # Check for privilege escalation
 if [[ "$command" == sudo* ]] || [[ "$command" == su* ]]; then
-  echo '{"hookSpecificOutput": {"permissionDecision": "ask"}, "systemMessage": "Command requires elevated privileges"}' >&2
+  echo '{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "ask", "permissionDecisionReason": "Command requires elevated privileges"}}' >&2
   exit 2
 fi
 

--- a/plugins/plugin-dev/skills/hook-development/examples/validate-write.sh
+++ b/plugins/plugin-dev/skills/hook-development/examples/validate-write.sh
@@ -18,19 +18,19 @@ fi
 
 # Check for path traversal
 if [[ "$file_path" == *".."* ]]; then
-  echo '{"hookSpecificOutput": {"permissionDecision": "deny"}, "systemMessage": "Path traversal detected in: '"$file_path"'"}' >&2
+  echo '{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": "Path traversal detected in: '"$file_path"'"}}' >&2
   exit 2
 fi
 
 # Check for system directories
 if [[ "$file_path" == /etc/* ]] || [[ "$file_path" == /sys/* ]] || [[ "$file_path" == /usr/* ]]; then
-  echo '{"hookSpecificOutput": {"permissionDecision": "deny"}, "systemMessage": "Cannot write to system directory: '"$file_path"'"}' >&2
+  echo '{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": "Cannot write to system directory: '"$file_path"'"}}' >&2
   exit 2
 fi
 
 # Check for sensitive files
 if [[ "$file_path" == *.env ]] || [[ "$file_path" == *secret* ]] || [[ "$file_path" == *credentials* ]]; then
-  echo '{"hookSpecificOutput": {"permissionDecision": "ask"}, "systemMessage": "Writing to potentially sensitive file: '"$file_path"'"}' >&2
+  echo '{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "ask", "permissionDecisionReason": "Writing to potentially sensitive file: '"$file_path"'"}}' >&2
   exit 2
 fi
 


### PR DESCRIPTION
## Summary

The PreToolUse hook documentation and examples in the `plugin-dev` skill are missing the required `hookEventName` field inside `hookSpecificOutput`. Without this field, hooks fail at runtime with:

```
Hook returned incorrect event name: expected 'PreToolUse' but got 'undefined'
```

## Changes

- **SKILL.md**: Add `hookEventName` and `permissionDecisionReason` to the PreToolUse output format example
- **validate-bash.sh**: Add `hookEventName: "PreToolUse"` to all JSON outputs
- **validate-write.sh**: Add `hookEventName: "PreToolUse"` to all JSON outputs

## Reference

The correct format matches the official docs at https://docs.anthropic.com/en/docs/claude-code/hooks which shows:

```json
{
  "hookSpecificOutput": {
    "hookEventName": "PreToolUse",
    "permissionDecision": "allow|deny|ask",
    "permissionDecisionReason": "string",
    "updatedInput": {...}
  }
}
```

## Test plan

- [x] Verified format against official Anthropic documentation
- [x] Confirmed this fix resolves the "undefined event name" error in a real hook implementation