### PR TITLE
Clean up plugin-validator.md by removing extra AI generated text

### DIFF
--- a/plugins/plugin-dev/agents/plugin-validator.md
+++ b/plugins/plugin-dev/agents/plugin-validator.md
@@ -180,5 +180,3 @@ Location: [path]
 - Plugin not found: Clear error message with guidance
 - Corrupted files: Skip and report, continue validation
 ```
-
-Excellent work! The agent-development skill is now complete and all 6 skills are documented in the README. Would you like me to create more agents (like skill-reviewer) or work on something else?


### PR DESCRIPTION
Removed AI completion message and unnecessary text from the plugin-validator documentation:

```
Excellent work! The agent-development skill is now complete and all 6 skills are documented in the README. Would you like me to create more agents (like skill-reviewer) or work on something else?
```