### PR TITLE
fix(plugins): add missing hooks/agents/skills declarations to plugin manifests

### DIFF
--- a/plugins/explanatory-output-style/.claude-plugin/plugin.json
+++ b/plugins/explanatory-output-style/.claude-plugin/plugin.json
@@ -5,5 +5,6 @@
   "author": {
     "name": "Dickson Tsai",
     "email": "dickson@anthropic.com"
-  }
+  },
+  "hooks": "./hooks/hooks.json"
 }

--- a/plugins/feature-dev/.claude-plugin/plugin.json
+++ b/plugins/feature-dev/.claude-plugin/plugin.json
@@ -5,5 +5,6 @@
   "author": {
     "name": "Sid Bidasaria",
     "email": "sbidasaria@anthropic.com"
-  }
+  },
+  "agents": "./agents"
 }

--- a/plugins/frontend-design/.claude-plugin/plugin.json
+++ b/plugins/frontend-design/.claude-plugin/plugin.json
@@ -5,5 +5,6 @@
   "author": {
     "name": "Prithvi Rajasekaran, Alexander Bricken",
     "email": "prithvi@anthropic.com, alexander@anthropic.com"
-  }
+  },
+  "skills": "./skills"
 }

--- a/plugins/hookify/.claude-plugin/plugin.json
+++ b/plugins/hookify/.claude-plugin/plugin.json
@@ -5,5 +5,8 @@
   "author": {
     "name": "Daisy Hollman",
     "email": "daisy@anthropic.com"
-  }
+  },
+  "hooks": "./hooks/hooks.json",
+  "agents": "./agents",
+  "skills": "./skills"
 }

--- a/plugins/ralph-wiggum/.claude-plugin/plugin.json
+++ b/plugins/ralph-wiggum/.claude-plugin/plugin.json
@@ -5,5 +5,6 @@
   "author": {
     "name": "Daisy Hollman",
     "email": "daisy@anthropic.com"
-  }
+  },
+  "hooks": "./hooks/hooks.json"
 }

--- a/plugins/security-guidance/.claude-plugin/plugin.json
+++ b/plugins/security-guidance/.claude-plugin/plugin.json
@@ -5,5 +5,6 @@
   "author": {
     "name": "David Dworken",
     "email": "dworken@anthropic.com"
-  }
+  },
+  "hooks": "./hooks/hooks.json"
 }


### PR DESCRIPTION
## Summary

Several plugins in the `plugins/` directory have hooks, agents, or skills directories that exist on the filesystem but are not declared in their `plugin.json` manifests. This causes Claude Code to never discover or load these assets since plugin loading is **manifest-driven, not filesystem-driven**.

### Fixed plugins:
- **hookify**: Added `hooks`, `agents`, `skills` declarations
- **explanatory-output-style**: Added `hooks` declaration  
- **ralph-wiggum**: Added `hooks` declaration
- **security-guidance**: Added `hooks` declaration
- **feature-dev**: Added `agents` declaration
- **frontend-design**: Added `skills` declaration

## Problem

Users can have these plugins enabled in their `settings.json`, but:
- Hooks never execute (PreToolUse, PostToolUse, Stop, UserPromptSubmit events ignored)
- Agents never load into the Task tool's available subagent types
- Skills are unavailable

For example, `hookify` provides powerful user-configurable hooks via `.local.md` files, but without the manifest declaration, the hook scripts in `hooks/` are never registered with Claude Code's hook system.

## Root Cause

The `plugin.json` manifest requires explicit declarations:

```json
{
  "hooks": "./hooks/hooks.json",
  "agents": "./agents",
  "skills": "./skills"
}
```

Simply having these directories exist is not sufficient - Claude Code only loads what's declared in the manifest.

## Test plan

- [ ] Verify hookify's PreToolUse/PostToolUse/Stop/UserPromptSubmit hooks fire after session restart
- [ ] Verify `/hookify`, `/hookify:list`, `/hookify:configure` commands work
- [ ] Verify security-guidance warnings appear when editing files
- [ ] Verify feature-dev agents (code-architect, code-explorer, code-reviewer) load
- [ ] Verify frontend-design skill is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)