### PR TITLE
docs(plugin-dev): improve skill documentation quality and reduce context size

### DIFF
--- a/plugins/plugin-dev/CLAUDE.md
+++ b/plugins/plugin-dev/CLAUDE.md
@@ -1,0 +1,141 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+This is the **plugin-dev** plugin - a comprehensive toolkit for developing Claude Code plugins. It provides 7 specialized skills, 3 agents, and 1 guided workflow command for building high-quality plugins.
+
+## Plugin Structure
+
+```
+plugin-dev/
+├── .claude-plugin/plugin.json   # Plugin manifest (required location)
+├── commands/                    # Slash commands
+│   └── create-plugin.md        # /plugin-dev:create-plugin workflow
+├── agents/                      # Autonomous agents
+│   ├── agent-creator.md        # AI-assisted agent generation
+│   ├── plugin-validator.md     # Plugin structure validation
+│   └── skill-reviewer.md       # Skill quality review
+└── skills/                      # 7 specialized skills
+    ├── agent-development/      # Creating agents
+    ├── command-development/    # Creating slash commands
+    ├── hook-development/       # Event-driven hooks
+    ├── mcp-integration/        # MCP server integration
+    ├── plugin-settings/        # Configuration patterns
+    ├── plugin-structure/       # Plugin organization
+    └── skill-development/      # Creating skills
+```
+
+## Key Conventions
+
+### Skill Structure
+
+Each skill follows progressive disclosure:
+
+- `SKILL.md` - Core content (1,500-2,000 words, lean)
+- `references/` - Detailed documentation (loaded as needed)
+- `examples/` - Working code examples
+- `scripts/` - Utility scripts
+
+### Writing Style
+
+- **Skill descriptions**: Third-person ("This skill should be used when...")
+- **Skill body**: Imperative/infinitive form ("To create X, do Y")
+- **Trigger phrases**: Include specific user queries in descriptions
+
+### Path References
+
+Always use `${CLAUDE_PLUGIN_ROOT}` for portable paths in hooks, MCP configs, and scripts.
+
+### Plugin hooks.json Format
+
+Plugin hooks use wrapper format with `hooks` field:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [...],
+    "Stop": [...]
+  }
+}
+```
+
+## Testing
+
+Test the plugin locally:
+
+```bash
+cc --plugin-dir /path/to/plugin-dev
+```
+
+Validate components:
+
+```bash
+# Validate hooks
+./skills/hook-development/scripts/validate-hook-schema.sh hooks/hooks.json
+
+# Validate agents
+./skills/agent-development/scripts/validate-agent.sh agents/agent-name.md
+
+# Validate settings
+./skills/plugin-settings/scripts/validate-settings.sh .claude/plugin.local.md
+```
+
+## Component Patterns
+
+### Agents
+
+Agents require YAML frontmatter with:
+
+- `name`: kebab-case identifier (3-50 chars)
+- `description`: Starts with "Use this agent when...", includes `<example>` blocks
+- `model`: inherit/sonnet/opus/haiku
+- `color`: blue/cyan/green/yellow/magenta/red
+- `tools`: Array of allowed tools (optional)
+
+### Skills
+
+Skills require:
+
+- Directory in `skills/skill-name/`
+- `SKILL.md` with YAML frontmatter (`name`, `description`)
+- Strong trigger phrases in description
+- Progressive disclosure (detailed content in `references/`)
+
+### Commands
+
+Commands are markdown files with frontmatter:
+
+- `description`: Brief explanation
+- `argument-hint`: Optional argument placeholder
+- `allowed-tools`: Array of permitted tools
+
+### Hooks
+
+Hooks defined in `hooks/hooks.json`:
+
+- Events: PreToolUse, PostToolUse, Stop, SubagentStop, SessionStart, SessionEnd, UserPromptSubmit, PreCompact, Notification
+- Types: `prompt` (LLM-driven) or `command` (bash scripts)
+- Use matchers for tool filtering (e.g., "Write|Edit", "*")
+
+## Workflow
+
+The `/plugin-dev:create-plugin` command provides an 8-phase guided workflow:
+
+1. Discovery - Understand requirements
+2. Component Planning - Determine needed components
+3. Detailed Design - Specify each component
+4. Structure Creation - Create directories and manifest
+5. Component Implementation - Build each component
+6. Validation - Run validators
+7. Testing - Verify in Claude Code
+8. Documentation - Finalize README
+
+## Validation Agents
+
+Use these agents proactively after creating components:
+
+- **plugin-validator**: Validates entire plugin structure
+- **skill-reviewer**: Reviews skill quality and triggering
+- **agent-creator**: Generates new agents from descriptions

--- a/plugins/plugin-dev/skills/command-development/README.md
+++ b/plugins/plugin-dev/skills/command-development/README.md
@@ -9,7 +9,7 @@ This skill provides knowledge about:
 - YAML frontmatter configuration fields
 - Dynamic arguments ($ARGUMENTS, $1, $2, etc.)
 - File references with @ syntax
-- Bash execution with !` syntax
+- Bash execution with ` syntax
 - Command organization and namespacing
 - Best practices for command development
 - Plugin-specific features (${CLAUDE_PLUGIN_ROOT}, plugin patterns)
@@ -28,7 +28,7 @@ Core skill content covering:
 - YAML frontmatter fields overview
 - Dynamic arguments ($ARGUMENTS and positional)
 - File references (@ syntax)
-- Bash execution (!` syntax)
+- Bash execution (` syntax)
 - Command organization patterns
 - Best practices and common patterns
 - Troubleshooting
@@ -124,7 +124,7 @@ allowed-tools: Read, Bash(git:*)
 Command prompt content with:
 - Arguments: $1, $2, or $ARGUMENTS
 - Files: @path/to/file
-- Bash: !`command here`
+- Bash: `command here`
 ```
 
 ### Locations
@@ -143,7 +143,7 @@ Command prompt content with:
 - `@path/to/file` - Include file contents
 
 **Bash execution:**
-- `!`command`` - Execute and include output
+- ``command`` - Execute and include output
 
 ## Frontmatter Fields Quick Reference
 
@@ -197,8 +197,8 @@ description: Show Git status
 allowed-tools: Bash(git:*)
 ---
 
-Current status: !`git status`
-Recent commits: !`git log --oneline -5`
+Current status: `git status`
+Recent commits: `git log --oneline -5`
 ```
 
 ## Development Workflow

--- a/plugins/plugin-dev/skills/command-development/SKILL.md
+++ b/plugins/plugin-dev/skills/command-development/SKILL.md
@@ -416,21 +416,6 @@ $IF($1,
 3. **List requirements:** Document dependencies
 4. **Version commands:** Note breaking changes
 
-```markdown
----
-description: Deploy application to environment
-argument-hint: [environment] [version]
----
-
-<!--
-Usage: /deploy [staging|production] [version]
-Requires: AWS credentials configured
-Example: /deploy staging v1.2.3
--->
-
-Deploy application to $1 environment using version $2...
-```
-
 ## Common Patterns
 
 ### Review Pattern
@@ -443,13 +428,7 @@ allowed-tools: Read, Bash(git:*)
 
 Files changed: !`git diff --name-only`
 
-Review each file for:
-1. Code quality and style
-2. Potential bugs or issues
-3. Test coverage
-4. Documentation needs
-
-Provide specific feedback for each file.
+Review each file for code quality, bugs, test coverage, documentation needs.
 ```
 
 ### Testing Pattern
@@ -462,24 +441,7 @@ allowed-tools: Bash(npm:*)
 ---
 
 Run tests: !`npm test $1`
-
 Analyze results and suggest fixes for failures.
-```
-
-### Documentation Pattern
-
-```markdown
----
-description: Generate documentation for file
-argument-hint: [source-file]
----
-
-Generate comprehensive documentation for @$1 including:
-- Function/class descriptions
-- Parameter documentation
-- Return value descriptions
-- Usage examples
-- Edge cases and errors
 ```
 
 ### Workflow Pattern
@@ -492,7 +454,6 @@ allowed-tools: Bash(gh:*), Read
 ---
 
 PR #$1 Workflow:
-
 1. Fetch PR: !`gh pr view $1`
 2. Review changes
 3. Run checks
@@ -646,189 +607,31 @@ Review outputs and report workflow status.
 
 ## Integration with Plugin Components
 
-Commands can integrate with other plugin components for powerful workflows.
+Commands integrate with other plugin components for powerful workflows:
 
-### Agent Integration
+- **Agents**: Launch plugin agents for complex tasks (agent must exist in `plugin/agents/`)
+- **Skills**: Leverage plugin skills for specialized knowledge (mention skill name to trigger)
+- **Hooks**: Coordinate with hooks that execute on tool events
+- **Multi-component**: Combine agents, skills, and scripts in phased workflows
 
-Launch plugin agents for complex tasks:
-
-```markdown
----
-description: Deep code review
-argument-hint: [file-path]
----
-
-Initiate comprehensive review of @$1 using the code-reviewer agent.
-
-The agent will analyze:
-- Code structure
-- Security issues
-- Performance
-- Best practices
-
-Agent uses plugin resources:
-- ${CLAUDE_PLUGIN_ROOT}/config/rules.json
-- ${CLAUDE_PLUGIN_ROOT}/checklists/review.md
-```
-
-**Key points:**
-- Agent must exist in `plugin/agents/` directory
-- Claude uses Task tool to launch agent
-- Document agent capabilities
-- Reference plugin resources agent uses
-
-### Skill Integration
-
-Leverage plugin skills for specialized knowledge:
-
-```markdown
----
-description: Document API with standards
-argument-hint: [api-file]
----
-
-Document API in @$1 following plugin standards.
-
-Use the api-docs-standards skill to ensure:
-- Complete endpoint documentation
-- Consistent formatting
-- Example quality
-- Error documentation
-
-Generate production-ready API docs.
-```
-
-**Key points:**
-- Skill must exist in `plugin/skills/` directory
-- Mention skill name to trigger invocation
-- Document skill purpose
-- Explain what skill provides
-
-### Hook Coordination
-
-Design commands that work with plugin hooks:
-- Commands can prepare state for hooks to process
-- Hooks execute automatically on tool events
-- Commands should document expected hook behavior
-- Guide Claude on interpreting hook output
-
-See `references/plugin-features-reference.md` for examples of commands that coordinate with hooks
-
-### Multi-Component Workflows
-
-Combine agents, skills, and scripts:
-
-```markdown
----
-description: Comprehensive review workflow
-argument-hint: [file]
-allowed-tools: Bash(node:*), Read
----
-
-Target: @$1
-
-Phase 1 - Static Analysis:
-!`node ${CLAUDE_PLUGIN_ROOT}/scripts/lint.js $1`
-
-Phase 2 - Deep Review:
-Launch code-reviewer agent for detailed analysis.
-
-Phase 3 - Standards Check:
-Use coding-standards skill for validation.
-
-Phase 4 - Report:
-Template: @${CLAUDE_PLUGIN_ROOT}/templates/review.md
-
-Compile findings into report following template.
-```
-
-**When to use:**
-- Complex multi-step workflows
-- Leverage multiple plugin capabilities
-- Require specialized analysis
-- Need structured outputs
+**See `references/plugin-integration.md` for detailed patterns and examples.**
 
 ## Validation Patterns
 
-Commands should validate inputs and resources before processing.
+Commands should validate inputs and resources before processing:
 
-### Argument Validation
+- **Argument validation**: Check required arguments match expected values
+- **File existence**: Verify files exist before processing
+- **Plugin resources**: Validate scripts and configs are present
+- **Error handling**: Capture failures and provide helpful messages
 
-```markdown
----
-description: Deploy with validation
-argument-hint: [environment]
----
+**Best practices:** Validate early, provide helpful errors, suggest corrections.
 
-Validate environment: !`echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
-
-If $1 is valid environment:
-  Deploy to $1
-Otherwise:
-  Explain valid environments: dev, staging, prod
-  Show usage: /deploy [environment]
-```
-
-### File Existence Checks
-
-```markdown
----
-description: Process configuration
-argument-hint: [config-file]
----
-
-Check file exists: !`test -f $1 && echo "EXISTS" || echo "MISSING"`
-
-If file exists:
-  Process configuration: @$1
-Otherwise:
-  Explain where to place config file
-  Show expected format
-  Provide example configuration
-```
-
-### Plugin Resource Validation
-
-```markdown
----
-description: Run plugin analyzer
-allowed-tools: Bash(test:*)
----
-
-Validate plugin setup:
-- Script: !`test -x ${CLAUDE_PLUGIN_ROOT}/bin/analyze && echo "✓" || echo "✗"`
-- Config: !`test -f ${CLAUDE_PLUGIN_ROOT}/config.json && echo "✓" || echo "✗"`
-
-If all checks pass, run analysis.
-Otherwise, report missing components.
-```
-
-### Error Handling
-
-```markdown
----
-description: Build with error handling
-allowed-tools: Bash(*)
----
-
-Execute build: !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/build.sh 2>&1 || echo "BUILD_FAILED"`
-
-If build succeeded:
-  Report success and output location
-If build failed:
-  Analyze error output
-  Suggest likely causes
-  Provide troubleshooting steps
-```
-
-**Best practices:**
-- Validate early in command
-- Provide helpful error messages
-- Suggest corrective actions
-- Handle edge cases gracefully
+**See `references/plugin-integration.md` for validation examples.**
 
 ---
 
 For detailed frontmatter field specifications, see `references/frontmatter-reference.md`.
 For plugin-specific features and patterns, see `references/plugin-features-reference.md`.
+For plugin integration and validation patterns, see `references/plugin-integration.md`.
 For command pattern examples, see `examples/` directory.

--- a/plugins/plugin-dev/skills/command-development/SKILL.md
+++ b/plugins/plugin-dev/skills/command-development/SKILL.md
@@ -446,7 +446,7 @@ description: Review code changes
 allowed-tools: Read, Bash(git:*)
 ---
 
-Files changed: !`git diff --name-only`
+Files changed: `git diff --name-only`
 
 Review each file for code quality, bugs, test coverage, documentation needs.
 ```
@@ -460,7 +460,7 @@ argument-hint: [test-file]
 allowed-tools: Bash(npm:*)
 ---
 
-Run tests: !`npm test $1`
+Run tests: `npm test $1`
 Analyze results and suggest fixes for failures.
 ```
 
@@ -474,7 +474,7 @@ allowed-tools: Bash(gh:*), Read
 ---
 
 PR #$1 Workflow:
-1. Fetch PR: !`gh pr view $1`
+1. Fetch PR: `gh pr view $1`
 2. Review changes
 3. Run checks
 4. Approve or request changes
@@ -530,7 +530,7 @@ description: Analyze using plugin script
 allowed-tools: Bash(node:*)
 ---
 
-Run analysis: !`node ${CLAUDE_PLUGIN_ROOT}/scripts/analyze.js $1`
+Run analysis: `node ${CLAUDE_PLUGIN_ROOT}/scripts/analyze.js $1`
 
 Review results and report findings.
 ```
@@ -539,7 +539,7 @@ Review results and report findings.
 
 ```markdown
 # Execute plugin script
-!`bash ${CLAUDE_PLUGIN_ROOT}/scripts/script.sh`
+`bash ${CLAUDE_PLUGIN_ROOT}/scripts/script.sh`
 
 # Load plugin configuration
 @${CLAUDE_PLUGIN_ROOT}/config/settings.json
@@ -624,9 +624,9 @@ description: Complete build workflow
 allowed-tools: Bash(*)
 ---
 
-Build: !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/build.sh`
-Test: !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/test.sh`
-Package: !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/package.sh`
+Build: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/build.sh`
+Test: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/test.sh`
+Package: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/package.sh`
 
 Review outputs and report workflow status.
 ```

--- a/plugins/plugin-dev/skills/command-development/SKILL.md
+++ b/plugins/plugin-dev/skills/command-development/SKILL.md
@@ -11,6 +11,7 @@ version: 0.2.0
 Slash commands are frequently-used prompts defined as Markdown files that Claude executes during interactive sessions. Understanding command structure, frontmatter options, and dynamic features enables creating powerful, reusable workflows.
 
 **Key concepts:**
+
 - Markdown file format for commands
 - YAML frontmatter for configuration
 - Dynamic arguments and file references
@@ -22,6 +23,7 @@ Slash commands are frequently-used prompts defined as Markdown files that Claude
 ### What is a Slash Command?
 
 A slash command is a Markdown file containing a prompt that Claude executes when invoked. Commands provide:
+
 - **Reusability**: Define once, use repeatedly
 - **Consistency**: Standardize common workflows
 - **Sharing**: Distribute across team or projects
@@ -34,6 +36,7 @@ A slash command is a Markdown file containing a prompt that Claude executes when
 When a user invokes `/command-name`, the command content becomes Claude's instructions. Write commands as directives TO Claude about what to do, not as messages TO the user.
 
 **Correct approach (instructions for Claude):**
+
 ```markdown
 Review this code for security vulnerabilities including:
 - SQL injection
@@ -44,6 +47,7 @@ Provide specific line numbers and severity ratings.
 ```
 
 **Incorrect approach (messages to user):**
+
 ```markdown
 This command will review your code for security issues.
 You'll receive a report with vulnerability details.
@@ -54,18 +58,21 @@ The first example tells Claude what to do. The second tells the user what will h
 ### Command Locations
 
 **Project commands** (shared with team):
+
 - Location: `.claude/commands/`
 - Scope: Available in specific project
 - Label: Shown as "(project)" in `/help`
 - Use for: Team workflows, project-specific tasks
 
 **Personal commands** (available everywhere):
+
 - Location: `~/.claude/commands/`
 - Scope: Available in all projects
 - Label: Shown as "(user)" in `/help`
 - Use for: Personal workflows, cross-project utilities
 
 **Plugin commands** (bundled with plugins):
+
 - Location: `plugin-name/commands/`
 - Scope: Available when plugin installed
 - Label: Shown as "(plugin-name)" in `/help`
@@ -85,6 +92,7 @@ Commands are Markdown files with `.md` extension:
 ```
 
 **Simple command:**
+
 ```markdown
 Review this code for security vulnerabilities including:
 - SQL injection
@@ -138,6 +146,7 @@ allowed-tools: Read, Write, Edit, Bash(git:*)
 ```
 
 **Patterns:**
+
 - `Read, Write, Edit` - Specific tools
 - `Bash(git:*)` - Bash with git commands only
 - `*` - All tools (rarely needed)
@@ -157,6 +166,7 @@ model: haiku
 ```
 
 **Use cases:**
+
 - `haiku` - Fast, simple commands
 - `sonnet` - Standard workflows
 - `opus` - Complex analysis
@@ -174,6 +184,7 @@ argument-hint: [pr-number] [priority] [assignee]
 ```
 
 **Benefits:**
+
 - Helps users understand command arguments
 - Improves command discovery
 - Documents command interface
@@ -208,12 +219,14 @@ Fix issue #$ARGUMENTS following our coding standards and best practices.
 ```
 
 **Usage:**
+
 ```
 > /fix-issue 123
 > /fix-issue 456
 ```
 
 **Expands to:**
+
 ```
 Fix issue #123 following our coding standards...
 Fix issue #456 following our coding standards...
@@ -234,11 +247,13 @@ After review, assign to $3 for follow-up.
 ```
 
 **Usage:**
+
 ```
 > /review-pr 123 high alice
 ```
 
 **Expands to:**
+
 ```
 Review pull request #123 with priority level high.
 After review, assign to alice for follow-up.
@@ -253,11 +268,13 @@ Deploy $1 to $2 environment with options: $3
 ```
 
 **Usage:**
+
 ```
 > /deploy api staging --force --skip-tests
 ```
 
 **Expands to:**
+
 ```
 Deploy api to staging environment with options: --force --skip-tests
 ```
@@ -281,6 +298,7 @@ Review @$1 for:
 ```
 
 **Usage:**
+
 ```
 > /review-file src/api/users.ts
 ```
@@ -318,6 +336,7 @@ Ensure:
 Commands can execute bash commands inline to dynamically gather context before Claude processes the command. This is useful for including repository state, environment information, or project-specific context.
 
 **When to use:**
+
 - Include dynamic context (git status, environment vars, etc.)
 - Gather project/repository state
 - Build context-aware workflows
@@ -361,6 +380,7 @@ Organize commands in subdirectories:
 ```
 
 **Benefits:**
+
 - Logical grouping by category
 - Namespace shown in `/help`
 - Easier to find related commands
@@ -463,23 +483,27 @@ PR #$1 Workflow:
 ## Troubleshooting
 
 **Command not appearing:**
+
 - Check file is in correct directory
 - Verify `.md` extension present
 - Ensure valid Markdown format
 - Restart Claude Code
 
 **Arguments not working:**
+
 - Verify `$1`, `$2` syntax correct
 - Check `argument-hint` matches usage
 - Ensure no extra spaces
 
 **Bash execution failing:**
+
 - Check `allowed-tools` includes Bash
 - Verify command syntax in backticks
 - Test command in terminal first
 - Check for required permissions
 
 **File references not working:**
+
 - Verify `@` syntax correct
 - Check file path is valid
 - Ensure Read tool allowed
@@ -492,6 +516,7 @@ PR #$1 Workflow:
 Plugin commands have access to `${CLAUDE_PLUGIN_ROOT}`, an environment variable that resolves to the plugin's absolute path.
 
 **Purpose:**
+
 - Reference plugin files portably
 - Execute plugin scripts
 - Load plugin configuration
@@ -527,6 +552,7 @@ Review results and report findings.
 ```
 
 **Why use it:**
+
 - Works across all installations
 - Portable between systems
 - No hardcoded paths needed
@@ -547,12 +573,14 @@ plugin-name/
 ```
 
 **Namespace benefits:**
+
 - Logical command grouping
 - Shown in `/help` output
 - Avoid name conflicts
 - Organize related commands
 
 **Naming conventions:**
+
 - Use descriptive action names
 - Avoid generic names (test, run)
 - Consider plugin-specific prefix
@@ -631,7 +659,14 @@ Commands should validate inputs and resources before processing:
 
 ---
 
+## Additional Resources
+
 For detailed frontmatter field specifications, see `references/frontmatter-reference.md`.
 For plugin-specific features and patterns, see `references/plugin-features-reference.md`.
 For plugin integration and validation patterns, see `references/plugin-integration.md`.
+For interactive user input patterns using AskUserQuestion, see `references/interactive-commands.md`.
+For multi-step command sequences and state management, see `references/advanced-workflows.md`.
+For self-documenting command patterns and maintenance docs, see `references/documentation-patterns.md`.
+For testing approaches from syntax validation to user acceptance, see `references/testing-strategies.md`.
+For distribution guidelines and quality standards, see `references/marketplace-considerations.md`.
 For command pattern examples, see `examples/` directory.

--- a/plugins/plugin-dev/skills/command-development/examples/plugin-commands.md
+++ b/plugins/plugin-dev/skills/command-development/examples/plugin-commands.md
@@ -32,7 +32,7 @@ allowed-tools: Bash(node:*), Read
 
 Analyze @$1 using plugin's quality checker:
 
-!`node ${CLAUDE_PLUGIN_ROOT}/scripts/quality-check.js $1`
+`node ${CLAUDE_PLUGIN_ROOT}/scripts/quality-check.js $1`
 
 Review the analysis output and provide:
 1. Summary of findings
@@ -65,13 +65,13 @@ model: sonnet
 Running complete audit on $1:
 
 **Security scan:**
-!`bash ${CLAUDE_PLUGIN_ROOT}/scripts/security-scan.sh $1`
+`bash ${CLAUDE_PLUGIN_ROOT}/scripts/security-scan.sh $1`
 
 **Performance analysis:**
-!`bash ${CLAUDE_PLUGIN_ROOT}/scripts/perf-analyze.sh $1`
+`bash ${CLAUDE_PLUGIN_ROOT}/scripts/perf-analyze.sh $1`
 
 **Best practices check:**
-!`bash ${CLAUDE_PLUGIN_ROOT}/scripts/best-practices.sh $1`
+`bash ${CLAUDE_PLUGIN_ROOT}/scripts/best-practices.sh $1`
 
 Analyze all results and create comprehensive report including:
 - Critical issues requiring immediate attention
@@ -141,16 +141,16 @@ allowed-tools: Bash(*), Read
 Executing release workflow for version $1:
 
 **Step 1 - Pre-release validation:**
-!`bash ${CLAUDE_PLUGIN_ROOT}/scripts/pre-release-check.sh $1`
+`bash ${CLAUDE_PLUGIN_ROOT}/scripts/pre-release-check.sh $1`
 
 **Step 2 - Build artifacts:**
-!`bash ${CLAUDE_PLUGIN_ROOT}/scripts/build-release.sh $1`
+`bash ${CLAUDE_PLUGIN_ROOT}/scripts/build-release.sh $1`
 
 **Step 3 - Run test suite:**
-!`bash ${CLAUDE_PLUGIN_ROOT}/scripts/run-tests.sh`
+`bash ${CLAUDE_PLUGIN_ROOT}/scripts/run-tests.sh`
 
 **Step 4 - Package release:**
-!`bash ${CLAUDE_PLUGIN_ROOT}/scripts/package.sh $1`
+`bash ${CLAUDE_PLUGIN_ROOT}/scripts/package.sh $1`
 
 Review all step outputs and report:
 1. Any failures or warnings
@@ -183,9 +183,9 @@ allowed-tools: Read, Bash(*)
 
 Deployment configuration for $1: @${CLAUDE_PLUGIN_ROOT}/config/$1-deploy.json
 
-Current git state: !`git rev-parse --short HEAD`
+Current git state: `git rev-parse --short HEAD`
 
-Build info: !`cat package.json | grep -E '(name|version)'`
+Build info: `cat package.json | grep -E '(name|version)'`
 
 Execute deployment to $1 environment using configuration above.
 
@@ -304,7 +304,7 @@ Target file: @$1
 Execute comprehensive review workflow:
 
 **Phase 1: Automated Analysis**
-Run plugin analyzer: !`node ${CLAUDE_PLUGIN_ROOT}/scripts/analyze.js $1`
+Run plugin analyzer: `node ${CLAUDE_PLUGIN_ROOT}/scripts/analyze.js $1`
 
 **Phase 2: Deep Review (Agent)**
 Launch the code-quality-reviewer agent for detailed analysis.
@@ -356,19 +356,19 @@ argument-hint: [environment]
 allowed-tools: Bash(*)
 ---
 
-Validate environment argument: !`echo "$1" | grep -E "^(dev|staging|prod)$" && echo "VALID" || echo "INVALID"`
+Validate environment argument: `echo "$1" | grep -E "^(dev|staging|prod)$" && echo "VALID" || echo "INVALID"`
 
-Check build script exists: !`test -x ${CLAUDE_PLUGIN_ROOT}/scripts/build.sh && echo "EXISTS" || echo "MISSING"`
+Check build script exists: `test -x ${CLAUDE_PLUGIN_ROOT}/scripts/build.sh && echo "EXISTS" || echo "MISSING"`
 
-Verify configuration available: !`test -f ${CLAUDE_PLUGIN_ROOT}/config/$1.json && echo "FOUND" || echo "NOT_FOUND"`
+Verify configuration available: `test -f ${CLAUDE_PLUGIN_ROOT}/config/$1.json && echo "FOUND" || echo "NOT_FOUND"`
 
 If all validations pass:
 
 **Configuration:** @${CLAUDE_PLUGIN_ROOT}/config/$1.json
 
-**Execute build:** !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/build.sh $1 2>&1`
+**Execute build:** `bash ${CLAUDE_PLUGIN_ROOT}/scripts/build.sh $1 2>&1`
 
-**Validation results:** !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/validate-build.sh $1 2>&1`
+**Validation results:** `bash ${CLAUDE_PLUGIN_ROOT}/scripts/validate-build.sh $1 2>&1`
 
 Report build status and any issues.
 
@@ -405,17 +405,17 @@ Environment: $1
 
 Load environment configuration: @${CLAUDE_PLUGIN_ROOT}/config/$1-checks.json
 
-Determine check level: !`echo "$1" | grep -E "^prod$" && echo "FULL" || echo "BASIC"`
+Determine check level: `echo "$1" | grep -E "^prod$" && echo "FULL" || echo "BASIC"`
 
 **For production environment:**
-- Full test suite: !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/test-full.sh`
-- Security scan: !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/security-scan.sh`
-- Performance audit: !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/perf-check.sh`
-- Compliance check: !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/compliance.sh`
+- Full test suite: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/test-full.sh`
+- Security scan: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/security-scan.sh`
+- Performance audit: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/perf-check.sh`
+- Compliance check: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/compliance.sh`
 
 **For non-production environments:**
-- Basic tests: !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/test-basic.sh`
-- Quick lint: !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/lint.sh`
+- Basic tests: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/test-basic.sh`
+- Quick lint: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/lint.sh`
 
 Analyze results based on environment requirements:
 
@@ -438,7 +438,7 @@ Report status and recommend proceed/block decision.
 
 ### Pattern: Plugin Script Execution
 ```markdown
-!`node ${CLAUDE_PLUGIN_ROOT}/scripts/script-name.js $1`
+`node ${CLAUDE_PLUGIN_ROOT}/scripts/script-name.js $1`
 ```
 Use for: Running plugin-provided Node.js scripts
 
@@ -468,13 +468,13 @@ Use for: Leveraging plugin skills for specialized knowledge
 
 ### Pattern: Input Validation
 ```markdown
-Validate input: !`echo "$1" | grep -E "^pattern$" && echo "OK" || echo "ERROR"`
+Validate input: `echo "$1" | grep -E "^pattern$" && echo "OK" || echo "ERROR"`
 ```
 Use for: Validating command arguments
 
 ### Pattern: Resource Validation
 ```markdown
-Check exists: !`test -f ${CLAUDE_PLUGIN_ROOT}/path/file && echo "YES" || echo "NO"`
+Check exists: `test -f ${CLAUDE_PLUGIN_ROOT}/path/file && echo "YES" || echo "NO"`
 ```
 Use for: Verifying required plugin files exist
 
@@ -493,7 +493,7 @@ Use for: Verifying required plugin files exist
 2. **Verify ${CLAUDE_PLUGIN_ROOT} expansion:**
    ```bash
    # Add debug output to command
-   !`echo "Plugin root: ${CLAUDE_PLUGIN_ROOT}"`
+   `echo "Plugin root: ${CLAUDE_PLUGIN_ROOT}"`
    ```
 
 3. **Test across different working directories:**
@@ -505,8 +505,8 @@ Use for: Verifying required plugin files exist
 4. **Validate resource availability:**
    ```bash
    # Check all plugin resources exist
-   !`ls -la ${CLAUDE_PLUGIN_ROOT}/scripts/`
-   !`ls -la ${CLAUDE_PLUGIN_ROOT}/config/`
+   `ls -la ${CLAUDE_PLUGIN_ROOT}/scripts/`
+   `ls -la ${CLAUDE_PLUGIN_ROOT}/config/`
    ```
 
 ### Common Mistakes to Avoid
@@ -514,22 +514,22 @@ Use for: Verifying required plugin files exist
 1. **Using relative paths instead of ${CLAUDE_PLUGIN_ROOT}:**
    ```markdown
    # Wrong
-   !`node ./scripts/analyze.js`
+   `node ./scripts/analyze.js`
 
    # Correct
-   !`node ${CLAUDE_PLUGIN_ROOT}/scripts/analyze.js`
+   `node ${CLAUDE_PLUGIN_ROOT}/scripts/analyze.js`
    ```
 
 2. **Forgetting to allow required tools:**
    ```markdown
    # Missing allowed-tools
-   !`bash script.sh`  # Will fail without Bash permission
+   `bash script.sh`  # Will fail without Bash permission
 
    # Correct
    ---
    allowed-tools: Bash(*)
    ---
-   !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/script.sh`
+   `bash ${CLAUDE_PLUGIN_ROOT}/scripts/script.sh`
    ```
 
 3. **Not validating inputs:**
@@ -538,7 +538,7 @@ Use for: Verifying required plugin files exist
    Deploy to $1 environment
 
    # Better - with validation
-   Validate: !`echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
+   Validate: `echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
    Deploy to $1 environment (if valid)
    ```
 

--- a/plugins/plugin-dev/skills/command-development/examples/simple-commands.md
+++ b/plugins/plugin-dev/skills/command-development/examples/simple-commands.md
@@ -97,7 +97,7 @@ allowed-tools: Bash(npm:*), Bash(jest:*)
 
 Run tests for $1:
 
-Test execution: !`npm test $1`
+Test execution: `npm test $1`
 
 Analyze results:
 - Tests passed/failed
@@ -172,13 +172,13 @@ allowed-tools: Bash(git:*)
 
 Repository Status Summary:
 
-**Current Branch:** !`git branch --show-current`
+**Current Branch:** `git branch --show-current`
 
-**Status:** !`git status --short`
+**Status:** `git status --short`
 
-**Recent Commits:** !`git log --oneline -5`
+**Recent Commits:** `git log --oneline -5`
 
-**Remote Status:** !`git fetch && git status -sb`
+**Remote Status:** `git fetch && git status -sb`
 
 Provide:
 - Summary of changes
@@ -209,7 +209,7 @@ Deploy to $1 environment using version $2
 **Pre-deployment Checks:**
 1. Verify $1 configuration exists
 2. Check version $2 is valid
-3. Verify cluster accessibility: !`kubectl cluster-info`
+3. Verify cluster accessibility: `kubectl cluster-info`
 
 **Deployment Steps:**
 1. Update deployment manifest with version $2
@@ -428,7 +428,7 @@ Analyze but don't modify...
 allowed-tools: Bash(git:*)
 ---
 
-!`git status`
+`git status`
 Analyze and suggest...
 ```
 
@@ -485,7 +485,7 @@ Compare @$1 with @$2...
 allowed-tools: Bash(git:*), Read
 ---
 
-Context: !`git status`
+Context: `git status`
 Files: @file1 @file2
 
 Analyze...

--- a/plugins/plugin-dev/skills/command-development/references/advanced-workflows.md
+++ b/plugins/plugin-dev/skills/command-development/references/advanced-workflows.md
@@ -22,10 +22,10 @@ allowed-tools: Bash(gh:*), Read, Grep
 # PR Review Workflow for #$1
 
 ## Step 1: Fetch PR Details
-!`gh pr view $1 --json title,body,author,files`
+`gh pr view $1 --json title,body,author,files`
 
 ## Step 2: Review Files
-Files changed: !`gh pr diff $1 --name-only`
+Files changed: `gh pr diff $1 --name-only`
 
 For each file:
 - Check code quality
@@ -33,7 +33,7 @@ For each file:
 - Review documentation
 
 ## Step 3: Run Checks
-Test status: !`gh pr checks $1`
+Test status: `gh pr checks $1`
 
 Verify:
 - All tests passing
@@ -75,8 +75,8 @@ allowed-tools: Write, Bash(git:*)
 
 Creating deployment tracking file...
 
-Current branch: !`git branch --show-current`
-Latest commit: !`git log -1 --format=%H`
+Current branch: `git branch --show-current`
+Latest commit: `git log -1 --format=%H`
 
 Deployment state saved to `.claude/deployment-state.local.md`:
 
@@ -112,7 +112,7 @@ allowed-tools: Read, Bash(npm:*)
 
 Reading deployment state from `.claude/deployment-state.local.md`...
 
-Running tests: !`npm test`
+Running tests: `npm test`
 
 Updating state to 'tested'...
 
@@ -140,8 +140,8 @@ allowed-tools: Bash(git:*), Bash(npm:*), Read
 
 ## Pre-flight Checks
 
-Branch: !`git branch --show-current`
-Status: !`git status --short`
+Branch: `git branch --show-current`
+Status: `git status --short`
 
 **Checking conditions:**
 
@@ -151,7 +151,7 @@ Status: !`git status --short`
    - If hotfix: Fast-track process
 
 2. Tests:
-   !`npm test`
+   `npm test`
    - If tests fail: STOP - fix tests first
    - If tests pass: Continue
 
@@ -528,7 +528,7 @@ description: Resilient deployment workflow
 Running steps with error handling...
 
 ## Step 1: Tests
-!`npm test`
+`npm test`
 
 if [ $? -ne 0 ]; then
   ERROR: Tests failed
@@ -557,17 +557,17 @@ description: Deployment with rollback
 # Deploy with Rollback
 
 Saving current state for rollback...
-Previous version: !`current-version.sh`
+Previous version: `current-version.sh`
 
 Deploying new version...
 
-!`deploy.sh`
+`deploy.sh`
 
 if [ $? -ne 0 ]; then
   DEPLOYMENT FAILED
 
   Initiating automatic rollback...
-  !`rollback.sh`
+  `rollback.sh`
 
   Rolled back to previous version.
   Check logs for failure details.
@@ -586,15 +586,15 @@ description: Workflow with checkpoints
 # Multi-Stage Deployment
 
 ## Checkpoint 1: Validation
-!`validate.sh`
+`validate.sh`
 echo "checkpoint:validation" >> .claude/deployment-checkpoints.log
 
 ## Checkpoint 2: Build
-!`build.sh`
+`build.sh`
 echo "checkpoint:build" >> .claude/deployment-checkpoints.log
 
 ## Checkpoint 3: Deploy
-!`deploy.sh`
+`deploy.sh`
 echo "checkpoint:deploy" >> .claude/deployment-checkpoints.log
 
 If any step fails, resume with:
@@ -653,10 +653,10 @@ Creating workflow state...
 ---
 workflow: deployment
 environment: $1
-branch: !`git branch --show-current`
-commit: !`git rev-parse HEAD`
+branch: `git branch --show-current`
+commit: `git rev-parse HEAD`
 stage: initialized
-timestamp: !`date -u +%Y-%m-%dT%H:%M:%SZ`
+timestamp: `date -u +%Y-%m-%dT%H:%M:%SZ`
 ---
 \`\`\`
 
@@ -697,7 +697,7 @@ Reading state: @.claude/deployment-state.local.md
 
 Executing deployment to [environment]...
 
-!`deploy.sh [environment]`
+`deploy.sh [environment]`
 
 Deployment complete.
 Updating state to 'completed'...

--- a/plugins/plugin-dev/skills/command-development/references/documentation-patterns.md
+++ b/plugins/plugin-dev/skills/command-development/references/documentation-patterns.md
@@ -126,7 +126,7 @@ description: Complex multi-step command
 <!-- This section checks prerequisites before proceeding -->
 
 Checking prerequisites...
-- Git repository: !`git rev-parse --git-dir 2>/dev/null`
+- Git repository: `git rev-parse --git-dir 2>/dev/null`
 - Branch exists: [validation logic]
 
 <!-- SECTION 2: ANALYSIS -->
@@ -156,7 +156,7 @@ description: Deployment command with inline docs
 ## Pre-flight Checks
 
 <!-- We check branch status to prevent deploying from wrong branch -->
-Current branch: !`git branch --show-current`
+Current branch: `git branch --show-current`
 
 <!-- Production deploys must come from main/master -->
 if [ "$1" = "production" ] && [ "$(git branch --show-current)" != "main" ]; then
@@ -165,7 +165,7 @@ if [ "$1" = "production" ] && [ "$(git branch --show-current)" != "main" ]; then
 fi
 
 <!-- Test status ensures we don't deploy broken code -->
-Running tests: !`npm test`
+Running tests: `npm test`
 
 ✓ All checks passed
 
@@ -202,7 +202,7 @@ description: Interactive deployment command
 ## Configuration Review
 
 Target: $1
-Current version: !`cat version.txt`
+Current version: `cat version.txt`
 New version: $2
 
 <!-- DECISION POINT: User confirms configuration -->
@@ -360,7 +360,7 @@ description: Command with recovery guidance
 
 Running operation...
 
-!`risky-operation.sh`
+`risky-operation.sh`
 
 if [ $? -ne 0 ]; then
   ❌ OPERATION FAILED

--- a/plugins/plugin-dev/skills/command-development/references/frontmatter-reference.md
+++ b/plugins/plugin-dev/skills/command-development/references/frontmatter-reference.md
@@ -353,7 +353,7 @@ description: Review Git changes
 allowed-tools: Bash(git:*), Read
 ---
 
-Current changes: !`git diff --name-only`
+Current changes: `git diff --name-only`
 
 Review each changed file for:
 - Code quality
@@ -377,7 +377,7 @@ Deploy $1 to $2 environment using version $3
 
 Pre-deployment checks:
 - Verify $2 configuration
-- Check cluster status: !`kubectl cluster-info`
+- Check cluster status: `kubectl cluster-info`
 - Validate version $3 exists
 
 Proceed with deployment following deployment runbook.
@@ -402,7 +402,7 @@ This command requires human judgment and cannot be automated.
 
 Review deployment $1 for production approval:
 
-Deployment details: !`gh api /deployments/$1`
+Deployment details: `gh api /deployments/$1`
 
 Verify:
 - All tests passed

--- a/plugins/plugin-dev/skills/command-development/references/interactive-commands.md
+++ b/plugins/plugin-dev/skills/command-development/references/interactive-commands.md
@@ -634,9 +634,9 @@ allowed-tools: AskUserQuestion, Bash, Read
 ## Detect Current State
 
 Check existing configuration:
-- Current language: !`detect-language.sh`
-- Existing frameworks: !`detect-frameworks.sh`
-- Available tools: !`check-tools.sh`
+- Current language: `detect-language.sh`
+- Existing frameworks: `detect-frameworks.sh`
+- Available tools: `check-tools.sh`
 
 ## Ask Context-Appropriate Questions
 

--- a/plugins/plugin-dev/skills/command-development/references/marketplace-considerations.md
+++ b/plugins/plugin-dev/skills/command-development/references/marketplace-considerations.md
@@ -49,7 +49,7 @@ fi
 
 ```markdown
 <!-- BAD: macOS-specific -->
-!`pbcopy < file.txt`
+`pbcopy < file.txt`
 
 <!-- GOOD: Platform detection -->
 if command -v pbcopy > /dev/null; then

--- a/plugins/plugin-dev/skills/command-development/references/plugin-features-reference.md
+++ b/plugins/plugin-dev/skills/command-development/references/plugin-features-reference.md
@@ -94,14 +94,14 @@ description: Analyze using plugin script
 allowed-tools: Bash(node:*), Read
 ---
 
-Run analysis: !`node ${CLAUDE_PLUGIN_ROOT}/scripts/analyze.js`
+Run analysis: `node ${CLAUDE_PLUGIN_ROOT}/scripts/analyze.js`
 
 Read template: @${CLAUDE_PLUGIN_ROOT}/templates/report.md
 ```
 
 **Expands to:**
 ```
-Run analysis: !`node /path/to/plugins/plugin-name/scripts/analyze.js`
+Run analysis: `node /path/to/plugins/plugin-name/scripts/analyze.js`
 
 Read template: @/path/to/plugins/plugin-name/templates/report.md
 ```
@@ -116,7 +116,7 @@ description: Run custom linter from plugin
 allowed-tools: Bash(node:*)
 ---
 
-Lint results: !`node ${CLAUDE_PLUGIN_ROOT}/bin/lint.js $1`
+Lint results: `node ${CLAUDE_PLUGIN_ROOT}/bin/lint.js $1`
 
 Review the linting output and suggest fixes.
 ```
@@ -154,9 +154,9 @@ description: Complete plugin workflow
 allowed-tools: Bash(*), Read
 ---
 
-Step 1 - Prepare: !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/prepare.sh $1`
+Step 1 - Prepare: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/prepare.sh $1`
 Step 2 - Config: @${CLAUDE_PLUGIN_ROOT}/config/$1.json
-Step 3 - Execute: !`${CLAUDE_PLUGIN_ROOT}/bin/execute $1`
+Step 3 - Execute: `${CLAUDE_PLUGIN_ROOT}/bin/execute $1`
 
 Review results and report status.
 ```
@@ -179,7 +179,7 @@ Review results and report status.
    allowed-tools: Bash(test:*), Read
    ---
 
-   !`test -f ${CLAUDE_PLUGIN_ROOT}/config.json && echo "exists" || echo "missing"`
+   `test -f ${CLAUDE_PLUGIN_ROOT}/config.json && echo "exists" || echo "missing"`
 
    If config exists, load it: @${CLAUDE_PLUGIN_ROOT}/config.json
    Otherwise, use defaults...
@@ -198,7 +198,7 @@ Review results and report status.
 
 4. **Combine with arguments:**
    ```markdown
-   Run: !`${CLAUDE_PLUGIN_ROOT}/bin/process.sh $1 $2`
+   Run: `${CLAUDE_PLUGIN_ROOT}/bin/process.sh $1 $2`
    ```
 
 ### Troubleshooting
@@ -234,8 +234,8 @@ Load configuration: @${CLAUDE_PLUGIN_ROOT}/deploy-config.json
 
 Deploy to $1 environment using:
 1. Configuration settings above
-2. Current git branch: !`git branch --show-current`
-3. Application version: !`cat package.json | grep version`
+2. Current git branch: `git branch --show-current`
+3. Application version: `cat package.json | grep version`
 
 Execute deployment and monitor progress.
 ```
@@ -274,9 +274,9 @@ description: Complete build and test workflow
 allowed-tools: Bash(*)
 ---
 
-Build: !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/build.sh`
-Validate: !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/validate.sh`
-Test: !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/test.sh`
+Build: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/build.sh`
+Validate: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/validate.sh`
+Test: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/test.sh`
 
 Review all outputs and report:
 1. Build status
@@ -299,7 +299,7 @@ argument-hint: [dev|staging|prod]
 
 Environment config: @${CLAUDE_PLUGIN_ROOT}/config/$1.json
 
-Environment check: !`echo "Deploying to: $1"`
+Environment check: `echo "Deploying to: $1"`
 
 Deploy application using $1 environment configuration.
 Verify deployment and run smoke tests.
@@ -320,7 +320,7 @@ allowed-tools: Bash(*), Read, Write
 Cache directory: ${CLAUDE_PLUGIN_ROOT}/cache/
 
 Analyze @$1 and save results to cache:
-!`mkdir -p ${CLAUDE_PLUGIN_ROOT}/cache && date > ${CLAUDE_PLUGIN_ROOT}/cache/last-run.txt`
+`mkdir -p ${CLAUDE_PLUGIN_ROOT}/cache && date > ${CLAUDE_PLUGIN_ROOT}/cache/last-run.txt`
 
 Store analysis for future reference and comparison.
 ```
@@ -420,7 +420,7 @@ File to review: @$1
 Execute comprehensive review:
 
 1. **Static Analysis** (via plugin scripts)
-   !`node ${CLAUDE_PLUGIN_ROOT}/scripts/lint.js $1`
+   `node ${CLAUDE_PLUGIN_ROOT}/scripts/lint.js $1`
 
 2. **Deep Review** (via plugin agent)
    Launch the code-reviewer agent for detailed analysis.
@@ -448,7 +448,7 @@ description: Deploy to environment with validation
 argument-hint: [environment]
 ---
 
-Validate environment: !`echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
+Validate environment: `echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
 
 $IF($1 in [dev, staging, prod],
   Deploy to $1 environment using validated configuration,
@@ -471,7 +471,7 @@ description: Process configuration file
 argument-hint: [config-file]
 ---
 
-Check file: !`test -f $1 && echo "EXISTS" || echo "MISSING"`
+Check file: `test -f $1 && echo "EXISTS" || echo "MISSING"`
 
 Process configuration if file exists: @$1
 
@@ -491,7 +491,7 @@ description: Create deployment with version
 argument-hint: [environment] [version]
 ---
 
-Validate inputs: !`test -n "$1" -a -n "$2" && echo "OK" || echo "MISSING"`
+Validate inputs: `test -n "$1" -a -n "$2" && echo "OK" || echo "MISSING"`
 
 $IF($1 AND $2,
   Deploy version $2 to $1 environment,
@@ -510,9 +510,9 @@ allowed-tools: Bash(test:*)
 ---
 
 Validate plugin setup:
-- Config exists: !`test -f ${CLAUDE_PLUGIN_ROOT}/config.json && echo "✓" || echo "✗"`
-- Scripts exist: !`test -d ${CLAUDE_PLUGIN_ROOT}/scripts && echo "✓" || echo "✗"`
-- Tools available: !`test -x ${CLAUDE_PLUGIN_ROOT}/bin/analyze && echo "✓" || echo "✗"`
+- Config exists: `test -f ${CLAUDE_PLUGIN_ROOT}/config.json && echo "✓" || echo "✗"`
+- Scripts exist: `test -d ${CLAUDE_PLUGIN_ROOT}/scripts && echo "✓" || echo "✗"`
+- Tools available: `test -x ${CLAUDE_PLUGIN_ROOT}/bin/analyze && echo "✓" || echo "✗"`
 
 If all checks pass, proceed with analysis.
 Otherwise, report missing components and installation steps.
@@ -528,12 +528,12 @@ description: Build and validate output
 allowed-tools: Bash(*)
 ---
 
-Build: !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/build.sh`
+Build: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/build.sh`
 
 Validate output:
-- Exit code: !`echo $?`
-- Output exists: !`test -d dist && echo "✓" || echo "✗"`
-- File count: !`find dist -type f | wc -l`
+- Exit code: `echo $?`
+- Output exists: `test -d dist && echo "✓" || echo "✗"`
+- File count: `find dist -type f | wc -l`
 
 Report build status and any validation failures.
 ```
@@ -548,7 +548,7 @@ description: Process file with error handling
 argument-hint: [file-path]
 ---
 
-Try processing: !`node ${CLAUDE_PLUGIN_ROOT}/scripts/process.js $1 2>&1 || echo "ERROR: $?"`
+Try processing: `node ${CLAUDE_PLUGIN_ROOT}/scripts/process.js $1 2>&1 || echo "ERROR: $?"`
 
 If processing succeeded:
 - Report results

--- a/plugins/plugin-dev/skills/command-development/references/plugin-integration.md
+++ b/plugins/plugin-dev/skills/command-development/references/plugin-integration.md
@@ -1,0 +1,187 @@
+# Plugin Integration Patterns
+
+Commands can integrate with other plugin components for powerful workflows.
+
+## Agent Integration
+
+Launch plugin agents for complex tasks:
+
+```markdown
+---
+description: Deep code review
+argument-hint: [file-path]
+---
+
+Initiate comprehensive review of @$1 using the code-reviewer agent.
+
+The agent will analyze:
+- Code structure
+- Security issues
+- Performance
+- Best practices
+
+Agent uses plugin resources:
+- ${CLAUDE_PLUGIN_ROOT}/config/rules.json
+- ${CLAUDE_PLUGIN_ROOT}/checklists/review.md
+```
+
+**Key points:**
+
+- Agent must exist in `plugin/agents/` directory
+- Claude uses Task tool to launch agent
+- Document agent capabilities
+- Reference plugin resources agent uses
+
+## Skill Integration
+
+Leverage plugin skills for specialized knowledge:
+
+```markdown
+---
+description: Document API with standards
+argument-hint: [api-file]
+---
+
+Document API in @$1 following plugin standards.
+
+Use the api-docs-standards skill to ensure:
+- Complete endpoint documentation
+- Consistent formatting
+- Example quality
+- Error documentation
+
+Generate production-ready API docs.
+```
+
+**Key points:**
+
+- Skill must exist in `plugin/skills/` directory
+- Mention skill name to trigger invocation
+- Document skill purpose
+- Explain what skill provides
+
+## Hook Coordination
+
+Design commands that work with plugin hooks:
+
+- Commands can prepare state for hooks to process
+- Hooks execute automatically on tool events
+- Commands should document expected hook behavior
+- Guide Claude on interpreting hook output
+
+See `plugin-features-reference.md` for examples of commands that coordinate with hooks.
+
+## Multi-Component Workflows
+
+Combine agents, skills, and scripts:
+
+```markdown
+---
+description: Comprehensive review workflow
+argument-hint: [file]
+allowed-tools: Bash(node:*), Read
+---
+
+Target: @$1
+
+Phase 1 - Static Analysis:
+!`node ${CLAUDE_PLUGIN_ROOT}/scripts/lint.js $1`
+
+Phase 2 - Deep Review:
+Launch code-reviewer agent for detailed analysis.
+
+Phase 3 - Standards Check:
+Use coding-standards skill for validation.
+
+Phase 4 - Report:
+Template: @${CLAUDE_PLUGIN_ROOT}/templates/review.md
+
+Compile findings into report following template.
+```
+
+**When to use:**
+
+- Complex multi-step workflows
+- Leverage multiple plugin capabilities
+- Require specialized analysis
+- Need structured outputs
+
+## Validation Patterns
+
+Commands should validate inputs and resources before processing.
+
+### Argument Validation
+
+```markdown
+---
+description: Deploy with validation
+argument-hint: [environment]
+---
+
+Validate environment: !`echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
+
+If $1 is valid environment:
+  Deploy to $1
+Otherwise:
+  Explain valid environments: dev, staging, prod
+  Show usage: /deploy [environment]
+```
+
+### File Existence Checks
+
+```markdown
+---
+description: Process configuration
+argument-hint: [config-file]
+---
+
+Check file exists: !`test -f $1 && echo "EXISTS" || echo "MISSING"`
+
+If file exists:
+  Process configuration: @$1
+Otherwise:
+  Explain where to place config file
+  Show expected format
+  Provide example configuration
+```
+
+### Plugin Resource Validation
+
+```markdown
+---
+description: Run plugin analyzer
+allowed-tools: Bash(test:*)
+---
+
+Validate plugin setup:
+- Script: !`test -x ${CLAUDE_PLUGIN_ROOT}/bin/analyze && echo "✓" || echo "✗"`
+- Config: !`test -f ${CLAUDE_PLUGIN_ROOT}/config.json && echo "✓" || echo "✗"`
+
+If all checks pass, run analysis.
+Otherwise, report missing components.
+```
+
+### Error Handling
+
+```markdown
+---
+description: Build with error handling
+allowed-tools: Bash(*)
+---
+
+Execute build: !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/build.sh 2>&1 || echo "BUILD_FAILED"`
+
+If build succeeded:
+  Report success and output location
+If build failed:
+  Analyze error output
+  Suggest likely causes
+  Provide troubleshooting steps
+```
+
+**Best practices:**
+
+- Validate early in command
+- Provide helpful error messages
+- Suggest corrective actions
+- Handle edge cases gracefully

--- a/plugins/plugin-dev/skills/command-development/references/plugin-integration.md
+++ b/plugins/plugin-dev/skills/command-development/references/plugin-integration.md
@@ -85,7 +85,7 @@ allowed-tools: Bash(node:*), Read
 Target: @$1
 
 Phase 1 - Static Analysis:
-!`node ${CLAUDE_PLUGIN_ROOT}/scripts/lint.js $1`
+`node ${CLAUDE_PLUGIN_ROOT}/scripts/lint.js $1`
 
 Phase 2 - Deep Review:
 Launch code-reviewer agent for detailed analysis.
@@ -118,7 +118,7 @@ description: Deploy with validation
 argument-hint: [environment]
 ---
 
-Validate environment: !`echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
+Validate environment: `echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
 
 If $1 is valid environment:
   Deploy to $1
@@ -135,7 +135,7 @@ description: Process configuration
 argument-hint: [config-file]
 ---
 
-Check file exists: !`test -f $1 && echo "EXISTS" || echo "MISSING"`
+Check file exists: `test -f $1 && echo "EXISTS" || echo "MISSING"`
 
 If file exists:
   Process configuration: @$1
@@ -154,8 +154,8 @@ allowed-tools: Bash(test:*)
 ---
 
 Validate plugin setup:
-- Script: !`test -x ${CLAUDE_PLUGIN_ROOT}/bin/analyze && echo "✓" || echo "✗"`
-- Config: !`test -f ${CLAUDE_PLUGIN_ROOT}/config.json && echo "✓" || echo "✗"`
+- Script: `test -x ${CLAUDE_PLUGIN_ROOT}/bin/analyze && echo "✓" || echo "✗"`
+- Config: `test -f ${CLAUDE_PLUGIN_ROOT}/config.json && echo "✓" || echo "✗"`
 
 If all checks pass, run analysis.
 Otherwise, report missing components.
@@ -169,7 +169,7 @@ description: Build with error handling
 allowed-tools: Bash(*)
 ---
 
-Execute build: !`bash ${CLAUDE_PLUGIN_ROOT}/scripts/build.sh 2>&1 || echo "BUILD_FAILED"`
+Execute build: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/build.sh 2>&1 || echo "BUILD_FAILED"`
 
 If build succeeded:
   Report success and output location

--- a/plugins/plugin-dev/skills/command-development/references/testing-strategies.md
+++ b/plugins/plugin-dev/skills/command-development/references/testing-strategies.md
@@ -246,7 +246,7 @@ rm /tmp/test-file*.txt /tmp/large-file.bin
 ### Level 6: Bash Execution Testing
 
 **What to test:**
-- !` commands execute correctly
+- ` commands execute correctly
 - Command output included in prompt
 - Command failures handled
 - Security: only allowed commands run
@@ -261,8 +261,8 @@ description: Test bash execution
 allowed-tools: Bash(echo:*), Bash(date:*)
 ---
 
-Current date: !`date`
-Test output: !`echo "Hello from bash"`
+Current date: `date`
+Test output: `echo "Hello from bash"`
 
 Analysis of output above...
 EOF
@@ -281,7 +281,7 @@ description: Test forbidden command
 allowed-tools: Bash(echo:*)
 ---
 
-Trying forbidden: !`ls -la /`
+Trying forbidden: `ls -la /`
 EOF
 
 > /test-forbidden
@@ -486,14 +486,14 @@ jobs:
 **Bash command edge cases:**
 ```markdown
 # Commands that might fail
-!`exit 1`
-!`false`
-!`command-that-does-not-exist`
+`exit 1`
+`false`
+`command-that-does-not-exist`
 
 # Commands with special output
-!`echo ""`
-!`cat /dev/null`
-!`yes | head -n 1000000`
+`echo ""`
+`cat /dev/null`
+`yes | head -n 1000000`
 ```
 
 ## Performance Testing

--- a/plugins/plugin-dev/skills/plugin-structure/SKILL.md
+++ b/plugins/plugin-dev/skills/plugin-structure/SKILL.md
@@ -11,6 +11,7 @@ version: 0.1.0
 Claude Code plugins follow a standardized directory structure with automatic component discovery. Understanding this structure enables creating well-organized, maintainable plugins that integrate seamlessly with Claude Code.
 
 **Key concepts:**
+
 - Conventional directory layout for automatic discovery
 - Manifest-driven configuration in `.claude-plugin/plugin.json`
 - Component-based organization (commands, agents, skills, hooks)
@@ -56,6 +57,7 @@ The manifest defines plugin metadata and configuration. Located at `.claude-plug
 ```
 
 **Name requirements:**
+
 - Use kebab-case format (lowercase with hyphens)
 - Must be unique across installed plugins
 - No spaces or special characters
@@ -100,6 +102,7 @@ Specify custom paths for components (supplements default directories):
 **Important**: Custom paths supplement defaults—they don't replace them. Components in both default directories and custom paths will load.
 
 **Path rules:**
+
 - Must be relative to plugin root
 - Must start with `./`
 - Cannot use absolute paths
@@ -114,6 +117,7 @@ Specify custom paths for components (supplements default directories):
 **Auto-discovery**: All `.md` files in `commands/` load automatically
 
 **Example structure**:
+
 ```
 commands/
 ├── review.md        # /review command
@@ -122,6 +126,7 @@ commands/
 ```
 
 **File format**:
+
 ```markdown
 ---
 name: command-name
@@ -140,6 +145,7 @@ Command implementation instructions...
 **Auto-discovery**: All `.md` files in `agents/` load automatically
 
 **Example structure**:
+
 ```
 agents/
 ├── code-reviewer.md
@@ -148,6 +154,7 @@ agents/
 ```
 
 **File format**:
+
 ```markdown
 ---
 description: Agent role and expertise
@@ -168,6 +175,7 @@ Detailed agent instructions and knowledge...
 **Auto-discovery**: All `SKILL.md` files in skill subdirectories load automatically
 
 **Example structure**:
+
 ```
 skills/
 ├── api-testing/
@@ -183,6 +191,7 @@ skills/
 ```
 
 **SKILL.md format**:
+
 ```markdown
 ---
 name: Skill Name
@@ -204,6 +213,7 @@ Skill instructions and guidance...
 **Registration**: Hooks register automatically when plugin enables
 
 **Example structure**:
+
 ```
 hooks/
 ├── hooks.json           # Hook configuration
@@ -213,6 +223,7 @@ hooks/
 ```
 
 **Configuration format**:
+
 ```json
 {
   "PreToolUse": [{
@@ -237,6 +248,7 @@ hooks/
 **Auto-start**: Servers start automatically when plugin enables
 
 **Example format**:
+
 ```json
 {
   "mcpServers": {
@@ -266,17 +278,20 @@ Use `${CLAUDE_PLUGIN_ROOT}` environment variable for all intra-plugin path refer
 ```
 
 **Why it matters**: Plugins install in different locations depending on:
+
 - User installation method (marketplace, local, npm)
 - Operating system conventions
 - User preferences
 
 **Where to use it**:
+
 - Hook command paths
 - MCP server command arguments
 - Script execution references
 - Resource file paths
 
 **Never use**:
+
 - Hardcoded absolute paths (`/Users/name/plugins/...`)
 - Relative paths from working directory (`./scripts/...` in commands)
 - Home directory shortcuts (`~/plugins/...`)
@@ -284,16 +299,19 @@ Use `${CLAUDE_PLUGIN_ROOT}` environment variable for all intra-plugin path refer
 ### Path Resolution Rules
 
 **In manifest JSON fields** (hooks, MCP servers):
+
 ```json
 "command": "${CLAUDE_PLUGIN_ROOT}/scripts/tool.sh"
 ```
 
 **In component files** (commands, agents, skills):
+
 ```markdown
 Reference scripts at: ${CLAUDE_PLUGIN_ROOT}/scripts/helper.py
 ```
 
 **In executed scripts**:
+
 ```bash
 #!/bin/bash
 # ${CLAUDE_PLUGIN_ROOT} available as environment variable
@@ -305,16 +323,19 @@ source "${CLAUDE_PLUGIN_ROOT}/lib/common.sh"
 ### Component Files
 
 **Commands**: Use kebab-case `.md` files
+
 - `code-review.md` → `/code-review`
 - `run-tests.md` → `/run-tests`
 - `api-docs.md` → `/api-docs`
 
 **Agents**: Use kebab-case `.md` files describing role
+
 - `test-generator.md`
 - `code-reviewer.md`
 - `performance-analyzer.md`
 
 **Skills**: Use kebab-case directory names
+
 - `api-testing/`
 - `database-migrations/`
 - `error-handling/`
@@ -322,16 +343,19 @@ source "${CLAUDE_PLUGIN_ROOT}/lib/common.sh"
 ### Supporting Files
 
 **Scripts**: Use descriptive kebab-case names with appropriate extensions
+
 - `validate-input.sh`
 - `generate-report.py`
 - `process-data.js`
 
 **Documentation**: Use kebab-case markdown files
+
 - `api-reference.md`
 - `migration-guide.md`
 - `best-practices.md`
 
 **Configuration**: Use standard names
+
 - `hooks.json`
 - `.mcp.json`
 - `plugin.json`
@@ -348,6 +372,7 @@ Claude Code automatically discovers and loads components:
 6. **MCP servers**: Loads configuration from `.mcp.json` or manifest
 
 **Discovery timing**:
+
 - Plugin installation: Components register with Claude Code
 - Plugin enable: Components become available for use
 - No restart required: Changes take effect on next Claude Code session
@@ -406,6 +431,7 @@ Claude Code automatically discovers and loads components:
 ### Minimal Plugin
 
 Single command with no dependencies:
+
 ```
 my-plugin/
 ├── .claude-plugin/
@@ -417,6 +443,7 @@ my-plugin/
 ### Full-Featured Plugin
 
 Complete plugin with all component types:
+
 ```
 my-plugin/
 ├── .claude-plugin/
@@ -434,6 +461,7 @@ my-plugin/
 ### Skill-Focused Plugin
 
 Plugin providing only skills:
+
 ```
 my-plugin/
 ├── .claude-plugin/
@@ -448,24 +476,28 @@ my-plugin/
 ## Troubleshooting
 
 **Component not loading**:
+
 - Verify file is in correct directory with correct extension
 - Check YAML frontmatter syntax (commands, agents, skills)
 - Ensure skill has `SKILL.md` (not `README.md` or other name)
 - Confirm plugin is enabled in Claude Code settings
 
 **Path resolution errors**:
+
 - Replace all hardcoded paths with `${CLAUDE_PLUGIN_ROOT}`
 - Verify paths are relative and start with `./` in manifest
 - Check that referenced files exist at specified paths
 - Test with `echo $CLAUDE_PLUGIN_ROOT` in hook scripts
 
 **Auto-discovery not working**:
+
 - Confirm directories are at plugin root (not in `.claude-plugin/`)
 - Check file naming follows conventions (kebab-case, correct extensions)
 - Verify custom paths in manifest are correct
 - Restart Claude Code to reload plugin configuration
 
 **Conflicts between plugins**:
+
 - Use unique, descriptive component names
 - Namespace commands with plugin name if needed
 - Document potential conflicts in plugin README
@@ -473,4 +505,17 @@ my-plugin/
 
 ---
 
-For detailed examples and advanced patterns, see files in `references/` and `examples/` directories.
+## Additional Resources
+
+### Reference Files
+
+- **`references/component-patterns.md`** - Detailed patterns for each component type
+- **`references/manifest-reference.md`** - Complete plugin.json field reference
+
+### Example Files
+
+Working examples in `examples/`:
+
+- **`minimal-plugin.md`** - Single command plugin structure
+- **`standard-plugin.md`** - Typical plugin with multiple components
+- **`advanced-plugin.md`** - Full-featured plugin with all component types

--- a/plugins/plugin-dev/skills/skill-development/SKILL.md
+++ b/plugins/plugin-dev/skills/skill-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Skill Development
-description: This skill should be used when the user wants to "create a skill", "add a skill to plugin", "write a new skill", "improve skill description", "organize skill content", or needs guidance on skill structure, progressive disclosure, or skill development best practices for Claude Code plugins.
+description: This skill should be used when the user asks to "create a skill", "add a skill to plugin", "write a new skill", "improve skill description", "organize skill content", or needs guidance on skill structure, progressive disclosure, or skill development best practices for Claude Code plugins.
 version: 0.1.0
 ---
 

--- a/plugins/plugin-dev/skills/skill-development/SKILL.md
+++ b/plugins/plugin-dev/skills/skill-development/SKILL.md
@@ -52,27 +52,22 @@ Executable code (Python/Bash/etc.) for tasks that require deterministic reliabil
 - **When to include**: When the same code is being rewritten repeatedly or deterministic reliability is needed
 - **Example**: `scripts/rotate_pdf.py` for PDF rotation tasks
 - **Benefits**: Token efficient, deterministic, may be executed without loading into context
-- **Note**: Scripts may still need to be read by Claude for patching or environment-specific adjustments
 
 ##### References (`references/`)
 
-Documentation and reference material intended to be loaded as needed into context to inform Claude's process and thinking.
+Documentation and reference material intended to be loaded as needed into context.
 
 - **When to include**: For documentation that Claude should reference while working
-- **Examples**: `references/finance.md` for financial schemas, `references/mnda.md` for company NDA template, `references/policies.md` for company policies, `references/api_docs.md` for API specifications
-- **Use cases**: Database schemas, API documentation, domain knowledge, company policies, detailed workflow guides
-- **Benefits**: Keeps SKILL.md lean, loaded only when Claude determines it's needed
+- **Examples**: `references/schema.md` for database schemas, `references/api_docs.md` for API specifications
 - **Best practice**: If files are large (>10k words), include grep search patterns in SKILL.md
-- **Avoid duplication**: Information should live in either SKILL.md or references files, not both. Prefer references files for detailed information unless it's truly core to the skill—this keeps SKILL.md lean while making information discoverable without hogging the context window. Keep only essential procedural instructions and workflow guidance in SKILL.md; move detailed reference material, schemas, and examples to references files.
+- **Avoid duplication**: Information should live in either SKILL.md or references files, not both
 
 ##### Assets (`assets/`)
 
 Files not intended to be loaded into context, but rather used within the output Claude produces.
 
 - **When to include**: When the skill needs files that will be used in the final output
-- **Examples**: `assets/logo.png` for brand assets, `assets/slides.pptx` for PowerPoint templates, `assets/frontend-template/` for HTML/React boilerplate, `assets/font.ttf` for typography
-- **Use cases**: Templates, images, icons, boilerplate code, fonts, sample documents that get copied or modified
-- **Benefits**: Separates output resources from documentation, enables Claude to use files without loading them into context
+- **Examples**: `assets/logo.png` for brand assets, `assets/slides.pptx` for templates
 
 ### Progressive Disclosure Design Principle
 
@@ -86,165 +81,20 @@ Skills use a three-level loading system to manage context efficiently:
 
 ## Skill Creation Process
 
-To create a skill, follow the "Skill Creation Process" in order, skipping steps only if there is a clear reason why they are not applicable.
+To create a skill, follow these six steps. For detailed instructions on each step, see `references/skill-creation-workflow.md`.
 
-### Step 1: Understanding the Skill with Concrete Examples
+1. **Understand the Skill**: Gather concrete examples of how the skill will be used through user questions and feedback
+2. **Plan Reusable Contents**: Analyze examples to identify what scripts, references, and assets would be helpful
+3. **Create Structure**: Set up the skill directory with `mkdir -p skills/skill-name/{references,examples,scripts}`
+4. **Edit the Skill**: Write SKILL.md with proper frontmatter and imperative-form body; create bundled resources
+5. **Validate and Test**: Check structure, trigger phrases, writing style, and progressive disclosure
+6. **Iterate**: Improve based on real-world usage and feedback
 
-Skip this step only when the skill's usage patterns are already clearly understood. It remains valuable even when working with an existing skill.
+### Key Writing Guidelines
 
-To create an effective skill, clearly understand concrete examples of how the skill will be used. This understanding can come from either direct user examples or generated examples that are validated with user feedback.
-
-For example, when building an image-editor skill, relevant questions include:
-
-- "What functionality should the image-editor skill support? Editing, rotating, anything else?"
-- "Can you give some examples of how this skill would be used?"
-- "I can imagine users asking for things like 'Remove the red-eye from this image' or 'Rotate this image'. Are there other ways you imagine this skill being used?"
-- "What would a user say that should trigger this skill?"
-
-To avoid overwhelming users, avoid asking too many questions in a single message. Start with the most important questions and follow up as needed for better effectiveness.
-
-Conclude this step when there is a clear sense of the functionality the skill should support.
-
-### Step 2: Planning the Reusable Skill Contents
-
-To turn concrete examples into an effective skill, analyze each example by:
-
-1. Considering how to execute on the example from scratch
-2. Identifying what scripts, references, and assets would be helpful when executing these workflows repeatedly
-
-Example: When building a `pdf-editor` skill to handle queries like "Help me rotate this PDF," the analysis shows:
-
-1. Rotating a PDF requires re-writing the same code each time
-2. A `scripts/rotate_pdf.py` script would be helpful to store in the skill
-
-Example: When designing a `frontend-webapp-builder` skill for queries like "Build me a todo app" or "Build me a dashboard to track my steps," the analysis shows:
-
-1. Writing a frontend webapp requires the same boilerplate HTML/React each time
-2. An `assets/hello-world/` template containing the boilerplate HTML/React project files would be helpful to store in the skill
-
-Example: When building a `big-query` skill to handle queries like "How many users have logged in today?" the analysis shows:
-
-1. Querying BigQuery requires re-discovering the table schemas and relationships each time
-2. A `references/schema.md` file documenting the table schemas would be helpful to store in the skill
-
-**For Claude Code plugins:** When building a hooks skill, the analysis shows:
-1. Developers repeatedly need to validate hooks.json and test hook scripts
-2. `scripts/validate-hook-schema.sh` and `scripts/test-hook.sh` utilities would be helpful
-3. `references/patterns.md` for detailed hook patterns to avoid bloating SKILL.md
-
-To establish the skill's contents, analyze each concrete example to create a list of the reusable resources to include: scripts, references, and assets.
-
-### Step 3: Create Skill Structure
-
-For Claude Code plugins, create the skill directory structure:
-
-```bash
-mkdir -p plugin-name/skills/skill-name/{references,examples,scripts}
-touch plugin-name/skills/skill-name/SKILL.md
-```
-
-**Note:** Unlike the generic skill-creator which uses `init_skill.py`, plugin skills are created directly in the plugin's `skills/` directory with a simpler manual structure.
-
-### Step 4: Edit the Skill
-
-When editing the (newly-created or existing) skill, remember that the skill is being created for another instance of Claude to use. Focus on including information that would be beneficial and non-obvious to Claude. Consider what procedural knowledge, domain-specific details, or reusable assets would help another Claude instance execute these tasks more effectively.
-
-#### Start with Reusable Skill Contents
-
-To begin implementation, start with the reusable resources identified above: `scripts/`, `references/`, and `assets/` files. Note that this step may require user input. For example, when implementing a `brand-guidelines` skill, the user may need to provide brand assets or templates to store in `assets/`, or documentation to store in `references/`.
-
-Also, delete any example files and directories not needed for the skill. Create only the directories you actually need (references/, examples/, scripts/).
-
-#### Update SKILL.md
-
-**Writing Style:** Write the entire skill using **imperative/infinitive form** (verb-first instructions), not second person. Use objective, instructional language (e.g., "To accomplish X, do Y" rather than "You should do X" or "If you need to do X"). This maintains consistency and clarity for AI consumption.
-
-**Description (Frontmatter):** Use third-person format with specific trigger phrases:
-
-```yaml
----
-name: Skill Name
-description: This skill should be used when the user asks to "specific phrase 1", "specific phrase 2", "specific phrase 3". Include exact phrases users would say that should trigger this skill. Be concrete and specific.
-version: 0.1.0
----
-```
-
-**Good description examples:**
-```yaml
-description: This skill should be used when the user asks to "create a hook", "add a PreToolUse hook", "validate tool use", "implement prompt-based hooks", or mentions hook events (PreToolUse, PostToolUse, Stop).
-```
-
-**Bad description examples:**
-```yaml
-description: Use this skill when working with hooks.  # Wrong person, vague
-description: Load when user needs hook help.  # Not third person
-description: Provides hook guidance.  # No trigger phrases
-```
-
-To complete SKILL.md body, answer the following questions:
-
-1. What is the purpose of the skill, in a few sentences?
-2. When should the skill be used? (Include this in frontmatter description with specific triggers)
-3. In practice, how should Claude use the skill? All reusable skill contents developed above should be referenced so that Claude knows how to use them.
-
-**Keep SKILL.md lean:** Target 1,500-2,000 words for the body. Move detailed content to references/:
-- Detailed patterns → `references/patterns.md`
-- Advanced techniques → `references/advanced.md`
-- Migration guides → `references/migration.md`
-- API references → `references/api-reference.md`
-
-**Reference resources in SKILL.md:**
-```markdown
-## Additional Resources
-
-### Reference Files
-
-For detailed patterns and techniques, consult:
-- **`references/patterns.md`** - Common patterns
-- **`references/advanced.md`** - Advanced use cases
-
-### Example Files
-
-Working examples in `examples/`:
-- **`example-script.sh`** - Working example
-```
-
-### Step 5: Validate and Test
-
-**For plugin skills, validation is different from generic skills:**
-
-1. **Check structure**: Skill directory in `plugin-name/skills/skill-name/`
-2. **Validate SKILL.md**: Has frontmatter with name and description
-3. **Check trigger phrases**: Description includes specific user queries
-4. **Verify writing style**: Body uses imperative/infinitive form, not second person
-5. **Test progressive disclosure**: SKILL.md is lean (~1,500-2,000 words), detailed content in references/
-6. **Check references**: All referenced files exist
-7. **Validate examples**: Examples are complete and correct
-8. **Test scripts**: Scripts are executable and work correctly
-
-**Use the skill-reviewer agent:**
-```
-Ask: "Review my skill and check if it follows best practices"
-```
-
-The skill-reviewer agent will check description quality, content organization, and progressive disclosure.
-
-### Step 6: Iterate
-
-After testing the skill, users may request improvements. Often this happens right after using the skill, with fresh context of how the skill performed.
-
-**Iteration workflow:**
-1. Use the skill on real tasks
-2. Notice struggles or inefficiencies
-3. Identify how SKILL.md or bundled resources should be updated
-4. Implement changes and test again
-
-**Common improvements:**
-- Strengthen trigger phrases in description
-- Move long sections from SKILL.md to references/
-- Add missing examples or scripts
-- Clarify ambiguous instructions
-- Add edge case handling
+- **Description**: Use third-person ("This skill should be used when...") with specific trigger phrases
+- **Body**: Use imperative/infinitive form ("To create X, do Y"), not second person ("You should...")
+- **Size**: Target 1,500-2,000 words; move detailed content to references/
 
 ## Plugin-Specific Considerations
 
@@ -269,6 +119,7 @@ my-plugin/
 ### Auto-Discovery
 
 Claude Code automatically discovers skills:
+
 - Scans `skills/` directory
 - Finds subdirectories containing `SKILL.md`
 - Loads skill metadata (name + description) always
@@ -296,6 +147,7 @@ cc --plugin-dir /path/to/plugin
 Study the skills in this plugin as examples of best practices:
 
 **hook-development skill:**
+
 - Excellent trigger phrases: "create a hook", "add a PreToolUse hook", etc.
 - Lean SKILL.md (1,651 words)
 - 3 references/ files for detailed content
@@ -303,240 +155,49 @@ Study the skills in this plugin as examples of best practices:
 - 3 scripts/ utilities
 
 **agent-development skill:**
+
 - Strong triggers: "create an agent", "agent frontmatter", etc.
 - Focused SKILL.md (1,438 words)
 - References include the AI generation prompt from Claude Code
 - Complete agent examples
 
 **plugin-settings skill:**
+
 - Specific triggers: "plugin settings", ".local.md files", "YAML frontmatter"
 - References show real implementations (multi-agent-swarm, ralph-wiggum)
 - Working parsing scripts
 
 Each demonstrates progressive disclosure and strong triggering.
 
-## Progressive Disclosure in Practice
-
-### What Goes in SKILL.md
-
-**Include (always loaded when skill triggers):**
-- Core concepts and overview
-- Essential procedures and workflows
-- Quick reference tables
-- Pointers to references/examples/scripts
-- Most common use cases
-
-**Keep under 3,000 words, ideally 1,500-2,000 words**
-
-### What Goes in references/
-
-**Move to references/ (loaded as needed):**
-- Detailed patterns and advanced techniques
-- Comprehensive API documentation
-- Migration guides
-- Edge cases and troubleshooting
-- Extensive examples and walkthroughs
-
-**Each reference file can be large (2,000-5,000+ words)**
-
-### What Goes in examples/
-
-**Working code examples:**
-- Complete, runnable scripts
-- Configuration files
-- Template files
-- Real-world usage examples
-
-**Users can copy and adapt these directly**
-
-### What Goes in scripts/
-
-**Utility scripts:**
-- Validation tools
-- Testing helpers
-- Parsing utilities
-- Automation scripts
-
-**Should be executable and documented**
-
-## Writing Style Requirements
-
-### Imperative/Infinitive Form
-
-Write using verb-first instructions, not second person:
-
-**Correct (imperative):**
-```
-To create a hook, define the event type.
-Configure the MCP server with authentication.
-Validate settings before use.
-```
-
-**Incorrect (second person):**
-```
-You should create a hook by defining the event type.
-You need to configure the MCP server.
-You must validate settings before use.
-```
-
-### Third-Person in Description
-
-The frontmatter description must use third person:
-
-**Correct:**
-```yaml
-description: This skill should be used when the user asks to "create X", "configure Y"...
-```
-
-**Incorrect:**
-```yaml
-description: Use this skill when you want to create X...
-description: Load this skill when user asks...
-```
-
-### Objective, Instructional Language
-
-Focus on what to do, not who should do it:
-
-**Correct:**
-```
-Parse the frontmatter using sed.
-Extract fields with grep.
-Validate values before use.
-```
-
-**Incorrect:**
-```
-You can parse the frontmatter...
-Claude should extract fields...
-The user might validate values...
-```
-
 ## Validation Checklist
 
 Before finalizing a skill:
 
 **Structure:**
+
 - [ ] SKILL.md file exists with valid YAML frontmatter
 - [ ] Frontmatter has `name` and `description` fields
 - [ ] Markdown body is present and substantial
 - [ ] Referenced files actually exist
 
 **Description Quality:**
+
 - [ ] Uses third person ("This skill should be used when...")
 - [ ] Includes specific trigger phrases users would say
 - [ ] Lists concrete scenarios ("create X", "configure Y")
-- [ ] Not vague or generic
 
 **Content Quality:**
+
 - [ ] SKILL.md body uses imperative/infinitive form
-- [ ] Body is focused and lean (1,500-2,000 words ideal, <5k max)
+- [ ] Body is focused and lean (1,500-2,000 words ideal, <3k max)
 - [ ] Detailed content moved to references/
 - [ ] Examples are complete and working
-- [ ] Scripts are executable and documented
-
-**Progressive Disclosure:**
-- [ ] Core concepts in SKILL.md
-- [ ] Detailed docs in references/
-- [ ] Working code in examples/
-- [ ] Utilities in scripts/
-- [ ] SKILL.md references these resources
 
 **Testing:**
+
 - [ ] Skill triggers on expected user queries
 - [ ] Content is helpful for intended tasks
 - [ ] No duplicated information across files
-- [ ] References load when needed
-
-## Common Mistakes to Avoid
-
-### Mistake 1: Weak Trigger Description
-
-❌ **Bad:**
-```yaml
-description: Provides guidance for working with hooks.
-```
-
-**Why bad:** Vague, no specific trigger phrases, not third person
-
-✅ **Good:**
-```yaml
-description: This skill should be used when the user asks to "create a hook", "add a PreToolUse hook", "validate tool use", or mentions hook events. Provides comprehensive hooks API guidance.
-```
-
-**Why good:** Third person, specific phrases, concrete scenarios
-
-### Mistake 2: Too Much in SKILL.md
-
-❌ **Bad:**
-```
-skill-name/
-└── SKILL.md  (8,000 words - everything in one file)
-```
-
-**Why bad:** Bloats context when skill loads, detailed content always loaded
-
-✅ **Good:**
-```
-skill-name/
-├── SKILL.md  (1,800 words - core essentials)
-└── references/
-    ├── patterns.md (2,500 words)
-    └── advanced.md (3,700 words)
-```
-
-**Why good:** Progressive disclosure, detailed content loaded only when needed
-
-### Mistake 3: Second Person Writing
-
-❌ **Bad:**
-```markdown
-You should start by reading the configuration file.
-You need to validate the input.
-You can use the grep tool to search.
-```
-
-**Why bad:** Second person, not imperative form
-
-✅ **Good:**
-```markdown
-Start by reading the configuration file.
-Validate the input before processing.
-Use the grep tool to search for patterns.
-```
-
-**Why good:** Imperative form, direct instructions
-
-### Mistake 4: Missing Resource References
-
-❌ **Bad:**
-```markdown
-# SKILL.md
-
-[Core content]
-
-[No mention of references/ or examples/]
-```
-
-**Why bad:** Claude doesn't know references exist
-
-✅ **Good:**
-```markdown
-# SKILL.md
-
-[Core content]
-
-## Additional Resources
-
-### Reference Files
-- **`references/patterns.md`** - Detailed patterns
-- **`references/advanced.md`** - Advanced techniques
-
-### Examples
-- **`examples/script.sh`** - Working example
-```
-
-**Why good:** Claude knows where to find additional information
 
 ## Quick Reference
 
@@ -581,7 +242,8 @@ Good for: Complex domains with validation utilities
 
 ## Best Practices Summary
 
-✅ **DO:**
+**DO:**
+
 - Use third-person in description ("This skill should be used when...")
 - Include specific trigger phrases ("create X", "configure Y")
 - Keep SKILL.md lean (1,500-2,000 words)
@@ -590,48 +252,31 @@ Good for: Complex domains with validation utilities
 - Reference supporting files clearly
 - Provide working examples
 - Create utility scripts for common operations
-- Study plugin-dev's skills as templates
 
-❌ **DON'T:**
-- Use second person anywhere
+**DON'T:**
+
+- Use second person ("You should...")
 - Have vague trigger conditions
 - Put everything in SKILL.md (>3,000 words without references/)
-- Write in second person ("You should...")
 - Leave resources unreferenced
 - Include broken or incomplete examples
-- Skip validation
 
 ## Additional Resources
+
+### Reference Files
+
+For detailed guidance, consult:
+
+- **`references/skill-creation-workflow.md`** - Complete step-by-step skill creation process with examples, writing style guide, and common mistakes to avoid
+- **`references/skill-creator-original.md`** - Full original skill-creator methodology
 
 ### Study These Skills
 
 Plugin-dev's skills demonstrate best practices:
+
 - `../hook-development/` - Progressive disclosure, utilities
 - `../agent-development/` - AI-assisted creation, references
 - `../mcp-integration/` - Comprehensive references
 - `../plugin-settings/` - Real-world examples
 - `../command-development/` - Clear critical concepts
 - `../plugin-structure/` - Good organization
-
-### Reference Files
-
-For complete skill-creator methodology:
-- **`references/skill-creator-original.md`** - Full original skill-creator content
-
-## Implementation Workflow
-
-To create a skill for your plugin:
-
-1. **Understand use cases**: Identify concrete examples of skill usage
-2. **Plan resources**: Determine what scripts/references/examples needed
-3. **Create structure**: `mkdir -p skills/skill-name/{references,examples,scripts}`
-4. **Write SKILL.md**:
-   - Frontmatter with third-person description and trigger phrases
-   - Lean body (1,500-2,000 words) in imperative form
-   - Reference supporting files
-5. **Add resources**: Create references/, examples/, scripts/ as needed
-6. **Validate**: Check description, writing style, organization
-7. **Test**: Verify skill loads on expected triggers
-8. **Iterate**: Improve based on usage
-
-Focus on strong trigger descriptions, progressive disclosure, and imperative writing style for effective skills that load when needed and provide targeted guidance.

--- a/plugins/plugin-dev/skills/skill-development/references/skill-creation-workflow.md
+++ b/plugins/plugin-dev/skills/skill-development/references/skill-creation-workflow.md
@@ -1,0 +1,376 @@
+# Skill Creation Workflow
+
+This reference provides detailed step-by-step instructions for creating skills for Claude Code plugins. For an overview, see the main SKILL.md.
+
+## Step 1: Understanding the Skill with Concrete Examples
+
+Skip this step only when the skill's usage patterns are already clearly understood. It remains valuable even when working with an existing skill.
+
+To create an effective skill, clearly understand concrete examples of how the skill will be used. This understanding can come from either direct user examples or generated examples that are validated with user feedback.
+
+For example, when building an image-editor skill, relevant questions include:
+
+- "What functionality should the image-editor skill support? Editing, rotating, anything else?"
+- "Can you give some examples of how this skill would be used?"
+- "I can imagine users asking for things like 'Remove the red-eye from this image' or 'Rotate this image'. Are there other ways you imagine this skill being used?"
+- "What would a user say that should trigger this skill?"
+
+To avoid overwhelming users, avoid asking too many questions in a single message. Start with the most important questions and follow up as needed for better effectiveness.
+
+Conclude this step when there is a clear sense of the functionality the skill should support.
+
+## Step 2: Planning the Reusable Skill Contents
+
+To turn concrete examples into an effective skill, analyze each example by:
+
+1. Considering how to execute on the example from scratch
+2. Identifying what scripts, references, and assets would be helpful when executing these workflows repeatedly
+
+### Examples
+
+**pdf-editor skill** for queries like "Help me rotate this PDF":
+
+1. Rotating a PDF requires re-writing the same code each time
+2. A `scripts/rotate_pdf.py` script would be helpful to store in the skill
+
+**frontend-webapp-builder skill** for queries like "Build me a todo app":
+
+1. Writing a frontend webapp requires the same boilerplate HTML/React each time
+2. An `assets/hello-world/` template containing the boilerplate HTML/React project files would be helpful
+
+**big-query skill** for queries like "How many users have logged in today?":
+
+1. Querying BigQuery requires re-discovering the table schemas and relationships each time
+2. A `references/schema.md` file documenting the table schemas would be helpful
+
+**hooks skill** for Claude Code plugins:
+
+1. Developers repeatedly need to validate hooks.json and test hook scripts
+2. `scripts/validate-hook-schema.sh` and `scripts/test-hook.sh` utilities would be helpful
+3. `references/patterns.md` for detailed hook patterns to avoid bloating SKILL.md
+
+To establish the skill's contents, analyze each concrete example to create a list of the reusable resources to include: scripts, references, and assets.
+
+## Step 3: Create Skill Structure
+
+For Claude Code plugins, create the skill directory structure:
+
+```bash
+mkdir -p plugin-name/skills/skill-name/{references,examples,scripts}
+touch plugin-name/skills/skill-name/SKILL.md
+```
+
+**Note:** Unlike the generic skill-creator which uses `init_skill.py`, plugin skills are created directly in the plugin's `skills/` directory with a simpler manual structure.
+
+## Step 4: Edit the Skill
+
+When editing the (newly-created or existing) skill, remember that the skill is being created for another instance of Claude to use. Focus on including information that would be beneficial and non-obvious to Claude. Consider what procedural knowledge, domain-specific details, or reusable assets would help another Claude instance execute these tasks more effectively.
+
+### Start with Reusable Skill Contents
+
+To begin implementation, start with the reusable resources identified above: `scripts/`, `references/`, and `assets/` files. Note that this step may require user input. For example, when implementing a `brand-guidelines` skill, the user may need to provide brand assets or templates to store in `assets/`, or documentation to store in `references/`.
+
+Also, delete any example files and directories not needed for the skill. Create only the directories you actually need (references/, examples/, scripts/).
+
+### Update SKILL.md
+
+**Writing Style:** Write the entire skill using **imperative/infinitive form** (verb-first instructions), not second person. Use objective, instructional language (e.g., "To accomplish X, do Y" rather than "You should do X" or "If you need to do X"). This maintains consistency and clarity for AI consumption.
+
+**Description (Frontmatter):** Use third-person format with specific trigger phrases:
+
+```yaml
+---
+name: Skill Name
+description: This skill should be used when the user asks to "specific phrase 1", "specific phrase 2", "specific phrase 3". Include exact phrases users would say that should trigger this skill. Be concrete and specific.
+version: 0.1.0
+---
+```
+
+**Good description examples:**
+
+```yaml
+description: This skill should be used when the user asks to "create a hook", "add a PreToolUse hook", "validate tool use", "implement prompt-based hooks", or mentions hook events (PreToolUse, PostToolUse, Stop).
+```
+
+**Bad description examples:**
+
+```yaml
+description: Use this skill when working with hooks.  # Wrong person, vague
+description: Load when user needs hook help.  # Not third person
+description: Provides hook guidance.  # No trigger phrases
+```
+
+To complete SKILL.md body, answer the following questions:
+
+1. What is the purpose of the skill, in a few sentences?
+2. When should the skill be used? (Include this in frontmatter description with specific triggers)
+3. In practice, how should Claude use the skill? All reusable skill contents developed above should be referenced so that Claude knows how to use them.
+
+**Keep SKILL.md lean:** Target 1,500-2,000 words for the body. Move detailed content to references/:
+
+- Detailed patterns → `references/patterns.md`
+- Advanced techniques → `references/advanced.md`
+- Migration guides → `references/migration.md`
+- API references → `references/api-reference.md`
+
+**Reference resources in SKILL.md:**
+
+```markdown
+## Additional Resources
+
+### Reference Files
+
+For detailed patterns and techniques, consult:
+- **`references/patterns.md`** - Common patterns
+- **`references/advanced.md`** - Advanced use cases
+
+### Example Files
+
+Working examples in `examples/`:
+- **`example-script.sh`** - Working example
+```
+
+## Step 5: Validate and Test
+
+**For plugin skills, validation is different from generic skills:**
+
+1. **Check structure**: Skill directory in `plugin-name/skills/skill-name/`
+2. **Validate SKILL.md**: Has frontmatter with name and description
+3. **Check trigger phrases**: Description includes specific user queries
+4. **Verify writing style**: Body uses imperative/infinitive form, not second person
+5. **Test progressive disclosure**: SKILL.md is lean (~1,500-2,000 words), detailed content in references/
+6. **Check references**: All referenced files exist
+7. **Validate examples**: Examples are complete and correct
+8. **Test scripts**: Scripts are executable and work correctly
+
+**Use the skill-reviewer agent:**
+
+```
+Ask: "Review my skill and check if it follows best practices"
+```
+
+The skill-reviewer agent will check description quality, content organization, and progressive disclosure.
+
+## Step 6: Iterate
+
+After testing the skill, users may request improvements. Often this happens right after using the skill, with fresh context of how the skill performed.
+
+**Iteration workflow:**
+
+1. Use the skill on real tasks
+2. Notice struggles or inefficiencies
+3. Identify how SKILL.md or bundled resources should be updated
+4. Implement changes and test again
+
+**Common improvements:**
+
+- Strengthen trigger phrases in description
+- Move long sections from SKILL.md to references/
+- Add missing examples or scripts
+- Clarify ambiguous instructions
+- Add edge case handling
+
+## Progressive Disclosure in Practice
+
+### What Goes in SKILL.md
+
+**Include (always loaded when skill triggers):**
+
+- Core concepts and overview
+- Essential procedures and workflows
+- Quick reference tables
+- Pointers to references/examples/scripts
+- Most common use cases
+
+**Keep under 3,000 words, ideally 1,500-2,000 words**
+
+### What Goes in references/
+
+**Move to references/ (loaded as needed):**
+
+- Detailed patterns and advanced techniques
+- Comprehensive API documentation
+- Migration guides
+- Edge cases and troubleshooting
+- Extensive examples and walkthroughs
+
+**Each reference file can be large (2,000-5,000+ words)**
+
+### What Goes in examples/
+
+**Working code examples:**
+
+- Complete, runnable scripts
+- Configuration files
+- Template files
+- Real-world usage examples
+
+**Users can copy and adapt these directly**
+
+### What Goes in scripts/
+
+**Utility scripts:**
+
+- Validation tools
+- Testing helpers
+- Parsing utilities
+- Automation scripts
+
+**Should be executable and documented**
+
+## Writing Style Guide
+
+### Imperative/Infinitive Form
+
+Write using verb-first instructions, not second person:
+
+**Correct (imperative):**
+
+```
+To create a hook, define the event type.
+Configure the MCP server with authentication.
+Validate settings before use.
+```
+
+**Incorrect (second person):**
+
+```
+You should create a hook by defining the event type.
+You need to configure the MCP server.
+You must validate settings before use.
+```
+
+### Third-Person in Description
+
+The frontmatter description must use third person:
+
+**Correct:**
+
+```yaml
+description: This skill should be used when the user asks to "create X", "configure Y"...
+```
+
+**Incorrect:**
+
+```yaml
+description: Use this skill when you want to create X...
+description: Load this skill when user asks...
+```
+
+### Objective, Instructional Language
+
+Focus on what to do, not who should do it:
+
+**Correct:**
+
+```
+Parse the frontmatter using sed.
+Extract fields with grep.
+Validate values before use.
+```
+
+**Incorrect:**
+
+```
+You can parse the frontmatter...
+Claude should extract fields...
+The user might validate values...
+```
+
+## Common Mistakes
+
+### Mistake 1: Weak Trigger Description
+
+**Bad:**
+
+```yaml
+description: Provides guidance for working with hooks.
+```
+
+Why bad: Vague, no specific trigger phrases, not third person
+
+**Good:**
+
+```yaml
+description: This skill should be used when the user asks to "create a hook", "add a PreToolUse hook", "validate tool use", or mentions hook events. Provides comprehensive hooks API guidance.
+```
+
+Why good: Third person, specific phrases, concrete scenarios
+
+### Mistake 2: Too Much in SKILL.md
+
+**Bad:**
+
+```
+skill-name/
+└── SKILL.md  (8,000 words - everything in one file)
+```
+
+Why bad: Bloats context when skill loads, detailed content always loaded
+
+**Good:**
+
+```
+skill-name/
+├── SKILL.md  (1,800 words - core essentials)
+└── references/
+    ├── patterns.md (2,500 words)
+    └── advanced.md (3,700 words)
+```
+
+Why good: Progressive disclosure, detailed content loaded only when needed
+
+### Mistake 3: Second Person Writing
+
+**Bad:**
+
+```markdown
+You should start by reading the configuration file.
+You need to validate the input.
+You can use the grep tool to search.
+```
+
+Why bad: Second person, not imperative form
+
+**Good:**
+
+```markdown
+Start by reading the configuration file.
+Validate the input before processing.
+Use the grep tool to search for patterns.
+```
+
+Why good: Imperative form, direct instructions
+
+### Mistake 4: Missing Resource References
+
+**Bad:**
+
+```markdown
+# SKILL.md
+
+[Core content]
+
+[No mention of references/ or examples/]
+```
+
+Why bad: Claude doesn't know references exist
+
+**Good:**
+
+```markdown
+# SKILL.md
+
+[Core content]
+
+## Additional Resources
+
+### Reference Files
+- **`references/patterns.md`** - Detailed patterns
+- **`references/advanced.md`** - Advanced techniques
+
+### Examples
+- **`examples/script.sh`** - Working example
+```
+
+Why good: Claude knows where to find additional information


### PR DESCRIPTION
## Summary

This PR improves the plugin-dev skills with a focus on leaner documentation and better consistency:

- **Reduced context size**: Cut skill-development SKILL.md from 3,196→1,298 words (~60% reduction) and command-development SKILL.md from 2,426→1,962 words (~20% reduction) by moving detailed content to references
- **Added missing references**: Created `references/skill-creation-workflow.md` and `references/plugin-integration.md` for content moved from SKILL.md files
- **Improved consistency**: Fixed description wording to use "asks to" instead of "wants to" across skills
- **Better citations**: Made plugin-structure reference citations explicit with direct file paths
- **Removed bash execution triggers**: Cleaned up command-development examples that could accidentally trigger bash execution
- **Consolidated hook format docs**: Unified the plugin hooks.json format explanation in hook-development

These changes follow the progressive disclosure principle - keeping SKILL.md files lean while making detailed information available in reference files.

## Test plan

- [ ] Verify plugin-dev skills load correctly with `cc --plugin-dir plugins/plugin-dev`
- [ ] Test skill triggering works with phrases like "create a skill", "add a command"
- [ ] Confirm reference files are accessible and well-structured

🤖 Generated with [Claude Code](https://claude.com/claude-code)