### PR TITLE
docs: align node requirements

### DIFF
--- a/plugins/plugin-dev/skills/command-development/references/documentation-patterns.md
+++ b/plugins/plugin-dev/skills/command-development/references/documentation-patterns.md
@@ -659,7 +659,7 @@ enable_feature: true
 
 - Git 2.x or later
 - jq (for JSON processing)
-- Node.js 14+ (optional, for advanced features)
+- Node.js 18+ (matches the minimum runtime required by Claude Code)
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary\n- plugin documentation still referenced "Node.js 14+" even though the CLI requires Node 18+ (per README badge/install notes)\n- update the requirements snippet in documentation-patterns.md so plugin authors see the correct runtime expectation\n\n## Testing\n- not run (docs change)