### PR TITLE
docs: update claude docs links

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -6,7 +6,7 @@ This directory contains some official Claude Code plugins that extend functional
 
 Claude Code plugins are extensions that enhance Claude Code with custom slash commands, specialized agents, hooks, and MCP servers. Plugins can be shared across projects and teams, providing consistent tooling and workflows.
 
-Learn more in the [official plugins documentation](https://docs.claude.com/en/docs/claude-code/plugins).
+Learn more in the [official plugins documentation](https://docs.anthropic.com/en/docs/claude-code/plugins).
 
 ## Plugins in This Directory
 
@@ -42,7 +42,7 @@ claude
 
 3. Use the `/plugin` command to install plugins from marketplaces, or configure them in your project's `.claude/settings.json`.
 
-For detailed plugin installation and configuration, see the [official documentation](https://docs.claude.com/en/docs/claude-code/plugins).
+For detailed plugin installation and configuration, see the [official documentation](https://docs.anthropic.com/en/docs/claude-code/plugins).
 
 ## Plugin Structure
 
@@ -72,6 +72,6 @@ When adding new plugins to this directory:
 
 ## Learn More
 
-- [Claude Code Documentation](https://docs.claude.com/en/docs/claude-code/overview)
-- [Plugin System Documentation](https://docs.claude.com/en/docs/claude-code/plugins)
-- [Agent SDK Documentation](https://docs.claude.com/en/api/agent-sdk/overview)
+- [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code/overview)
+- [Plugin System Documentation](https://docs.anthropic.com/en/docs/claude-code/plugins)
+- [Agent SDK Documentation](https://docs.anthropic.com/en/api/agent-sdk/overview)

--- a/plugins/agent-sdk-dev/README.md
+++ b/plugins/agent-sdk-dev/README.md
@@ -165,10 +165,10 @@ This plugin is included in the Claude Code repository. To use it:
 
 ## Resources
 
-- [Agent SDK Overview](https://docs.claude.com/en/api/agent-sdk/overview)
-- [TypeScript SDK Reference](https://docs.claude.com/en/api/agent-sdk/typescript)
-- [Python SDK Reference](https://docs.claude.com/en/api/agent-sdk/python)
-- [Agent SDK Examples](https://docs.claude.com/en/api/agent-sdk/examples)
+- [Agent SDK Overview](https://docs.anthropic.com/en/api/agent-sdk/overview)
+- [TypeScript SDK Reference](https://docs.anthropic.com/en/api/agent-sdk/typescript)
+- [Python SDK Reference](https://docs.anthropic.com/en/api/agent-sdk/python)
+- [Agent SDK Examples](https://docs.anthropic.com/en/api/agent-sdk/examples)
 
 ## Troubleshooting
 

--- a/plugins/agent-sdk-dev/agents/agent-sdk-verifier-py.md
+++ b/plugins/agent-sdk-dev/agents/agent-sdk-verifier-py.md
@@ -88,7 +88,7 @@ Your verification should prioritize SDK functionality and best practices over ge
 
 2. **Check SDK Documentation Adherence**:
 
-   - Use WebFetch to reference the official Python SDK docs: https://docs.claude.com/en/api/agent-sdk/python
+   - Use WebFetch to reference the official Python SDK docs: https://docs.anthropic.com/en/api/agent-sdk/python
    - Compare the implementation against official patterns and recommendations
    - Note any deviations from documented best practices
 

--- a/plugins/agent-sdk-dev/agents/agent-sdk-verifier-ts.md
+++ b/plugins/agent-sdk-dev/agents/agent-sdk-verifier-ts.md
@@ -94,7 +94,7 @@ Your verification should prioritize SDK functionality and best practices over ge
 
 2. **Check SDK Documentation Adherence**:
 
-   - Use WebFetch to reference the official TypeScript SDK docs: https://docs.claude.com/en/api/agent-sdk/typescript
+   - Use WebFetch to reference the official TypeScript SDK docs: https://docs.anthropic.com/en/api/agent-sdk/typescript
    - Compare the implementation against official patterns and recommendations
    - Note any deviations from documented best practices
 

--- a/plugins/agent-sdk-dev/commands/new-sdk-app.md
+++ b/plugins/agent-sdk-dev/commands/new-sdk-app.md
@@ -9,10 +9,10 @@ You are tasked with helping the user create a new Claude Agent SDK application. 
 
 Before starting, review the official documentation to ensure you provide accurate and up-to-date guidance. Use WebFetch to read these pages:
 
-1. **Start with the overview**: https://docs.claude.com/en/api/agent-sdk/overview
+1. **Start with the overview**: https://docs.anthropic.com/en/api/agent-sdk/overview
 2. **Based on the user's language choice, read the appropriate SDK reference**:
-   - TypeScript: https://docs.claude.com/en/api/agent-sdk/typescript
-   - Python: https://docs.claude.com/en/api/agent-sdk/python
+   - TypeScript: https://docs.anthropic.com/en/api/agent-sdk/typescript
+   - Python: https://docs.anthropic.com/en/api/agent-sdk/python
 3. **Read relevant guides mentioned in the overview** such as:
    - Streaming vs Single Mode
    - Permissions
@@ -147,8 +147,8 @@ Once setup is complete and verified, provide the user with:
 
 2. **Useful resources**:
 
-   - Link to TypeScript SDK reference: https://docs.claude.com/en/api/agent-sdk/typescript
-   - Link to Python SDK reference: https://docs.claude.com/en/api/agent-sdk/python
+   - Link to TypeScript SDK reference: https://docs.anthropic.com/en/api/agent-sdk/typescript
+   - Link to Python SDK reference: https://docs.anthropic.com/en/api/agent-sdk/python
    - Explain key concepts: system prompts, permissions, tools, MCP servers
 
 3. **Common next steps**:

--- a/plugins/explanatory-output-style/README.md
+++ b/plugins/explanatory-output-style/README.md
@@ -57,7 +57,7 @@ CLAUDE.md, but it is more flexible and allows for distribution through plugins.
 
 Note: Output styles that involve tasks besides software development, are better
 expressed as
-[subagents](https://docs.claude.com/en/docs/claude-code/sub-agents), not as
+[subagents](https://docs.anthropic.com/en/docs/claude-code/sub-agents), not as
 SessionStart hooks. Subagents change the system prompt while SessionStart hooks
 add to the default system prompt.
 
@@ -68,5 +68,5 @@ add to the default system prompt.
 - Update the plugin - create a local copy of this plugin to personalize this
   plugin
   - Hint: Ask Claude to read
-    https://docs.claude.com/en/docs/claude-code/plugins.md and set it up for
+    https://docs.anthropic.com/en/docs/claude-code/plugins.md and set it up for
     you!

--- a/plugins/learning-output-style/README.md
+++ b/plugins/learning-output-style/README.md
@@ -86,7 +86,7 @@ This SessionStart hook pattern is roughly equivalent to CLAUDE.md, but it is mor
 - Disable the plugin - keep the code installed on your device
 - Uninstall the plugin - remove the code from your device
 - Update the plugin - create a local copy of this plugin to personalize it
-  - Hint: Ask Claude to read https://docs.claude.com/en/docs/claude-code/plugins.md and set it up for you!
+  - Hint: Ask Claude to read https://docs.anthropic.com/en/docs/claude-code/plugins.md and set it up for you!
 
 ## Philosophy
 

--- a/plugins/plugin-dev/skills/hook-development/SKILL.md
+++ b/plugins/plugin-dev/skills/hook-development/SKILL.md
@@ -690,7 +690,7 @@ Development tools in `scripts/`:
 
 ### External Resources
 
-- **Official Docs**: https://docs.claude.com/en/docs/claude-code/hooks
+- **Official Docs**: https://docs.anthropic.com/en/docs/claude-code/hooks
 - **Examples**: See security-guidance plugin in marketplace
 - **Testing**: Use `claude --debug` for detailed logs
 - **Validation**: Use `jq` to validate hook JSON output

--- a/plugins/plugin-dev/skills/mcp-integration/SKILL.md
+++ b/plugins/plugin-dev/skills/mcp-integration/SKILL.md
@@ -533,7 +533,7 @@ Working examples in `examples/`:
 ### External Resources
 
 - **Official MCP Docs**: https://modelcontextprotocol.io/
-- **Claude Code MCP Docs**: https://docs.claude.com/en/docs/claude-code/mcp
+- **Claude Code MCP Docs**: https://docs.anthropic.com/en/docs/claude-code/mcp
 - **MCP SDK**: @modelcontextprotocol/sdk
 - **Testing**: Use `claude --debug` and `/mcp` command
 


### PR DESCRIPTION
## Summary\n- replace remaining  links in plugin docs with the canonical  URLs\n- keeps references aligned with the main README and avoids relying on legacy redirects that are already flaky for scripted fetches\n\n## Testing\n- not run (docs change)