### PR TITLE
fix(hookify): resolve import errors when CLAUDE_PLUGIN_ROOT is not set

### DIFF
--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -6,8 +6,11 @@ import sys
 from functools import lru_cache
 from typing import List, Dict, Any, Optional
 
-# Import from local module
-from hookify.core.config_loader import Rule, Condition
+# Import from local module (relative to allow both package and direct execution)
+try:
+    from core.config_loader import Rule, Condition
+except ImportError:
+    from hookify.core.config_loader import Rule, Condition
 
 
 # Cache compiled regexes (max 128 patterns)
@@ -275,7 +278,7 @@ class RuleEngine:
 
 # For testing
 if __name__ == '__main__':
-    from hookify.core.config_loader import Condition, Rule
+    from config_loader import Condition, Rule
 
     # Test rule evaluation
     rule = Rule(

--- a/plugins/hookify/hooks/posttooluse.py
+++ b/plugins/hookify/hooks/posttooluse.py
@@ -11,16 +11,19 @@ import json
 
 # CRITICAL: Add plugin root to Python path for imports
 PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+if not PLUGIN_ROOT:
+    # Fallback: derive from script location (hooks/ -> plugin root)
+    PLUGIN_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+parent_dir = os.path.dirname(PLUGIN_ROOT)
+if parent_dir not in sys.path:
+    sys.path.insert(0, parent_dir)
+if PLUGIN_ROOT not in sys.path:
+    sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)

--- a/plugins/hookify/hooks/pretooluse.py
+++ b/plugins/hookify/hooks/pretooluse.py
@@ -10,21 +10,20 @@ import sys
 import json
 
 # CRITICAL: Add plugin root to Python path for imports
-# We need to add the parent of the plugin directory so Python can find "hookify" package
 PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    # Add the parent directory of the plugin
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
+if not PLUGIN_ROOT:
+    # Fallback: derive from script location (hooks/ -> plugin root)
+    PLUGIN_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-    # Also add PLUGIN_ROOT itself in case we have other scripts
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+parent_dir = os.path.dirname(PLUGIN_ROOT)
+if parent_dir not in sys.path:
+    sys.path.insert(0, parent_dir)
+if PLUGIN_ROOT not in sys.path:
+    sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     # If imports fail, allow operation and log error
     error_msg = {"systemMessage": f"Hookify import error: {e}"}

--- a/plugins/hookify/hooks/stop.py
+++ b/plugins/hookify/hooks/stop.py
@@ -11,16 +11,19 @@ import json
 
 # CRITICAL: Add plugin root to Python path for imports
 PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+if not PLUGIN_ROOT:
+    # Fallback: derive from script location (hooks/ -> plugin root)
+    PLUGIN_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+parent_dir = os.path.dirname(PLUGIN_ROOT)
+if parent_dir not in sys.path:
+    sys.path.insert(0, parent_dir)
+if PLUGIN_ROOT not in sys.path:
+    sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)

--- a/plugins/hookify/hooks/userpromptsubmit.py
+++ b/plugins/hookify/hooks/userpromptsubmit.py
@@ -11,16 +11,19 @@ import json
 
 # CRITICAL: Add plugin root to Python path for imports
 PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+if not PLUGIN_ROOT:
+    # Fallback: derive from script location (hooks/ -> plugin root)
+    PLUGIN_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+parent_dir = os.path.dirname(PLUGIN_ROOT)
+if parent_dir not in sys.path:
+    sys.path.insert(0, parent_dir)
+if PLUGIN_ROOT not in sys.path:
+    sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)


### PR DESCRIPTION
## Summary
- Fix hookify plugin import errors that occurred when `CLAUDE_PLUGIN_ROOT` environment variable was not set
- Add fallback path resolution using `__file__` when env var is missing
- Change imports from `hookify.core.*` to `core.*` for cache directory compatibility

## Problem
The hookify hooks displayed "Hookify import error: No module named 'hookify'" on every tool use (PreToolUse, PostToolUse, Stop, UserPromptSubmit). This happened because:

1. The hooks assumed `CLAUDE_PLUGIN_ROOT` env var would always be set
2. The import paths (`from hookify.core.*`) didn't work with the cache directory structure (`hookify/0.1.0/` instead of `hookify/`)

## Solution
1. Added fallback to derive `PLUGIN_ROOT` from script location when env var is missing
2. Changed to `from core.*` imports which work when `PLUGIN_ROOT` is in `sys.path`
3. Made path setup unconditional (always runs, not just when env var exists)

## Test plan
- [x] Tested all 4 hook scripts manually with `echo '{}' | python3 <script>`
- [x] Verified no import errors in new Claude Code session
- [x] Confirmed hooks return `{}` (empty JSON) when no rules match

🤖 Generated with [Claude Code](https://claude.com/claude-code)