### PR TITLE
Revise commit-push-pr.md for clarity and accuracy

### DIFF
--- a/plugins/commit-commands/commands/commit-push-pr.md
+++ b/plugins/commit-commands/commands/commit-push-pr.md
@@ -8,6 +8,7 @@ description: Commit, push, and open a PR
 - Current git status: !`git status`
 - Current git diff (staged and unstaged changes): !`git diff HEAD`
 - Current branch: !`git branch --show-current`
+- Available remotes: !`git remote` — default to `origin`
 
 ## Your task
 
@@ -15,6 +16,11 @@ Based on the above changes:
 
 1. Create a new branch if on main
 2. Create a single commit with an appropriate message
-3. Push the branch to origin
+3. Push the branch to the most suitable remote
 4. Create a pull request using `gh pr create`
-5. You have the capability to call multiple tools in a single response. You MUST do all of the above in a single message. Do not use any other tools or do anything else. Do not send any other text or messages besides these tool calls.
+
+## Guidance
+
+* You have the capability to call multiple tools in a single response. You MUST do all of the above in a single message. Do not use any other tools or do anything else. Do not send any other text or messages besides these tool calls.
+* Pay attention to the exit code when you commit: there can be pre-commit hooks that fail with useful feedback
+* Ask the user for confirmation before force-pushing: that is a last resort and may be dangerous


### PR DESCRIPTION
Updated instructions for pushing branches and creating pull requests.

I'm proposing this change because I noticed that commit-push-pr can miss failed commit hooks, spot that there's nothing to push, then immediately `commit --amend` onto the previous (potentially unrelated!) commit and force push... which is not good behaviour.

I also noticed the assumption of "origin" which is likely but not a given, and seems an easy fix.