### PR TITLE
fix(hookify): fix Python import path for cached plugins

### DIFF
--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -6,8 +6,8 @@ import sys
 from functools import lru_cache
 from typing import List, Dict, Any, Optional
 
-# Import from local module
-from hookify.core.config_loader import Rule, Condition
+# Import from local module (using direct import since PLUGIN_ROOT is in sys.path)
+from core.config_loader import Rule, Condition
 
 
 # Cache compiled regexes (max 128 patterns)
@@ -275,7 +275,7 @@ class RuleEngine:
 
 # For testing
 if __name__ == '__main__':
-    from hookify.core.config_loader import Condition, Rule
+    from core.config_loader import Condition, Rule
 
     # Test rule evaluation
     rule = Rule(

--- a/plugins/hookify/hooks/posttooluse.py
+++ b/plugins/hookify/hooks/posttooluse.py
@@ -10,17 +10,17 @@ import sys
 import json
 
 # CRITICAL: Add plugin root to Python path for imports
+# We import directly from 'core' (not 'hookify.core') because when plugins are
+# cached, the directory structure becomes hookify/<version>/core/ instead of
+# hookify/core/, breaking package-style imports. Since PLUGIN_ROOT points to
+# the versioned directory and is added to sys.path, direct imports work.
 PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+if PLUGIN_ROOT and PLUGIN_ROOT not in sys.path:
+    sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)

--- a/plugins/hookify/hooks/pretooluse.py
+++ b/plugins/hookify/hooks/pretooluse.py
@@ -10,21 +10,17 @@ import sys
 import json
 
 # CRITICAL: Add plugin root to Python path for imports
-# We need to add the parent of the plugin directory so Python can find "hookify" package
+# We import directly from 'core' (not 'hookify.core') because when plugins are
+# cached, the directory structure becomes hookify/<version>/core/ instead of
+# hookify/core/, breaking package-style imports. Since PLUGIN_ROOT points to
+# the versioned directory and is added to sys.path, direct imports work.
 PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    # Add the parent directory of the plugin
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-
-    # Also add PLUGIN_ROOT itself in case we have other scripts
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+if PLUGIN_ROOT and PLUGIN_ROOT not in sys.path:
+    sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     # If imports fail, allow operation and log error
     error_msg = {"systemMessage": f"Hookify import error: {e}"}

--- a/plugins/hookify/hooks/stop.py
+++ b/plugins/hookify/hooks/stop.py
@@ -10,17 +10,17 @@ import sys
 import json
 
 # CRITICAL: Add plugin root to Python path for imports
+# We import directly from 'core' (not 'hookify.core') because when plugins are
+# cached, the directory structure becomes hookify/<version>/core/ instead of
+# hookify/core/, breaking package-style imports. Since PLUGIN_ROOT points to
+# the versioned directory and is added to sys.path, direct imports work.
 PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+if PLUGIN_ROOT and PLUGIN_ROOT not in sys.path:
+    sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)

--- a/plugins/hookify/hooks/userpromptsubmit.py
+++ b/plugins/hookify/hooks/userpromptsubmit.py
@@ -10,17 +10,17 @@ import sys
 import json
 
 # CRITICAL: Add plugin root to Python path for imports
+# We import directly from 'core' (not 'hookify.core') because when plugins are
+# cached, the directory structure becomes hookify/<version>/core/ instead of
+# hookify/core/, breaking package-style imports. Since PLUGIN_ROOT points to
+# the versioned directory and is added to sys.path, direct imports work.
 PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+if PLUGIN_ROOT and PLUGIN_ROOT not in sys.path:
+    sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)


### PR DESCRIPTION
## Summary

Fixes the hookify plugin's Python import path issue that occurs when plugins are cached by Claude Code.

**The Problem:**
When Claude Code caches plugins, it creates a versioned directory structure:
```
~/.claude/plugins/cache/claude-code-plugins/hookify/0.1.0/core/config_loader.py
```

The original code tried to import using package-style imports:
```python
from hookify.core.config_loader import load_rules
```

This fails because:
1. `CLAUDE_PLUGIN_ROOT` points to `.../hookify/0.1.0/`
2. The code adds `parent_dir` (`.../hookify/`) to `sys.path`
3. Python looks for a `hookify` directory with `core/` inside it
4. But the actual structure is `hookify/0.1.0/core/` - the version directory breaks the package path

**The Fix:**
Since `PLUGIN_ROOT` is already added to `sys.path` and points directly to the versioned directory (`.../0.1.0/`), we can import directly:
```python
from core.config_loader import load_rules
```

This works because `core/` is a direct child of `PLUGIN_ROOT`.

## Files Changed

- `plugins/hookify/hooks/stop.py` - Updated imports and path setup
- `plugins/hookify/hooks/pretooluse.py` - Updated imports and path setup  
- `plugins/hookify/hooks/posttooluse.py` - Updated imports and path setup
- `plugins/hookify/hooks/userpromptsubmit.py` - Updated imports and path setup
- `plugins/hookify/core/rule_engine.py` - Updated internal imports

## Test Plan

- [x] Verified imports work with simulated cached plugin structure
- [x] Manual testing with fresh plugin installation
- [x] Verify all hook events (Stop, PreToolUse, PostToolUse, UserPromptSubmit) work correctly

## Reproduction Steps (for the original bug)

1. Install the hookify plugin via marketplace
2. Observe error on Stop hook: `Hookify import error: No module named 'hookify'`
3. Check `~/.claude/plugins/cache/claude-code-plugins/hookify/` to see versioned structure