### PR TITLE
fix(hookify): Fix Python import errors in plugin hooks

### DIFF
--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -6,8 +6,8 @@ import sys
 from functools import lru_cache
 from typing import List, Dict, Any, Optional
 
-# Import from local module
-from hookify.core.config_loader import Rule, Condition
+# Import from local module (relative import within core package)
+from .config_loader import Rule, Condition
 
 
 # Cache compiled regexes (max 128 patterns)
@@ -275,7 +275,7 @@ class RuleEngine:
 
 # For testing
 if __name__ == '__main__':
-    from hookify.core.config_loader import Condition, Rule
+    from config_loader import Condition, Rule
 
     # Test rule evaluation
     rule = Rule(

--- a/plugins/hookify/hooks/common.py
+++ b/plugins/hookify/hooks/common.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Shared utilities for hookify hook executors.
+
+This module centralizes the import logic and common utilities used by all
+hook scripts (PreToolUse, PostToolUse, Stop, UserPromptSubmit).
+
+The key fix here is using CLAUDE_PLUGIN_ROOT directly on sys.path rather than
+its parent directory. Claude Code's plugin cache structure is:
+    .../plugins/cache/{marketplace}/{plugin-name}/{version}/
+
+Where {version}/ IS the CLAUDE_PLUGIN_ROOT and contains the actual code.
+The original code expected a nested {plugin-name}/ package inside the parent,
+which doesn't exist in Claude Code's cache structure.
+"""
+
+import os
+import sys
+import json
+
+# Add plugin root to Python path for imports
+# CLAUDE_PLUGIN_ROOT points to the versioned plugin directory containing core/
+PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
+if PLUGIN_ROOT and PLUGIN_ROOT not in sys.path:
+    sys.path.insert(0, PLUGIN_ROOT)
+
+# Import core modules - these live directly under PLUGIN_ROOT
+from core.config_loader import load_rules
+from core.rule_engine import RuleEngine
+
+__all__ = ['load_rules', 'RuleEngine', 'json', 'handle_error', 'safe_exit']
+
+
+def handle_error(error: Exception) -> None:
+    """Output general error as JSON."""
+    error_output = {"systemMessage": f"Hookify error: {str(error)}"}
+    print(json.dumps(error_output), file=sys.stdout)
+
+
+def safe_exit(code: int = 0) -> None:
+    """Always exit with code 0 to never block operations due to hook errors."""
+    sys.exit(0)

--- a/plugins/hookify/hooks/posttooluse.py
+++ b/plugins/hookify/hooks/posttooluse.py
@@ -1,65 +1,44 @@
 #!/usr/bin/env python3
 """PostToolUse hook executor for hookify plugin.
 
-This script is called by Claude Code after a tool executes.
-It reads .claude/hookify.*.local.md files and evaluates rules.
+Called by Claude Code after a tool executes.
+Evaluates rules from .claude/hookify.*.local.md files.
 """
 
-import os
 import sys
 import json
 
-# CRITICAL: Add plugin root to Python path for imports
-PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
-
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from common import load_rules, RuleEngine, handle_error, safe_exit
 except ImportError as e:
-    error_msg = {"systemMessage": f"Hookify import error: {e}"}
-    print(json.dumps(error_msg), file=sys.stdout)
+    print(json.dumps({"systemMessage": f"Hookify import error: {e}"}))
     sys.exit(0)
 
 
 def main():
-    """Main entry point for PostToolUse hook."""
+    """Evaluate PostToolUse rules and return result."""
     try:
-        # Read input from stdin
         input_data = json.load(sys.stdin)
-
-        # Determine event type based on tool
         tool_name = input_data.get('tool_name', '')
+
+        # Map tool to event type
         event = None
         if tool_name == 'Bash':
             event = 'bash'
         elif tool_name in ['Edit', 'Write', 'MultiEdit']:
             event = 'file'
 
-        # Load rules
         rules = load_rules(event=event)
-
-        # Evaluate rules
         engine = RuleEngine()
         result = engine.evaluate_rules(rules, input_data)
 
-        # Always output JSON (even if empty)
-        print(json.dumps(result), file=sys.stdout)
+        print(json.dumps(result))
 
     except Exception as e:
-        error_output = {
-            "systemMessage": f"Hookify error: {str(e)}"
-        }
-        print(json.dumps(error_output), file=sys.stdout)
+        handle_error(e)
 
     finally:
-        # ALWAYS exit 0
-        sys.exit(0)
+        safe_exit()
 
 
 if __name__ == '__main__':

--- a/plugins/hookify/hooks/pretooluse.py
+++ b/plugins/hookify/hooks/pretooluse.py
@@ -1,73 +1,44 @@
 #!/usr/bin/env python3
 """PreToolUse hook executor for hookify plugin.
 
-This script is called by Claude Code before any tool executes.
-It reads .claude/hookify.*.local.md files and evaluates rules.
+Called by Claude Code before any tool executes.
+Evaluates rules from .claude/hookify.*.local.md files.
 """
 
-import os
 import sys
 import json
 
-# CRITICAL: Add plugin root to Python path for imports
-# We need to add the parent of the plugin directory so Python can find "hookify" package
-PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    # Add the parent directory of the plugin
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-
-    # Also add PLUGIN_ROOT itself in case we have other scripts
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
-
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from common import load_rules, RuleEngine, handle_error, safe_exit
 except ImportError as e:
-    # If imports fail, allow operation and log error
-    error_msg = {"systemMessage": f"Hookify import error: {e}"}
-    print(json.dumps(error_msg), file=sys.stdout)
+    print(json.dumps({"systemMessage": f"Hookify import error: {e}"}))
     sys.exit(0)
 
 
 def main():
-    """Main entry point for PreToolUse hook."""
+    """Evaluate PreToolUse rules and return result."""
     try:
-        # Read input from stdin
         input_data = json.load(sys.stdin)
-
-        # Determine event type for filtering
-        # For PreToolUse, we use tool_name to determine "bash" vs "file" event
         tool_name = input_data.get('tool_name', '')
 
+        # Map tool to event type
         event = None
         if tool_name == 'Bash':
             event = 'bash'
         elif tool_name in ['Edit', 'Write', 'MultiEdit']:
             event = 'file'
 
-        # Load rules
         rules = load_rules(event=event)
-
-        # Evaluate rules
         engine = RuleEngine()
         result = engine.evaluate_rules(rules, input_data)
 
-        # Always output JSON (even if empty)
-        print(json.dumps(result), file=sys.stdout)
+        print(json.dumps(result))
 
     except Exception as e:
-        # On any error, allow the operation and log
-        error_output = {
-            "systemMessage": f"Hookify error: {str(e)}"
-        }
-        print(json.dumps(error_output), file=sys.stdout)
+        handle_error(e)
 
     finally:
-        # ALWAYS exit 0 - never block operations due to hook errors
-        sys.exit(0)
+        safe_exit()
 
 
 if __name__ == '__main__':

--- a/plugins/hookify/hooks/stop.py
+++ b/plugins/hookify/hooks/stop.py
@@ -1,58 +1,36 @@
 #!/usr/bin/env python3
 """Stop hook executor for hookify plugin.
 
-This script is called by Claude Code when agent wants to stop.
-It reads .claude/hookify.*.local.md files and evaluates stop rules.
+Called by Claude Code when agent wants to stop.
+Evaluates stop rules from .claude/hookify.*.local.md files.
 """
 
-import os
 import sys
 import json
 
-# CRITICAL: Add plugin root to Python path for imports
-PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
-
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from common import load_rules, RuleEngine, handle_error, safe_exit
 except ImportError as e:
-    error_msg = {"systemMessage": f"Hookify import error: {e}"}
-    print(json.dumps(error_msg), file=sys.stdout)
+    print(json.dumps({"systemMessage": f"Hookify import error: {e}"}))
     sys.exit(0)
 
 
 def main():
-    """Main entry point for Stop hook."""
+    """Evaluate Stop rules and return result."""
     try:
-        # Read input from stdin
         input_data = json.load(sys.stdin)
 
-        # Load stop rules
         rules = load_rules(event='stop')
-
-        # Evaluate rules
         engine = RuleEngine()
         result = engine.evaluate_rules(rules, input_data)
 
-        # Always output JSON (even if empty)
-        print(json.dumps(result), file=sys.stdout)
+        print(json.dumps(result))
 
     except Exception as e:
-        # On any error, allow the operation
-        error_output = {
-            "systemMessage": f"Hookify error: {str(e)}"
-        }
-        print(json.dumps(error_output), file=sys.stdout)
+        handle_error(e)
 
     finally:
-        # ALWAYS exit 0
-        sys.exit(0)
+        safe_exit()
 
 
 if __name__ == '__main__':

--- a/plugins/hookify/hooks/userpromptsubmit.py
+++ b/plugins/hookify/hooks/userpromptsubmit.py
@@ -1,57 +1,36 @@
 #!/usr/bin/env python3
 """UserPromptSubmit hook executor for hookify plugin.
 
-This script is called by Claude Code when user submits a prompt.
-It reads .claude/hookify.*.local.md files and evaluates rules.
+Called by Claude Code when user submits a prompt.
+Evaluates rules from .claude/hookify.*.local.md files.
 """
 
-import os
 import sys
 import json
 
-# CRITICAL: Add plugin root to Python path for imports
-PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
-
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from common import load_rules, RuleEngine, handle_error, safe_exit
 except ImportError as e:
-    error_msg = {"systemMessage": f"Hookify import error: {e}"}
-    print(json.dumps(error_msg), file=sys.stdout)
+    print(json.dumps({"systemMessage": f"Hookify import error: {e}"}))
     sys.exit(0)
 
 
 def main():
-    """Main entry point for UserPromptSubmit hook."""
+    """Evaluate UserPromptSubmit rules and return result."""
     try:
-        # Read input from stdin
         input_data = json.load(sys.stdin)
 
-        # Load user prompt rules
         rules = load_rules(event='prompt')
-
-        # Evaluate rules
         engine = RuleEngine()
         result = engine.evaluate_rules(rules, input_data)
 
-        # Always output JSON (even if empty)
-        print(json.dumps(result), file=sys.stdout)
+        print(json.dumps(result))
 
     except Exception as e:
-        error_output = {
-            "systemMessage": f"Hookify error: {str(e)}"
-        }
-        print(json.dumps(error_output), file=sys.stdout)
+        handle_error(e)
 
     finally:
-        # ALWAYS exit 0
-        sys.exit(0)
+        safe_exit()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Fixes Python import errors (`No module named 'hookify'`) in the hookify plugin when running in Claude Code's versioned plugin cache.

## Problem

The hookify plugin's Python hooks fail to import core modules because:

1. Original code assumed: `parent_dir/hookify/core/...` exists
2. Claude Code's actual structure: `.../cache/{marketplace}/{plugin}/{version}/core/...`
3. `CLAUDE_PLUGIN_ROOT` points to the versioned directory (e.g., `.../hookify/0.1.0/`)
4. There's no nested `hookify/` package inside - the code lives directly under the version directory

```python
# Original (broken)
from hookify.core.config_loader import load_rules  # ❌ No 'hookify' package

# Fixed
from core.config_loader import load_rules  # ✅ Relative to PLUGIN_ROOT
```

## Solution

1. **Add `hooks/common.py`** - Centralizes import logic with correct `sys.path` handling
2. **Update all hook scripts** - Import from `common` module (DRY principle)
3. **Fix `core/rule_engine.py`** - Use relative imports (`.config_loader`)

## Changes

| File | Change |
|------|--------|
| `hooks/common.py` | New shared module for imports and utilities |
| `hooks/*.py` | Simplified to use common module |
| `core/rule_engine.py` | Changed to relative import |

## Testing

Verified imports work correctly:
```bash
CLAUDE_PLUGIN_ROOT=.../hookify/0.1.0 python3 -c "from common import load_rules; print('OK')"
# Output: OK
```

## Test plan

- [ ] Install hookify plugin fresh
- [ ] Verify no import errors on tool use
- [ ] Test rule evaluation works correctly