### PR TITLE
feat(hookify): Add support for global rules in ~/.claude/

### DIFF
--- a/plugins/hookify/core/config_loader.py
+++ b/plugins/hookify/core/config_loader.py
@@ -198,6 +198,10 @@ def extract_frontmatter(content: str) -> tuple[Dict[str, Any], str]:
 def load_rules(event: Optional[str] = None) -> List[Rule]:
     """Load all hookify rules from .claude directory.
 
+    Loads rules from both:
+    - Project-level: ./.claude/hookify.*.local.md (relative to cwd)
+    - Global: ~/.claude/hookify.*.local.md (user's home directory)
+
     Args:
         event: Optional event filter ("bash", "file", "stop", etc.)
 
@@ -206,9 +210,14 @@ def load_rules(event: Optional[str] = None) -> List[Rule]:
     """
     rules = []
 
-    # Find all hookify.*.local.md files
-    pattern = os.path.join('.claude', 'hookify.*.local.md')
-    files = glob.glob(pattern)
+    # Find all hookify.*.local.md files from both project and global .claude
+    patterns = [
+        os.path.join('.claude', 'hookify.*.local.md'),  # Project-level
+        os.path.expanduser(os.path.join('~', '.claude', 'hookify.*.local.md')),  # Global
+    ]
+    files = []
+    for pattern in patterns:
+        files.extend(glob.glob(pattern))
 
     for file_path in files:
         try:


### PR DESCRIPTION
## Summary
- Adds support for loading hookify rules from global `~/.claude/` directory in addition to project-level `.claude/`
- Allows users to define personal rules that apply across all projects

## Problem
Currently, hookify only loads rules from the project's `.claude/` directory (relative to cwd). This means users cannot define global rules that apply across all their projects.

## Solution
Modified `load_rules()` in `config_loader.py` to search for `hookify.*.local.md` files in both:
1. Project-level: `./.claude/hookify.*.local.md` (existing behavior)
2. Global: `~/.claude/hookify.*.local.md` (new)

## Test Plan
- [x] Verified rules load from `~/.claude/hookify.*.local.md`
- [x] Verified project-level rules still work
- [x] Verified rules from both locations are combined
- [x] Tested with actual hookify rule matching