### PR TITLE
fix(hookify): add permissionDecisionReason to PreToolUse blocking response

### DIFF
--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -73,9 +73,10 @@ class RuleEngine:
                 return {
                     "hookSpecificOutput": {
                         "hookEventName": hook_event,
-                        "permissionDecision": "deny"
+                        "permissionDecision": "deny",
+                        "permissionDecisionReason": combined_message  # Message shown to Claude
                     },
-                    "systemMessage": combined_message
+                    "systemMessage": combined_message  # Message shown to user in verbose mode
                 }
             else:
                 # For other events, just show message


### PR DESCRIPTION
## Summary

The hookify plugin was only setting `systemMessage` (shown to user) but not `permissionDecisionReason` (shown to Claude) when blocking tool use. This meant Claude only saw a generic "Hook denied this tool" message instead of the helpful rule message explaining why the tool was blocked and what to do instead.

## The Problem

When a hookify rule blocks a tool, the agent receives:
```
Hook PreToolUse:Bash denied this tool
PreToolUse:Callback hook blocking error from command: "callback": Blocked by hook
```

Instead of the helpful message defined in the rule file like:
```
# Use `automux beads` Instead of `bd`
Direct `bd` CLI usage is blocked. Use `automux beads` instead.
```

## The Fix

Add `permissionDecisionReason` to the `hookSpecificOutput` for PreToolUse/PostToolUse events:

```python
return {
    "hookSpecificOutput": {
        "hookEventName": hook_event,
        "permissionDecision": "deny",
        "permissionDecisionReason": combined_message  # NEW: Message shown to Claude
    },
    "systemMessage": combined_message  # Kept: Message shown to user in verbose mode
}
```

Per the [hooks documentation](https://docs.claude.com/en/hooks), `permissionDecisionReason` is what Claude sees when a tool is blocked.

## Test Plan

- [ ] Create a hookify rule that blocks a bash command
- [ ] Trigger the blocked command
- [ ] Verify Claude receives the custom message from `permissionDecisionReason`

🤖 Generated with [Claude Code](https://claude.com/claude-code)