### PR TITLE
feat(code-review): Add --no-comment option for local-only review

### DIFF
--- a/plugins/code-review/README.md
+++ b/plugins/code-review/README.md
@@ -26,8 +26,11 @@ Performs automated code review on a pull request using multiple specialized agen
 
 **Usage:**
 ```bash
-/code-review
+/code-review [--no-comment]
 ```
+
+**Options:**
+- `--no-comment`: Skip posting the review to GitHub. Output the review to the terminal only. Useful for local review without creating PR comments.
 
 **Example workflow:**
 ```bash
@@ -39,6 +42,9 @@ Performs automated code review on a pull request using multiple specialized agen
 # - Score each issue for confidence
 # - Post comment with issues ≥80 confidence
 # - Skip posting if no high-confidence issues found
+
+# For local-only review (no GitHub comment):
+/code-review --no-comment
 ```
 
 **Features:**
@@ -49,6 +55,7 @@ Performs automated code review on a pull request using multiple specialized agen
 - Historical context analysis via git blame
 - Automatic skipping of closed, draft, or already-reviewed PRs
 - Links directly to code with full SHA and line ranges
+- Optional `--no-comment` flag for local-only review without posting to GitHub
 
 **Review comment format:**
 ```markdown
@@ -196,6 +203,7 @@ https://github.com/owner/repo/blob/[full-sha]/path/file.ext#L[start]-L[end]
 - **Iterate on guidelines**: Update CLAUDE.md based on patterns
 - **Review automatically**: Set up as part of PR workflow
 - **Trust the filtering**: Threshold prevents noise
+- **Use `--no-comment` for local development**: Get review feedback without cluttering the PR
 
 ## Configuration
 

--- a/plugins/code-review/README.md
+++ b/plugins/code-review/README.md
@@ -26,25 +26,24 @@ Performs automated code review on a pull request using multiple specialized agen
 
 **Usage:**
 ```bash
-/code-review [--no-comment]
+/code-review [--comment]
 ```
 
 **Options:**
-- `--no-comment`: Skip posting the review to GitHub. Output the review to the terminal only. Useful for local review without creating PR comments.
+- `--comment`: Post the review as a PR comment on GitHub. By default, the review is output to the terminal only.
 
 **Example workflow:**
 ```bash
-# On a PR branch, run:
+# On a PR branch, run (outputs to terminal only):
 /code-review
 
 # Claude will:
 # - Launch 4 review agents in parallel
 # - Score each issue for confidence
-# - Post comment with issues ≥80 confidence
-# - Skip posting if no high-confidence issues found
+# - Output review with issues ≥80 confidence to terminal
 
-# For local-only review (no GitHub comment):
-/code-review --no-comment
+# To post review as a GitHub PR comment:
+/code-review --comment
 ```
 
 **Features:**
@@ -55,7 +54,7 @@ Performs automated code review on a pull request using multiple specialized agen
 - Historical context analysis via git blame
 - Automatic skipping of closed, draft, or already-reviewed PRs
 - Links directly to code with full SHA and line ranges
-- Optional `--no-comment` flag for local-only review without posting to GitHub
+- Local-only output by default; use `--comment` flag to post to GitHub PR
 
 **Review comment format:**
 ```markdown
@@ -203,7 +202,7 @@ https://github.com/owner/repo/blob/[full-sha]/path/file.ext#L[start]-L[end]
 - **Iterate on guidelines**: Update CLAUDE.md based on patterns
 - **Review automatically**: Set up as part of PR workflow
 - **Trust the filtering**: Threshold prevents noise
-- **Use `--no-comment` for local development**: Get review feedback without cluttering the PR
+- **Use `--comment` for CI/CD**: Post review to PR when running in automated workflows
 
 ## Configuration
 

--- a/plugins/code-review/commands/code-review.md
+++ b/plugins/code-review/commands/code-review.md
@@ -6,7 +6,7 @@ description: Code review a pull request
 Provide a code review for the given pull request.
 
 **Arguments:**
-- `--no-comment`: Skip posting the review as a PR comment. Instead, output the review to the terminal only. This is useful when running locally and you don't want to post to GitHub.
+- `--comment`: Post the review as a PR comment on GitHub. By default, the review is output to the terminal only.
 
 To do this, follow these steps precisely:
 
@@ -56,8 +56,8 @@ Note: Still review Claude generated PR's.
 6. Filter out any issues that were not validated in step 5. This step will give us our list of high signal issues for our review.
 
 7. Finally, output the review:
-   - If `--no-comment` was passed as an argument, output the review directly to the terminal (do NOT post to GitHub)
-   - Otherwise, post the review as a comment on the pull request using `gh pr comment`
+   - If `--comment` was passed as an argument, post the review as a comment on the pull request using `gh pr comment`
+   - Otherwise, output the review directly to the terminal (do NOT post to GitHub)
 
    When writing your review, follow these guidelines:
    a. Keep your output brief

--- a/plugins/code-review/commands/code-review.md
+++ b/plugins/code-review/commands/code-review.md
@@ -5,6 +5,9 @@ description: Code review a pull request
 
 Provide a code review for the given pull request.
 
+**Arguments:**
+- `--no-comment`: Skip posting the review as a PR comment. Instead, output the review to the terminal only. This is useful when running locally and you don't want to post to GitHub.
+
 To do this, follow these steps precisely:
 
 1. Launch a haiku agent to check if any of the following are true:
@@ -52,8 +55,11 @@ Note: Still review Claude generated PR's.
 
 6. Filter out any issues that were not validated in step 5. This step will give us our list of high signal issues for our review.
 
-7. Finally, comment on the pull request.
-   When writing your comment, follow these guidelines:
+7. Finally, output the review:
+   - If `--no-comment` was passed as an argument, output the review directly to the terminal (do NOT post to GitHub)
+   - Otherwise, post the review as a comment on the pull request using `gh pr comment`
+
+   When writing your review, follow these guidelines:
    a. Keep your output brief
    b. Avoid emojis
    c. Link and cite relevant code, files, and URLs for each issue


### PR DESCRIPTION
Add ability to run /code-review without posting to GitHub PR. When --no-comment is passed, the review is output to the terminal only. This is useful when running locally and users don't want to clutter PRs with automated comments.