### PR TITLE
Add 'git checkout -b' to allowed tools

### DIFF
--- a/.claude/commands/commit-push-pr.md
+++ b/.claude/commands/commit-push-pr.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*)
+allowed-tools: Bash(git checkout --branch:*), Bash(git checkout -b:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*)
 description: Commit, push, and open a PR
 ---
 


### PR DESCRIPTION
Fixes issue with shorthand flag not being allowed in the commit-push-pr example command/plugin.