### PR TITLE
refactor commit-push-pr description

### DIFF
--- a/.claude/commands/commit-push-pr.md
+++ b/.claude/commands/commit-push-pr.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*)
-description: Commit, push, and open a PR
+description: Check out a branch, commit, push, and open a PR
 ---
 
 ## Context


### PR DESCRIPTION
https://github.com/anthropics/claude-code/blob/main/.claude/commands/commit-push-pr.md

In the linked commit-push-pr.md, the description currently only says “Commit, push, and open a PR,” but this command set also includes branch checkout. It might be worth updating the description to reflect that.

thank you for taking a look!