### PR TITLE
fix: add -- separator to git diff HEAD command

### DIFF
--- a/plugins/commit-commands/commands/commit.md
+++ b/plugins/commit-commands/commands/commit.md
@@ -6,7 +6,7 @@ description: Create a git commit
 ## Context
 
 - Current git status: !`git status`
-- Current git diff (staged and unstaged changes): !`git diff HEAD`
+- Current git diff (staged and unstaged changes): !`git diff HEAD --`
 - Current branch: !`git branch --show-current`
 - Recent commits: !`git log --oneline -10`
 


### PR DESCRIPTION
## Summary
- Add `--` separator to `git diff HEAD` command in commit-commands plugin

## Problem
The current implementation uses `git diff HEAD` without the `--` separator. This can cause issues when a file named `HEAD` exists in the working directory, as git may interpret it ambiguously.

## Solution
Changed `git diff HEAD` to `git diff HEAD --` to explicitly separate revision arguments from file paths, following git best practices.

## Test plan
- Verify the commit command still works correctly
- Test with a file named "HEAD" in the working directory to confirm the fix