### PR TITLE
fix: add -- to git diff HEAD to avoid ambiguity

### DIFF
--- a/plugins/commit-commands/commands/commit-push-pr.md
+++ b/plugins/commit-commands/commands/commit-push-pr.md
@@ -6,7 +6,7 @@ description: Commit, push, and open a PR
 ## Context
 
 - Current git status: !`git status`
-- Current git diff (staged and unstaged changes): !`git diff HEAD`
+- Current git diff (staged and unstaged changes): !`git diff HEAD --`
 - Current branch: !`git branch --show-current`
 
 ## Your task

--- a/plugins/commit-commands/commands/commit.md
+++ b/plugins/commit-commands/commands/commit.md
@@ -6,7 +6,7 @@ description: Create a git commit
 ## Context
 
 - Current git status: !`git status`
-- Current git diff (staged and unstaged changes): !`git diff HEAD`
+- Current git diff (staged and unstaged changes): !`git diff HEAD --`
 - Current branch: !`git branch --show-current`
 - Recent commits: !`git log --oneline -10`
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where the commit-commands plugin fails when a project contains a file named `HEAD` in the root directory.

## Problem

When executing `/commit-commands:commit`, if the repository has a file named `HEAD`, the command `git diff HEAD` becomes ambiguous and fails with:

```
fatal: ambiguous argument 'HEAD': both revision and filename
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

## Solution

Add `--` to `git diff HEAD` commands to explicitly separate revisions from file paths, following git best practices:

- Changed: `git diff HEAD` → `git diff HEAD --`

This ensures git interprets `HEAD` as a revision reference, not a filename.

## Files Changed

- `plugins/commit-commands/commands/commit.md`
- `plugins/commit-commands/commands/commit-push-pr.md`

## Test Plan

✅ Tested with a repository containing a `HEAD` file in the root directory
✅ The `/commit-commands:commit` command now executes successfully
✅ No impact on normal repositories without a `HEAD` file