### PR TITLE
Correct overview link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows -- all through natural language commands. Use it in your terminal, IDE, or tag @claude on Github.
 
-**Learn more in the [official documentation](https://docs.anthropic.com/en/docs/claude-code/overview)**.
+**Learn more in the [official documentation](https://code.claude.com/docs/en/overview)**.
 
 <img src="./demo.gif" />
 


### PR DESCRIPTION
The current link leads to a page that displays the following error message: 

> Page Not Found
> The requested page could not be found.

<img width="2694" height="1688" alt="image" src="https://github.com/user-attachments/assets/717d393a-0ebd-4cd5-a5c7-bc5232294a1c" />

I am not claiming that the URL I have replace the original with is the the most appropriate one, but it may be, and failing that, it seems good enough as a first step in the right direction:

<img width="2876" height="1574" alt="image" src="https://github.com/user-attachments/assets/4cd0069a-632e-4c30-9272-5605a840d470" />
