### PR TITLE
fix(hookify): pass educational messages to Claude for warn and block

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows -- all through natural language commands. Use it in your terminal, IDE, or tag @claude on Github.
 
-**Learn more in the [official documentation](https://docs.anthropic.com/en/docs/claude-code/overview)**.
+**Learn more in the [official documentation](https://code.claude.com/docs/en/overview)**.
 
 <img src="./demo.gif" />
 

--- a/plugins/hookify/README.md
+++ b/plugins/hookify/README.md
@@ -91,8 +91,10 @@ This command could delete important files. Please:
 ```
 
 **Action field:**
-- `warn`: Shows warning but allows operation (default)
-- `block`: Prevents operation from executing (PreToolUse) or stops session (Stop events)
+- `warn`: Shows warning but allows operation (default). Claude receives the message via `additionalContext` for `PostToolUse` and `UserPromptSubmit` events.
+- `block`: Prevents operation from executing. Claude receives the reason via `permissionDecisionReason`.
+
+> **Note:** Due to Claude Code platform limitations, `warn` rules for `PreToolUse` events (bash, file) cannot pass messages to Claude before the operation. The warning is shown to the user but Claude only sees it after the tool executes (via `PostToolUse`). For pre-execution education, consider using `block` rules instead.
 
 ### Advanced Rule (Multiple Conditions)
 

--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -73,7 +73,8 @@ class RuleEngine:
                 return {
                     "hookSpecificOutput": {
                         "hookEventName": hook_event,
-                        "permissionDecision": "deny"
+                        "permissionDecision": "deny",
+                        "permissionDecisionReason": combined_message
                     },
                     "systemMessage": combined_message
                 }
@@ -86,8 +87,13 @@ class RuleEngine:
         # If only warnings, show them but allow operation
         if warning_rules:
             messages = [f"**[{r.name}]**\n{r.message}" for r in warning_rules]
+            combined_message = "\n\n".join(messages)
             return {
-                "systemMessage": "\n\n".join(messages)
+                "hookSpecificOutput": {
+                    "hookEventName": hook_event,
+                    "additionalContext": combined_message
+                },
+                "systemMessage": combined_message
             }
 
         # No matches - allow operation


### PR DESCRIPTION
## Problem

Hookify's warn and block rules weren't actually reaching Claude:

- Warn rules sent messages to `systemMessage` (user-visible only), so Claude never learned from them
- Block rules denied operations without explaining why, leaving Claude confused

## Fix

**rule_engine.py:**
- Warn rules now use `additionalContext` so Claude sees the warning
- Block rules now include `permissionDecisionReason` so Claude knows what went wrong

**README.md:**
- Updated docs to reflect new behavior
- Added note about PreToolUse limitation (the hooks API doesn't support `additionalContext` there, so warns work via PostToolUse instead)

## Tested

Ran both scenarios locally - warn outputs `additionalContext`, block outputs `permissionDecisionReason`. Works as expected.

Fixes #15203, #12446