### PR TITLE
docs: fix broken documentation link in README - Fixes #15177

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows -- all through natural language commands. Use it in your terminal, IDE, or tag @claude on Github.
 
-**Learn more in the [official documentation](https://docs.anthropic.com/en/docs/claude-code/overview)**.
+**Learn more in the [official documentation](https://code.claude.com/docs/en/overview)**.
 
 <img src="./demo.gif" />
 
@@ -56,7 +56,7 @@ When you use Claude Code, we collect feedback, which includes usage data (such a
 
 ### How we use your data
 
-See our [data usage policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).
+See our [data usage policies](https://code.claude.com/docs/en/data-usage).
 
 ### Privacy safeguards
 


### PR DESCRIPTION
The README has two documentation links pointing to 404 pages on the old docs.anthropic.com domain.

**Fixed:**
- Line 9: Official documentation link
- Line 59: Data usage policies link

Both now point to the correct code.claude.com domain.

Fixes #15177, #15089