### PR TITLE
feat: Add component metadata to plugin.json for improved discoverability

### DIFF
--- a/plugins/agent-sdk-dev/.claude-plugin/plugin.json
+++ b/plugins/agent-sdk-dev/.claude-plugin/plugin.json
@@ -5,5 +5,15 @@
   "author": {
     "name": "Ashwin Bhat",
     "email": "ashwin@anthropic.com"
+  },
+  "components": {
+    "agents": ["agent-sdk-verifier-py", "agent-sdk-verifier-ts"],
+    "commands": ["new-sdk-app"],
+    "skills": [],
+    "hooks": [],
+    "mcpServers": []
+  },
+  "metadata": {
+    "tags": ["sdk", "development", "python", "typescript"]
   }
 }

--- a/plugins/claude-opus-4-5-migration/.claude-plugin/plugin.json
+++ b/plugins/claude-opus-4-5-migration/.claude-plugin/plugin.json
@@ -5,5 +5,15 @@
   "author": {
     "name": "William Hu",
     "email": "whu@anthropic.com"
+  },
+  "components": {
+    "agents": [],
+    "commands": [],
+    "skills": ["claude-opus-4-5-migration"],
+    "hooks": [],
+    "mcpServers": []
+  },
+  "metadata": {
+    "tags": ["migration", "opus", "upgrade"]
   }
 }

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -5,6 +5,15 @@
   "author": {
     "name": "Boris Cherny",
     "email": "boris@anthropic.com"
+  },
+  "components": {
+    "agents": [],
+    "commands": ["code-review"],
+    "skills": [],
+    "hooks": [],
+    "mcpServers": []
+  },
+  "metadata": {
+    "tags": ["code-review", "pull-request", "quality"]
   }
 }
-

--- a/plugins/commit-commands/.claude-plugin/plugin.json
+++ b/plugins/commit-commands/.claude-plugin/plugin.json
@@ -5,6 +5,15 @@
   "author": {
     "name": "Anthropic",
     "email": "support@anthropic.com"
+  },
+  "components": {
+    "agents": [],
+    "commands": ["commit", "commit-push-pr", "clean_gone"],
+    "skills": [],
+    "hooks": [],
+    "mcpServers": []
+  },
+  "metadata": {
+    "tags": ["git", "workflow", "commit", "pull-request"]
   }
 }
-

--- a/plugins/explanatory-output-style/.claude-plugin/plugin.json
+++ b/plugins/explanatory-output-style/.claude-plugin/plugin.json
@@ -5,5 +5,15 @@
   "author": {
     "name": "Dickson Tsai",
     "email": "dickson@anthropic.com"
+  },
+  "components": {
+    "agents": [],
+    "commands": [],
+    "skills": [],
+    "hooks": ["SessionStart"],
+    "mcpServers": []
+  },
+  "metadata": {
+    "tags": ["output-style", "educational", "learning"]
   }
 }

--- a/plugins/feature-dev/.claude-plugin/plugin.json
+++ b/plugins/feature-dev/.claude-plugin/plugin.json
@@ -5,5 +5,15 @@
   "author": {
     "name": "Sid Bidasaria",
     "email": "sbidasaria@anthropic.com"
+  },
+  "components": {
+    "agents": ["code-explorer", "code-architect", "code-reviewer"],
+    "commands": ["feature-dev"],
+    "skills": [],
+    "hooks": [],
+    "mcpServers": []
+  },
+  "metadata": {
+    "tags": ["feature-development", "architecture", "workflow"]
   }
 }

--- a/plugins/frontend-design/.claude-plugin/plugin.json
+++ b/plugins/frontend-design/.claude-plugin/plugin.json
@@ -5,5 +5,15 @@
   "author": {
     "name": "Prithvi Rajasekaran, Alexander Bricken",
     "email": "prithvi@anthropic.com, alexander@anthropic.com"
+  },
+  "components": {
+    "agents": [],
+    "commands": [],
+    "skills": ["frontend-design"],
+    "hooks": [],
+    "mcpServers": []
+  },
+  "metadata": {
+    "tags": ["frontend", "ui", "ux", "design", "css"]
   }
 }

--- a/plugins/hookify/.claude-plugin/plugin.json
+++ b/plugins/hookify/.claude-plugin/plugin.json
@@ -5,5 +5,15 @@
   "author": {
     "name": "Daisy Hollman",
     "email": "daisy@anthropic.com"
+  },
+  "components": {
+    "agents": ["conversation-analyzer"],
+    "commands": ["hookify", "list", "configure", "help"],
+    "skills": ["writing-rules"],
+    "hooks": ["PreToolUse", "PostToolUse", "Stop", "UserPromptSubmit"],
+    "mcpServers": []
+  },
+  "metadata": {
+    "tags": ["hooks", "automation", "rules", "behavior"]
   }
 }

--- a/plugins/learning-output-style/.claude-plugin/plugin.json
+++ b/plugins/learning-output-style/.claude-plugin/plugin.json
@@ -5,5 +5,15 @@
   "author": {
     "name": "Boris Cherny",
     "email": "boris@anthropic.com"
+  },
+  "components": {
+    "agents": [],
+    "commands": [],
+    "skills": [],
+    "hooks": ["SessionStart"],
+    "mcpServers": []
+  },
+  "metadata": {
+    "tags": ["output-style", "learning", "interactive", "educational"]
   }
 }

--- a/plugins/plugin-dev/.claude-plugin/plugin.json
+++ b/plugins/plugin-dev/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "plugin-dev",
+  "version": "1.0.0",
+  "description": "Comprehensive toolkit for developing Claude Code plugins with expert skills and AI-assisted creation",
+  "author": {
+    "name": "Anthropic",
+    "email": "support@anthropic.com"
+  },
+  "components": {
+    "agents": ["agent-creator", "plugin-validator", "skill-reviewer"],
+    "commands": ["create-plugin"],
+    "skills": ["agent-development", "command-development", "hook-development", "mcp-integration", "plugin-settings", "plugin-structure", "skill-development"],
+    "hooks": [],
+    "mcpServers": []
+  },
+  "metadata": {
+    "tags": ["plugin", "development", "tooling", "sdk"]
+  }
+}

--- a/plugins/pr-review-toolkit/.claude-plugin/plugin.json
+++ b/plugins/pr-review-toolkit/.claude-plugin/plugin.json
@@ -5,5 +5,15 @@
   "author": {
     "name": "Daisy",
     "email": "daisy@anthropic.com"
+  },
+  "components": {
+    "agents": ["code-reviewer", "code-simplifier", "comment-analyzer", "pr-test-analyzer", "silent-failure-hunter", "type-design-analyzer"],
+    "commands": ["review-pr"],
+    "skills": [],
+    "hooks": [],
+    "mcpServers": []
+  },
+  "metadata": {
+    "tags": ["code-review", "pull-request", "testing", "quality"]
   }
 }

--- a/plugins/ralph-wiggum/.claude-plugin/plugin.json
+++ b/plugins/ralph-wiggum/.claude-plugin/plugin.json
@@ -5,5 +5,15 @@
   "author": {
     "name": "Daisy Hollman",
     "email": "daisy@anthropic.com"
+  },
+  "components": {
+    "agents": [],
+    "commands": ["ralph-loop", "cancel-ralph", "help"],
+    "skills": [],
+    "hooks": ["Stop"],
+    "mcpServers": []
+  },
+  "metadata": {
+    "tags": ["automation", "loops", "iterative", "workflow"]
   }
 }

--- a/plugins/security-guidance/.claude-plugin/plugin.json
+++ b/plugins/security-guidance/.claude-plugin/plugin.json
@@ -5,5 +5,15 @@
   "author": {
     "name": "David Dworken",
     "email": "dworken@anthropic.com"
+  },
+  "components": {
+    "agents": [],
+    "commands": [],
+    "skills": [],
+    "hooks": ["PreToolUse"],
+    "mcpServers": []
+  },
+  "metadata": {
+    "tags": ["security", "owasp", "xss", "injection", "safety"]
   }
 }

--- a/proposals/001-plugin-component-badges.md
+++ b/proposals/001-plugin-component-badges.md
@@ -1,0 +1,179 @@
+# RFC 001: Plugin Component Badges and Expanded View
+
+## Summary
+
+Enhance the Claude Code plugin discovery and management UI by displaying component badges (agents, commands, skills, hooks, MCPs) and providing an expanded view with detailed composition information.
+
+## Problem Statement
+
+Currently, when users browse plugins in the Claude Code marketplace or plugin list, they only see:
+- Plugin name
+- Version number
+- Short description
+
+**Users cannot tell:**
+- What components a plugin includes (agents, commands, skills, hooks, MCP servers)
+- The "weight" or complexity of a plugin
+- Whether a plugin fits their tech stack
+- Approximate context impact
+
+This makes it difficult to:
+1. Compare plugins with similar functionality
+2. Understand what you're installing before installation
+3. Find plugins that match specific needs (e.g., "I want a plugin with code review agents")
+
+## Proposed Solution
+
+### 1. Component Badges in Plugin List
+
+Display component counts as badges in the plugin listing:
+
+```
+feature-dev v1.0.0
+├─ 🤖 3 agents  📝 0 skills  ⚡ 1 command  🪝 0 hooks
+└─ 🏷️ feature-development, architecture, workflow
+```
+
+### 2. Expanded View on Selection
+
+When a user selects a plugin, show detailed composition:
+
+```
+feature-dev
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Agents (3):              Commands (1):
+• code-explorer          • /feature-dev
+• code-architect
+• code-reviewer
+
+Skills (0)               Hooks (0)
+
+MCP Servers (0)
+
+Tags: feature-development, architecture, workflow
+```
+
+### 3. Filter Options in Discover
+
+Allow users to filter plugins by component type:
+
+```
+[x] Has agents
+[ ] Has skills only
+[ ] Has MCP servers
+[ ] Filter by tag: [workflow ▼]
+```
+
+## Schema Changes
+
+This PR extends the `plugin.json` schema with two new optional fields:
+
+### `components` Object
+
+```json
+{
+  "components": {
+    "agents": ["agent-name-1", "agent-name-2"],
+    "commands": ["command-1", "command-2"],
+    "skills": ["skill-1"],
+    "hooks": ["PreToolUse", "Stop"],
+    "mcpServers": ["server-1"]
+  }
+}
+```
+
+### `metadata` Object
+
+```json
+{
+  "metadata": {
+    "tags": ["git", "workflow", "automation"]
+  }
+}
+```
+
+## Complete Example
+
+```json
+{
+  "name": "pr-review-toolkit",
+  "version": "1.0.0",
+  "description": "Comprehensive PR review agents...",
+  "author": {
+    "name": "Daisy",
+    "email": "daisy@anthropic.com"
+  },
+  "components": {
+    "agents": [
+      "code-reviewer",
+      "code-simplifier",
+      "comment-analyzer",
+      "pr-test-analyzer",
+      "silent-failure-hunter",
+      "type-design-analyzer"
+    ],
+    "commands": ["review-pr"],
+    "skills": [],
+    "hooks": [],
+    "mcpServers": []
+  },
+  "metadata": {
+    "tags": ["code-review", "pull-request", "testing", "quality"]
+  }
+}
+```
+
+## Implementation Notes
+
+### Phase 1: Schema (This PR)
+- Add `components` and `metadata` fields to all official plugins
+- Document the extended schema
+
+### Phase 2: UI (Future - requires Claude Code changes)
+- Parse `components` field in plugin browser
+- Render badges in list view
+- Render expanded view on selection
+- Add filter controls
+
+## Benefits
+
+1. **Better Discoverability**: Users can quickly identify what a plugin offers
+2. **Informed Decisions**: See exactly what you're installing
+3. **Easier Comparison**: Compare plugins by their composition
+4. **Stack Filtering**: Find plugins relevant to your tech stack via tags
+
+## Backwards Compatibility
+
+**Critical**: The new fields MUST be optional and non-breaking.
+
+### For Existing Plugins (without new fields)
+- Plugins without `components` or `metadata` fields MUST continue to work
+- The UI should gracefully handle missing fields by not showing badges
+- No validation errors should occur for missing optional fields
+
+### For New Schema (with new fields)
+- Adding extra fields to JSON typically doesn't break parsers
+- If Claude Code uses strict schema validation (`additionalProperties: false`), the schema would need updating
+- Recommended: Test with existing Claude Code version before merging
+
+### Graceful Degradation Example
+```javascript
+// UI should handle missing components gracefully
+const agents = plugin.components?.agents ?? [];
+const commands = plugin.components?.commands ?? [];
+// Only show badges if data exists
+if (agents.length > 0) showBadge('agents', agents.length);
+```
+
+## Open Questions
+
+1. Should we include estimated token impact in metadata?
+2. Should tags be free-form or from a controlled vocabulary?
+3. Should component lists be auto-generated from directory structure or manually maintained?
+
+---
+
+**Author**: richlira (Claude CDMX Community)
+**Date**: December 2025
+**Status**: Proposal


### PR DESCRIPTION
## Summary

**This is a proposal** to improve plugin discoverability in Claude Code by extending the `plugin.json` schema with component metadata.

### Problem
When users browse plugins, they only see name + description. There's no way to know:
- What components a plugin includes (agents, commands, skills, hooks, MCPs)
- The "weight" or complexity of a plugin
- **How much context/tokens a plugin consumes**
- Whether it fits their use case

### Solution
Extend `plugin.json` with optional fields:

```json
{
  "components": {
    "agents": ["code-reviewer", "code-architect"],
    "commands": ["feature-dev"],
    "skills": [],
    "hooks": [],
    "mcpServers": []
  },
  "metadata": {
    "tags": ["development", "workflow"],
    "estimatedTokens": 8500
  }
}
```

## Changes

- **12 modified**: Updated all existing `plugin.json` files with component metadata
- **1 new file**: Added missing `plugin.json` for `plugin-dev` plugin  
- **1 RFC**: `proposals/001-plugin-component-badges.md` - Full proposal for UI changes

---

## Proposed UI Changes (requires Claude Code implementation)

### 1. Component Badges in Plugin List

Display component counts and token impact as compact badges:

```
pr-review-toolkit v1.0.0
├─ 🤖 6 agents  ⚡ 1 command  📝 0 skills  🪝 0 hooks
├─ 🏷️ code-review, pull-request, testing, quality
└─ 📊 ~12,000 tokens

hookify v0.1.0
├─ 🤖 1 agent  ⚡ 4 commands  📝 1 skill  🪝 4 hooks
├─ 🏷️ hooks, automation, rules, behavior
└─ 📊 ~5,200 tokens

security-guidance v1.0.0
├─ 🪝 1 hook
├─ 🏷️ security, owasp, xss, injection, safety
└─ 📊 ~800 tokens (lightweight)
```

### 2. Expanded View on Selection

When a user clicks/selects a plugin, show detailed composition:

```
┌─────────────────────────────────────────────────────────────┐
│  pr-review-toolkit v1.0.0                                   │
│  Comprehensive PR review agents specializing in comments,   │
│  tests, error handling, type design, and code quality       │
├─────────────────────────────────────────────────────────────┤
│                                                             │
│  Agents (6):                    Commands (1):               │
│  • code-reviewer                • /review-pr                │
│  • code-simplifier                                          │
│  • comment-analyzer             Skills (0)                  │
│  • pr-test-analyzer                                         │
│  • silent-failure-hunter        Hooks (0)                   │
│  • type-design-analyzer                                     │
│                                 MCP Servers (0)             │
│                                                             │
│  Tags: code-review, pull-request, testing, quality          │
│                                                             │
│  ┌─ Context Impact ───────────────────────────────────────┐ │
│  │  📊 Estimated: ~12,000 tokens                          │ │
│  │  ⚠️  This plugin adds significant context overhead.    │ │
│  │     Consider for dedicated code review sessions.       │ │
│  └────────────────────────────────────────────────────────┘ │
│                                                             │
│  [Install]  [View Source]                                   │
└─────────────────────────────────────────────────────────────┘
```

### 3. Filter Options in Discover/Marketplace

Allow users to filter plugins by component type, tags, and context impact:

```
┌─ Filter Plugins ─────────────────────────────┐
│                                              │
│  Component Type:                             │
│  [x] Has agents                              │
│  [ ] Has skills                              │
│  [ ] Has hooks                               │
│  [ ] Has MCP servers                         │
│                                              │
│  Context Impact:                             │
│  ○ Any                                       │
│  ○ Lightweight (<2k tokens)                  │
│  ● Medium (2k-10k tokens)                    │
│  ○ Heavy (>10k tokens)                       │
│                                              │
│  Tags:                                       │
│  [ workflow ] [ security ] [ git ]           │
│  [ code-review ] [ development ] [ ui ]      │
│                                              │
└──────────────────────────────────────────────┘
```

### 4. Quick Comparison View

Enable side-by-side comparison of similar plugins:

```
┌────────────────────────┬────────────────────────┐
│  code-review           │  pr-review-toolkit     │
├────────────────────────┼────────────────────────┤
│  🤖 0 agents           │  🤖 6 agents           │
│  ⚡ 1 command          │  ⚡ 1 command          │
│  📝 0 skills           │  📝 0 skills           │
│  🪝 0 hooks            │  🪝 0 hooks            │
│  📊 ~3k tokens         │  📊 ~12k tokens        │
├────────────────────────┼────────────────────────┤
│  Simpler, lightweight  │  Comprehensive with    │
│  single command        │  specialized agents    │
│                        │  Higher context cost   │
└────────────────────────┴────────────────────────┘
```

### 5. Context Budget Awareness

Show users their available context and plugin impact:

```
┌─ Your Context Budget ────────────────────────────────────┐
│                                                          │
│  Total available: 200,000 tokens                         │
│  Currently used by plugins: 18,500 tokens (9.25%)        │
│                                                          │
│  Installed plugins:                                      │
│  • pr-review-toolkit     📊 12,000 tokens                │
│  • commit-commands       📊  1,500 tokens                │
│  • hookify               📊  5,000 tokens                │
│                                                          │
│  💡 Tip: Disable unused plugins to free up context       │
│                                                          │
└──────────────────────────────────────────────────────────┘
```

---

## Token Estimation Methodology

The `estimatedTokens` field could be calculated by:

1. **Static analysis**: Sum of all prompt/instruction text in agents, skills, commands
2. **Runtime sampling**: Measure actual token usage during typical sessions
3. **Manual estimation**: Author provides approximate value based on content size

Suggested categories:
| Category | Token Range | Examples |
|----------|-------------|----------|
| Lightweight | <2,000 | security-guidance, commit-commands |
| Medium | 2,000-10,000 | hookify, feature-dev |
| Heavy | >10,000 | pr-review-toolkit, plugin-dev |

---

## Backwards Compatibility

- New fields are **optional** - existing plugins without them continue to work
- JSON parsers typically ignore unknown fields
- UI should gracefully degrade when fields are missing:

```javascript
// Graceful handling of missing components
const agents = plugin.components?.agents ?? [];
const tokens = plugin.metadata?.estimatedTokens;

if (agents.length > 0) showBadge('agents', agents.length);
if (tokens) showTokenBadge(tokens);
```

## Test plan

- [ ] Verify existing Claude Code version doesn't break with new fields
- [ ] Review RFC proposal in `proposals/001-plugin-component-badges.md`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)