### PR TITLE
fix(plugin-dev): correct tools format in agent/command examples

### DIFF
--- a/plugins/plugin-dev/agents/agent-creator.md
+++ b/plugins/plugin-dev/agents/agent-creator.md
@@ -31,7 +31,7 @@ Plugin development with agent addition, trigger agent-creator.
 
 model: sonnet
 color: magenta
-tools: ["Write", "Read"]
+tools: Write, Read
 ---
 
 You are an elite AI agent architect specializing in crafting high-performance agent configurations. Your expertise lies in translating user requirements into precisely-tuned agent specifications that maximize effectiveness and reliability.
@@ -116,7 +116,7 @@ When a user describes what they want an agent to do, you will:
    description: [Use this agent when... Examples: <example>...</example>]
    model: inherit
    color: [chosen-color]
-   tools: ["Tool1", "Tool2"]  # Optional
+   tools: Tool1, Tool2  # Optional
    ---
 
    [Complete system prompt]

--- a/plugins/plugin-dev/agents/plugin-validator.md
+++ b/plugins/plugin-dev/agents/plugin-validator.md
@@ -33,7 +33,7 @@ assistant: "I'll use the plugin-validator agent to check the manifest."
 
 model: inherit
 color: yellow
-tools: ["Read", "Grep", "Glob", "Bash"]
+tools: Read, Grep, Glob, Bash
 ---
 
 You are an expert plugin validator specializing in comprehensive validation of Claude Code plugin structure, configuration, and components.

--- a/plugins/plugin-dev/agents/skill-reviewer.md
+++ b/plugins/plugin-dev/agents/skill-reviewer.md
@@ -32,7 +32,7 @@ Skill description modified, review for triggering effectiveness.
 
 model: inherit
 color: cyan
-tools: ["Read", "Grep", "Glob"]
+tools: Read, Grep, Glob
 ---
 
 You are an expert skill architect specializing in reviewing and improving Claude Code skills for maximum effectiveness and reliability.

--- a/plugins/plugin-dev/commands/create-plugin.md
+++ b/plugins/plugin-dev/commands/create-plugin.md
@@ -1,7 +1,7 @@
 ---
 description: Guided end-to-end plugin creation workflow with component design, implementation, and validation
 argument-hint: Optional plugin description
-allowed-tools: ["Read", "Write", "Grep", "Glob", "Bash", "TodoWrite", "AskUserQuestion", "Skill", "Task"]
+allowed-tools: Read, Write, Grep, Glob, Bash, TodoWrite, AskUserQuestion, Skill, Task
 ---
 
 # Plugin Creation Workflow

--- a/plugins/plugin-dev/skills/agent-development/SKILL.md
+++ b/plugins/plugin-dev/skills/agent-development/SKILL.md
@@ -41,7 +41,7 @@ assistant: "[How assistant should respond and use this agent]"
 
 model: inherit
 color: blue
-tools: ["Read", "Write", "Grep"]
+tools: Read, Write, Grep
 ---
 
 You are [agent role description]...
@@ -146,7 +146,7 @@ Restrict agent to specific tools.
 **Format:** Array of tool names
 
 ```yaml
-tools: ["Read", "Write", "Grep", "Bash"]
+tools: Read, Write, Grep, Bash
 ```
 
 **Default:** If omitted, agent has access to all tools
@@ -154,10 +154,10 @@ tools: ["Read", "Write", "Grep", "Bash"]
 **Best practice:** Limit tools to minimum needed (principle of least privilege)
 
 **Common tool sets:**
-- Read-only analysis: `["Read", "Grep", "Glob"]`
-- Code generation: `["Read", "Write", "Grep"]`
-- Testing: `["Read", "Bash", "Grep"]`
-- Full access: Omit field or use `["*"]`
+- Read-only analysis: `Read, Grep, Glob`
+- Code generation: `Read, Write, Grep`
+- Testing: `Read, Bash, Grep`
+- Full access: Omit field entirely
 
 ## System Prompt Design
 
@@ -354,7 +354,7 @@ Output: [What to provide]
 | description | Yes | Text + examples | Use when... <example>... |
 | model | Yes | inherit/sonnet/opus/haiku | inherit |
 | color | Yes | Color name | blue |
-| tools | No | Array of tool names | ["Read", "Grep"] |
+| tools | No | Comma-separated tool names | Read, Grep |
 
 ### Best Practices
 

--- a/plugins/plugin-dev/skills/agent-development/examples/agent-creation-prompt.md
+++ b/plugins/plugin-dev/skills/agent-development/examples/agent-creation-prompt.md
@@ -46,7 +46,7 @@ name: [identifier from JSON]
 description: [whenToUse from JSON]
 model: inherit
 color: [choose: blue/cyan/green/yellow/magenta/red]
-tools: ["Read", "Write", "Grep"]  # Optional: restrict tools
+tools: Read, Write, Grep  # Optional: restrict tools
 ---
 
 [systemPrompt from JSON]
@@ -98,7 +98,7 @@ Explicit review request triggers the agent.
 
 model: inherit
 color: blue
-tools: ["Read", "Grep", "Glob"]
+tools: Read, Grep, Glob
 ---
 
 You are an expert code quality reviewer specializing in identifying issues in software implementations.

--- a/plugins/plugin-dev/skills/agent-development/examples/complete-agent-examples.md
+++ b/plugins/plugin-dev/skills/agent-development/examples/complete-agent-examples.md
@@ -43,7 +43,7 @@ assistant: "I'll use the code-reviewer agent to validate the changes."
 
 model: inherit
 color: blue
-tools: ["Read", "Grep", "Glob"]
+tools: Read, Grep, Glob
 ---
 
 You are an expert code quality reviewer specializing in identifying issues, security vulnerabilities, and opportunities for improvement in software implementations.
@@ -141,7 +141,7 @@ Direct test generation request triggers the agent.
 
 model: inherit
 color: green
-tools: ["Read", "Write", "Grep", "Bash"]
+tools: Read, Write, Grep, Bash
 ---
 
 You are an expert test engineer specializing in creating comprehensive, maintainable unit tests that ensure code correctness and reliability.
@@ -238,7 +238,7 @@ Explicit documentation request triggers the agent.
 
 model: inherit
 color: cyan
-tools: ["Read", "Write", "Grep", "Glob"]
+tools: Read, Write, Grep, Glob
 ---
 
 You are an expert technical writer specializing in creating clear, comprehensive documentation for software projects.
@@ -323,7 +323,7 @@ Explicit security review request triggers the agent.
 
 model: inherit
 color: red
-tools: ["Read", "Grep", "Glob"]
+tools: Read, Grep, Glob
 ---
 
 You are an expert security analyst specializing in identifying vulnerabilities and security issues in software implementations.
@@ -399,9 +399,9 @@ Take these templates and customize:
 ### Adjust Tool Access
 
 Restrict or expand based on agent needs:
-- **Read-only agents**: `["Read", "Grep", "Glob"]`
-- **Generator agents**: `["Read", "Write", "Grep"]`
-- **Executor agents**: `["Read", "Write", "Bash", "Grep"]`
+- **Read-only agents**: `Read, Grep, Glob`
+- **Generator agents**: `Read, Write, Grep`
+- **Executor agents**: `Read, Write, Bash, Grep`
 - **Full access**: Omit tools field
 
 ### Customize Colors

--- a/plugins/plugin-dev/skills/mcp-integration/SKILL.md
+++ b/plugins/plugin-dev/skills/mcp-integration/SKILL.md
@@ -205,17 +205,14 @@ Pre-allow specific MCP tools in command frontmatter:
 
 ```markdown
 ---
-allowed-tools: [
-  "mcp__plugin_asana_asana__asana_create_task",
-  "mcp__plugin_asana_asana__asana_search_tasks"
-]
+allowed-tools: mcp__plugin_asana_asana__asana_create_task, mcp__plugin_asana_asana__asana_search_tasks
 ---
 ```
 
 **Wildcard (use sparingly):**
 ```markdown
 ---
-allowed-tools: ["mcp__plugin_asana_asana__*"]
+allowed-tools: mcp__plugin_asana_asana__*
 ---
 ```
 
@@ -294,7 +291,7 @@ Commands use MCP tools with user interaction:
 ```markdown
 # Command: create-item.md
 ---
-allowed-tools: ["mcp__plugin_name_server__create_item"]
+allowed-tools: mcp__plugin_name_server__create_item
 ---
 
 Steps:
@@ -367,12 +364,9 @@ Always use secure connections:
 Pre-allow only necessary MCP tools:
 
 ```markdown
-✅ allowed-tools: [
-  "mcp__plugin_api_server__read_data",
-  "mcp__plugin_api_server__create_item"
-]
+✅ allowed-tools: mcp__plugin_api_server__read_data, mcp__plugin_api_server__create_item
 
-❌ allowed-tools: ["mcp__plugin_api_server__*"]
+❌ allowed-tools: mcp__plugin_api_server__*
 ```
 
 ## Error Handling

--- a/plugins/plugin-dev/skills/mcp-integration/references/tool-usage.md
+++ b/plugins/plugin-dev/skills/mcp-integration/references/tool-usage.md
@@ -48,9 +48,7 @@ Specify MCP tools in command frontmatter:
 ```markdown
 ---
 description: Create a new Asana task
-allowed-tools: [
-  "mcp__plugin_asana_asana__asana_create_task"
-]
+allowed-tools: mcp__plugin_asana_asana__asana_create_task
 ---
 
 # Create Task Command
@@ -65,11 +63,7 @@ To create a task:
 
 ```markdown
 ---
-allowed-tools: [
-  "mcp__plugin_asana_asana__asana_create_task",
-  "mcp__plugin_asana_asana__asana_search_tasks",
-  "mcp__plugin_asana_asana__asana_get_project"
-]
+allowed-tools: mcp__plugin_asana_asana__asana_create_task, mcp__plugin_asana_asana__asana_search_tasks, mcp__plugin_asana_asana__asana_get_project
 ---
 ```
 
@@ -77,7 +71,7 @@ allowed-tools: [
 
 ```markdown
 ---
-allowed-tools: ["mcp__plugin_asana_asana__*"]
+allowed-tools: mcp__plugin_asana_asana__*
 ---
 ```
 
@@ -89,10 +83,7 @@ allowed-tools: ["mcp__plugin_asana_asana__*"]
 ```markdown
 ---
 description: Search and create Asana tasks
-allowed-tools: [
-  "mcp__plugin_asana_asana__asana_search_tasks",
-  "mcp__plugin_asana_asana__asana_create_task"
-]
+allowed-tools: mcp__plugin_asana_asana__asana_search_tasks, mcp__plugin_asana_asana__asana_create_task
 ---
 
 # Asana Task Management
@@ -451,12 +442,7 @@ Steps:
 
 ```markdown
 ---
-allowed-tools: [
-  "mcp__plugin_api_server__create_item",
-  "mcp__plugin_api_server__read_item",
-  "mcp__plugin_api_server__update_item",
-  "mcp__plugin_api_server__delete_item"
-]
+allowed-tools: mcp__plugin_api_server__create_item, mcp__plugin_api_server__read_item, mcp__plugin_api_server__update_item, mcp__plugin_api_server__delete_item
 ---
 
 # Item Management

--- a/plugins/plugin-dev/skills/plugin-settings/SKILL.md
+++ b/plugins/plugin-dev/skills/plugin-settings/SKILL.md
@@ -103,7 +103,7 @@ Commands can read settings files to customize behavior:
 ```markdown
 ---
 description: Process data with plugin
-allowed-tools: ["Read", "Bash"]
+allowed-tools: Read, Bash
 ---
 
 # Process Command

--- a/plugins/plugin-dev/skills/plugin-settings/examples/create-settings-command.md
+++ b/plugins/plugin-dev/skills/plugin-settings/examples/create-settings-command.md
@@ -1,6 +1,6 @@
 ---
 description: "Create plugin settings file with user preferences"
-allowed-tools: ["Write", "AskUserQuestion"]
+allowed-tools: Write, AskUserQuestion
 ---
 
 # Create Plugin Settings


### PR DESCRIPTION
## Summary

- Fixes YAML parsing issue where JSON arrays in `tools:` and `allowed-tools:` fields are treated as literal strings
- Converts `["Read", "Write"]` format to `Read, Write` (YAML comma-separated format)
- Updates 11 files in the plugin-dev plugin

## Problem

The YAML parser interprets:
```yaml
tools: ["Read", "Write"]
```

as the literal string `["Read", "Write"]` instead of an array, causing agents and commands to receive **zero tools silently**.

## Solution

Changed all instances to the correct YAML format:
```yaml
tools: Read, Write
```

## Files Changed

**Actual frontmatter (causing silent failures):**
- `agents/agent-creator.md`
- `agents/plugin-validator.md`
- `agents/skill-reviewer.md`
- `commands/create-plugin.md`
- `skills/plugin-settings/examples/create-settings-command.md`

**Documentation examples (preventing users from copying incorrect patterns):**
- `skills/agent-development/SKILL.md`
- `skills/agent-development/examples/agent-creation-prompt.md`
- `skills/agent-development/examples/complete-agent-examples.md`
- `skills/mcp-integration/SKILL.md`
- `skills/mcp-integration/references/tool-usage.md`
- `skills/plugin-settings/SKILL.md`

## Test plan

- [ ] Verify agents receive correct tools after this change
- [ ] Check that `allowed-tools` in commands work as expected
- [ ] Confirm documentation examples now show correct format

Fixes #13331

🤖 Generated with [Claude Code](https://claude.com/claude-code)