### PR TITLE
fix(hookify): correct Python import paths for hook modules

### DIFF
--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -7,7 +7,7 @@ from functools import lru_cache
 from typing import List, Dict, Any, Optional
 
 # Import from local module
-from hookify.core.config_loader import Rule, Condition
+from core.config_loader import Rule, Condition
 
 
 # Cache compiled regexes (max 128 patterns)
@@ -275,7 +275,7 @@ class RuleEngine:
 
 # For testing
 if __name__ == '__main__':
-    from hookify.core.config_loader import Condition, Rule
+    from core.config_loader import Condition, Rule
 
     # Test rule evaluation
     rule = Rule(

--- a/plugins/hookify/hooks/posttooluse.py
+++ b/plugins/hookify/hooks/posttooluse.py
@@ -19,8 +19,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)

--- a/plugins/hookify/hooks/pretooluse.py
+++ b/plugins/hookify/hooks/pretooluse.py
@@ -23,8 +23,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     # If imports fail, allow operation and log error
     error_msg = {"systemMessage": f"Hookify import error: {e}"}

--- a/plugins/hookify/hooks/stop.py
+++ b/plugins/hookify/hooks/stop.py
@@ -19,8 +19,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)

--- a/plugins/hookify/hooks/userpromptsubmit.py
+++ b/plugins/hookify/hooks/userpromptsubmit.py
@@ -19,8 +19,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)


### PR DESCRIPTION
## Summary

- Fixes the hookify plugin failing with `No module named 'hookify'` error
- The hook scripts were trying to import `from hookify.core.config_loader` but CLAUDE_PLUGIN_ROOT points directly to the plugin directory where `core/` exists at the root level
- Changed imports from `hookify.core.*` to `core.*` to match the actual directory structure

## Changes

| File | Change |
|------|--------|
| `hooks/pretooluse.py` | Fix import path |
| `hooks/posttooluse.py` | Fix import path |
| `hooks/stop.py` | Fix import path |
| `hooks/userpromptsubmit.py` | Fix import path |
| `core/rule_engine.py` | Fix import path (2 locations) |

## Test plan

- [x] Verified imports work locally with `python -c "from core.config_loader import load_rules; from core.rule_engine import RuleEngine; print('OK')"`
- [x] Confirmed claude-plugins-official already has correct imports (this aligns with that)

## Note

This fix matches the existing correct structure in `claude-plugins-official/plugins/hookify/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)