### PR TITLE
fix(ralph-wiggum): Fix multi-line bash command causing execution failure

### DIFF
--- a/plugins/ralph-wiggum/commands/ralph-loop.md
+++ b/plugins/ralph-wiggum/commands/ralph-loop.md
@@ -10,37 +10,7 @@ hide-from-slash-command-tool: "true"
 Execute the setup script to initialize the Ralph loop:
 
 ```!
-"${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh" $ARGUMENTS
-
-# Extract and display completion promise if set
-if [ -f .claude/ralph-loop.local.md ]; then
-  PROMISE=$(grep '^completion_promise:' .claude/ralph-loop.local.md | sed 's/completion_promise: *//' | sed 's/^"\(.*\)"$/\1/')
-  if [ -n "$PROMISE" ] && [ "$PROMISE" != "null" ]; then
-    echo ""
-    echo "═══════════════════════════════════════════════════════════"
-    echo "CRITICAL - Ralph Loop Completion Promise"
-    echo "═══════════════════════════════════════════════════════════"
-    echo ""
-    echo "To complete this loop, output this EXACT text:"
-    echo "  <promise>$PROMISE</promise>"
-    echo ""
-    echo "STRICT REQUIREMENTS (DO NOT VIOLATE):"
-    echo "  ✓ Use <promise> XML tags EXACTLY as shown above"
-    echo "  ✓ The statement MUST be completely and unequivocally TRUE"
-    echo "  ✓ Do NOT output false statements to exit the loop"
-    echo "  ✓ Do NOT lie even if you think you should exit"
-    echo ""
-    echo "IMPORTANT - Do not circumvent the loop:"
-    echo "  Even if you believe you're stuck, the task is impossible,"
-    echo "  or you've been running too long - you MUST NOT output a"
-    echo "  false promise statement. The loop is designed to continue"
-    echo "  until the promise is GENUINELY TRUE. Trust the process."
-    echo ""
-    echo "  If the loop should stop, the promise statement will become"
-    echo "  true naturally. Do not force it by lying."
-    echo "═══════════════════════════════════════════════════════════"
-  fi
-fi
+"${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh" $ARGUMENTS && if [ -f .claude/ralph-loop.local.md ]; then PROMISE=$(grep '^completion_promise:' .claude/ralph-loop.local.md | sed 's/completion_promise: *//' | sed 's/^"\(.*\)"$/\1/'); if [ -n "$PROMISE" ] && [ "$PROMISE" != "null" ]; then echo "" && echo "═══════════════════════════════════════════════════════════" && echo "CRITICAL - Ralph Loop Completion Promise" && echo "═══════════════════════════════════════════════════════════" && echo "" && echo "To complete this loop, output this EXACT text:" && echo "  <promise>$PROMISE</promise>" && echo "" && echo "STRICT REQUIREMENTS (DO NOT VIOLATE):" && echo "  ✓ Use <promise> XML tags EXACTLY as shown above" && echo "  ✓ The statement MUST be completely and unequivocally TRUE" && echo "  ✓ Do NOT output false statements to exit the loop" && echo "  ✓ Do NOT lie even if you think you should exit" && echo "" && echo "IMPORTANT - Do not circumvent the loop:" && echo "  Even if you believe you're stuck, the task is impossible," && echo "  or you've been running too long - you MUST NOT output a" && echo "  false promise statement. The loop is designed to continue" && echo "  until the promise is GENUINELY TRUE. Trust the process." && echo "" && echo "  If the loop should stop, the promise statement will become" && echo "  true naturally. Do not force it by lying." && echo "═══════════════════════════════════════════════════════════"; fi; fi
 ```
 
 Please work on the task. When you try to exit, the Ralph loop will feed the SAME PROMPT back to you for the next iteration. You'll see your previous work in files and git history, allowing you to iterate and improve.


### PR DESCRIPTION
## Summary

Fix the ralph-wiggum plugin's `/ralph-loop` command which fails to execute due to Claude Code's security restrictions on multi-line bash commands.

## Problem

When running `/ralph-loop`, users receive:
```
Error: Bash command permission check failed ... Command contains newlines that could separate multiple commands
```

This is because Claude Code blocks bash commands that contain newlines for security reasons (to prevent command chaining attacks).

## Solution

Convert the multi-line bash command block in `commands/ralph-loop.md` to a single line using `&&` operators to chain commands, which is allowed by Claude Code's security model.

### Before (broken):
```bash
"${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh" $ARGUMENTS

if [ -f .claude/ralph-loop.local.md ]; then
  # multiple lines...
fi
```

### After (fixed):
```bash
"${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh" $ARGUMENTS && if [ -f .claude/ralph-loop.local.md ]; then ...; fi
```

## Test plan

- [x] Run `/ralph-wiggum:ralph-loop "test task" --completion-promise "DONE"`
- [x] Verify loop initializes correctly without the newline error
- [x] Verify completion promise instructions display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)