### PR TITLE
fix(ralph-wiggum): Move multiline bash to setup script

### DIFF
--- a/plugins/ralph-wiggum/commands/ralph-loop.md
+++ b/plugins/ralph-wiggum/commands/ralph-loop.md
@@ -11,36 +11,6 @@ Execute the setup script to initialize the Ralph loop:
 
 ```!
 "${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh" $ARGUMENTS
-
-# Extract and display completion promise if set
-if [ -f .claude/ralph-loop.local.md ]; then
-  PROMISE=$(grep '^completion_promise:' .claude/ralph-loop.local.md | sed 's/completion_promise: *//' | sed 's/^"\(.*\)"$/\1/')
-  if [ -n "$PROMISE" ] && [ "$PROMISE" != "null" ]; then
-    echo ""
-    echo "═══════════════════════════════════════════════════════════"
-    echo "CRITICAL - Ralph Loop Completion Promise"
-    echo "═══════════════════════════════════════════════════════════"
-    echo ""
-    echo "To complete this loop, output this EXACT text:"
-    echo "  <promise>$PROMISE</promise>"
-    echo ""
-    echo "STRICT REQUIREMENTS (DO NOT VIOLATE):"
-    echo "  ✓ Use <promise> XML tags EXACTLY as shown above"
-    echo "  ✓ The statement MUST be completely and unequivocally TRUE"
-    echo "  ✓ Do NOT output false statements to exit the loop"
-    echo "  ✓ Do NOT lie even if you think you should exit"
-    echo ""
-    echo "IMPORTANT - Do not circumvent the loop:"
-    echo "  Even if you believe you're stuck, the task is impossible,"
-    echo "  or you've been running too long - you MUST NOT output a"
-    echo "  false promise statement. The loop is designed to continue"
-    echo "  until the promise is GENUINELY TRUE. Trust the process."
-    echo ""
-    echo "  If the loop should stop, the promise statement will become"
-    echo "  true naturally. Do not force it by lying."
-    echo "═══════════════════════════════════════════════════════════"
-  fi
-fi
 ```
 
 Please work on the task. When you try to exit, the Ralph loop will feed the SAME PROMPT back to you for the next iteration. You'll see your previous work in files and git history, allowing you to iterate and improve.

--- a/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
+++ b/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
@@ -154,7 +154,7 @@ cat <<EOF
 🔄 Ralph loop activated in this session!
 
 Iteration: 1
-Max iterations: $(if [[ $MAX_ITERATIONS -gt 0 ]]; then echo $MAX_ITERATIONS; else echo "unlimited"; fi)
+Max iterations: $(if [[ $MAX_ITERATIONS -gt 0 ]]; then echo "$MAX_ITERATIONS"; else echo "unlimited"; fi)
 Completion promise: $(if [[ "$COMPLETION_PROMISE" != "null" ]]; then echo "${COMPLETION_PROMISE//\"/} (ONLY output when TRUE - do not lie!)"; else echo "none (runs forever)"; fi)
 
 The stop hook is now active. When you try to exit, the SAME PROMPT will be
@@ -173,4 +173,31 @@ EOF
 if [[ -n "$PROMPT" ]]; then
   echo ""
   echo "$PROMPT"
+fi
+
+# Display completion promise instructions if set
+if [[ "$COMPLETION_PROMISE" != "null" ]] && [[ -n "$COMPLETION_PROMISE" ]]; then
+  echo ""
+  echo "═══════════════════════════════════════════════════════════"
+  echo "CRITICAL - Ralph Loop Completion Promise"
+  echo "═══════════════════════════════════════════════════════════"
+  echo ""
+  echo "To complete this loop, output this EXACT text:"
+  echo "  <promise>$COMPLETION_PROMISE</promise>"
+  echo ""
+  echo "STRICT REQUIREMENTS (DO NOT VIOLATE):"
+  echo "  ✓ Use <promise> XML tags EXACTLY as shown above"
+  echo "  ✓ The statement MUST be completely and unequivocally TRUE"
+  echo "  ✓ Do NOT output false statements to exit the loop"
+  echo "  ✓ Do NOT lie even if you think you should exit"
+  echo ""
+  echo "IMPORTANT - Do not circumvent the loop:"
+  echo "  Even if you believe you're stuck, the task is impossible,"
+  echo "  or you've been running too long - you MUST NOT output a"
+  echo "  false promise statement. The loop is designed to continue"
+  echo "  until the promise is GENUINELY TRUE. Trust the process."
+  echo ""
+  echo "  If the loop should stop, the promise statement will become"
+  echo "  true naturally. Do not force it by lying."
+  echo "═══════════════════════════════════════════════════════════"
 fi


### PR DESCRIPTION
## Summary

- Moved completion promise display logic from inline command in `ralph-loop.md` into `setup-ralph-loop.sh`
- Command is now a single line that passes Claude Code's newline safety check
- Also fixes a pre-existing shellcheck warning about unquoted variable

## Problem

Claude Code's safety check blocks bash commands containing newlines to prevent command injection. The ralph-loop command had an inline multi-line bash script that triggered this check:

```
Error: Bash command permission check failed for pattern "...": Command contains newlines that could separate multiple commands
```

## Solution

Move the completion promise display logic into the setup script, which already has access to the `$COMPLETION_PROMISE` variable. This simplifies the command to a single line while maintaining the same functionality.

## Test plan

- [x] Verified shellcheck passes on `setup-ralph-loop.sh`
- [ ] Test `/ralph-wiggum:ralph-loop` command executes without permission error
- [ ] Test completion promise is displayed correctly when `--completion-promise` is set