### PR TITLE
fix(ralph-wiggum): add session isolation for stop hook

### DIFF
--- a/plugins/ralph-wiggum/.gitignore
+++ b/plugins/ralph-wiggum/.gitignore
@@ -1,0 +1,2 @@
+# Session state files (created at runtime, session-specific)
+state/

--- a/plugins/ralph-wiggum/commands/ralph-loop.md
+++ b/plugins/ralph-wiggum/commands/ralph-loop.md
@@ -13,8 +13,10 @@ Execute the setup script to initialize the Ralph loop:
 "${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh" $ARGUMENTS
 
 # Extract and display completion promise if set
-if [ -f .claude/ralph-loop.local.md ]; then
-  PROMISE=$(grep '^completion_promise:' .claude/ralph-loop.local.md | sed 's/completion_promise: *//' | sed 's/^"\(.*\)"$/\1/')
+# State files are now stored in the plugin's state directory with session ID
+RALPH_STATE_FILE="${CLAUDE_PLUGIN_ROOT}/state/${CLAUDE_SESSION_ID}.md"
+if [ -f "$RALPH_STATE_FILE" ]; then
+  PROMISE=$(grep '^completion_promise:' "$RALPH_STATE_FILE" | sed 's/completion_promise: *//' | sed 's/^"\(.*\)"$/\1/')
   if [ -n "$PROMISE" ] && [ "$PROMISE" != "null" ]; then
     echo ""
     echo "═══════════════════════════════════════════════════════════"

--- a/plugins/ralph-wiggum/hooks/hooks.json
+++ b/plugins/ralph-wiggum/hooks/hooks.json
@@ -1,6 +1,16 @@
 {
-  "description": "Ralph Wiggum plugin stop hook for self-referential loops",
+  "description": "Ralph Wiggum plugin hooks for self-referential loops",
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start-hook.sh"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/plugins/ralph-wiggum/hooks/session-start-hook.sh
+++ b/plugins/ralph-wiggum/hooks/session-start-hook.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Ralph Wiggum Session Start Hook
+# Extracts session_id from hook input and persists it as CLAUDE_SESSION_ID
+# This makes the session ID available to command scripts via environment variable
+
+set -euo pipefail
+
+# Read hook input from stdin
+HOOK_INPUT=$(cat)
+
+# Extract session_id from hook input
+SESSION_ID=$(echo "$HOOK_INPUT" | jq -r '.session_id // empty')
+
+if [[ -z "$SESSION_ID" ]]; then
+  # No session ID available - this shouldn't happen but exit gracefully
+  exit 0
+fi
+
+# CLAUDE_ENV_FILE is provided by Claude Code for SessionStart hooks
+# Writing to this file persists environment variables for the session
+if [[ -n "${CLAUDE_ENV_FILE:-}" ]]; then
+  echo "export CLAUDE_SESSION_ID=\"$SESSION_ID\"" >> "$CLAUDE_ENV_FILE"
+fi
+
+exit 0

--- a/plugins/ralph-wiggum/hooks/stop-hook.sh
+++ b/plugins/ralph-wiggum/hooks/stop-hook.sh
@@ -9,11 +9,26 @@ set -euo pipefail
 # Read hook input from stdin (advanced stop hook API)
 HOOK_INPUT=$(cat)
 
-# Check if ralph-loop is active
-RALPH_STATE_FILE=".claude/ralph-loop.local.md"
+# Determine state directory (plugin-relative for session isolation)
+if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" ]]; then
+  STATE_DIR="$CLAUDE_PLUGIN_ROOT/state"
+else
+  # Fallback: derive from script location (hooks/stop-hook.sh -> plugin root)
+  STATE_DIR="$(dirname "$(dirname "$0")")/state"
+fi
+
+# Extract session_id from hook input
+SESSION_ID=$(echo "$HOOK_INPUT" | jq -r '.session_id // empty')
+if [[ -z "$SESSION_ID" ]]; then
+  # No session ID available - allow exit
+  exit 0
+fi
+
+# Check if ralph-loop is active for THIS session
+RALPH_STATE_FILE="$STATE_DIR/${SESSION_ID}.md"
 
 if [[ ! -f "$RALPH_STATE_FILE" ]]; then
-  # No active loop - allow exit
+  # No active loop for this session - allow exit
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

Fixes #15047 
Related: #15790

Fixes the ralph-wiggum stop hook triggering across ALL Claude Code sessions instead of being isolated to individual sessions.

**Problem:** The stop hook checked for a state file at a CWD-relative path (`.claude/ralph-loop.local.md`), which caused cross-session interference:
1. Session A starts ralph-loop in directory X
2. Session B (in the same directory) stops → hook finds Session A's state file
3. Session B gets hijacked into continuing Session A's loop, receiving the same prompt and continuing iterations

This made it impossible to run ralph-loop in one session while using other Claude Code sessions normally in the same directory - they would all get pulled into the same loop.

**Solution:** Session-based state file isolation:

- **SessionStart hook**: Extracts `session_id` from hook input JSON and persists it as `CLAUDE_SESSION_ID` environment variable via `CLAUDE_ENV_FILE`. This makes the session ID available to command scripts.

- **Session-specific state files**: State files are now stored in the plugin's `state/` directory as `${session_id}.md` instead of CWD-relative paths.

- **Stop hook isolation**: Extracts `session_id` from its JSON input and only checks for state files matching that specific session.

## Changes

- `hooks/session-start-hook.sh` (NEW) - Persists session_id as CLAUDE_SESSION_ID
- `hooks/hooks.json` - Added SessionStart hook configuration  
- `hooks/stop-hook.sh` - Uses session-specific state files
- `scripts/setup-ralph-loop.sh` - Uses CLAUDE_SESSION_ID for state file naming
- `commands/ralph-loop.md` - Updated state file path reference
- `.gitignore` (NEW) - Ignores state/ directory

## Test plan

- [x] Start a ralph-loop in Session A
- [x] Verify Session B can exit normally without being hijacked into the loop
- [x] Verify Session A's ralph-loop continues working as expected
- [x] Verify state files are created in `<plugin-root>/state/<session-id>.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)