### PR TITLE
fix: use portable shebangs in shell scripts

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail  # Exit on error, undefined vars, and pipeline failures
 IFS=$'\n\t'       # Stricter word splitting
 

--- a/plugins/plugin-dev/skills/agent-development/scripts/validate-agent.sh
+++ b/plugins/plugin-dev/skills/agent-development/scripts/validate-agent.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Agent File Validator
 # Validates agent markdown files for correct structure and content
 

--- a/plugins/plugin-dev/skills/hook-development/examples/load-context.sh
+++ b/plugins/plugin-dev/skills/hook-development/examples/load-context.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Example SessionStart hook for loading project context
 # This script detects project type and sets environment variables
 

--- a/plugins/plugin-dev/skills/hook-development/examples/validate-bash.sh
+++ b/plugins/plugin-dev/skills/hook-development/examples/validate-bash.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Example PreToolUse hook for validating Bash commands
 # This script demonstrates bash command validation patterns
 

--- a/plugins/plugin-dev/skills/hook-development/examples/validate-write.sh
+++ b/plugins/plugin-dev/skills/hook-development/examples/validate-write.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Example PreToolUse hook for validating Write/Edit operations
 # This script demonstrates file write validation patterns
 

--- a/plugins/plugin-dev/skills/hook-development/scripts/hook-linter.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/hook-linter.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook Linter
 # Checks hook scripts for common issues and best practices
 
@@ -42,7 +42,7 @@ check_script() {
   # Check 2: Shebang
   first_line=$(head -1 "$script")
   if [[ ! "$first_line" =~ ^#!/ ]]; then
-    echo "❌ Missing shebang (#!/bin/bash)"
+    echo "❌ Missing shebang (#!/usr/bin/env bash)"
     ((errors++))
   fi
 

--- a/plugins/plugin-dev/skills/hook-development/scripts/test-hook.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/test-hook.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook Testing Helper
 # Tests a hook with sample input and shows output
 

--- a/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook Schema Validator
 # Validates hooks.json structure and checks for common issues
 

--- a/plugins/plugin-dev/skills/plugin-settings/examples/read-settings-hook.sh
+++ b/plugins/plugin-dev/skills/plugin-settings/examples/read-settings-hook.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Example hook that reads plugin settings from .claude/my-plugin.local.md
 # Demonstrates the complete pattern for settings-driven hook behavior
 

--- a/plugins/plugin-dev/skills/plugin-settings/scripts/parse-frontmatter.sh
+++ b/plugins/plugin-dev/skills/plugin-settings/scripts/parse-frontmatter.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Frontmatter Parser Utility
 # Extracts YAML frontmatter from .local.md files
 

--- a/plugins/plugin-dev/skills/plugin-settings/scripts/validate-settings.sh
+++ b/plugins/plugin-dev/skills/plugin-settings/scripts/validate-settings.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Settings File Validator
 # Validates .claude/plugin-name.local.md structure
 

--- a/plugins/ralph-wiggum/hooks/stop-hook.sh
+++ b/plugins/ralph-wiggum/hooks/stop-hook.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Ralph Wiggum Stop Hook
 # Prevents session exit when a ralph-loop is active

--- a/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
+++ b/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Ralph Loop Setup Script
 # Creates state file for in-session Ralph loop


### PR DESCRIPTION
Fixes #12880
Fixes #15876

## Summary

Change all shebangs from `#!/bin/bash` to `#!/usr/bin/env bash`.

This is the portable POSIX standard that finds bash via PATH, working on NixOS, Guix, macOS, FreeBSD, and standard Linux distributions.

## Changes

Updated 13 shell scripts across:
- `.devcontainer/init-firewall.sh`
- `plugins/plugin-dev/skills/*/scripts/*.sh`
- `plugins/plugin-dev/skills/*/examples/*.sh`
- `plugins/ralph-wiggum/hooks/stop-hook.sh`
- `plugins/ralph-wiggum/scripts/setup-ralph-loop.sh`

Also updated `hook-linter.sh` to recommend the portable shebang in its error message.

## Testing

Tested locally on NixOS - all scripts now work correctly.