### PR TITLE
fix(hookify): handle Write tool content in new_text field and add Update tool support

### DIFF
--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -232,12 +232,12 @@ class RuleEngine:
             if field == 'command':
                 return tool_input.get('command', '')
 
-        elif tool_name in ['Write', 'Edit']:
+        elif tool_name in ['Write', 'Edit', 'Update']:
             if field == 'content':
                 # Write uses 'content', Edit has 'new_string'
                 return tool_input.get('content') or tool_input.get('new_string', '')
             elif field == 'new_text' or field == 'new_string':
-                return tool_input.get('new_string', '')
+                return tool_input.get('new_string') or tool_input.get('content', '')
             elif field == 'old_text' or field == 'old_string':
                 return tool_input.get('old_string', '')
             elif field == 'file_path':

--- a/plugins/hookify/hooks/posttooluse.py
+++ b/plugins/hookify/hooks/posttooluse.py
@@ -38,7 +38,7 @@ def main():
         event = None
         if tool_name == 'Bash':
             event = 'bash'
-        elif tool_name in ['Edit', 'Write', 'MultiEdit']:
+        elif tool_name in ['Edit', 'Write', 'MultiEdit', 'Update']:
             event = 'file'
 
         # Load rules

--- a/plugins/hookify/hooks/pretooluse.py
+++ b/plugins/hookify/hooks/pretooluse.py
@@ -45,7 +45,7 @@ def main():
         event = None
         if tool_name == 'Bash':
             event = 'bash'
-        elif tool_name in ['Edit', 'Write', 'MultiEdit']:
+        elif tool_name in ['Edit', 'Write', 'MultiEdit', 'Update']:
             event = 'file'
 
         # Load rules


### PR DESCRIPTION
## Summary

Fixes the `new_text` field in hookify rules to work correctly with the Write tool, and adds support for the Update tool.

### Changes

- `new_text` field now checks both `new_string` (Edit) and `content` (Write) parameters
- Added `Update` tool to file event handlers in rule_engine.py, pretooluse.py, and posttooluse.py

Fixes #13885