### PR TITLE
Update broken docs link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows -- all through natural language commands. Use it in your terminal, IDE, or tag @claude on Github.
 
-**Learn more in the [official documentation](https://docs.anthropic.com/en/docs/claude-code/overview)**.
+**Learn more in the [official documentation](https://code.claude.com/docs/en/overview)**.
 
 <img src="./demo.gif" />
 


### PR DESCRIPTION
The previous docs link 404s. The new one points to the updated docs.