### PR TITLE
fix(docs): fix broken CONTRIBUTING and LICENSE links in plugin docs

### DIFF
--- a/plugins/plugin-dev/skills/command-development/references/documentation-patterns.md
+++ b/plugins/plugin-dev/skills/command-development/references/documentation-patterns.md
@@ -673,11 +673,11 @@ enable_feature: true
 
 ## Contributing
 
-Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md).
+Contributions welcome! Open an issue or pull request on [GitHub](https://github.com/anthropics/claude-code).
 
 ## License
 
-MIT License - See [LICENSE](LICENSE).
+MIT License - See [LICENSE.md](../../../../../LICENSE.md).
 
 ## Support
 


### PR DESCRIPTION
## Summary

Fixes 2 broken relative links in `plugins/plugin-dev/skills/command-development/references/documentation-patterns.md`:

- `CONTRIBUTING.md` → Link to GitHub repo (no CONTRIBUTING.md exists)
- `LICENSE` → Correct relative path to `LICENSE.md`

## Test plan

- [x] Verified LICENSE.md exists at repo root
- [x] Verified relative path `../../../../../LICENSE.md` resolves correctly from the docs location

🤖 Generated with [Claude Code](https://claude.com/claude-code)