### PR TITLE
chore: Update Node.js version from 20 to 24 in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:24
 
 ARG TZ
 ENV TZ="$TZ"


### PR DESCRIPTION
The Node.js version used in the DevContainer was v20, which has entered the maintenance phase.
This change updates it to a currently supported version.

I have updated and used the version locally, and no issues have been observed.