### PR TITLE
fix(ralph-wiggum): move multi-line bash from command to setup script

### DIFF
--- a/plugins/ralph-wiggum/commands/cancel-ralph.md
+++ b/plugins/ralph-wiggum/commands/cancel-ralph.md
@@ -1,26 +1,18 @@
 ---
 description: "Cancel active Ralph Wiggum loop"
-allowed-tools: ["Bash"]
+allowed-tools: ["Bash(test -f .claude/ralph-loop.local.md:*)", "Bash(rm .claude/ralph-loop.local.md)", "Read(.claude/ralph-loop.local.md)"]
 hide-from-slash-command-tool: "true"
 ---
 
 # Cancel Ralph
 
-```!
-if [[ -f .claude/ralph-loop.local.md ]]; then
-  ITERATION=$(grep '^iteration:' .claude/ralph-loop.local.md | sed 's/iteration: *//')
-  echo "FOUND_LOOP=true"
-  echo "ITERATION=$ITERATION"
-else
-  echo "FOUND_LOOP=false"
-fi
-```
+To cancel the Ralph loop:
 
-Check the output above:
+1. Check if `.claude/ralph-loop.local.md` exists using Bash: `test -f .claude/ralph-loop.local.md && echo "EXISTS" || echo "NOT_FOUND"`
 
-1. **If FOUND_LOOP=false**:
-   - Say "No active Ralph loop found."
+2. **If NOT_FOUND**: Say "No active Ralph loop found."
 
-2. **If FOUND_LOOP=true**:
-   - Use Bash: `rm .claude/ralph-loop.local.md`
-   - Report: "Cancelled Ralph loop (was at iteration N)" where N is the ITERATION value from above.
+3. **If EXISTS**:
+   - Read `.claude/ralph-loop.local.md` to get the current iteration number from the `iteration:` field
+   - Remove the file using Bash: `rm .claude/ralph-loop.local.md`
+   - Report: "Cancelled Ralph loop (was at iteration N)" where N is the iteration value

--- a/plugins/ralph-wiggum/commands/ralph-loop.md
+++ b/plugins/ralph-wiggum/commands/ralph-loop.md
@@ -11,36 +11,6 @@ Execute the setup script to initialize the Ralph loop:
 
 ```!
 "${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh" $ARGUMENTS
-
-# Extract and display completion promise if set
-if [ -f .claude/ralph-loop.local.md ]; then
-  PROMISE=$(grep '^completion_promise:' .claude/ralph-loop.local.md | sed 's/completion_promise: *//' | sed 's/^"\(.*\)"$/\1/')
-  if [ -n "$PROMISE" ] && [ "$PROMISE" != "null" ]; then
-    echo ""
-    echo "═══════════════════════════════════════════════════════════"
-    echo "CRITICAL - Ralph Loop Completion Promise"
-    echo "═══════════════════════════════════════════════════════════"
-    echo ""
-    echo "To complete this loop, output this EXACT text:"
-    echo "  <promise>$PROMISE</promise>"
-    echo ""
-    echo "STRICT REQUIREMENTS (DO NOT VIOLATE):"
-    echo "  ✓ Use <promise> XML tags EXACTLY as shown above"
-    echo "  ✓ The statement MUST be completely and unequivocally TRUE"
-    echo "  ✓ Do NOT output false statements to exit the loop"
-    echo "  ✓ Do NOT lie even if you think you should exit"
-    echo ""
-    echo "IMPORTANT - Do not circumvent the loop:"
-    echo "  Even if you believe you're stuck, the task is impossible,"
-    echo "  or you've been running too long - you MUST NOT output a"
-    echo "  false promise statement. The loop is designed to continue"
-    echo "  until the promise is GENUINELY TRUE. Trust the process."
-    echo ""
-    echo "  If the loop should stop, the promise statement will become"
-    echo "  true naturally. Do not force it by lying."
-    echo "═══════════════════════════════════════════════════════════"
-  fi
-fi
 ```
 
 Please work on the task. When you try to exit, the Ralph loop will feed the SAME PROMPT back to you for the next iteration. You'll see your previous work in files and git history, allowing you to iterate and improve.

--- a/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
+++ b/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
@@ -174,3 +174,30 @@ if [[ -n "$PROMPT" ]]; then
   echo ""
   echo "$PROMPT"
 fi
+
+# Display completion promise requirements if set
+if [[ "$COMPLETION_PROMISE" != "null" ]]; then
+  echo ""
+  echo "═══════════════════════════════════════════════════════════"
+  echo "CRITICAL - Ralph Loop Completion Promise"
+  echo "═══════════════════════════════════════════════════════════"
+  echo ""
+  echo "To complete this loop, output this EXACT text:"
+  echo "  <promise>$COMPLETION_PROMISE</promise>"
+  echo ""
+  echo "STRICT REQUIREMENTS (DO NOT VIOLATE):"
+  echo "  ✓ Use <promise> XML tags EXACTLY as shown above"
+  echo "  ✓ The statement MUST be completely and unequivocally TRUE"
+  echo "  ✓ Do NOT output false statements to exit the loop"
+  echo "  ✓ Do NOT lie even if you think you should exit"
+  echo ""
+  echo "IMPORTANT - Do not circumvent the loop:"
+  echo "  Even if you believe you're stuck, the task is impossible,"
+  echo "  or you've been running too long - you MUST NOT output a"
+  echo "  false promise statement. The loop is designed to continue"
+  echo "  until the promise is GENUINELY TRUE. Trust the process."
+  echo ""
+  echo "  If the loop should stop, the promise statement will become"
+  echo "  true naturally. Do not force it by lying."
+  echo "═══════════════════════════════════════════════════════════"
+fi


### PR DESCRIPTION
## Summary

Fixes #12170

The ralph-wiggum slash commands had multi-line bash scripts in their ```!` blocks. Claude Code's security check blocks commands with newlines to prevent command injection, causing the error:

```
Command contains newlines that could separate multiple commands
```

## Changes

**ralph-loop.md:**
- Remove multi-line bash from ```!` block
- Keep single-line call to setup script
- Keep scoped `allowed-tools` for security

**cancel-ralph.md:**
- Replace multi-line bash with step-by-step instructions
- Tighten `allowed-tools` to specific file paths:
  - `Bash(test -f .claude/ralph-loop.local.md:*)`
  - `Bash(rm .claude/ralph-loop.local.md)`
  - `Read(.claude/ralph-loop.local.md)`

**setup-ralph-loop.sh:**
- Add completion promise display logic (moved from ralph-loop.md)
- Uses `$COMPLETION_PROMISE` variable directly instead of reading from file

## Why This Approach vs PR #12642

This PR improves on #12642 by:
1. Keeping scoped `allowed-tools` instead of broadening to `["Bash"]`
2. Tightening `cancel-ralph.md` permissions to specific file paths
3. Simplifying the logic (no redundant file read for completion promise)

## Test Plan

- Tested locally with both `/ralph-wiggum:ralph-loop` and `/ralph-wiggum:cancel-ralph`
- Verified no permission errors
- Verified completion promise displays correctly