### PR TITLE
fix(ralph-wiggum): add :* to allowed-tools pattern to permit arguments

### DIFF
--- a/plugins/ralph-wiggum/commands/ralph-loop.md
+++ b/plugins/ralph-wiggum/commands/ralph-loop.md
@@ -1,7 +1,7 @@
 ---
 description: "Start Ralph Wiggum loop in current session"
 argument-hint: "PROMPT [--max-iterations N] [--completion-promise TEXT]"
-allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh)"]
+allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh:*)"]
 hide-from-slash-command-tool: "true"
 ---
 


### PR DESCRIPTION
## Summary

Fixes #16398

The `/ralph-wiggum:ralph-loop` slash command was failing with a permission error because the `allowed-tools` pattern was missing the `:*` suffix to permit arguments.

## Root Cause

The `allowed-tools` pattern:
```
Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh)
```

Doesn't match commands with arguments. When users pass arguments like:
```
/ralph-wiggum:ralph-loop "Simple task" --completion-promise "DONE" --max-iterations 5
```

The permission check fails because the pattern doesn't allow for the additional arguments.

## Fix

Add `:*` to the pattern to permit any arguments:
```
Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh:*)
```

## Testing

Verified the fix works by running the command after updating the plugin cache.