### PR TITLE
fix(ralph-wiggum): use portable shebang in shell scripts

### DIFF
--- a/plugins/ralph-wiggum/hooks/stop-hook.sh
+++ b/plugins/ralph-wiggum/hooks/stop-hook.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Ralph Wiggum Stop Hook
 # Prevents session exit when a ralph-loop is active

--- a/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
+++ b/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Ralph Loop Setup Script
 # Creates state file for in-session Ralph loop


### PR DESCRIPTION
## Summary
- Change `#!/bin/bash` to `#!/usr/bin/env bash` in ralph-wiggum shell scripts
- Fixes compatibility issues on NixOS, WSL2, and other Linux distributions where `/bin/bash` may not exist

## Test plan
- [x] Tested `setup-ralph-loop.sh --help` works on WSL2 Ubuntu
- [x] Tested `setup-ralph-loop.sh "Test task" --max-iterations 3` creates state file correctly
- [ ] Verify scripts work on NixOS

Fixes #12880

🤖 Generated with [Claude Code](https://claude.com/claude-code)