### PR TITLE
Fix: `This command uses shell operators that require approval for safety`

### DIFF
--- a/plugins/ralph-wiggum/commands/ralph-loop.md
+++ b/plugins/ralph-wiggum/commands/ralph-loop.md
@@ -9,9 +9,7 @@ hide-from-slash-command-tool: "true"
 
 Execute the setup script to initialize the Ralph loop:
 
-```!
-"${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh" $ARGUMENTS
-```
+Bash("${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh" $ARGUMENTS)
 
 Please work on the task. When you try to exit, the Ralph loop will feed the SAME PROMPT back to you for the next iteration. You'll see your previous work in files and git history, allowing you to iterate and improve.
 


### PR DESCRIPTION
Fixes #16389

## Summary
Migrates the ralph-loop initialization from a Markdown-formatted code block to a functional Bash tool call.

## Technical Brief
The previous implementation used a !-prefixed code block (```!), which the Claude Code engine treats as a display-only suggestion or a legacy command format. This change wraps the invocation in the explicit Bash() tool syntax.