### PR TITLE
fix: validate that issues exist before commenting on duplicates

### DIFF
--- a/scripts/comment-on-duplicates.sh
+++ b/scripts/comment-on-duplicates.sh
@@ -60,6 +60,20 @@ for dup in "${DUPLICATES[@]}"; do
   fi
 done
 
+# Validate that base issue exists
+if ! gh issue view "$BASE_ISSUE" --repo "$REPO" &>/dev/null; then
+  echo "Error: issue #$BASE_ISSUE does not exist in $REPO" >&2
+  exit 1
+fi
+
+# Validate that all duplicate issues exist
+for dup in "${DUPLICATES[@]}"; do
+  if ! gh issue view "$dup" --repo "$REPO" &>/dev/null; then
+    echo "Error: issue #$dup does not exist in $REPO" >&2
+    exit 1
+  fi
+done
+
 # Build comment body
 COUNT=${#DUPLICATES[@]}
 if [[ $COUNT -eq 1 ]]; then


### PR DESCRIPTION
## Summary
- Add validation to `comment-on-duplicates.sh` that verifies the base issue and all potential duplicate issues actually exist in the repo before posting a comment

## Test plan
- [ ] Run script with valid issue numbers
- [ ] Run script with invalid issue number for base-issue
- [ ] Run script with invalid issue number in potential-duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)