### PR TITLE
fix: Remove date suffix from version header to fix semver parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.1.0 (2026-01-07)
+## 2.1.0
 
 - Added automatic skill hot-reload - skills created or modified in `~/.claude/skills` or `.claude/skills` are now immediately available without restarting the session
 - Added support for running skills and slash commands in a forked sub-agent context using `context: fork` in skill frontmatter


### PR DESCRIPTION
## Summary
- Removes date suffix from version 2.1.0 header to fix CLI crash

## Problem
The CLI crashes on startup with:
```
ERROR  Invalid Version: 2.1.0 (2026-01-07)
```

The semver parser cannot handle dates in parentheses. This affects all users on v2.1.0.

## Root Cause
CHANGELOG.md line 3 uses a new format:
```markdown
## 2.1.0 (2026-01-07)  ← Breaks parser
```

All other 50+ versions use:
```markdown
## 2.0.76  ← Works fine
```

## Fix
Remove the date suffix to match the existing format:
```markdown
## 2.1.0
```

## Long-term Recommendation
The version parser should be updated to strip date suffixes before parsing:
```js
version = version.replace(/\s*\([^)]+\)$/, '').trim()
```

This would allow dates in changelog headers (a common convention) without breaking the parser.

## Related Issues
Fixes #16678, #16675, #16673, #16671

## Test Plan
After this change, `claude --dangerously-skip-permissions` should no longer crash.

---
🤖 Generated with [Claude Code](https://claude.ai/code)