### PR TITLE
Add session-unique state files with --id and RALPH_SESSION_ID support

### DIFF
--- a/plugins/ralph-wiggum/commands/cancel-ralph.md
+++ b/plugins/ralph-wiggum/commands/cancel-ralph.md
@@ -1,18 +1,32 @@
 ---
-description: "Cancel active Ralph Wiggum loop"
-allowed-tools: ["Bash(test -f .claude/ralph-loop.local.md:*)", "Bash(rm .claude/ralph-loop.local.md)", "Read(.claude/ralph-loop.local.md)"]
+description: "Cancel active Ralph Loop"
+allowed-tools: ["Bash(ls .claude/ralph-loop-*.local.md:*)", "Bash(rm .claude/ralph-loop-*.local.md)", "Read(.claude/ralph-loop-*.local.md)"]
 hide-from-slash-command-tool: "true"
 ---
 
 # Cancel Ralph
 
-To cancel the Ralph loop:
+Arguments: $ARGUMENTS
 
-1. Check if `.claude/ralph-loop.local.md` exists using Bash: `test -f .claude/ralph-loop.local.md && echo "EXISTS" || echo "NOT_FOUND"`
+To cancel a Ralph loop:
 
-2. **If NOT_FOUND**: Say "No active Ralph loop found."
+1. **Parse the --id argument from $ARGUMENTS**:
+   - If `--id <name>` is provided, the target file is `.claude/ralph-loop-<name>.local.md`
+   - If no `--id` is provided, list all active loops first
 
-3. **If EXISTS**:
-   - Read `.claude/ralph-loop.local.md` to get the current iteration number from the `iteration:` field
-   - Remove the file using Bash: `rm .claude/ralph-loop.local.md`
-   - Report: "Cancelled Ralph loop (was at iteration N)" where N is the iteration value
+2. **If no --id provided**:
+   - List all active loops using Bash: `ls .claude/ralph-loop-*.local.md 2>/dev/null || echo "NONE"`
+   - If "NONE" or empty: Say "No active Ralph loops found."
+   - If one or more loops exist: Show the list and ask user to specify which one to cancel with `--id`
+
+3. **If --id is provided**:
+   - Check if `.claude/ralph-loop-<id>.local.md` exists using Bash: `test -f .claude/ralph-loop-<id>.local.md && echo "EXISTS" || echo "NOT_FOUND"`
+   - **If NOT_FOUND**: Say "No Ralph loop found with ID '<id>'."
+   - **If EXISTS**:
+     - Read `.claude/ralph-loop-<id>.local.md` to get the current iteration number from the `iteration:` field
+     - Remove the file using Bash: `rm .claude/ralph-loop-<id>.local.md`
+     - Report: "Cancelled Ralph loop '<id>' (was at iteration N)" where N is the iteration value
+
+Examples:
+- `/cancel-ralph` - List all active loops
+- `/cancel-ralph --id my-task` - Cancel the loop with ID "my-task"

--- a/plugins/ralph-wiggum/commands/help.md
+++ b/plugins/ralph-wiggum/commands/help.md
@@ -37,16 +37,23 @@ Start a Ralph loop in your current session.
 
 **Usage:**
 ```
-/ralph-loop "Refactor the cache layer" --max-iterations 20
-/ralph-loop "Add tests" --completion-promise "TESTS COMPLETE"
+/ralph-loop --id my-task "Refactor the cache layer" --max-iterations 20
+/ralph-loop --id tests "Add tests" --completion-promise "TESTS COMPLETE"
+```
+
+Or set the session ID via environment variable before starting Claude:
+```bash
+export RALPH_SESSION_ID=my-session
+claude
 ```
 
 **Options:**
+- `--id <name>` - Session ID for the loop (required, or set RALPH_SESSION_ID env var)
 - `--max-iterations <n>` - Max iterations before auto-stop
 - `--completion-promise <text>` - Promise phrase to signal completion
 
 **How it works:**
-1. Creates `.claude/.ralph-loop.local.md` state file
+1. Creates `.claude/ralph-loop-<id>.local.md` state file
 2. You work on the task
 3. When you try to exit, stop hook intercepts
 4. Same prompt fed back
@@ -55,18 +62,19 @@ Start a Ralph loop in your current session.
 
 ---
 
-### /cancel-ralph
+### /cancel-ralph [--id <name>]
 
 Cancel an active Ralph loop (removes the loop state file).
 
 **Usage:**
 ```
-/cancel-ralph
+/cancel-ralph                 # List all active loops
+/cancel-ralph --id my-task    # Cancel specific loop
 ```
 
 **How it works:**
-- Checks for active loop state file
-- Removes `.claude/.ralph-loop.local.md`
+- Without `--id`: Lists all active loop state files
+- With `--id`: Removes `.claude/ralph-loop-<id>.local.md`
 - Reports cancellation with iteration count
 
 ---
@@ -96,7 +104,7 @@ The "loop" doesn't mean Claude talks to itself. It means:
 ### Interactive Bug Fix
 
 ```
-/ralph-loop "Fix the token refresh logic in auth.ts. Output <promise>FIXED</promise> when all tests pass." --completion-promise "FIXED" --max-iterations 10
+/ralph-loop --id auth-fix "Fix the token refresh logic in auth.ts. Output <promise>FIXED</promise> when all tests pass." --completion-promise "FIXED" --max-iterations 10
 ```
 
 You'll see Ralph:

--- a/plugins/ralph-wiggum/hooks/stop-hook.sh
+++ b/plugins/ralph-wiggum/hooks/stop-hook.sh
@@ -9,16 +9,23 @@ set -euo pipefail
 # Read hook input from stdin (advanced stop hook API)
 HOOK_INPUT=$(cat)
 
-# Check if ralph-loop is active
-RALPH_STATE_FILE=".claude/ralph-loop.local.md"
+# Check if ralph-loop is active (find state files matching pattern)
+shopt -s nullglob  # Prevent literal *.md if no matches
+LOOP_FILES=(.claude/ralph-loop-*.local.md)
+shopt -u nullglob
 
-if [[ ! -f "$RALPH_STATE_FILE" ]]; then
-  # No active loop - allow exit
+if [[ ${#LOOP_FILES[@]} -eq 0 ]]; then
+  # No active loops - allow exit
   exit 0
 fi
 
+# Use the first active loop file found
+# (Each Claude session should have at most one active loop)
+RALPH_STATE_FILE="${LOOP_FILES[0]}"
+
 # Parse markdown frontmatter (YAML between ---) and extract values
 FRONTMATTER=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$RALPH_STATE_FILE")
+SESSION_ID=$(echo "$FRONTMATTER" | grep '^session_id:' | sed 's/session_id: *//')
 ITERATION=$(echo "$FRONTMATTER" | grep '^iteration:' | sed 's/iteration: *//')
 MAX_ITERATIONS=$(echo "$FRONTMATTER" | grep '^max_iterations:' | sed 's/max_iterations: *//')
 # Extract completion_promise and strip surrounding quotes if present
@@ -49,7 +56,11 @@ fi
 
 # Check if max iterations reached
 if [[ $MAX_ITERATIONS -gt 0 ]] && [[ $ITERATION -ge $MAX_ITERATIONS ]]; then
-  echo "🛑 Ralph loop: Max iterations ($MAX_ITERATIONS) reached."
+  if [[ -n "$SESSION_ID" ]]; then
+    echo "🛑 Ralph loop [$SESSION_ID]: Max iterations ($MAX_ITERATIONS) reached."
+  else
+    echo "🛑 Ralph loop: Max iterations ($MAX_ITERATIONS) reached."
+  fi
   rm "$RALPH_STATE_FILE"
   exit 0
 fi
@@ -121,7 +132,11 @@ if [[ "$COMPLETION_PROMISE" != "null" ]] && [[ -n "$COMPLETION_PROMISE" ]]; then
   # Use = for literal string comparison (not pattern matching)
   # == in [[ ]] does glob pattern matching which breaks with *, ?, [ characters
   if [[ -n "$PROMISE_TEXT" ]] && [[ "$PROMISE_TEXT" = "$COMPLETION_PROMISE" ]]; then
-    echo "✅ Ralph loop: Detected <promise>$COMPLETION_PROMISE</promise>"
+    if [[ -n "$SESSION_ID" ]]; then
+      echo "✅ Ralph loop [$SESSION_ID]: Detected <promise>$COMPLETION_PROMISE</promise>"
+    else
+      echo "✅ Ralph loop: Detected <promise>$COMPLETION_PROMISE</promise>"
+    fi
     rm "$RALPH_STATE_FILE"
     exit 0
   fi
@@ -156,10 +171,15 @@ sed "s/^iteration: .*/iteration: $NEXT_ITERATION/" "$RALPH_STATE_FILE" > "$TEMP_
 mv "$TEMP_FILE" "$RALPH_STATE_FILE"
 
 # Build system message with iteration count and completion promise info
+SESSION_INFO=""
+if [[ -n "$SESSION_ID" ]]; then
+  SESSION_INFO=" [$SESSION_ID]"
+fi
+
 if [[ "$COMPLETION_PROMISE" != "null" ]] && [[ -n "$COMPLETION_PROMISE" ]]; then
-  SYSTEM_MSG="🔄 Ralph iteration $NEXT_ITERATION | To stop: output <promise>$COMPLETION_PROMISE</promise> (ONLY when statement is TRUE - do not lie to exit!)"
+  SYSTEM_MSG="🔄 Ralph iteration $NEXT_ITERATION$SESSION_INFO | To stop: output <promise>$COMPLETION_PROMISE</promise> (ONLY when statement is TRUE - do not lie to exit!)"
 else
-  SYSTEM_MSG="🔄 Ralph iteration $NEXT_ITERATION | No completion promise set - loop runs infinitely"
+  SYSTEM_MSG="🔄 Ralph iteration $NEXT_ITERATION$SESSION_INFO | No completion promise set - loop runs infinitely"
 fi
 
 # Output JSON to block the stop and feed prompt back


### PR DESCRIPTION
Enable multiple concurrent Ralph loops by making state files unique per session.

Changes:
- Add --id <name> argument to /ralph-loop command
- Support RALPH_SESSION_ID environment variable (--id takes priority)
- State files now named .claude/ralph-loop-<id>.local.md
- Update stop-hook.sh to use glob pattern matching for state files
- Update /cancel-ralph to support --id argument
- Display session ID in all status messages

Usage:
  export RALPH_SESSION_ID=my-session && claude # or /ralph-loop --id my-task Build API --max-iterations 20
  
  
  Proposal to solve https://github.com/anthropics/claude-code/issues/15885