### PR TITLE
fix(ralph-wiggum): handle empty PROMPT_PARTS array with set -u

### DIFF
--- a/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
+++ b/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
@@ -109,8 +109,8 @@ HELP_EOF
   esac
 done
 
-# Join all prompt parts with spaces
-PROMPT="${PROMPT_PARTS[*]}"
+# Join all prompt parts with spaces (handle empty array with set -u)
+PROMPT="${PROMPT_PARTS[*]:-}"
 
 # Validate prompt is non-empty
 if [[ -z "$PROMPT" ]]; then


### PR DESCRIPTION
## Summary
Fixes a bash strict mode compatibility bug in the ralph-wiggum plugin that causes the script to crash when invoked without arguments.

## Problem
The `setup-ralph-loop.sh` script uses `set -euo pipefail` for strict error handling. When invoked without arguments (e.g., `/ralph-loop --help` or just `/ralph-loop`), the `PROMPT_PARTS` array remains empty.

Accessing an empty array with `${PROMPT_PARTS[*]}` on line 113 triggers bash's unbound variable error under `set -u`:

```
PROMPT_PARTS[*]: unbound variable
```

This prevents the script from reaching the helpful "No prompt provided" error message.

## Solution
Use bash's default value syntax `${PROMPT_PARTS[*]:-}` which provides an empty string when the array is unset/empty, satisfying strict mode while allowing the script to continue to proper validation.

## Changes
```diff
-# Join all prompt parts with spaces
-PROMPT="${PROMPT_PARTS[*]}"
+# Join all prompt parts with spaces (handle empty array with set -u)
+PROMPT="${PROMPT_PARTS[*]:-}"
```

## Testing
- ✅ `/ralph-loop` without args - now shows helpful usage message instead of crashing
- ✅ `/ralph-loop --help` - displays help documentation correctly  
- ✅ `/ralph-loop <task>` - works as expected (unchanged behavior)
