### PR TITLE
feat(commit-commands): add commit-push command

### DIFF
--- a/plugins/commit-commands/README.md
+++ b/plugins/commit-commands/README.md
@@ -44,6 +44,49 @@ Creates a git commit with an automatically generated commit message based on sta
 - Avoids committing files with secrets (.env, credentials.json)
 - Includes Claude Code attribution in commit message
 
+### `/commit-push`
+
+Commits and pushes changes to the remote repository without creating a pull request.
+
+**What it does:**
+1. Analyzes current git status
+2. Reviews both staged and unstaged changes
+3. Examines recent commit messages to match your repository's style
+4. Drafts an appropriate commit message
+5. Stages relevant files
+6. Creates the commit
+7. Pushes to the remote repository
+
+**Usage:**
+```bash
+/commit-push
+```
+
+**Example workflow:**
+```bash
+# Make some changes to your code
+# Then simply run:
+/commit-push
+
+# Claude will:
+# - Review your changes
+# - Stage the files
+# - Create a commit with an appropriate message
+# - Push to the remote repository
+```
+
+**Features:**
+- All features of `/commit` plus automatic push
+- Does not create a new branch (stays on current branch)
+- Does not create a pull request
+- Ideal for collaborative branches or when you want to push without PR
+
+**When to use:**
+- Working on a shared branch with collaborators
+- Want to trigger CI/CD without creating a PR
+- Planning to create PR later after multiple commits
+- Pushing to your own feature branch for backup
+
 ### `/commit-push-pr`
 
 Complete workflow command that commits, pushes, and creates a pull request in one step.
@@ -137,6 +180,12 @@ This plugin is included in the Claude Code repository. The commands are automati
 - Trust the automated message, but verify it's accurate
 - Use for routine commits during development
 
+### Using `/commit-push`
+- Use when you want to commit and push without creating a PR
+- Ideal for collaborative branches where multiple people push
+- Good for triggering CI/CD pipelines without PR overhead
+- Use when you plan to create a PR later after multiple commits
+
 ### Using `/commit-push-pr`
 - Use when you're ready to create a PR
 - Ensure all your changes are complete and tested
@@ -159,6 +208,13 @@ This plugin is included in the Claude Code repository. The commands are automati
 # Continue development
 ```
 
+### Commit and push workflow:
+```bash
+# Write code
+/commit-push
+# Changes are committed and pushed, but no PR yet
+```
+
 ### Feature branch workflow:
 ```bash
 # Develop feature across multiple commits
@@ -167,6 +223,18 @@ This plugin is included in the Claude Code repository. The commands are automati
 /commit  # Second commit
 # Ready to create PR
 /commit-push-pr
+```
+
+### Collaborative branch workflow:
+```bash
+# Working on shared branch with teammates
+/commit-push  # Push your changes
+# Teammate pushes their changes
+git pull
+# Continue development
+/commit-push  # Push more changes
+# When feature is complete
+/commit-push-pr  # Create the PR
 ```
 
 ### Maintenance workflow:

--- a/plugins/commit-commands/commands/commit-push.md
+++ b/plugins/commit-commands/commands/commit-push.md
@@ -1,0 +1,19 @@
+---
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*)
+description: Commit and push to remote
+---
+
+## Context
+
+- Current git status: !`git status`
+- Current git diff (staged and unstaged changes): !`git diff HEAD`
+- Current branch: !`git branch --show-current`
+- Recent commits: !`git log --oneline -10`
+
+## Your task
+
+Based on the above changes:
+
+1. Create a single commit with an appropriate message
+2. Push the branch to origin
+3. You have the capability to call multiple tools in a single response. You MUST do all of the above in a single message. Do not use any other tools or do anything else. Do not send any other text or messages besides these tool calls.


### PR DESCRIPTION
## Summary

- Add `/commit-push` command to fill the workflow gap between `/commit` and `/commit-push-pr`

## Motivation

Currently, the commit-commands plugin has:
- `/commit` - stages and commits only
- `/commit-push-pr` - creates branch + commits + pushes + creates PR

However, there are many cases where you want to **commit + push without creating a PR**:
- Working on a collaborative branch (push without PR)
- Accumulating multiple commits before creating a PR later
- Just wanting to trigger CI/CD

## Changes

| Command | Behavior |
|---------|----------|
| `/commit` | add + commit |
| `/commit-push` | add + commit + push **(NEW)** |
| `/commit-push-pr` | branch + commit + push + PR |

## Files Changed

- `commands/commit-push.md` - New command definition
- `README.md` - Documentation for the new command

## Test Plan

- [ ] Run `/commit-push` command in Claude Code
- [ ] Verify changes are committed and pushed
- [ ] Verify no PR is created
- [ ] Verify it stays on current branch (no new branch created)