### PR TITLE
Improve bug report template for usage limit reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -81,6 +81,26 @@ body:
         Note: The bug only happens with Python files containing...
     validations:
       required: true
+
+  - type: textarea
+    id: usage_limit_details
+    attributes:
+      label: Usage Limit Details (if relevant)
+      description: |
+        If this report is about usage limits, unexpected spending, or rate limiting, include:
+        - Output of `/usage` and `/cost` (redact any sensitive info)
+        - Approximate timestamps and timezone when limits triggered
+        - Any recent plan changes or top-ups
+      placeholder: |
+        /usage:
+        (paste output here)
+
+        /cost:
+        (paste output here)
+
+        Limit hit at ~5:30 PM PST on 2026-01-08. Added $5 top-up twice at 5:40 PM PST.
+    validations:
+      required: false
       
   - type: dropdown
     id: model


### PR DESCRIPTION
## Summary
- add an optional Usage Limit Details section to collect /usage and /cost output plus timestamps
- clarify what to include for limit or spending reports to speed up triage

## Alignment
- keeps the existing issue form structure and wording style
- adds a non-required field so other bug reports are unaffected

## Implementation notes
- new `usage_limit_details` textarea placed after reproduction steps

## Testing
- not applicable (documentation-only change)

Closes #17016