### PR TITLE
Add workflow for publishing package to WinGet repository

### DIFF
--- a/.github/workflows/winget-submit-package.yml
+++ b/.github/workflows/winget-submit-package.yml
@@ -1,0 +1,36 @@
+name: Submit release to the WinGet community repository
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-winget:
+    name: Submit to WinGet repository
+    permissions:
+      contents: read
+
+    # winget-create is only supported on Windows
+    runs-on: windows-latest
+
+    # Only submit stable releases for now. We will update the workflow later to handle preview releases.
+    if: ${{ !github.event.release.prerelease }}
+
+    # winget-create will read the following environment variable to access the GitHub token needed for submitting a PR
+    # See https://aka.ms/winget-create-token
+    env:
+      WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_CREATE_GITHUB_TOKEN }}
+
+    steps:
+      - name: Submit package using wingetcreate
+        run: |
+          # Get installer info from release event
+          $wingetPackageId = "Anthropic.ClaudeCode"
+          $packageVersion = (${{ toJSON(github.event.release.tag_name) }}).Trim('v')
+          $installerUrl = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/$packageVersion/win32-x64/claude.exe"
+          # Update package using wingetcreate
+          curl.exe -JLO https://aka.ms/wingetcreate/latest
+          .\wingetcreate.exe update $wingetPackageId `
+            --version $packageVersion `
+            --urls $installerUrl `
+            --submit

--- a/.github/workflows/winget-submit-package.yml
+++ b/.github/workflows/winget-submit-package.yml
@@ -24,8 +24,8 @@ jobs:
     steps:
       - name: Submit package using wingetcreate
         run: |
-          # Get installer info from release event
           $wingetPackageId = "Anthropic.ClaudeCode"
+          # Get version info from release event
           $packageVersion = (${{ toJSON(github.event.release.tag_name) }}).Trim('v')
           $installerUrl = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/$packageVersion/win32-x64/claude.exe"
           # Update package using wingetcreate


### PR DESCRIPTION
PR creates a GitHub action workflow to trigger on every stable release to publish Claude Code package to WinGet repository. [microsoft/winget-create](https://github.com/microsoft/winget-create) is the tool used for creating and submitting the manifest

- Resolves #17160

## Steps needed from maintainers

- Add a repository secret named `WINGET_CREATE_GITHUB_TOKEN` that's a [public access token (classic)](https://github.com/microsoft/winget-create?tab=readme-ov-file#github-personal-access-token-classic-permissions) with [`public_repo`](https://raw.githubusercontent.com/microsoft/winget-create/main/doc/images/tokenscope-publicrepo.png) scope from the user account where the winget-pkgs fork will exist for submitting a PR. Recommend using a bot account for this purpose.

## Validation

To validate one can just run the same powershell commands listed in the workflow job, but omit the `--submit` flag to prevent opening an actual PR.

```powershell
curl.exe -JLO https://aka.ms/wingetcreate/latest
.\wingetcreate.exe update Anthropic.ClaudeCode `
  --version 10.0.0 `
  --urls https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.0.76/win32-x64/claude.exe
```