### PR TITLE
Add missing plugin.json for plugin-dev

### DIFF
--- a/plugins/plugin-dev/.claude-plugin/plugin.json
+++ b/plugins/plugin-dev/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "plugin-dev",
+  "version": "0.1.0",
+  "description": "Toolkit for developing Claude Code plugins with expert guidance on hooks, MCP integration, and structure",
+  "author": {
+    "name": "Daisy Hollman",
+    "email": "daisy@anthropic.com"
+  }
+}


### PR DESCRIPTION
## Summary
- Add the missing plugin manifest for plugin-dev to enable auto-discovery/installation.

## Details
- New file: plugins/plugin-dev/.claude-plugin/plugin.json
- Aligns metadata format with other plugins in this repo.

