### PR TITLE
Fix Hookify Read event handling

### DIFF
--- a/plugins/hookify/README.md
+++ b/plugins/hookify/README.md
@@ -122,7 +122,7 @@ Ensure credentials are not hardcoded and file is in .gitignore.
 ## Event Types
 
 - **`bash`**: Triggers on Bash tool commands
-- **`file`**: Triggers on Edit, Write, MultiEdit tools
+- **`file`**: Triggers on Read, Edit, Write, MultiEdit tools
 - **`stop`**: Triggers when Claude wants to stop (for completion checks)
 - **`prompt`**: Triggers on user prompt submission
 - **`all`**: Triggers on all events
@@ -247,7 +247,7 @@ Use environment variables instead of hardcoded values.
 - `command`: The bash command string
 
 **For file events:**
-- `file_path`: Path to file being edited
+- `file_path`: Path to file being read or edited
 - `new_text`: New content being added (Edit, Write)
 - `old_text`: Old content being replaced (Edit only)
 - `content`: File content (Write only)

--- a/plugins/hookify/commands/hookify.md
+++ b/plugins/hookify/commands/hookify.md
@@ -158,7 +158,7 @@ Use the current working directory (where Claude Code was started) as the base pa
 ## Event Types Reference
 
 - **bash**: Matches Bash tool commands
-- **file**: Matches Edit, Write, MultiEdit tools
+- **file**: Matches Read, Edit, Write, MultiEdit tools
 - **stop**: Matches when agent wants to stop (use for completion checks)
 - **prompt**: Matches when user submits prompts
 - **all**: Matches all events

--- a/plugins/hookify/hooks/posttooluse.py
+++ b/plugins/hookify/hooks/posttooluse.py
@@ -35,11 +35,12 @@ def main():
 
         # Determine event type based on tool
         tool_name = input_data.get('tool_name', '')
-        event = None
         if tool_name == 'Bash':
             event = 'bash'
-        elif tool_name in ['Edit', 'Write', 'MultiEdit']:
+        elif tool_name in ['Edit', 'Write', 'MultiEdit', 'Read']:
             event = 'file'
+        else:
+            event = 'all'
 
         # Load rules
         rules = load_rules(event=event)

--- a/plugins/hookify/hooks/pretooluse.py
+++ b/plugins/hookify/hooks/pretooluse.py
@@ -42,11 +42,12 @@ def main():
         # For PreToolUse, we use tool_name to determine "bash" vs "file" event
         tool_name = input_data.get('tool_name', '')
 
-        event = None
         if tool_name == 'Bash':
             event = 'bash'
-        elif tool_name in ['Edit', 'Write', 'MultiEdit']:
+        elif tool_name in ['Edit', 'Write', 'MultiEdit', 'Read']:
             event = 'file'
+        else:
+            event = 'all'
 
         # Load rules
         rules = load_rules(event=event)

--- a/plugins/hookify/skills/writing-rules/SKILL.md
+++ b/plugins/hookify/skills/writing-rules/SKILL.md
@@ -40,7 +40,7 @@ Can include markdown formatting, warnings, suggestions, etc.
 
 **event** (required): Which hook event to trigger on
 - `bash`: Bash tool commands
-- `file`: Edit, Write, MultiEdit tools
+- `file`: Read, Edit, Write, MultiEdit tools
 - `stop`: When agent wants to stop
 - `prompt`: When user submits a prompt
 - `all`: All events
@@ -146,7 +146,7 @@ Dangerous command detected!
 
 ### file Events
 
-Match Edit/Write/MultiEdit operations:
+Match Read/Edit/Write/MultiEdit operations:
 
 ```markdown
 ---


### PR DESCRIPTION
## Summary
- Map Read tool usage to file events and fall back to all for unknown tools.
- Update Hookify documentation and skill references to include Read as file events.

## Details
- hooks: plugins/hookify/hooks/pretooluse.py, plugins/hookify/hooks/posttooluse.py
- docs: plugins/hookify/README.md, plugins/hookify/skills/writing-rules/SKILL.md, plugins/hookify/commands/hookify.md

## Testing
- python3.9 plugins/hookify/hooks/pretooluse.py (with Read tool input)

