### PR TITLE
Use portable shebang for cross-platform compatibility

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail  # Exit on error, undefined vars, and pipeline failures
 IFS=$'\n\t'       # Stricter word splitting
 

--- a/plugins/plugin-dev/skills/agent-development/scripts/validate-agent.sh
+++ b/plugins/plugin-dev/skills/agent-development/scripts/validate-agent.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Agent File Validator
 # Validates agent markdown files for correct structure and content
 

--- a/plugins/plugin-dev/skills/command-development/references/testing-strategies.md
+++ b/plugins/plugin-dev/skills/command-development/references/testing-strategies.md
@@ -34,7 +34,7 @@ test -f .claude/commands/my-command.md && echo "Found" || echo "Missing"
 **Automated validation script:**
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # validate-command.sh
 
 COMMAND_FILE="$1"
@@ -80,7 +80,7 @@ echo "✓ Command file structure valid"
 **Validation script:**
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # validate-frontmatter.sh
 
 COMMAND_FILE="$1"
@@ -175,7 +175,7 @@ tail -f ~/.claude/debug-logs/latest
 **Test script:**
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # test-command-arguments.sh
 
 COMMAND="$1"
@@ -345,7 +345,7 @@ EOF
 Create a test suite script:
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # test-commands.sh - Command test suite
 
 TEST_DIR=".claude/commands"
@@ -390,7 +390,7 @@ exit $FAILED_TESTS
 Validate commands before committing:
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # .git/hooks/pre-commit
 
 echo "Validating commands..."
@@ -501,7 +501,7 @@ jobs:
 ### Response Time Testing
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # test-command-performance.sh
 
 COMMAND="$1"

--- a/plugins/plugin-dev/skills/hook-development/SKILL.md
+++ b/plugins/plugin-dev/skills/hook-development/SKILL.md
@@ -431,7 +431,7 @@ Plugin hooks merge with user's hooks and run in parallel.
 Always validate inputs in command hooks:
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 input=$(cat)
@@ -529,7 +529,7 @@ Create hooks that activate conditionally by checking for a flag file or configur
 
 **Pattern: Flag file activation**
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # Only active when flag file exists
 FLAG_FILE="$CLAUDE_PROJECT_DIR/.enable-strict-validation"
 
@@ -545,7 +545,7 @@ input=$(cat)
 
 **Pattern: Configuration-based activation**
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # Check configuration for activation
 CONFIG_FILE="$CLAUDE_PROJECT_DIR/.claude/plugin-config.json"
 

--- a/plugins/plugin-dev/skills/hook-development/examples/load-context.sh
+++ b/plugins/plugin-dev/skills/hook-development/examples/load-context.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Example SessionStart hook for loading project context
 # This script detects project type and sets environment variables
 

--- a/plugins/plugin-dev/skills/hook-development/examples/validate-bash.sh
+++ b/plugins/plugin-dev/skills/hook-development/examples/validate-bash.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Example PreToolUse hook for validating Bash commands
 # This script demonstrates bash command validation patterns
 

--- a/plugins/plugin-dev/skills/hook-development/examples/validate-write.sh
+++ b/plugins/plugin-dev/skills/hook-development/examples/validate-write.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Example PreToolUse hook for validating Write/Edit operations
 # This script demonstrates file write validation patterns
 

--- a/plugins/plugin-dev/skills/hook-development/references/advanced.md
+++ b/plugins/plugin-dev/skills/hook-development/references/advanced.md
@@ -32,7 +32,7 @@ Combine command and prompt hooks for layered validation:
 
 **Example quick-check.sh:**
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 input=$(cat)
 command=$(echo "$input" | jq -r '.tool_input.command')
 
@@ -52,7 +52,7 @@ The command hook quickly approves obviously safe commands, while the prompt hook
 Execute hooks based on environment or context:
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # Only run in CI environment
 if [ -z "$CI" ]; then
   echo '{"continue": true}' # Skip in non-CI
@@ -71,7 +71,7 @@ input=$(cat)
 
 **Example: Skip certain checks for trusted users:**
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # Skip detailed checks for admin users
 if [ "$USER" = "admin" ]; then
   exit 0
@@ -88,7 +88,7 @@ Share state between hooks using temporary files:
 
 ```bash
 # Hook 1: Analyze and save state
-#!/bin/bash
+#!/usr/bin/env bash
 input=$(cat)
 command=$(echo "$input" | jq -r '.tool_input.command')
 
@@ -101,7 +101,7 @@ exit 0
 
 ```bash
 # Hook 2: Use saved state
-#!/bin/bash
+#!/usr/bin/env bash
 risk_level=$(cat /tmp/hook-state-$$ 2>/dev/null || echo "unknown")
 
 if [ "$risk_level" = "high" ]; then
@@ -117,7 +117,7 @@ fi
 Modify hook behavior based on project configuration:
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$CLAUDE_PROJECT_DIR" || exit 1
 
 # Read project-specific config
@@ -170,7 +170,7 @@ The LLM can read the transcript file and make context-aware decisions.
 ### Caching Validation Results
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 input=$(cat)
 file_path=$(echo "$input" | jq -r '.tool_input.file_path')
 cache_key=$(echo -n "$file_path" | md5sum | cut -d' ' -f1)
@@ -232,7 +232,7 @@ Coordinate hooks across different events:
 
 **SessionStart - Set up tracking:**
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # Initialize session tracking
 echo "0" > /tmp/test-count-$$
 echo "0" > /tmp/build-count-$$
@@ -240,7 +240,7 @@ echo "0" > /tmp/build-count-$$
 
 **PostToolUse - Track events:**
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 input=$(cat)
 tool_name=$(echo "$input" | jq -r '.tool_name')
 
@@ -255,7 +255,7 @@ fi
 
 **Stop - Verify based on tracking:**
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 test_count=$(cat /tmp/test-count-$$ 2>/dev/null || echo "0")
 
 if [ "$test_count" -eq 0 ]; then
@@ -269,7 +269,7 @@ fi
 ### Slack Notifications
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 input=$(cat)
 tool_name=$(echo "$input" | jq -r '.tool_name')
 decision="blocked"
@@ -287,7 +287,7 @@ exit 2
 ### Database Logging
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 input=$(cat)
 
 # Log to database
@@ -300,7 +300,7 @@ exit 0
 ### Metrics Collection
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 input=$(cat)
 tool_name=$(echo "$input" | jq -r '.tool_name')
 
@@ -315,7 +315,7 @@ exit 0
 ### Rate Limiting
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 input=$(cat)
 command=$(echo "$input" | jq -r '.tool_input.command')
 
@@ -349,7 +349,7 @@ exit 0
 ### Audit Logging
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 input=$(cat)
 tool_name=$(echo "$input" | jq -r '.tool_name')
 timestamp=$(date -Iseconds)
@@ -363,7 +363,7 @@ exit 0
 ### Secret Detection
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 input=$(cat)
 content=$(echo "$input" | jq -r '.tool_input.content')
 
@@ -382,7 +382,7 @@ exit 0
 
 ```bash
 # test-hook.sh
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Test 1: Approve safe command
 result=$(echo '{"tool_input": {"command": "ls"}}' | bash validate-bash.sh)
@@ -407,7 +407,7 @@ Create test scenarios that exercise the full hook workflow:
 
 ```bash
 # integration-test.sh
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Set up test environment
 export CLAUDE_PROJECT_DIR="/tmp/test-project"

--- a/plugins/plugin-dev/skills/hook-development/references/migration.md
+++ b/plugins/plugin-dev/skills/hook-development/references/migration.md
@@ -34,7 +34,7 @@ Prompt-based hooks offer several advantages:
 
 **Script (validate-bash.sh):**
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 input=$(cat)
 command=$(echo "$input" | jq -r '.tool_input.command')
 
@@ -103,7 +103,7 @@ fi
 
 **Script (validate-write.sh):**
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 input=$(cat)
 file_path=$(echo "$input" | jq -r '.tool_input.file_path')
 
@@ -159,7 +159,7 @@ Command hooks still have their place:
 ### 1. Deterministic Performance Checks
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # Check file size quickly
 file_path=$(echo "$input" | jq -r '.tool_input.file_path')
 size=$(stat -f%z "$file_path" 2>/dev/null || stat -c%s "$file_path" 2>/dev/null)
@@ -175,7 +175,7 @@ fi
 ### 2. External Tool Integration
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # Run security scanner
 file_path=$(echo "$input" | jq -r '.tool_input.file_path')
 scan_result=$(security-scanner "$file_path")
@@ -191,7 +191,7 @@ fi
 ### 3. Very Fast Checks (< 50ms)
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # Quick regex check
 command=$(echo "$input" | jq -r '.tool_input.command')
 

--- a/plugins/plugin-dev/skills/hook-development/references/patterns.md
+++ b/plugins/plugin-dev/skills/hook-development/references/patterns.md
@@ -68,7 +68,7 @@ Load project-specific context at session start:
 
 **Example script (load-context.sh):**
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$CLAUDE_PROJECT_DIR" || exit 1
 
 # Detect project type
@@ -193,7 +193,7 @@ Run linters or formatters on file edits:
 
 **Example script (check-quality.sh):**
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 input=$(cat)
 file_path=$(echo "$input" | jq -r '.tool_input.file_path')
 
@@ -263,7 +263,7 @@ This provides multi-layered protection and automation.
 Create hooks that only run when explicitly enabled via flag files:
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook only active when flag file exists
 FLAG_FILE="$CLAUDE_PROJECT_DIR/.enable-security-scan"
 
@@ -302,7 +302,7 @@ rm .enable-security-scan
 Use JSON configuration to control hook behavior:
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 CONFIG_FILE="$CLAUDE_PROJECT_DIR/.claude/my-plugin.local.json"
 
 # Read configuration

--- a/plugins/plugin-dev/skills/hook-development/scripts/README.md
+++ b/plugins/plugin-dev/skills/hook-development/scripts/README.md
@@ -140,7 +140,7 @@ Checks hook scripts for common issues and best practices violations.
 ### Hook doesn't execute
 
 Check:
-- Script has shebang (`#!/bin/bash`)
+- Script has shebang (`#!/usr/bin/env bash`)
 - Script is executable (`chmod +x`)
 - Path in hooks.json is correct (use `${CLAUDE_PLUGIN_ROOT}`)
 

--- a/plugins/plugin-dev/skills/hook-development/scripts/hook-linter.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/hook-linter.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook Linter
 # Checks hook scripts for common issues and best practices
 

--- a/plugins/plugin-dev/skills/hook-development/scripts/test-hook.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/test-hook.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook Testing Helper
 # Tests a hook with sample input and shows output
 

--- a/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook Schema Validator
 # Validates hooks.json structure and checks for common issues
 

--- a/plugins/plugin-dev/skills/mcp-integration/references/authentication.md
+++ b/plugins/plugin-dev/skills/mcp-integration/references/authentication.md
@@ -242,7 +242,7 @@ For tokens that change or expire, use a helper script:
 
 **Script (get-headers.sh):**
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # Generate dynamic authentication headers
 
 # Fetch fresh token
@@ -482,7 +482,7 @@ Some enterprise services require client certificates.
 Generate JWT tokens dynamically with headers helper:
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # generate-jwt.sh
 
 # Generate JWT (using library or API call)
@@ -502,7 +502,7 @@ echo "{\"Authorization\": \"Bearer $JWT\"}"
 For APIs requiring request signing:
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # generate-hmac.sh
 
 TIMESTAMP=$(date -Iseconds)

--- a/plugins/plugin-dev/skills/plugin-settings/SKILL.md
+++ b/plugins/plugin-dev/skills/plugin-settings/SKILL.md
@@ -64,7 +64,7 @@ Contact @team-lead with questions.
 **Pattern: Check existence and parse frontmatter**
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Define state file path
@@ -177,7 +177,7 @@ BODY=$(awk '/^---$/{i++; next} i>=2' "$FILE")
 Use settings file to control hook activation:
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 STATE_FILE=".claude/security-scan.local.md"
 
 # Quick exit if not configured

--- a/plugins/plugin-dev/skills/plugin-settings/examples/read-settings-hook.sh
+++ b/plugins/plugin-dev/skills/plugin-settings/examples/read-settings-hook.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Example hook that reads plugin settings from .claude/my-plugin.local.md
 # Demonstrates the complete pattern for settings-driven hook behavior
 

--- a/plugins/plugin-dev/skills/plugin-settings/references/parsing-techniques.md
+++ b/plugins/plugin-dev/skills/plugin-settings/references/parsing-techniques.md
@@ -26,7 +26,7 @@ It's useful for prompts, documentation, or additional context.
 ### Extract Frontmatter Block
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 FILE=".claude/my-plugin.local.md"
 
 # Extract everything between --- markers (excluding the markers themselves)
@@ -103,7 +103,7 @@ done
 ### Extract Body Content
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 FILE=".claude/my-plugin.local.md"
 
 # Extract everything after the closing ---
@@ -194,7 +194,7 @@ done <<< "$FRONTMATTER"
 Always use temp file + atomic move to prevent corruption:
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 FILE=".claude/my-plugin.local.md"
 NEW_VALUE="updated_value"
 
@@ -397,7 +397,7 @@ FIELD3=$(echo "$FRONTMATTER" | grep '^field3:' | sed 's/field3: *//')
 Only parse settings when needed:
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 input=$(cat)
 
 # Quick checks first (no file I/O)
@@ -418,7 +418,7 @@ fi
 ### Print Parsed Values
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 set -x  # Enable debug tracing
 
 FILE=".claude/my-plugin.local.md"
@@ -486,7 +486,7 @@ done
 ## Complete Example
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Configuration

--- a/plugins/plugin-dev/skills/plugin-settings/references/real-world-examples.md
+++ b/plugins/plugin-dev/skills/plugin-settings/references/real-world-examples.md
@@ -48,7 +48,7 @@ Report status to 'team-leader' session.
 **Implementation:**
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 SWARM_STATE_FILE=".claude/multi-agent-swarm.local.md"
@@ -154,7 +154,7 @@ Document any changes needed in CLAUDE.md.
 **Implementation:**
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 RALPH_STATE_FILE=".claude/ralph-loop.local.md"
@@ -231,7 +231,7 @@ exit 0
 **File:** `scripts/setup-ralph-loop.sh`
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 PROMPT="$1"
 MAX_ITERATIONS="${2:-0}"
 COMPLETION_PROMISE="${3:-}"

--- a/plugins/plugin-dev/skills/plugin-settings/scripts/parse-frontmatter.sh
+++ b/plugins/plugin-dev/skills/plugin-settings/scripts/parse-frontmatter.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Frontmatter Parser Utility
 # Extracts YAML frontmatter from .local.md files
 

--- a/plugins/plugin-dev/skills/plugin-settings/scripts/validate-settings.sh
+++ b/plugins/plugin-dev/skills/plugin-settings/scripts/validate-settings.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Settings File Validator
 # Validates .claude/plugin-name.local.md structure
 

--- a/plugins/plugin-dev/skills/plugin-structure/SKILL.md
+++ b/plugins/plugin-dev/skills/plugin-structure/SKILL.md
@@ -295,7 +295,7 @@ Reference scripts at: ${CLAUDE_PLUGIN_ROOT}/scripts/helper.py
 
 **In executed scripts**:
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # ${CLAUDE_PLUGIN_ROOT} available as environment variable
 source "${CLAUDE_PLUGIN_ROOT}/lib/common.sh"
 ```

--- a/plugins/plugin-dev/skills/plugin-structure/examples/standard-plugin.md
+++ b/plugins/plugin-dev/skills/plugin-structure/examples/standard-plugin.md
@@ -457,7 +457,7 @@ See language-specific guides for:
 ### hooks/scripts/validate-commit.sh
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # Validate code quality before task completion
 
 set -e

--- a/plugins/plugin-dev/skills/plugin-structure/references/component-patterns.md
+++ b/plugins/plugin-dev/skills/plugin-structure/references/component-patterns.md
@@ -468,7 +468,7 @@ plugin/
 
 **Usage in components**:
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 source "${CLAUDE_PLUGIN_ROOT}/lib/test-utils.sh"
 run_tests
 ```

--- a/plugins/ralph-wiggum/hooks/stop-hook.sh
+++ b/plugins/ralph-wiggum/hooks/stop-hook.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Ralph Wiggum Stop Hook
 # Prevents session exit when a ralph-loop is active

--- a/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
+++ b/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Ralph Loop Setup Script
 # Creates state file for in-session Ralph loop


### PR DESCRIPTION
## Summary
- Replace `#!/bin/bash` with `#!/usr/bin/env bash` in all shell scripts and documentation
- Fixes compatibility issues on systems like NixOS where bash is not located at `/bin/bash`

## Motivation
The hardcoded `/bin/bash` shebang breaks on several systems:
- **NixOS**: Doesn't use traditional FHS paths, bash is not at `/bin/bash`
- **BSD variants**: May have bash installed in different locations
- **Custom installations**: Systems where bash is installed in non-standard locations

Using `/usr/bin/env bash` resolves the bash executable from the user's `PATH`, making the scripts portable across all Unix-like systems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)