### PR TITLE
fix: prevent unbound variable error in setup-ralph-loop.sh

### DIFF
--- a/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
+++ b/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
@@ -110,7 +110,7 @@ HELP_EOF
 done
 
 # Join all prompt parts with spaces
-PROMPT="${PROMPT_PARTS[*]}"
+PROMPT="${PROMPT_PARTS[*]:-}"
 
 # Validate prompt is non-empty
 if [[ -z "$PROMPT" ]]; then


### PR DESCRIPTION
ran into this bug when using ralph-loop - the script crashes with "PROMPT_PARTS[*]: unbound variable" because of set -u strict mode

the fix is just adding :- to provide a default empty string

before: PROMPT="${PROMPT_PARTS[*]}"
after: PROMPT="${PROMPT_PARTS[*]:-}"

tested locally and it works now