### PR TITLE
fix(security-guidance): use cross-platform temp directory for debug log

### DIFF
--- a/plugins/security-guidance/hooks/security_reminder_hook.py
+++ b/plugins/security-guidance/hooks/security_reminder_hook.py
@@ -8,10 +8,11 @@ import json
 import os
 import random
 import sys
+import tempfile
 from datetime import datetime
 
-# Debug log file
-DEBUG_LOG_FILE = "/tmp/security-warnings-log.txt"
+# Debug log file (cross-platform temp directory)
+DEBUG_LOG_FILE = os.path.join(tempfile.gettempdir(), "security-warnings-log.txt")
 
 
 def debug_log(message):


### PR DESCRIPTION
## problem
the hardcoded `/tmp/` path in the debug log file fails on windows systems where the temp directory is typically `C:\Users\...\AppData\Local\Temp\`.

i used python's `tempfile.gettempdir()` to get the platform-appropriate temporary directory. the verified implementation uses standard library approach and `tempfile.gettempdir()` is documented to work cross-platform in python docs


this fixes compatibility for windows users and uses python standard library best practices for cross-platform temp file handling.