### PR TITLE
fix: revert workflow action to @beta tag that exists

### DIFF
--- a/.github/workflows/claude-dedupe-issues.yml
+++ b/.github/workflows/claude-dedupe-issues.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Claude Code slash command
-        uses: anthropics/claude-code-base-action@v1
+        uses: anthropics/claude-code-base-action@beta
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Run Claude Code for Issue Triage
         timeout-minutes: 5
-        uses: anthropics/claude-code-base-action@v1
+        uses: anthropics/claude-code-base-action@beta
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/oncall-triage.yml
+++ b/.github/workflows/oncall-triage.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Run Claude Code for Oncall Triage
         timeout-minutes: 10
-        uses: anthropics/claude-code-base-action@v1
+        uses: anthropics/claude-code-base-action@beta
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary

Fixes #17915

The `@v1` tag doesn't exist on `anthropics/claude-code-base-action` (only `@beta` and versioned tags like `v0.0.x`), causing all three Claude workflows to fail with:

```
Error: Unable to resolve action `anthropics/claude-code-base-action@v1`, unable to find version `v1`
```

This reverts the action reference from `@v1` back to `@beta` which exists and was working before #17238.

## Test plan

- [x] Verify `@beta` tag exists on claude-code-base-action repo
- [ ] Workflow runs successfully on next issue creation