### PR TITLE
chore: allow non-write users to trigger claude-code-action workflows

### DIFF
--- a/.github/workflows/claude-dedupe-issues.yml
+++ b/.github/workflows/claude-dedupe-issues.yml
@@ -29,6 +29,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_non_write_users: "*"
           prompt: "/dedupe ${{ github.repository }}/issues/${{ github.event.issue.number || inputs.issue_number }}"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: "--model claude-sonnet-4-5-20250929"

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -48,6 +48,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_non_write_users: "*"
           prompt: |
             You're an issue triage assistant for GitHub issues. Your task is to analyze the issue and select appropriate labels from the provided list.
 

--- a/.github/workflows/oncall-triage.yml
+++ b/.github/workflows/oncall-triage.yml
@@ -53,6 +53,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_non_write_users: "*"
           prompt: |
             You're an oncall triage assistant for GitHub issues. Your task is to identify critical issues that require immediate oncall attention.
 


### PR DESCRIPTION
The `claude-code-action` workflow has extra security checks that weren't in the `claude-code-base-action`, so disabling those checks for now