### PR TITLE
fix(hookify): add read event type for Read/Glob/Grep/LS tools

### DIFF
--- a/plugins/hookify/README.md
+++ b/plugins/hookify/README.md
@@ -123,6 +123,7 @@ Ensure credentials are not hardcoded and file is in .gitignore.
 
 - **`bash`**: Triggers on Bash tool commands
 - **`file`**: Triggers on Edit, Write, MultiEdit tools
+- **`read`**: Triggers on Read, Glob, Grep, LS tools (file reads, not modifications)
 - **`stop`**: Triggers when Claude wants to stop (for completion checks)
 - **`prompt`**: Triggers on user prompt submission
 - **`all`**: Triggers on all events

--- a/plugins/hookify/hooks/posttooluse.py
+++ b/plugins/hookify/hooks/posttooluse.py
@@ -33,13 +33,19 @@ def main():
         # Read input from stdin
         input_data = json.load(sys.stdin)
 
-        # Determine event type based on tool
+        # Map tools to event types for rule filtering:
+        # - 'bash': Bash commands
+        # - 'file': File modifications (Edit, Write, MultiEdit)
+        # - 'read': File reads (Read, Glob, Grep, LS) - should NOT trigger file rules
+        # - None: Other tools - only 'all' rules fire
         tool_name = input_data.get('tool_name', '')
         event = None
         if tool_name == 'Bash':
             event = 'bash'
         elif tool_name in ['Edit', 'Write', 'MultiEdit']:
             event = 'file'
+        elif tool_name in ['Read', 'Glob', 'Grep', 'LS']:
+            event = 'read'
 
         # Load rules
         rules = load_rules(event=event)

--- a/plugins/hookify/hooks/pretooluse.py
+++ b/plugins/hookify/hooks/pretooluse.py
@@ -42,11 +42,18 @@ def main():
         # For PreToolUse, we use tool_name to determine "bash" vs "file" event
         tool_name = input_data.get('tool_name', '')
 
+        # Map tools to event types for rule filtering:
+        # - 'bash': Bash commands
+        # - 'file': File modifications (Edit, Write, MultiEdit)
+        # - 'read': File reads (Read, Glob, Grep, LS) - should NOT trigger file rules
+        # - None: Other tools - only 'all' rules fire
         event = None
         if tool_name == 'Bash':
             event = 'bash'
         elif tool_name in ['Edit', 'Write', 'MultiEdit']:
             event = 'file'
+        elif tool_name in ['Read', 'Glob', 'Grep', 'LS']:
+            event = 'read'
 
         # Load rules
         rules = load_rules(event=event)

--- a/plugins/hookify/skills/writing-rules/SKILL.md
+++ b/plugins/hookify/skills/writing-rules/SKILL.md
@@ -41,6 +41,7 @@ Can include markdown formatting, warnings, suggestions, etc.
 **event** (required): Which hook event to trigger on
 - `bash`: Bash tool commands
 - `file`: Edit, Write, MultiEdit tools
+- `read`: Read, Glob, Grep, LS tools (file reads, not modifications)
 - `stop`: When agent wants to stop
 - `prompt`: When user submits a prompt
 - `all`: All events
@@ -361,6 +362,7 @@ Warning message
 **Event types:**
 - `bash` - Bash commands
 - `file` - File edits
+- `read` - File reads (Read, Glob, Grep, LS)
 - `stop` - Completion checks
 - `prompt` - User input
 - `all` - All events


### PR DESCRIPTION
## Summary

Add a dedicated `read` event type for Read/Glob/Grep/LS tools to prevent file-editing rules from incorrectly triggering on read operations.

**Fixes Issue 1 from #13464** — Rules load for ALL tools when tool isn't mapped to an event.

## Problem

Currently, Read/Glob/Grep/LS tools have no event mapping (`event = None`), which causes ALL rules to load regardless of their event field. This is problematic:

```
User: "Read src/Button.tsx"
Hookify: "⚠️ Console.log detected!"  ← WRONG - user is just reading!
```

As documented in #13464:
> For other tools (Read, Glob, TodoWrite, etc.), `event=None` is passed to `load_rules()`, which skips filtering and loads ALL rules regardless of event type.

This causes:
- **False positives**: File-editing rules (`event: file`) incorrectly fire on read operations
- **Noisy UX**: Users see warnings when simply exploring code
- **Unexpected blocking**: Rules with negative operators can block read operations

## Related: #17246

PR #17246 addresses the same issue but maps Read → `file` event. This approach has a UX problem: file-editing rules like "no console.log in production" would still trigger when reading files.

**This PR proposes a better solution:** a dedicated `read` event type.

## Solution

Add `read` as a new event type:

```python
elif tool_name in ['Read', 'Glob', 'Grep', 'LS']:
    event = 'read'
```

This gives users precise control:
- `event: file` → Only Edit/Write/MultiEdit (actual modifications)
- `event: read` → Only Read/Glob/Grep/LS (read operations)  
- `event: all` → Everything

## Files Changed

| File | Change |
|------|--------|
| `hooks/pretooluse.py` | Add read event mapping |
| `hooks/posttooluse.py` | Add read event mapping |
| `README.md` | Document read event type |
| `skills/writing-rules/SKILL.md` | Document read event type |

## Usage Examples

### Prevent false positives (the problem this fixes)
```yaml
---
name: no-console-log
enabled: true
event: file  # Now correctly only triggers on Edit/Write, NOT Read
conditions:
  - field: new_text
    operator: contains
    pattern: console.log
---
Remove console.log before committing.
```

### Create read-specific rules (new capability)
```yaml
---
name: warn-reading-secrets
enabled: true
event: read  # Only triggers on Read, not Edit
conditions:
  - field: file_path
    operator: regex_match
    pattern: (\.env|secrets|credentials)
---
You're reading a sensitive file. Be careful with the contents.
```

## Why `read` is Better Than Reusing `file`

| Scenario | Map to `file` (#17246) | Map to `read` (this PR) |
|----------|----------------------|------------------------|
| "no console.log" rule fires on Read | ❌ Yes (noisy) | ✅ No |
| Can create read-specific rules | ❌ No | ✅ Yes |
| Backwards compatible | ✅ Yes | ✅ Yes |
| Semantic clarity | ❌ Confusing | ✅ Clear |
| Addresses #13464 Issue 1 | ⚠️ Partially | ✅ Fully |

## Test Plan

- [x] Python syntax check passes
- [x] Manual testing confirms read operations don't trigger file rules
- [x] Backward compatible - existing rules unchanged
- [x] Verified against scenarios described in #13464