### PR TITLE
Normalize workflow path matching on Windows

### DIFF
--- a/plugins/security-guidance/hooks/security_reminder_hook.py
+++ b/plugins/security-guidance/hooks/security_reminder_hook.py
@@ -183,7 +183,7 @@ def save_state(session_id, shown_warnings):
 def check_patterns(file_path, content):
     """Check if file path or content matches any security patterns."""
     # Normalize path by removing leading slashes
-    normalized_path = file_path.lstrip("/")
+    normalized_path = file_path.replace("\\", "/").lstrip("/")
 
     for pattern in SECURITY_PATTERNS:
         # Check path-based patterns


### PR DESCRIPTION
## Summary
- Normalize path separators before workflow path checks
- Ensure workflow security reminder triggers on Windows-style paths

## Testing
- `python -c` invocation of `security_reminder_hook.py` with Windows-style path

Fixes #18508