### PR TITLE
fix(ralph-wiggum): portable shebangs, empty array fix, and interactive ux

### DIFF
--- a/plugins/ralph-wiggum/commands/ralph-loop.md
+++ b/plugins/ralph-wiggum/commands/ralph-loop.md
@@ -1,18 +1,85 @@
 ---
 description: "Start Ralph Wiggum loop in current session"
-argument-hint: "PROMPT [--max-iterations N] [--completion-promise TEXT]"
+argument-hint: "[PROMPT] [--max-iterations N] [--completion-promise TEXT]"
 allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh:*)"]
-hide-from-slash-command-tool: "true"
 ---
 
 # Ralph Loop Command
 
-Execute the setup script to initialize the Ralph loop:
+You are setting up a Ralph Wiggum loop - an iterative development loop where you work on a task repeatedly until completion.
 
-```!
-"${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh" $ARGUMENTS
+## Step 1: Parse Provided Arguments
+
+Check what's already provided in `$ARGUMENTS`:
+
+- **PROMPT**: Any text that's not a flag (e.g., `Fix the auth bug`)
+- **--max-iterations N**: Check if this flag is present with a value
+- **--completion-promise TEXT**: Check if this flag is present with a value
+
+Note which values are missing and need to be gathered.
+
+## Step 2: Gather Missing Values
+
+For each missing value, prompt the user:
+
+### If PROMPT is missing:
+
+Ask the user directly:
+
+"What task should Ralph work on? Describe the task or provide a file path containing the task description."
+
+### If --completion-promise is missing:
+
+Use `AskUserQuestion`:
+
+```
+question: "What phrase signals task completion?"
+header: "Promise"
+options:
+  - label: "STOP (Recommended)"
+    description: "Output <promise>STOP</promise> when genuinely complete"
+  - label: "No completion phrase"
+    description: "Loop stops only when max iterations reached"
+multiSelect: false
 ```
 
-Please work on the task. When you try to exit, the Ralph loop will feed the SAME PROMPT back to you for the next iteration. You'll see your previous work in files and git history, allowing you to iterate and improve.
+Map: `STOP` → `--completion-promise 'STOP'`, `No completion phrase` → omit flag, Other → use custom input
 
-CRITICAL RULE: If a completion promise is set, you may ONLY output it when the statement is completely and unequivocally TRUE. Do not output false promises to escape the loop, even if you think you're stuck or should exit for other reasons. The loop is designed to continue until genuine completion.
+### If --max-iterations is missing:
+
+Use `AskUserQuestion`:
+
+```
+question: "Maximum iterations before auto-stop?"
+header: "Max Iters"
+options:
+  - label: "20 (Recommended)"
+    description: "Good balance for most tasks"
+  - label: "10"
+    description: "Quick iterations, simpler tasks"
+  - label: "50"
+    description: "Complex features needing many iterations"
+  - label: "Unlimited"
+    description: "No limit - runs until promise (dangerous!)"
+multiSelect: false
+```
+
+Map: `20` → `--max-iterations 20`, `Unlimited` → omit flag
+
+## Step 3: Execute Setup Script
+
+Build the command combining provided arguments with gathered values:
+
+```!
+"${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh" [PROMPT] [--completion-promise 'PROMISE'] [--max-iterations N]
+```
+
+Only include flags that have values (from arguments or user input).
+
+## Step 4: Begin Work
+
+After the script outputs the activation message, begin working on the task.
+
+When you try to exit, the Ralph loop will feed the SAME PROMPT back to you for the next iteration. You'll see your previous work in files and git history, allowing you to iterate and improve.
+
+**CRITICAL RULE:** If a completion promise is set, you may ONLY output it when the statement is completely and unequivocally TRUE. Do not output false promises to escape the loop, even if you think you're stuck or should exit for other reasons. The loop is designed to continue until genuine completion.

--- a/plugins/ralph-wiggum/hooks/stop-hook.sh
+++ b/plugins/ralph-wiggum/hooks/stop-hook.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Ralph Wiggum Stop Hook
 # Prevents session exit when a ralph-loop is active

--- a/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
+++ b/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Ralph Loop Setup Script
 # Creates state file for in-session Ralph loop
@@ -109,8 +109,8 @@ HELP_EOF
   esac
 done
 
-# Join all prompt parts with spaces
-PROMPT="${PROMPT_PARTS[*]}"
+# Join all prompt parts with spaces (handle empty array with set -u)
+PROMPT="${PROMPT_PARTS[*]:-}"
 
 # Validate prompt is non-empty
 if [[ -z "$PROMPT" ]]; then


### PR DESCRIPTION
## Summary

This PR includes three improvements to the ralph-wiggum plugin:

1. **Portable shebangs** - Use `#!/usr/bin/env bash` for NixOS/Nix compatibility
2. **Empty array fix** - Handle empty `PROMPT_PARTS` array with `set -u` strict mode
3. **Interactive UX** - Prompt for missing arguments instead of failing

## Changes

### Portable shebangs (NixOS compatibility)

Changed `#!/bin/bash` to `#!/usr/bin/env bash` in both shell scripts. In NixOS and some other environments, bash is not located at `/bin/bash`.

**Files:** `hooks/stop-hook.sh`, `scripts/setup-ralph-loop.sh`

### Empty array fix

The script uses `set -euo pipefail` for strict error handling. When invoked without positional arguments, the `PROMPT_PARTS` array remains empty, causing:

```
PROMPT_PARTS[*]: unbound variable
```

This crashes the script before it can reach the helpful error message that was already implemented.

Fixed by using `${PROMPT_PARTS[*]:-}` which provides an empty default, allowing the script to reach proper validation:

```
❌ Error: No prompt provided

   Ralph needs a task description to work on.

   Examples:
     /ralph-loop Build a REST API for todos
     /ralph-loop Fix the auth bug --max-iterations 20

   For all options: /ralph-loop --help
```

**File:** `scripts/setup-ralph-loop.sh`

### Interactive UX

The command now intelligently prompts for only the missing arguments:

| Invocation | Behavior |
|------------|----------|
| `/ralph-loop` | Prompt for task, promise, iterations |
| `/ralph-loop "Fix bug"` | Prompt for promise, iterations |
| `/ralph-loop --max-iterations 20` | Prompt for task, promise |
| `/ralph-loop "Fix bug" --max-iterations 20` | Prompt for promise only |
| `/ralph-loop "Fix bug" --completion-promise STOP --max-iterations 20` | Execute directly |

Uses `AskUserQuestion` for structured choices (completion promise, max iterations) and natural conversation for free-form input (task description).

**File:** `commands/ralph-loop.md`

## Related PRs

Note: Some of these fixes overlap with existing open PRs:
- #16562 - Portable shebangs
- #16755 - Empty array fix
- #16605 - NixOS shebang (partial)

The interactive UX improvement is novel to this PR.

## Test Plan

- [x] `setup-ralph-loop.sh --help` displays help correctly
- [x] `setup-ralph-loop.sh` without args shows friendly error message
- [x] `/ralph-loop` without args prompts for all missing values
- [x] `/ralph-loop "Task"` prompts only for promise and iterations
- [x] `/ralph-loop "Task" --max-iterations 10` prompts only for promise
- [x] `/ralph-loop "Task" --completion-promise STOP --max-iterations 10` executes directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)