### PR TITLE
fix(ralph-wiggum): Add Windows compatibility for stop hook

### DIFF
--- a/plugins/ralph-wiggum/hooks/hooks.json
+++ b/plugins/ralph-wiggum/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd stop-hook.sh"
           }
         ]
       }

--- a/plugins/ralph-wiggum/hooks/run-hook.cmd
+++ b/plugins/ralph-wiggum/hooks/run-hook.cmd
@@ -1,0 +1,19 @@
+: << 'CMDBLOCK'
+@echo off
+REM Polyglot wrapper: runs .sh scripts cross-platform
+REM Usage: run-hook.cmd <script-name> [args...]
+REM The script should be in the same directory as this wrapper
+
+if "%~1"=="" (
+    echo run-hook.cmd: missing script name >&2
+    exit /b 1
+)
+"C:\Program Files\Git\bin\bash.exe" -l "%~dp0%~1" %2 %3 %4 %5 %6 %7 %8 %9
+exit /b
+CMDBLOCK
+
+# Unix shell runs from here
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_NAME="$1"
+shift
+"${SCRIPT_DIR}/${SCRIPT_NAME}" "$@"


### PR DESCRIPTION
## Summary

The ralph-wiggum plugin's stop hook fails on Windows with:
```
Stop hook error: Failed with non-blocking status code: <3>WSL (9 - Relay) ERROR: CreateProcessCommon:640:
execvpe(/bin/bash) failed: No such file or directory
```

**Root cause:** `stop-hook.sh` uses `#!/bin/bash` shebang which tries to invoke `/bin/bash` (Linux path). On Windows, this path doesn't exist and the system tries WSL which may not be available.

**Solution:** Added `run-hook.cmd` polyglot wrapper that:
- On Windows: Routes to Git Bash (`C:\Program Files\Git\bin\bash.exe`)
- On Unix: Passes through to the shell script directly

This follows the same pattern used by the superpowers plugin.

## Changes
- Added `plugins/ralph-wiggum/hooks/run-hook.cmd` - polyglot wrapper script
- Updated `plugins/ralph-wiggum/hooks/hooks.json` to use the wrapper

## Test plan
- [x] Verified wrapper executes successfully on Windows
- [x] Verified Git Bash path exists on standard Git for Windows installation
- [x] Pattern matches working superpowers plugin implementation