### PR TITLE
Add voice-to-claude plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -145,6 +145,17 @@
       },
       "source": "./plugins/security-guidance",
       "category": "security"
+    },
+    {
+      "name": "voice-to-claude",
+      "description": "High-quality voice dictation for Claude Code using whisper.cpp with local on-device processing",
+      "version": "0.1.0",
+      "author": {
+        "name": "Enes Basbug",
+        "email": "enesbasbugeng@gmail.com"
+      },
+      "source": "./plugins/voice-to-claude",
+      "category": "accessibility"
     }
   ]
 }

--- a/plugins/voice-to-claude/.claude-plugin/marketplace.json
+++ b/plugins/voice-to-claude/.claude-plugin/marketplace.json
@@ -1,0 +1,33 @@
+{
+  "name": "voice-to-claude-marketplace",
+  "owner": {
+    "name": "Enes Basbug",
+    "url": "https://github.com/enesbasbug"
+  },
+  "plugins": [
+    {
+      "name": "voice-to-claude",
+      "source": "./",
+      "description": "High-quality voice dictation using whisper.cpp with Metal GPU acceleration. Hold Ctrl+Alt, speak, release to transcribe.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Enes Basbug",
+        "url": "https://github.com/enesbasbug"
+      },
+      "homepage": "https://github.com/enesbasbug/voice-to-claude",
+      "repository": "https://github.com/enesbasbug/voice-to-claude",
+      "license": "MIT",
+      "keywords": [
+        "speech-to-text",
+        "stt",
+        "voice",
+        "dictation",
+        "whisper",
+        "audio",
+        "accessibility",
+        "metal",
+        "gpu"
+      ]
+    }
+  ]
+}

--- a/plugins/voice-to-claude/.claude-plugin/plugin.json
+++ b/plugins/voice-to-claude/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "voice-to-claude",
+  "description": "High-quality voice dictation for Claude Code using whisper.cpp with Metal GPU acceleration",
+  "version": "0.1.0",
+  "author": {
+    "name": "Enes Basbug",
+    "url": "https://github.com/enesbasbug"
+  },
+  "homepage": "https://github.com/enesbasbug/voice-to-claude",
+  "repository": "https://github.com/enesbasbug/voice-to-claude",
+  "license": "MIT",
+  "keywords": ["speech-to-text", "stt", "voice", "dictation", "whisper", "audio", "accessibility", "metal", "gpu"]
+}

--- a/plugins/voice-to-claude/.gitignore
+++ b/plugins/voice-to-claude/.gitignore
@@ -1,0 +1,31 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+*.egg-info/
+dist/
+build/
+.venv/
+venv/
+ENV/
+env/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Claude Code plugin
+*.log
+
+# Local config (user-specific, shouldn't be in repo)
+# But we don't create this in the repo, so no need to ignore
+

--- a/plugins/voice-to-claude/.gitignore
+++ b/plugins/voice-to-claude/.gitignore
@@ -11,6 +11,7 @@ build/
 venv/
 ENV/
 env/
+.pytest_cache/
 
 # IDE
 .vscode/

--- a/plugins/voice-to-claude/LICENSE
+++ b/plugins/voice-to-claude/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 VoiceToClipboard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/voice-to-claude/README.md
+++ b/plugins/voice-to-claude/README.md
@@ -1,6 +1,6 @@
 # Voice-to-Claude
 
-High-quality voice dictation for Claude Code using whisper.cpp with Metal GPU acceleration.
+High-quality voice dictation for Claude Code using whisper.cpp with local on-device processing.
 
 [![License](https://img.shields.io/github/license/enesbasbug/voice-to-claude)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/enesbasbug/voice-to-claude)](https://github.com/enesbasbug/voice-to-claude/stargazers)
@@ -27,7 +27,8 @@ High-quality voice dictation for Claude Code using whisper.cpp with Metal GPU ac
 **That's it!** Hold **Ctrl+Alt** (or **Ctrl+Option** on macOS) to record, release to transcribe.
 
 > **Note**: 
-> - First-time setup takes ~3-5 minutes (builds whisper.cpp with Metal support)
+> - First-time setup takes ~3-5 minutes (builds whisper.cpp)
+> - Uses Metal GPU acceleration on macOS, CPU on Linux
 > - Downloads the base Whisper model (~142MB)
 > - Works with Python 3.10, 3.11, or 3.12 (auto-detected)
 > - Creates a local virtual environment (`.venv`) in the plugin directory to isolate dependencies
@@ -38,15 +39,16 @@ High-quality voice dictation for Claude Code using whisper.cpp with Metal GPU ac
 
 ## What is Voice-to-Claude?
 
-Voice-to-Claude gives you high-quality voice input directly into Claude Code using whisper.cpp with Metal GPU acceleration.
+Voice-to-Claude gives you high-quality voice input directly into Claude Code using whisper.cpp with local on-device processing.
 
 | What You Get | Why It Matters |
 |--------------|----------------|
 | **Local processing** | All audio processed on-device using whisper.cpp |
-| **Metal GPU acceleration** | Fast transcription on Apple Silicon |
+| **GPU acceleration** | Metal on macOS (Apple Silicon), CPU on Linux |
 | **Multiple models** | Choose quality/speed tradeoff (tiny to large-v3) |
 | **Push-to-talk** | Hold hotkey to record, release to transcribe |
 | **Privacy first** | No audio or text sent to external services |
+| **Cross-platform** | Works on macOS and Linux |
 
 ### How It Works
 
@@ -64,9 +66,9 @@ Text inserted into Claude Code input
 
 **Key details:**
 - Uses whisper.cpp (GGML) for high-quality transcription
-- Metal acceleration for fast GPU inference on macOS
+- Metal acceleration for fast GPU inference on macOS, CPU on Linux
 - Keyboard injection or clipboard fallback
-- Native system sounds for audio feedback
+- Native system sounds for audio feedback (macOS and Linux)
 
 ---
 
@@ -102,18 +104,31 @@ Settings stored in `~/.config/voice-to-claude/config.json`.
 
 ## Requirements
 
-- **macOS** (Apple Silicon recommended for Metal acceleration)
+- **macOS** or **Linux**
 - **Python 3.10+**
-- **cmake** and **Xcode Command Line Tools** (for building whisper.cpp)
+- **cmake** and build tools (for building whisper.cpp)
 - **~200MB-3GB disk space** depending on model
 
 ### Prerequisites
 
+**macOS:**
 ```bash
-# Install build tools (if not already installed)
 brew install cmake
 xcode-select --install
 ```
+
+**Linux (Debian/Ubuntu):**
+```bash
+sudo apt install cmake build-essential python3-dev portaudio19-dev xclip
+```
+
+**Linux (Fedora):**
+```bash
+sudo dnf install cmake gcc-c++ python3-devel portaudio-devel xclip
+```
+
+> **Note:** `portaudio19-dev` is required for microphone access via `sounddevice`.  
+> `xclip` is needed for clipboard mode. You can also use `xsel` or `wl-copy` (Wayland).
 
 ---
 
@@ -133,9 +148,10 @@ xcode-select --install
 
 | Issue | Solution |
 |-------|----------|
-| No audio input | Check microphone permissions in System Settings > Privacy & Security > Microphone |
-| Keyboard injection not working | Grant Accessibility permissions in System Settings > Privacy & Security > Accessibility |
-| Build failed | Ensure cmake and Xcode tools are installed: `brew install cmake && xcode-select --install` |
+| No audio input | **macOS:** Check System Settings > Privacy & Security > Microphone. **Linux:** Ensure `portaudio19-dev` is installed and microphone is accessible |
+| Keyboard injection not working | **macOS:** Grant Accessibility permissions in System Settings > Privacy & Security > Accessibility. **Linux:** May need to run with `sudo` or add user to `input` group |
+| Build failed | **macOS:** `brew install cmake && xcode-select --install`. **Linux:** `sudo apt install cmake build-essential` |
+| Clipboard not working (Linux) | Install `xclip`, `xsel`, or `wl-copy` (Wayland) |
 | Model not loading | Run `/voice-to-claude:setup` to download. Check disk space |
 | Hotkey not triggering | Check for conflicts with other apps. Try `/voice-to-claude:config` to change hotkey |
 

--- a/plugins/voice-to-claude/README.md
+++ b/plugins/voice-to-claude/README.md
@@ -1,0 +1,198 @@
+# Voice-to-Claude
+
+High-quality voice dictation for Claude Code using whisper.cpp with Metal GPU acceleration.
+
+[![License](https://img.shields.io/github/license/enesbasbug/voice-to-claude)](LICENSE)
+[![Stars](https://img.shields.io/github/stars/enesbasbug/voice-to-claude)](https://github.com/enesbasbug/voice-to-claude/stargazers)
+
+## Install
+
+**Quick Start (3 steps):**
+
+1. **Add marketplace** (one-time setup):
+   ```
+   /plugin marketplace add enesbasbug/voice-to-claude
+   ```
+
+2. **Install plugin**:
+   ```
+   /plugin install voice-to-claude@voice-to-claude-marketplace
+   ```
+
+3. **Run setup** (downloads dependencies, builds whisper.cpp):
+   ```
+   /voice-to-claude:setup
+   ```
+
+**That's it!** Hold **Ctrl+Alt** (or **Ctrl+Option** on macOS) to record, release to transcribe.
+
+> **Note**: 
+> - First-time setup takes ~3-5 minutes (builds whisper.cpp with Metal support)
+> - Downloads the base Whisper model (~142MB)
+> - Works with Python 3.10, 3.11, or 3.12 (auto-detected)
+> - Creates a local virtual environment (`.venv`) in the plugin directory to isolate dependencies
+> - No system-wide Python package installation required
+> - Claude Code may ask for permission to run commands during setup (this is normal)
+
+---
+
+## What is Voice-to-Claude?
+
+Voice-to-Claude gives you high-quality voice input directly into Claude Code using whisper.cpp with Metal GPU acceleration.
+
+| What You Get | Why It Matters |
+|--------------|----------------|
+| **Local processing** | All audio processed on-device using whisper.cpp |
+| **Metal GPU acceleration** | Fast transcription on Apple Silicon |
+| **Multiple models** | Choose quality/speed tradeoff (tiny to large-v3) |
+| **Push-to-talk** | Hold hotkey to record, release to transcribe |
+| **Privacy first** | No audio or text sent to external services |
+
+### How It Works
+
+```
+Hold Ctrl+Alt (Ctrl+Option on macOS) → start recording
+        ↓
+Audio captured from microphone
+        ↓
+Release Ctrl+Alt → stop recording
+        ↓
+whisper.cpp transcribes locally (~1s for base model)
+        ↓
+Text inserted into Claude Code input
+```
+
+**Key details:**
+- Uses whisper.cpp (GGML) for high-quality transcription
+- Metal acceleration for fast GPU inference on macOS
+- Keyboard injection or clipboard fallback
+- Native system sounds for audio feedback
+
+---
+
+## Configuration
+
+Customize your settings anytime:
+
+```
+/voice-to-claude:config
+```
+
+### Options
+
+| Option | Values | Default | Description |
+|--------|--------|---------|-------------|
+| `model` | `tiny`, `base`, `medium`, `large-v3` | `base` | Whisper model |
+| `hotkey` | Key combo | `ctrl+alt` | Trigger recording (Ctrl+Option on macOS) |
+| `output_mode` | `keyboard`, `clipboard` | `keyboard` | How text is inserted |
+| `sound_effects` | `true`, `false` | `true` | Play audio feedback |
+
+### Available Models
+
+| Model | Size | Speed | Quality |
+|-------|------|-------|---------|
+| tiny | ~75MB | ~0.5s | Basic |
+| base | ~142MB | ~1s | Good (default) |
+| medium | ~1.5GB | ~2s | Better |
+| large-v3 | ~3GB | ~3s | Best |
+
+Settings stored in `~/.config/voice-to-claude/config.json`.
+
+---
+
+## Requirements
+
+- **macOS** (Apple Silicon recommended for Metal acceleration)
+- **Python 3.10+**
+- **cmake** and **Xcode Command Line Tools** (for building whisper.cpp)
+- **~200MB-3GB disk space** depending on model
+
+### Prerequisites
+
+```bash
+# Install build tools (if not already installed)
+brew install cmake
+xcode-select --install
+```
+
+---
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/voice-to-claude:setup` | First-time setup: build whisper.cpp, download model |
+| `/voice-to-claude:start` | Start the voice dictation daemon |
+| `/voice-to-claude:stop` | Stop the daemon |
+| `/voice-to-claude:status` | Show daemon status and configuration |
+| `/voice-to-claude:config` | Change settings (model, hotkey, etc.) |
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| No audio input | Check microphone permissions in System Settings > Privacy & Security > Microphone |
+| Keyboard injection not working | Grant Accessibility permissions in System Settings > Privacy & Security > Accessibility |
+| Build failed | Ensure cmake and Xcode tools are installed: `brew install cmake && xcode-select --install` |
+| Model not loading | Run `/voice-to-claude:setup` to download. Check disk space |
+| Hotkey not triggering | Check for conflicts with other apps. Try `/voice-to-claude:config` to change hotkey |
+
+### Logs
+
+```bash
+tail -50 ~/.config/voice-to-claude/daemon.log
+```
+
+---
+
+## Privacy
+
+**All processing is local:**
+- Audio captured from your microphone is processed entirely on-device
+- whisper.cpp runs locally — no cloud API calls
+- Audio is never sent anywhere, never stored
+- Transcribed text only goes to Claude Code input or clipboard
+
+**No telemetry or analytics.**
+
+---
+
+## Development (for contributors)
+
+If you're contributing to this repo, clone it and load the plugin locally:
+
+```bash
+git clone https://github.com/enesbasbug/voice-to-claude
+cd voice-to-claude
+
+# Test locally without marketplace install
+claude --plugin-dir .
+```
+
+In Claude Code:
+
+```
+/voice-to-claude:setup
+/voice-to-claude:start
+```
+
+Notes:
+- The setup script creates a local `.venv` and installs dependencies there.
+- If `python3` points to 3.9, you can run:
+  `python3.11 ./scripts/setup.py`
+- On macOS, you may need to grant Microphone and Accessibility permissions.
+
+---
+
+## License
+
+MIT — see [LICENSE](LICENSE)
+
+---
+
+## Credits
+
+- [whisper.cpp](https://github.com/ggerganov/whisper.cpp) - Fast C++ implementation of OpenAI's Whisper
+- [OpenAI Whisper](https://github.com/openai/whisper) - Original speech recognition model

--- a/plugins/voice-to-claude/commands/config.md
+++ b/plugins/voice-to-claude/commands/config.md
@@ -1,0 +1,103 @@
+---
+description: Configure voice-to-claude settings - model, hotkey, output mode
+---
+
+# voice-to-claude Configuration
+
+Change voice-to-claude settings including the Whisper model, hotkey, and output mode.
+
+## Instructions
+
+When the user runs `/voice-to-claude:config`:
+
+### Step 1: Show current configuration
+
+```bash
+PYTHON_CMD=$([ -f "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" ] && echo "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" || (command -v python3.11 >/dev/null && echo python3.11) || (command -v python3.10 >/dev/null && echo python3.10) || echo python3); $PYTHON_CMD ${CLAUDE_PLUGIN_ROOT}/scripts/exec.py config show
+```
+
+Display current settings:
+```
+Current Configuration
+========================================
+Model:    base
+Hotkey:   Ctrl+Alt
+Output:   keyboard
+Sounds:   enabled
+```
+
+### Step 2: Ask what to change
+
+Ask the user what they'd like to configure:
+
+1. **Model** - Change Whisper model (affects quality/speed)
+2. **Hotkey** - Change the recording hotkey
+3. **Output** - Change how text is inserted (keyboard/clipboard)
+4. **Sounds** - Enable/disable audio feedback
+
+### Changing Model
+
+Available models:
+| Model | Size | Speed | Quality |
+|-------|------|-------|---------|
+| tiny | ~75MB | ~0.5s | Basic |
+| base | ~142MB | ~1s | Good (default) |
+| medium | ~1.5GB | ~2s | Better |
+| large-v3 | ~3GB | ~3s | Best |
+
+To change model, first check if it's downloaded:
+```bash
+PYTHON_CMD=$([ -f "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" ] && echo "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" || (command -v python3.11 >/dev/null && echo python3.11) || (command -v python3.10 >/dev/null && echo python3.10) || echo python3); $PYTHON_CMD ${CLAUDE_PLUGIN_ROOT}/scripts/exec.py config model <model_name>
+```
+
+If model isn't downloaded, download it:
+```bash
+cd ~/.local/share/voice-to-claude/whisper.cpp && ./models/download-ggml-model.sh <model_name>
+```
+
+Then set it:
+```bash
+PYTHON_CMD=$([ -f "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" ] && echo "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" || (command -v python3.11 >/dev/null && echo python3.11) || (command -v python3.10 >/dev/null && echo python3.10) || echo python3); $PYTHON_CMD ${CLAUDE_PLUGIN_ROOT}/scripts/exec.py config model <model_name>
+```
+
+### Changing Hotkey
+
+Available modifier keys: ctrl, alt, shift, cmd
+
+Examples:
+- `ctrl+alt` (default)
+- `ctrl+shift`
+- `cmd+shift`
+
+```bash
+PYTHON_CMD=$([ -f "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" ] && echo "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" || (command -v python3.11 >/dev/null && echo python3.11) || (command -v python3.10 >/dev/null && echo python3.10) || echo python3); $PYTHON_CMD ${CLAUDE_PLUGIN_ROOT}/scripts/exec.py config hotkey <keys>
+```
+
+### Changing Output Mode
+
+- `keyboard` - Types text directly (default)
+- `clipboard` - Copies to clipboard and pastes
+
+```bash
+PYTHON_CMD=$([ -f "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" ] && echo "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" || (command -v python3.11 >/dev/null && echo python3.11) || (command -v python3.10 >/dev/null && echo python3.10) || echo python3); $PYTHON_CMD ${CLAUDE_PLUGIN_ROOT}/scripts/exec.py config output <mode>
+```
+
+### Changing Sound Effects
+
+```bash
+PYTHON_CMD=$([ -f "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" ] && echo "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" || (command -v python3.11 >/dev/null && echo python3.11) || (command -v python3.10 >/dev/null && echo python3.10) || echo python3); $PYTHON_CMD ${CLAUDE_PLUGIN_ROOT}/scripts/exec.py config sounds <on|off>
+```
+
+### Step 3: Restart daemon
+
+After changing settings, restart the daemon:
+
+```bash
+PYTHON_CMD=$([ -f "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" ] && echo "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" || (command -v python3.11 >/dev/null && echo python3.11) || (command -v python3.10 >/dev/null && echo python3.10) || echo python3); $PYTHON_CMD ${CLAUDE_PLUGIN_ROOT}/scripts/exec.py daemon restart
+```
+
+Confirm:
+```
+Configuration updated. Daemon restarted.
+New settings are now active.
+```

--- a/plugins/voice-to-claude/commands/setup.md
+++ b/plugins/voice-to-claude/commands/setup.md
@@ -1,0 +1,75 @@
+---
+description: Set up voice-to-claude - install dependencies, build whisper.cpp, download model
+---
+
+# voice-to-claude Setup
+
+Run the setup script directly. Do not manually check prerequisites - the script handles everything automatically.
+
+## Instructions
+
+**IMPORTANT: Run the command below directly. Do NOT manually check Python version or install dependencies first - the setup script handles all of this automatically.**
+
+```bash
+python3.10 ${CLAUDE_PLUGIN_ROOT}/scripts/setup.py 2>/dev/null || python3.11 ${CLAUDE_PLUGIN_ROOT}/scripts/setup.py 2>/dev/null || python3.12 ${CLAUDE_PLUGIN_ROOT}/scripts/setup.py 2>/dev/null || python3 ${CLAUDE_PLUGIN_ROOT}/scripts/setup.py
+```
+
+The script will:
+- Auto-detect Python 3.10+ (works with 3.10, 3.11, or 3.12)
+- Create a local `.venv` in the plugin directory
+- Install dependencies in the venv (isolated)
+- Build whisper.cpp with Metal support (~3-5 min)
+- Download the Whisper model (~142MB)
+- Configure everything
+
+**Important:** Do not manually check Python version or install dependencies - the script does this automatically.
+
+### Step 2: Handle Common Errors
+
+**"Microphone permission denied" (macOS):**
+```
+macOS requires Microphone permission for audio recording.
+
+1. Open System Settings > Privacy & Security > Microphone
+2. Find your terminal app (Terminal, iTerm, etc.) and enable it
+3. Re-run: /voice-to-claude:setup
+```
+
+**"Accessibility permission needed" (macOS):**
+```
+macOS requires Accessibility permission for keyboard input.
+
+1. Open System Settings > Privacy & Security > Accessibility
+2. Find your terminal app and enable it
+3. Re-run: /voice-to-claude:start
+```
+
+**cmake or build errors:**
+```bash
+# Ensure Xcode tools are installed
+xcode-select --install
+
+# Try rebuilding
+cd ~/.local/share/voice-to-claude/whisper.cpp
+rm -rf build
+cmake -B build -DGGML_METAL=ON
+cmake --build build -j
+```
+
+**PortAudio errors:**
+```bash
+brew install portaudio
+```
+
+### Success
+
+When setup completes successfully, you'll see:
+```
+Setup Complete!
+To start voice dictation:
+  /voice-to-claude:start
+
+Then hold Ctrl+Alt and speak!
+```
+
+Use `/voice-to-claude:start` to start the daemon.

--- a/plugins/voice-to-claude/commands/start.md
+++ b/plugins/voice-to-claude/commands/start.md
@@ -1,0 +1,57 @@
+---
+description: Start the voice dictation daemon
+---
+
+# Start voice-to-claude Daemon
+
+Start the speech-to-text daemon for voice dictation.
+
+## Instructions
+
+When the user runs `/voice-to-claude:start`:
+
+### Step 1: Check if setup is complete
+
+```bash
+PYTHON_CMD=$([ -f "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" ] && echo "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" || (command -v python3.11 >/dev/null && echo python3.11) || (command -v python3.10 >/dev/null && echo python3.10) || echo python3); test -f ~/.config/voice-to-claude/config.json && $PYTHON_CMD -c "import json; c=json.load(open('$HOME/.config/voice-to-claude/config.json')); exit(0 if c.get('setup_complete') else 1)" 2>/dev/null && echo "SETUP_OK" || echo "SETUP_NEEDED"
+```
+
+- If output is `SETUP_NEEDED`: Tell user to run `/voice-to-claude:setup` first.
+- If output is `SETUP_OK`: Proceed to Step 2.
+
+### Step 2: Check daemon status
+
+```bash
+PYTHON_CMD=$([ -f "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" ] && echo "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" || (command -v python3.11 >/dev/null && echo python3.11) || (command -v python3.10 >/dev/null && echo python3.10) || echo python3); $PYTHON_CMD ${CLAUDE_PLUGIN_ROOT}/scripts/exec.py daemon status
+```
+
+### Step 3: Start if not running
+
+If daemon is not running:
+
+```bash
+PYTHON_CMD=$([ -f "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" ] && echo "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" || (command -v python3.11 >/dev/null && echo python3.11) || (command -v python3.10 >/dev/null && echo python3.10) || echo python3); $PYTHON_CMD ${CLAUDE_PLUGIN_ROOT}/scripts/exec.py daemon start --background
+```
+
+### Step 4: Confirm and show usage
+
+```bash
+PYTHON_CMD=$([ -f "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" ] && echo "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" || (command -v python3.11 >/dev/null && echo python3.11) || (command -v python3.10 >/dev/null && echo python3.10) || echo python3); $PYTHON_CMD ${CLAUDE_PLUGIN_ROOT}/scripts/exec.py daemon status
+```
+
+Show usage reminder:
+```
+voice-to-claude daemon started.
+
+Usage:
+  Hotkey: Ctrl+Alt (hold to record, release to transcribe)
+
+  1. Hold Ctrl+Alt - Recording starts
+  2. Speak clearly
+  3. Release - Text appears in input
+
+Tips:
+  - Speak in complete sentences for best accuracy
+  - Use /voice-to-claude:config to change model or hotkey
+  - Use /voice-to-claude:stop to stop the daemon
+```

--- a/plugins/voice-to-claude/commands/status.md
+++ b/plugins/voice-to-claude/commands/status.md
@@ -1,0 +1,50 @@
+---
+description: Check voice-to-claude daemon status and configuration
+---
+
+# voice-to-claude Status
+
+Check the status of the voice dictation daemon and current configuration.
+
+## Instructions
+
+When the user runs `/voice-to-claude:status`:
+
+### Step 1: Check setup status
+
+```bash
+test -f ~/.config/voice-to-claude/config.json && echo "CONFIG_EXISTS" || echo "NOT_SETUP"
+```
+
+If `NOT_SETUP`: Tell user to run `/voice-to-claude:setup` first.
+
+### Step 2: Get full status
+
+```bash
+PYTHON_CMD=$([ -f "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" ] && echo "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" || (command -v python3.11 >/dev/null && echo python3.11) || (command -v python3.10 >/dev/null && echo python3.10) || echo python3); $PYTHON_CMD ${CLAUDE_PLUGIN_ROOT}/scripts/exec.py daemon status --verbose
+```
+
+### Step 3: Display status
+
+Format the output nicely:
+
+```
+voice-to-claude Status
+========================================
+Setup:    Complete
+Daemon:   Running (PID: 12345)
+Model:    base (~142MB, ~1s transcription)
+Hotkey:   Ctrl+Alt (hold to record)
+Output:   keyboard
+
+Available Models:
+  - tiny     (~75MB,  ~0.5s) - Quick notes
+  - base     (~142MB, ~1s)   - General use [ACTIVE]
+  - medium   (~1.5GB, ~2s)   - Better accuracy
+  - large-v3 (~3GB,   ~3s)   - Best quality
+
+Commands:
+  /voice-to-claude:start  - Start daemon
+  /voice-to-claude:stop   - Stop daemon
+  /voice-to-claude:config - Change settings
+```

--- a/plugins/voice-to-claude/commands/stop.md
+++ b/plugins/voice-to-claude/commands/stop.md
@@ -1,0 +1,36 @@
+---
+description: Stop the voice dictation daemon
+---
+
+# Stop voice-to-claude Daemon
+
+Stop the speech-to-text daemon.
+
+## Instructions
+
+When the user runs `/voice-to-claude:stop`:
+
+### Step 1: Check daemon status
+
+```bash
+PYTHON_CMD=$([ -f "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" ] && echo "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" || (command -v python3.11 >/dev/null && echo python3.11) || (command -v python3.10 >/dev/null && echo python3.10) || echo python3); $PYTHON_CMD ${CLAUDE_PLUGIN_ROOT}/scripts/exec.py daemon status
+```
+
+### Step 2: Stop if running
+
+```bash
+PYTHON_CMD=$([ -f "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" ] && echo "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" || (command -v python3.11 >/dev/null && echo python3.11) || (command -v python3.10 >/dev/null && echo python3.10) || echo python3); $PYTHON_CMD ${CLAUDE_PLUGIN_ROOT}/scripts/exec.py daemon stop
+```
+
+### Step 3: Confirm stopped
+
+```bash
+PYTHON_CMD=$([ -f "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" ] && echo "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python" || (command -v python3.11 >/dev/null && echo python3.11) || (command -v python3.10 >/dev/null && echo python3.10) || echo python3); $PYTHON_CMD ${CLAUDE_PLUGIN_ROOT}/scripts/exec.py daemon status
+```
+
+Show confirmation:
+```
+voice-to-claude daemon stopped.
+
+To restart: /voice-to-claude:start
+```

--- a/plugins/voice-to-claude/hooks/hooks.json
+++ b/plugins/voice-to-claude/hooks/hooks.json
@@ -1,0 +1,8 @@
+{
+  "hooks": [
+    {
+      "event": "PostStart",
+      "command": "PYTHON_CMD=$([ -f \"${CLAUDE_PLUGIN_ROOT}/.venv/bin/python\" ] && echo \"${CLAUDE_PLUGIN_ROOT}/.venv/bin/python\" || (command -v python3.11 >/dev/null && echo python3.11) || (command -v python3.10 >/dev/null && echo python3.10) || echo python3); $PYTHON_CMD ${CLAUDE_PLUGIN_ROOT}/scripts/exec.py daemon start --background --quiet 2>/dev/null || true"
+    }
+  ]
+}

--- a/plugins/voice-to-claude/pyproject.toml
+++ b/plugins/voice-to-claude/pyproject.toml
@@ -1,0 +1,52 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "voice-to-claude"
+version = "0.1.0"
+description = "High-quality voice dictation for Claude Code using whisper.cpp with Metal GPU acceleration"
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.10"
+authors = [
+    {name = "Enes Basbug", email = "enesbasbugeng@gmail.com"}
+]
+keywords = ["speech-to-text", "stt", "voice", "dictation", "whisper", "claude", "metal", "gpu"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: MacOS",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Multimedia :: Sound/Audio :: Speech",
+]
+
+dependencies = [
+    "sounddevice>=0.4.6",
+    "numpy>=1.24.0",
+    "scipy>=1.10.0",
+    "pynput>=1.7.6",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "black>=23.0.0",
+    "ruff>=0.0.200",
+]
+
+[project.urls]
+Homepage = "https://github.com/enesbasbug/voice-to-claude"
+Repository = "https://github.com/enesbasbug/voice-to-claude"
+Issues = "https://github.com/enesbasbug/voice-to-claude/issues"
+
+[project.scripts]
+voice-to-claude = "voice_to_claude.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/plugins/voice-to-claude/pyproject.toml
+++ b/plugins/voice-to-claude/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "voice-to-claude"
 version = "0.1.0"
-description = "High-quality voice dictation for Claude Code using whisper.cpp with Metal GPU acceleration"
+description = "High-quality voice dictation for Claude Code using whisper.cpp with local on-device processing"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.10"
@@ -19,6 +19,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: MacOS",
+    "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -50,3 +51,7 @@ voice-to-claude = "voice_to_claude.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/plugins/voice-to-claude/scripts/exec.py
+++ b/plugins/voice-to-claude/scripts/exec.py
@@ -21,7 +21,7 @@ def main():
 
     # Daemon commands
     daemon_parser = subparsers.add_parser("daemon", help="Daemon management")
-    daemon_parser.add_argument("action", choices=["start", "stop", "status", "restart"],
+    daemon_parser.add_argument("action", choices=["start", "stop", "status", "restart", "run"],
                                help="Action to perform")
     daemon_parser.add_argument("--background", "-b", action="store_true",
                                help="Run in background")
@@ -87,6 +87,10 @@ def handle_daemon(args):
         stop_daemon()
         time.sleep(0.5)
         start_daemon(background=args.background, quiet=args.quiet)
+
+    elif args.action == "run":
+        # Run in foreground (used by background launcher)
+        start_daemon(background=False, quiet=args.quiet)
 
     elif args.action == "status":
         status = daemon_status()

--- a/plugins/voice-to-claude/scripts/exec.py
+++ b/plugins/voice-to-claude/scripts/exec.py
@@ -60,7 +60,7 @@ def main():
 def handle_daemon(args):
     """Handle daemon commands."""
     from voice_to_claude.daemon import (
-        start_daemon, stop_daemon, daemon_status, is_daemon_running
+        start_daemon, stop_daemon, daemon_status
     )
     from voice_to_claude.config import Config
     import time
@@ -73,11 +73,7 @@ def handle_daemon(args):
                 print("Setup not complete. Run /voice-to-claude:setup first.")
             sys.exit(1)
 
-        if is_daemon_running():
-            if not args.quiet:
-                print("Daemon is already running.")
-            sys.exit(0)
-
+        # start_daemon already checks if daemon is running
         start_daemon(background=args.background, quiet=args.quiet)
 
     elif args.action == "stop":

--- a/plugins/voice-to-claude/scripts/exec.py
+++ b/plugins/voice-to-claude/scripts/exec.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""
+Entry point for voice-to-claude commands.
+Routes subcommands to appropriate handlers.
+"""
+
+import os
+import sys
+import argparse
+
+# Add src directory to path
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PLUGIN_ROOT = os.path.dirname(SCRIPT_DIR)
+SRC_DIR = os.path.join(PLUGIN_ROOT, "src")
+sys.path.insert(0, SRC_DIR)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="voice-to-claude CLI")
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # Daemon commands
+    daemon_parser = subparsers.add_parser("daemon", help="Daemon management")
+    daemon_parser.add_argument("action", choices=["start", "stop", "status", "restart"],
+                               help="Action to perform")
+    daemon_parser.add_argument("--background", "-b", action="store_true",
+                               help="Run in background")
+    daemon_parser.add_argument("--quiet", "-q", action="store_true",
+                               help="Suppress output")
+    daemon_parser.add_argument("--verbose", "-v", action="store_true",
+                               help="Verbose output")
+
+    # Config commands
+    config_parser = subparsers.add_parser("config", help="Configuration management")
+    config_parser.add_argument("setting", nargs="?",
+                               choices=["show", "model", "hotkey", "output", "sounds"],
+                               default="show", help="Setting to configure")
+    config_parser.add_argument("value", nargs="?", help="New value")
+
+    # Setup command
+    setup_parser = subparsers.add_parser("setup", help="Run setup")
+    setup_parser.add_argument("--skip-build", action="store_true",
+                              help="Skip whisper.cpp build")
+    setup_parser.add_argument("--skip-model", action="store_true",
+                              help="Skip model download")
+
+    args = parser.parse_args()
+
+    if args.command == "daemon":
+        handle_daemon(args)
+    elif args.command == "config":
+        handle_config(args)
+    elif args.command == "setup":
+        handle_setup(args)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+def handle_daemon(args):
+    """Handle daemon commands."""
+    from voice_to_claude.daemon import (
+        start_daemon, stop_daemon, daemon_status, is_daemon_running
+    )
+    from voice_to_claude.config import Config
+    import time
+
+    config = Config.load()
+
+    if args.action == "start":
+        if not config.setup_complete:
+            if not args.quiet:
+                print("Setup not complete. Run /voice-to-claude:setup first.")
+            sys.exit(1)
+
+        if is_daemon_running():
+            if not args.quiet:
+                print("Daemon is already running.")
+            sys.exit(0)
+
+        start_daemon(background=args.background, quiet=args.quiet)
+
+    elif args.action == "stop":
+        stop_daemon()
+
+    elif args.action == "restart":
+        stop_daemon()
+        time.sleep(0.5)
+        start_daemon(background=args.background, quiet=args.quiet)
+
+    elif args.action == "status":
+        status = daemon_status()
+        if args.verbose:
+            print("voice-to-claude Status")
+            print("=" * 40)
+            print(f"Setup:    {'Complete' if status['setup_complete'] else 'Not complete'}")
+            if status['running']:
+                print(f"Daemon:   Running (PID: {status['pid']})")
+            else:
+                print("Daemon:   Stopped")
+            print(f"Model:    {status['model']}")
+            print(f"Hotkey:   {status['hotkey']}")
+            print(f"Output:   {status['output_mode']}")
+        else:
+            if status['running']:
+                print(f"Running (PID: {status['pid']})")
+            else:
+                print("Stopped")
+
+
+def handle_config(args):
+    """Handle config commands."""
+    from voice_to_claude.config import Config, WHISPER_MODELS
+    from pathlib import Path
+    import json
+
+    config = Config.load()
+
+    if args.setting == "show" or args.setting is None:
+        print("Current Configuration")
+        print("=" * 40)
+        print(f"Model:    {config.model}")
+        print(f"Hotkey:   {config.get_hotkey_description()}")
+        print(f"Output:   {config.output_mode}")
+        print(f"Sounds:   {'enabled' if config.sound_effects else 'disabled'}")
+        return
+
+    if args.value is None:
+        # Show current value
+        if args.setting == "model":
+            print(f"Current model: {config.model}")
+            print("\nAvailable models: tiny, base, medium, large-v3")
+        elif args.setting == "hotkey":
+            print(f"Current hotkey: {config.get_hotkey_description()}")
+            print("\nOptions: ctrl, alt, shift, cmd (combine with +)")
+        elif args.setting == "output":
+            print(f"Current output mode: {config.output_mode}")
+            print("\nOptions: keyboard, clipboard")
+        elif args.setting == "sounds":
+            print(f"Sound effects: {'on' if config.sound_effects else 'off'}")
+        return
+
+    # Set new value
+    if args.setting == "model":
+        if args.value not in WHISPER_MODELS:
+            print(f"Invalid model: {args.value}")
+            print("Available: tiny, base, medium, large-v3")
+            sys.exit(1)
+
+        # Check if model exists
+        if config.models_dir:
+            model_path = Path(config.models_dir) / WHISPER_MODELS[args.value]["file"]
+            if not model_path.exists():
+                print(f"Model '{args.value}' not downloaded.")
+                print(f"Download with:")
+                print(f"  cd ~/.local/share/voice-to-claude/whisper.cpp")
+                print(f"  ./models/download-ggml-model.sh {args.value}")
+                sys.exit(1)
+
+        config.model = args.value
+        config.save()
+        print(f"Model changed to: {args.value}")
+        print("Restart daemon for changes to take effect.")
+
+    elif args.setting == "hotkey":
+        keys = args.value.lower().split("+")
+        config.hotkey_ctrl = "ctrl" in keys
+        config.hotkey_alt = "alt" in keys
+        config.hotkey_shift = "shift" in keys
+        config.hotkey_cmd = "cmd" in keys
+        config.save()
+        print(f"Hotkey changed to: {config.get_hotkey_description()}")
+        print("Restart daemon for changes to take effect.")
+
+    elif args.setting == "output":
+        if args.value not in ["keyboard", "clipboard"]:
+            print("Invalid output mode. Options: keyboard, clipboard")
+            sys.exit(1)
+        config.output_mode = args.value
+        config.save()
+        print(f"Output mode changed to: {args.value}")
+        print("Restart daemon for changes to take effect.")
+
+    elif args.setting == "sounds":
+        config.sound_effects = args.value.lower() in ["on", "true", "1", "yes"]
+        config.save()
+        print(f"Sound effects: {'on' if config.sound_effects else 'off'}")
+
+
+def handle_setup(args):
+    """Handle setup command."""
+    from scripts.setup import run_setup
+    run_setup(skip_build=args.skip_build, skip_model=args.skip_model)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/voice-to-claude/scripts/setup.py
+++ b/plugins/voice-to-claude/scripts/setup.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""
+Bootstrap setup for voice-to-claude (stdlib only).
+Creates venv and installs dependencies, then runs main setup.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import venv
+from pathlib import Path
+from typing import Sequence
+
+
+def _get_plugin_root() -> Path:
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        return Path(env_root).expanduser()
+    return Path(__file__).resolve().parents[1]
+
+
+def _print_error(message: str) -> None:
+    print(f"Error: {message}", file=sys.stderr)
+
+
+def _print_info(message: str) -> None:
+    print(message)
+
+
+def _check_python() -> bool:
+    """Check if Python version is 3.10+."""
+    if sys.version_info < (3, 10):
+        current = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+        _print_error(f"Python 3.10+ required, but found {current}.")
+        _print_info("")
+        system = platform.system()
+        if system == "Darwin":
+            _print_info("Install with: brew install python@3.11")
+            _print_info("Or download from: https://www.python.org/downloads/")
+        elif system == "Linux":
+            _print_info("Install with: sudo apt install python3.11 python3-venv python3-pip")
+        else:
+            _print_info("Download from: https://www.python.org/downloads/")
+        return False
+    return True
+
+
+def _check_uv() -> str | None:
+    """Check if uv is available."""
+    return shutil.which("uv")
+
+
+def _run(cmd: list[str], cwd: Path) -> int:
+    """Run a command."""
+    return subprocess.call(cmd, cwd=str(cwd))
+
+
+def _venv_python(plugin_root: Path) -> Path:
+    """Get path to venv Python."""
+    venv_dir = plugin_root / ".venv"
+    if os.name == "nt":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+def _ensure_venv(plugin_root: Path) -> Path | None:
+    """Create venv if it doesn't exist."""
+    venv_dir = plugin_root / ".venv"
+    python_path = _venv_python(plugin_root)
+    
+    if python_path.exists():
+        # Verify the venv Python is the same version as current Python
+        try:
+            venv_version = subprocess.check_output(
+                [str(python_path), "--version"], text=True, stderr=subprocess.STDOUT
+            ).strip()
+            current_version = f"Python {sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+            if venv_version != current_version:
+                # Venv was created with wrong Python version, recreate it
+                _print_info(f"Recreating venv (found {venv_version}, need {current_version})...")
+                shutil.rmtree(venv_dir)
+            else:
+                return python_path
+        except Exception:
+            # If we can't check, try to recreate
+            if venv_dir.exists():
+                shutil.rmtree(venv_dir)
+
+    _print_info(f"Creating virtual environment with Python {sys.version_info.major}.{sys.version_info.minor}...")
+    try:
+        # CRITICAL: Use sys.executable to ensure we use the SAME Python that's running this script
+        # This prevents venv from using a different Python version
+        builder = venv.EnvBuilder(with_pip=True, system_site_packages=False)
+        # Explicitly set the Python executable to the one running this script
+        builder.create(venv_dir)
+        
+        # Verify the venv was created with the correct Python
+        if python_path.exists():
+            venv_version_output = subprocess.check_output(
+                [str(python_path), "--version"], text=True, stderr=subprocess.STDOUT
+            ).strip()
+            expected_version = f"Python {sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+            if venv_version_output != expected_version:
+                _print_error(f"Venv created with wrong Python! Expected {expected_version}, got {venv_version_output}")
+                shutil.rmtree(venv_dir)
+                return None
+    except Exception as e:
+        _print_error(f"Failed to create virtual environment: {e}")
+        if venv_dir.exists():
+            shutil.rmtree(venv_dir)
+        return None
+
+    return python_path if python_path.exists() else None
+
+
+def _pip_install(python_path: Path, plugin_root: Path) -> int:
+    """Install package in venv."""
+    return _run(
+        [
+            str(python_path),
+            "-m",
+            "pip",
+            "install",
+            "--disable-pip-version-check",
+            "--no-input",
+            ".",
+        ],
+        plugin_root,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="voice-to-claude setup bootstrap")
+    parser.add_argument(
+        "--skip-install",
+        action="store_true",
+        help="Skip dependency installation.",
+    )
+    parser.add_argument(
+        "--skip-build",
+        action="store_true",
+        help="Skip whisper.cpp build.",
+    )
+    parser.add_argument(
+        "--skip-model",
+        action="store_true",
+        help="Skip model download.",
+    )
+    args, passthrough = parser.parse_known_args(argv)
+
+    if not _check_python():
+        return 1
+
+    plugin_root = _get_plugin_root()
+    os.environ.setdefault("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+
+    # Check for uv first (faster)
+    uv = _check_uv()
+    if uv:
+        _print_info("Using uv for dependency management.")
+        if not args.skip_install:
+            sync_cmd = [uv, "sync", "--directory", str(plugin_root)]
+            exit_code = _run(sync_cmd, plugin_root)
+            if exit_code != 0:
+                _print_error("uv sync failed.")
+                return exit_code
+
+        # Run setup using uv
+        cmd = [
+            uv,
+            "run",
+            "--directory",
+            str(plugin_root),
+            "python",
+            "-m",
+            "voice_to_claude.setup",
+            *passthrough,
+        ]
+        if args.skip_build:
+            cmd.append("--skip-build")
+        if args.skip_model:
+            cmd.append("--skip-model")
+        return _run(cmd, plugin_root)
+
+    # Fallback to venv
+    venv_python = _ensure_venv(plugin_root)
+    if venv_python is None:
+        return 1
+
+    if not args.skip_install:
+        _print_info("Installing dependencies in local .venv...")
+        exit_code = _pip_install(venv_python, plugin_root)
+        if exit_code != 0:
+            _print_error("pip install failed.")
+            return exit_code
+
+    # Run main setup
+    cmd = [str(venv_python), "-m", "voice_to_claude.setup"]
+    if args.skip_build:
+        cmd.append("--skip-build")
+    if args.skip_model:
+        cmd.append("--skip-model")
+    cmd.extend(passthrough)
+    return _run(cmd, plugin_root)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/voice-to-claude/src/voice_to_claude/__init__.py
+++ b/plugins/voice-to-claude/src/voice_to_claude/__init__.py
@@ -1,0 +1,8 @@
+"""
+Voice-to-Claude: High-quality voice dictation for Claude Code.
+
+Uses whisper.cpp (GGML) for fast on-device speech recognition with Metal GPU acceleration.
+Works entirely offline with no cloud APIs.
+"""
+
+__version__ = "1.0.0"

--- a/plugins/voice-to-claude/src/voice_to_claude/__init__.py
+++ b/plugins/voice-to-claude/src/voice_to_claude/__init__.py
@@ -1,8 +1,19 @@
 """
 Voice-to-Claude: High-quality voice dictation for Claude Code.
 
-Uses whisper.cpp (GGML) for fast on-device speech recognition with Metal GPU acceleration.
+Uses whisper.cpp (GGML) for fast on-device speech recognition.
+Supports Metal GPU acceleration on macOS and CPU inference on Linux.
 Works entirely offline with no cloud APIs.
 """
 
-__version__ = "1.0.0"
+__version__ = "0.1.0"
+
+__all__ = [
+    "config",
+    "daemon",
+    "keyboard",
+    "recorder",
+    "sounds",
+    "transcriber",
+    "utils",
+]

--- a/plugins/voice-to-claude/src/voice_to_claude/config.py
+++ b/plugins/voice-to-claude/src/voice_to_claude/config.py
@@ -1,0 +1,127 @@
+"""Configuration management for voice-to-claude."""
+
+import json
+from pathlib import Path
+from dataclasses import dataclass, asdict
+from typing import Optional
+
+# Default paths
+DEFAULT_CONFIG_DIR = Path.home() / ".config" / "voice-to-claude"
+DEFAULT_CONFIG_FILE = DEFAULT_CONFIG_DIR / "config.json"
+DEFAULT_PID_FILE = DEFAULT_CONFIG_DIR / "daemon.pid"
+DEFAULT_LOG_FILE = DEFAULT_CONFIG_DIR / "daemon.log"
+
+# Whisper model definitions
+WHISPER_MODELS = {
+    "tiny": {
+        "file": "ggml-tiny.bin",
+        "size": "~75MB",
+        "speed": "Fastest (~0.5s)",
+        "url": "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin"
+    },
+    "base": {
+        "file": "ggml-base.bin",
+        "size": "~142MB",
+        "speed": "Fast (~1s)",
+        "url": "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin"
+    },
+    "medium": {
+        "file": "ggml-medium.bin",
+        "size": "~1.5GB",
+        "speed": "Medium (~2s)",
+        "url": "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.bin"
+    },
+    "large-v3": {
+        "file": "ggml-large-v3.bin",
+        "size": "~3GB",
+        "speed": "Slow (~3s)",
+        "url": "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3.bin"
+    }
+}
+
+# Audio settings
+SAMPLE_RATE = 16000  # Whisper expects 16kHz
+
+
+@dataclass
+class Config:
+    """Voice-to-claude configuration."""
+
+    # Hotkey settings (modifier keys to hold)
+    hotkey_ctrl: bool = True
+    hotkey_alt: bool = True
+    hotkey_shift: bool = False
+    hotkey_cmd: bool = False
+
+    # Model settings
+    model: str = "base"
+
+    # Output settings
+    output_mode: str = "keyboard"  # "keyboard" or "clipboard"
+
+    # Audio settings
+    sound_effects: bool = True
+    max_recording_seconds: int = 60
+
+    # Paths (set during setup)
+    whisper_cpp_path: Optional[str] = None
+    models_dir: Optional[str] = None
+
+    # Setup status
+    setup_complete: bool = False
+
+    @classmethod
+    def load(cls) -> "Config":
+        """Load configuration from file."""
+        if DEFAULT_CONFIG_FILE.exists():
+            try:
+                with open(DEFAULT_CONFIG_FILE) as f:
+                    data = json.load(f)
+                return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+            except (json.JSONDecodeError, TypeError):
+                pass
+        return cls()
+
+    def save(self) -> None:
+        """Save configuration to file."""
+        DEFAULT_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        with open(DEFAULT_CONFIG_FILE, "w") as f:
+            json.dump(asdict(self), f, indent=2)
+
+    def get_model_path(self) -> Optional[Path]:
+        """Get path to current model file."""
+        if not self.models_dir or self.model not in WHISPER_MODELS:
+            return None
+        return Path(self.models_dir) / WHISPER_MODELS[self.model]["file"]
+
+    def get_whisper_cli(self) -> Optional[Path]:
+        """Get path to whisper-cli executable."""
+        if not self.whisper_cpp_path:
+            return None
+        return Path(self.whisper_cpp_path)
+
+    def get_hotkey_description(self) -> str:
+        """Get human-readable hotkey description."""
+        keys = []
+        if self.hotkey_ctrl:
+            keys.append("Ctrl")
+        if self.hotkey_alt:
+            keys.append("Alt")
+        if self.hotkey_shift:
+            keys.append("Shift")
+        if self.hotkey_cmd:
+            keys.append("Cmd")
+        return "+".join(keys) if keys else "None"
+
+
+def get_plugin_root() -> Path:
+    """Get the plugin root directory."""
+    # This file is at src/voice_to_claude/config.py
+    # Plugin root is two directories up
+    return Path(__file__).parent.parent.parent
+
+
+def ensure_config_dir() -> Path:
+    """Ensure config directory exists and return it."""
+    DEFAULT_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    return DEFAULT_CONFIG_DIR

--- a/plugins/voice-to-claude/src/voice_to_claude/daemon.py
+++ b/plugins/voice-to-claude/src/voice_to_claude/daemon.py
@@ -1,0 +1,360 @@
+"""Background daemon for voice dictation hotkey listening."""
+
+import os
+import sys
+import signal
+import threading
+import time
+import logging
+from pathlib import Path
+from typing import Set, Optional
+
+from pynput import keyboard
+
+from .config import Config, DEFAULT_PID_FILE, DEFAULT_LOG_FILE, ensure_config_dir
+from .recorder import AudioRecorder, MicrophoneError
+from .transcriber import Transcriber
+from .keyboard import TextInjector
+from . import sounds
+
+# Set up logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+class VoiceDaemon:
+    """Background daemon that listens for hotkeys and handles voice transcription."""
+
+    def __init__(self, config: Config, quiet: bool = False):
+        self.config = config
+        self.quiet = quiet
+
+        # Components
+        self.recorder = AudioRecorder(max_seconds=config.max_recording_seconds)
+        self.transcriber = Transcriber(config)
+        self.injector = TextInjector(mode=config.output_mode)
+
+        # State
+        self.is_recording = False
+        self.pressed_keys: Set[keyboard.Key] = set()
+        self.keyboard_listener: Optional[keyboard.Listener] = None
+        self.running = False
+
+        # Build required keys set based on config
+        self.required_keys = self._build_required_keys()
+
+    def _build_required_keys(self) -> Set[keyboard.Key]:
+        """Build set of required modifier keys from config."""
+        keys = set()
+        if self.config.hotkey_ctrl:
+            keys.add(keyboard.Key.ctrl_l)
+        if self.config.hotkey_alt:
+            keys.add(keyboard.Key.alt_l)
+        if self.config.hotkey_shift:
+            keys.add(keyboard.Key.shift_l)
+        if self.config.hotkey_cmd:
+            keys.add(keyboard.Key.cmd_l)
+        return keys
+
+    def _log(self, message: str) -> None:
+        """Log message unless in quiet mode."""
+        if not self.quiet:
+            logger.info(message)
+
+    def _on_press(self, key: keyboard.Key) -> None:
+        """Handle key press."""
+        if key in self.required_keys:
+            self.pressed_keys.add(key)
+
+            # Start recording when all required keys are pressed
+            if self.pressed_keys == self.required_keys and not self.is_recording:
+                self._start_recording()
+
+    def _on_release(self, key: keyboard.Key) -> None:
+        """Handle key release."""
+        if key in self.required_keys:
+            self.pressed_keys.discard(key)
+
+            # Stop recording when any required key is released
+            if self.is_recording:
+                self._stop_recording()
+
+    def _start_recording(self) -> None:
+        """Start recording audio."""
+        self.is_recording = True
+        self._log("Recording started...")
+
+        if self.config.sound_effects:
+            threading.Thread(target=sounds.play_start_sound, daemon=True).start()
+
+        try:
+            self.recorder.start()
+        except MicrophoneError as e:
+            self._log(f"Microphone error: {e}")
+            if self.config.sound_effects:
+                threading.Thread(target=sounds.play_error_sound, daemon=True).start()
+            self.is_recording = False
+
+    def _stop_recording(self) -> None:
+        """Stop recording and process audio."""
+        if not self.is_recording:
+            return
+
+        self.is_recording = False
+        self._log("Recording stopped, processing...")
+
+        if self.config.sound_effects:
+            threading.Thread(target=sounds.play_stop_sound, daemon=True).start()
+
+        # Stop recording and get audio
+        audio = self.recorder.stop()
+
+        # Process in background thread
+        threading.Thread(
+            target=self._process_audio,
+            args=(audio,),
+            daemon=True
+        ).start()
+
+    def _process_audio(self, audio) -> None:
+        """Process recorded audio (runs in background thread)."""
+        if audio is None:
+            self._log("No audio recorded")
+            return
+
+        duration = self.recorder.get_duration(audio)
+        if duration < 0.3:
+            self._log("Recording too short, ignoring")
+            return
+
+        self._log(f"Audio duration: {duration:.1f}s")
+
+        # Save to temp file
+        try:
+            wav_path = self.recorder.save_to_wav(audio)
+            self._log(f"Saved to: {wav_path}")
+
+            # Transcribe
+            result = self.transcriber.transcribe(wav_path)
+
+            # Clean up temp file
+            wav_path.unlink(missing_ok=True)
+
+            if result.success:
+                self._log(f"Transcribed ({result.duration_seconds:.1f}s): {result.text[:50]}...")
+
+                # Inject text
+                if self.injector.inject(result.text):
+                    self._log("Text injected successfully")
+                    if self.config.sound_effects:
+                        threading.Thread(target=sounds.play_success_sound, daemon=True).start()
+                else:
+                    self._log("Failed to inject text, copied to clipboard")
+                    TextInjector.copy_to_clipboard(result.text)
+            else:
+                self._log(f"Transcription failed: {result.error}")
+                if self.config.sound_effects:
+                    threading.Thread(target=sounds.play_error_sound, daemon=True).start()
+
+        except Exception as e:
+            self._log(f"Error processing audio: {e}")
+            if self.config.sound_effects:
+                threading.Thread(target=sounds.play_error_sound, daemon=True).start()
+
+    def start(self) -> None:
+        """Start the daemon."""
+        if not self.config.setup_complete:
+            print("Setup not complete. Run /voice-to-claude:setup first.")
+            sys.exit(1)
+
+        self.running = True
+
+        # Set up signal handlers
+        signal.signal(signal.SIGTERM, self._handle_signal)
+        signal.signal(signal.SIGINT, self._handle_signal)
+
+        # Start keyboard listener
+        self.keyboard_listener = keyboard.Listener(
+            on_press=self._on_press,
+            on_release=self._on_release
+        )
+        self.keyboard_listener.start()
+
+        if not self.quiet:
+            print("=" * 50)
+            print("Voice-to-Claude Daemon")
+            print("=" * 50)
+            print(f"Hotkey: {self.config.get_hotkey_description()}")
+            print(f"Model: {self.config.model}")
+            print(f"Output: {self.config.output_mode}")
+            print("=" * 50)
+            print("\nReady! Hold hotkey and speak.\n")
+
+        # Keep running
+        try:
+            while self.running:
+                time.sleep(0.1)
+        except KeyboardInterrupt:
+            pass
+
+        self.stop()
+
+    def stop(self) -> None:
+        """Stop the daemon."""
+        self.running = False
+
+        if self.keyboard_listener:
+            self.keyboard_listener.stop()
+            self.keyboard_listener = None
+
+        self._log("Daemon stopped")
+
+    def _handle_signal(self, signum, frame) -> None:
+        """Handle shutdown signals."""
+        self._log(f"Received signal {signum}, shutting down...")
+        self.running = False
+
+
+def write_pid_file() -> None:
+    """Write PID to file."""
+    ensure_config_dir()
+    DEFAULT_PID_FILE.write_text(str(os.getpid()))
+
+
+def remove_pid_file() -> None:
+    """Remove PID file."""
+    DEFAULT_PID_FILE.unlink(missing_ok=True)
+
+
+def read_pid_file() -> Optional[int]:
+    """Read PID from file."""
+    if DEFAULT_PID_FILE.exists():
+        try:
+            return int(DEFAULT_PID_FILE.read_text().strip())
+        except (ValueError, FileNotFoundError):
+            pass
+    return None
+
+
+def is_daemon_running() -> bool:
+    """Check if daemon is running."""
+    pid = read_pid_file()
+    if pid is None:
+        return False
+
+    try:
+        # Check if process exists
+        os.kill(pid, 0)
+        return True
+    except (OSError, ProcessLookupError):
+        # Process doesn't exist, clean up stale PID file
+        remove_pid_file()
+        return False
+
+
+def start_daemon(background: bool = False, quiet: bool = False) -> None:
+    """Start the daemon."""
+    if is_daemon_running():
+        print("Daemon is already running.")
+        return
+
+    config = Config.load()
+
+    if background:
+        # Fork to background
+        pid = os.fork()
+        if pid > 0:
+            # Parent process
+            print(f"Daemon started in background (PID: {pid})")
+            return
+
+        # Child process - daemonize
+        os.setsid()
+
+        # Redirect stdout/stderr to log file
+        ensure_config_dir()
+        log_file = open(DEFAULT_LOG_FILE, 'a')
+        os.dup2(log_file.fileno(), sys.stdout.fileno())
+        os.dup2(log_file.fileno(), sys.stderr.fileno())
+
+    write_pid_file()
+
+    try:
+        daemon = VoiceDaemon(config, quiet=quiet)
+        daemon.start()
+    finally:
+        remove_pid_file()
+
+
+def stop_daemon() -> None:
+    """Stop the daemon."""
+    pid = read_pid_file()
+    if pid is None:
+        print("Daemon is not running.")
+        return
+
+    try:
+        os.kill(pid, signal.SIGTERM)
+        print("Daemon stopped.")
+        remove_pid_file()
+    except ProcessLookupError:
+        print("Daemon was not running (stale PID file removed).")
+        remove_pid_file()
+
+
+def daemon_status() -> dict:
+    """Get daemon status."""
+    running = is_daemon_running()
+    pid = read_pid_file() if running else None
+    config = Config.load()
+
+    return {
+        "running": running,
+        "pid": pid,
+        "setup_complete": config.setup_complete,
+        "model": config.model,
+        "hotkey": config.get_hotkey_description(),
+        "output_mode": config.output_mode
+    }
+
+
+def main():
+    """CLI entry point for daemon."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Voice-to-Claude daemon")
+    parser.add_argument("action", choices=["start", "stop", "status", "restart"],
+                       help="Action to perform")
+    parser.add_argument("--background", "-b", action="store_true",
+                       help="Run in background")
+    parser.add_argument("--quiet", "-q", action="store_true",
+                       help="Suppress output")
+
+    args = parser.parse_args()
+
+    if args.action == "start":
+        start_daemon(background=args.background, quiet=args.quiet)
+    elif args.action == "stop":
+        stop_daemon()
+    elif args.action == "restart":
+        stop_daemon()
+        time.sleep(0.5)
+        start_daemon(background=args.background, quiet=args.quiet)
+    elif args.action == "status":
+        status = daemon_status()
+        if status["running"]:
+            print(f"Daemon is running (PID: {status['pid']})")
+            print(f"  Model: {status['model']}")
+            print(f"  Hotkey: {status['hotkey']}")
+            print(f"  Output: {status['output_mode']}")
+        else:
+            print("Daemon is not running.")
+            if not status["setup_complete"]:
+                print("  Setup not complete. Run /voice-to-claude:setup first.")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/voice-to-claude/src/voice_to_claude/keyboard.py
+++ b/plugins/voice-to-claude/src/voice_to_claude/keyboard.py
@@ -1,0 +1,95 @@
+"""Text injection functionality for Claude Code."""
+
+import subprocess
+import time
+from typing import Optional
+
+from pynput.keyboard import Controller, Key
+
+
+class TextInjector:
+    """Injects text into Claude Code's input."""
+
+    def __init__(self, mode: str = "keyboard"):
+        """
+        Initialize text injector.
+
+        Args:
+            mode: "keyboard" for typing simulation, "clipboard" for paste
+        """
+        self.mode = mode
+        self.keyboard = Controller()
+
+    def inject(self, text: str) -> bool:
+        """
+        Inject text into the active input.
+
+        Args:
+            text: Text to inject
+
+        Returns:
+            True if successful
+        """
+        if not text:
+            return False
+
+        if self.mode == "keyboard":
+            return self._inject_keyboard(text)
+        else:
+            return self._inject_clipboard(text)
+
+    def _inject_keyboard(self, text: str) -> bool:
+        """Type text character by character."""
+        try:
+            # Small delay to ensure focus
+            time.sleep(0.05)
+
+            # Type the text
+            self.keyboard.type(text)
+            return True
+        except Exception as e:
+            # Fall back to clipboard
+            print(f"Keyboard typing failed, falling back to clipboard: {e}")
+            return self._inject_clipboard(text)
+
+    def _inject_clipboard(self, text: str) -> bool:
+        """Copy text to clipboard and paste."""
+        try:
+            # Copy to clipboard using pbcopy
+            process = subprocess.Popen(
+                ['pbcopy'],
+                stdin=subprocess.PIPE,
+                env={'LANG': 'en_US.UTF-8'}
+            )
+            process.communicate(text.encode('utf-8'))
+
+            if process.returncode != 0:
+                return False
+
+            # Small delay then paste
+            time.sleep(0.05)
+
+            # Simulate Cmd+V
+            self.keyboard.press(Key.cmd)
+            self.keyboard.press('v')
+            self.keyboard.release('v')
+            self.keyboard.release(Key.cmd)
+
+            return True
+        except Exception as e:
+            print(f"Clipboard injection failed: {e}")
+            return False
+
+    @staticmethod
+    def copy_to_clipboard(text: str) -> bool:
+        """Just copy text to clipboard without pasting."""
+        try:
+            process = subprocess.Popen(
+                ['pbcopy'],
+                stdin=subprocess.PIPE,
+                env={'LANG': 'en_US.UTF-8'}
+            )
+            process.communicate(text.encode('utf-8'))
+            return process.returncode == 0
+        except Exception:
+            return False

--- a/plugins/voice-to-claude/src/voice_to_claude/keyboard.py
+++ b/plugins/voice-to-claude/src/voice_to_claude/keyboard.py
@@ -1,10 +1,12 @@
-"""Text injection functionality for Claude Code."""
+"""Text injection functionality for Claude Code with cross-platform support."""
 
 import subprocess
 import time
 from typing import Optional
 
 from pynput.keyboard import Controller, Key
+
+from .utils import find_clipboard_command, get_paste_key
 
 
 class TextInjector:
@@ -55,9 +57,13 @@ class TextInjector:
     def _inject_clipboard(self, text: str) -> bool:
         """Copy text to clipboard and paste."""
         try:
-            # Copy to clipboard using pbcopy
+            clip_cmd = find_clipboard_command()
+            if clip_cmd is None:
+                print("No clipboard command found (install xclip or xsel on Linux)")
+                return False
+
             process = subprocess.Popen(
-                ['pbcopy'],
+                clip_cmd,
                 stdin=subprocess.PIPE,
                 env={'LANG': 'en_US.UTF-8'}
             )
@@ -69,11 +75,12 @@ class TextInjector:
             # Small delay then paste
             time.sleep(0.05)
 
-            # Simulate Cmd+V
-            self.keyboard.press(Key.cmd)
+            # Use platform-appropriate paste shortcut
+            paste_key = get_paste_key()
+            self.keyboard.press(paste_key)
             self.keyboard.press('v')
             self.keyboard.release('v')
-            self.keyboard.release(Key.cmd)
+            self.keyboard.release(paste_key)
 
             return True
         except Exception as e:
@@ -84,8 +91,12 @@ class TextInjector:
     def copy_to_clipboard(text: str) -> bool:
         """Just copy text to clipboard without pasting."""
         try:
+            clip_cmd = find_clipboard_command()
+            if clip_cmd is None:
+                return False
+
             process = subprocess.Popen(
-                ['pbcopy'],
+                clip_cmd,
                 stdin=subprocess.PIPE,
                 env={'LANG': 'en_US.UTF-8'}
             )

--- a/plugins/voice-to-claude/src/voice_to_claude/recorder.py
+++ b/plugins/voice-to-claude/src/voice_to_claude/recorder.py
@@ -1,0 +1,112 @@
+"""Audio recording functionality."""
+
+import tempfile
+from pathlib import Path
+from typing import Optional, List
+
+import numpy as np
+import sounddevice as sd
+from scipy.io import wavfile
+
+from .config import SAMPLE_RATE
+
+
+class AudioRecorder:
+    """Records audio from the default microphone."""
+
+    def __init__(self, sample_rate: int = SAMPLE_RATE, max_seconds: int = 60):
+        self.sample_rate = sample_rate
+        self.max_seconds = max_seconds
+        self.is_recording = False
+        self.audio_data: List[np.ndarray] = []
+        self.stream: Optional[sd.InputStream] = None
+
+    def _audio_callback(self, indata: np.ndarray, frames: int, time_info, status) -> None:
+        """Callback for audio stream."""
+        if self.is_recording:
+            self.audio_data.append(indata.copy())
+
+    def start(self) -> bool:
+        """Start recording audio. Returns True if successful."""
+        if self.is_recording:
+            return False
+
+        self.is_recording = True
+        self.audio_data = []
+
+        try:
+            self.stream = sd.InputStream(
+                samplerate=self.sample_rate,
+                channels=1,
+                dtype=np.float32,
+                callback=self._audio_callback
+            )
+            self.stream.start()
+            return True
+        except sd.PortAudioError as e:
+            self.is_recording = False
+            raise MicrophoneError(
+                f"Microphone error: {e}\n\n"
+                "Please grant Microphone permission:\n"
+                "System Settings -> Privacy & Security -> Microphone\n"
+                "Enable Terminal (or the app you're running from)\n"
+                "Then restart the daemon."
+            )
+        except Exception as e:
+            self.is_recording = False
+            raise RecordingError(f"Error starting recording: {e}")
+
+    def stop(self) -> Optional[np.ndarray]:
+        """Stop recording and return audio data. Returns None if no audio."""
+        if not self.is_recording:
+            return None
+
+        self.is_recording = False
+
+        # Stop and close stream
+        if self.stream:
+            self.stream.stop()
+            self.stream.close()
+            self.stream = None
+
+        # Return concatenated audio
+        if not self.audio_data:
+            return None
+
+        return np.concatenate(self.audio_data)
+
+    def save_to_wav(self, audio: np.ndarray, path: Optional[Path] = None) -> Path:
+        """Save audio data to a WAV file. Returns the path."""
+        if path is None:
+            # Create temp file
+            fd, temp_path = tempfile.mkstemp(suffix=".wav")
+            path = Path(temp_path)
+
+        # Convert to int16 for WAV
+        audio_int16 = (audio * 32767).astype(np.int16)
+        wavfile.write(str(path), self.sample_rate, audio_int16)
+        return path
+
+    def get_duration(self, audio: np.ndarray) -> float:
+        """Get duration of audio in seconds."""
+        return len(audio) / self.sample_rate
+
+    @staticmethod
+    def check_microphone() -> bool:
+        """Check if microphone is available."""
+        try:
+            devices = sd.query_devices()
+            default_input = sd.query_devices(kind='input')
+            return default_input is not None
+        except Exception:
+            return False
+
+
+class RecordingError(Exception):
+    """Error during recording."""
+    pass
+
+
+class MicrophoneError(RecordingError):
+    """Microphone permission or hardware error."""
+    pass

--- a/plugins/voice-to-claude/src/voice_to_claude/setup.py
+++ b/plugins/voice-to-claude/src/voice_to_claude/setup.py
@@ -1,0 +1,214 @@
+"""
+Main setup module for voice-to-claude.
+Builds whisper.cpp, downloads model, configures daemon.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _get_plugin_root() -> Path:
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        return Path(env_root).expanduser()
+    # If running as module, go up from src/voice_to_claude
+    return Path(__file__).resolve().parents[2]
+
+
+HOME = Path.home()
+INSTALL_DIR = HOME / ".local" / "share" / "voice-to-claude"
+CONFIG_DIR = HOME / ".config" / "voice-to-claude"
+CONFIG_FILE = CONFIG_DIR / "config.json"
+WHISPER_DIR = INSTALL_DIR / "whisper.cpp"
+PLUGIN_ROOT = _get_plugin_root()
+
+
+def print_header(text):
+    print(f"\n{'=' * 50}")
+    print(text)
+    print('=' * 50)
+
+
+def print_step(num, total, text):
+    print(f"\n[{num}/{total}] {text}")
+
+
+def run_command(cmd, cwd=None, capture=False):
+    """Run a shell command."""
+    try:
+        if capture:
+            result = subprocess.run(cmd, shell=True, cwd=cwd, capture_output=True, text=True)
+            return result.returncode == 0, result.stdout, result.stderr
+        else:
+            result = subprocess.run(cmd, shell=True, cwd=cwd)
+            return result.returncode == 0, "", ""
+    except Exception as e:
+        return False, "", str(e)
+
+
+def check_whisper_built():
+    """Check if whisper.cpp is built."""
+    whisper_cli = WHISPER_DIR / "build" / "bin" / "whisper-cli"
+    return whisper_cli.exists()
+
+
+def build_whisper():
+    """Clone and build whisper.cpp with Metal support."""
+    print("  Creating install directory...")
+    INSTALL_DIR.mkdir(parents=True, exist_ok=True)
+
+    if not WHISPER_DIR.exists():
+        print("  Cloning whisper.cpp...")
+        success, _, err = run_command(
+            "git clone https://github.com/ggerganov/whisper.cpp.git",
+            cwd=INSTALL_DIR
+        )
+        if not success:
+            print(f"  Error cloning whisper.cpp: {err}")
+            return False
+
+    print("  Building with Metal support (this may take a few minutes)...")
+    success, _, err = run_command(
+        "cmake -B build -DGGML_METAL=ON",
+        cwd=WHISPER_DIR
+    )
+    if not success:
+        print(f"  Error running cmake: {err}")
+        return False
+
+    success, _, err = run_command(
+        "cmake --build build -j",
+        cwd=WHISPER_DIR
+    )
+    if not success:
+        print(f"  Error building: {err}")
+        return False
+
+    if check_whisper_built():
+        print("  ✓ whisper.cpp built successfully")
+        return True
+    else:
+        print("  ✗ Build failed - whisper-cli not found")
+        return False
+
+
+def check_model_exists(model="base"):
+    """Check if a model is downloaded."""
+    model_file = WHISPER_DIR / "models" / f"ggml-{model}.bin"
+    return model_file.exists()
+
+
+def download_model(model="base"):
+    """Download a Whisper model."""
+    print(f"  Downloading {model} model...")
+    success, _, err = run_command(
+        f"./models/download-ggml-model.sh {model}",
+        cwd=WHISPER_DIR
+    )
+    if success and check_model_exists(model):
+        print(f"  ✓ {model} model downloaded")
+        return True
+    else:
+        print(f"  ✗ Failed to download model: {err}")
+        return False
+
+
+def save_config():
+    """Save configuration file."""
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+
+    config = {
+        "whisper_cpp_path": str(WHISPER_DIR / "build" / "bin" / "whisper-cli"),
+        "models_dir": str(WHISPER_DIR / "models"),
+        "model": "base",
+        "hotkey_ctrl": True,
+        "hotkey_alt": True,
+        "hotkey_shift": False,
+        "hotkey_cmd": False,
+        "output_mode": "keyboard",
+        "sound_effects": True,
+        "max_recording_seconds": 60,
+        "setup_complete": True
+    }
+
+    with open(CONFIG_FILE, "w") as f:
+        json.dump(config, f, indent=2)
+
+    print("  ✓ Configuration saved")
+    return True
+
+
+def run_setup(skip_build=False, skip_model=False):
+    """Run the full setup process."""
+    print_header("voice-to-claude Setup")
+
+    total_steps = 2
+    if not skip_build:
+        total_steps += 1
+    if not skip_model:
+        total_steps += 1
+
+    current_step = 0
+
+    # Step 1: Build whisper.cpp
+    if not skip_build:
+        current_step += 1
+        print_step(current_step, total_steps, "Setting up whisper.cpp...")
+
+        if check_whisper_built():
+            print("  ✓ whisper.cpp already built")
+        else:
+            if not build_whisper():
+                print("\n  ✗ Failed to build whisper.cpp")
+                print("  Make sure you have cmake and Xcode tools installed:")
+                print("    brew install cmake")
+                print("    xcode-select --install")
+                sys.exit(1)
+
+    # Step 2: Download model
+    if not skip_model:
+        current_step += 1
+        print_step(current_step, total_steps, "Downloading Whisper model...")
+
+        if check_model_exists("base"):
+            print("  ✓ Base model already downloaded")
+        else:
+            if not download_model("base"):
+                print("\n  ✗ Failed to download model")
+                print("  Try manually:")
+                print(f"    cd {WHISPER_DIR}")
+                print("    ./models/download-ggml-model.sh base")
+                sys.exit(1)
+
+    # Step 3: Save configuration
+    current_step += 1
+    print_step(current_step, total_steps, "Saving configuration...")
+
+    save_config()
+
+    # Done!
+    print_header("Setup Complete!")
+    print("""
+To start voice dictation:
+  /voice-to-claude:start
+
+Then hold Ctrl+Alt and speak!
+""")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="voice-to-claude setup")
+    parser.add_argument("--skip-build", action="store_true", help="Skip whisper.cpp build")
+    parser.add_argument("--skip-model", action="store_true", help="Skip model download")
+    args = parser.parse_args()
+
+    run_setup(skip_build=args.skip_build, skip_model=args.skip_model)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/plugins/voice-to-claude/src/voice_to_claude/sounds.py
+++ b/plugins/voice-to-claude/src/voice_to_claude/sounds.py
@@ -1,0 +1,37 @@
+"""Audio feedback sounds."""
+
+import subprocess
+from pathlib import Path
+
+
+def play_start_sound() -> None:
+    """Play sound when recording starts."""
+    # Use macOS system sound
+    subprocess.run(
+        ["afplay", "/System/Library/Sounds/Pop.aiff"],
+        capture_output=True
+    )
+
+
+def play_stop_sound() -> None:
+    """Play sound when recording stops."""
+    subprocess.run(
+        ["afplay", "/System/Library/Sounds/Tink.aiff"],
+        capture_output=True
+    )
+
+
+def play_success_sound() -> None:
+    """Play sound on successful transcription."""
+    subprocess.run(
+        ["afplay", "/System/Library/Sounds/Glass.aiff"],
+        capture_output=True
+    )
+
+
+def play_error_sound() -> None:
+    """Play sound on error."""
+    subprocess.run(
+        ["afplay", "/System/Library/Sounds/Basso.aiff"],
+        capture_output=True
+    )

--- a/plugins/voice-to-claude/src/voice_to_claude/sounds.py
+++ b/plugins/voice-to-claude/src/voice_to_claude/sounds.py
@@ -1,37 +1,65 @@
-"""Audio feedback sounds."""
+"""Audio feedback sounds with cross-platform support."""
 
 import subprocess
 from pathlib import Path
+from typing import Optional
+
+from .utils import IS_MACOS, IS_LINUX, find_sound_player
+
+# macOS system sounds
+_MACOS_SOUNDS = {
+    "start": "/System/Library/Sounds/Pop.aiff",
+    "stop": "/System/Library/Sounds/Tink.aiff",
+    "success": "/System/Library/Sounds/Glass.aiff",
+    "error": "/System/Library/Sounds/Basso.aiff",
+}
+
+# Linux: XDG sound theme paths (freedesktop standard)
+_LINUX_SOUNDS = {
+    "start": "/usr/share/sounds/freedesktop/stereo/message-new-instant.oga",
+    "stop": "/usr/share/sounds/freedesktop/stereo/message.oga",
+    "success": "/usr/share/sounds/freedesktop/stereo/complete.oga",
+    "error": "/usr/share/sounds/freedesktop/stereo/dialog-error.oga",
+}
+
+
+def _play(sound_key: str) -> None:
+    """Play a named sound effect using the platform audio player."""
+    player = find_sound_player()
+    if player is None:
+        return  # No audio player available; silently skip
+
+    if IS_MACOS:
+        sound_file = _MACOS_SOUNDS.get(sound_key)
+    elif IS_LINUX:
+        sound_file = _LINUX_SOUNDS.get(sound_key)
+    else:
+        return
+
+    if sound_file is None or not Path(sound_file).exists():
+        return
+
+    try:
+        subprocess.run([player, sound_file], capture_output=True, timeout=5)
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
 
 
 def play_start_sound() -> None:
     """Play sound when recording starts."""
-    # Use macOS system sound
-    subprocess.run(
-        ["afplay", "/System/Library/Sounds/Pop.aiff"],
-        capture_output=True
-    )
+    _play("start")
 
 
 def play_stop_sound() -> None:
     """Play sound when recording stops."""
-    subprocess.run(
-        ["afplay", "/System/Library/Sounds/Tink.aiff"],
-        capture_output=True
-    )
+    _play("stop")
 
 
 def play_success_sound() -> None:
     """Play sound on successful transcription."""
-    subprocess.run(
-        ["afplay", "/System/Library/Sounds/Glass.aiff"],
-        capture_output=True
-    )
+    _play("success")
 
 
 def play_error_sound() -> None:
     """Play sound on error."""
-    subprocess.run(
-        ["afplay", "/System/Library/Sounds/Basso.aiff"],
-        capture_output=True
-    )
+    _play("error")

--- a/plugins/voice-to-claude/src/voice_to_claude/transcriber.py
+++ b/plugins/voice-to-claude/src/voice_to_claude/transcriber.py
@@ -1,0 +1,160 @@
+"""Whisper.cpp transcription functionality."""
+
+import subprocess
+import time
+from pathlib import Path
+from typing import Optional, Tuple
+from dataclasses import dataclass
+
+from .config import Config, WHISPER_MODELS
+
+
+@dataclass
+class TranscriptionResult:
+    """Result of a transcription."""
+    text: str
+    duration_seconds: float
+    model: str
+    success: bool
+    error: Optional[str] = None
+
+
+class Transcriber:
+    """Transcribes audio using whisper.cpp."""
+
+    def __init__(self, config: Config):
+        self.config = config
+
+    def transcribe(self, audio_path: Path, timeout: int = 120) -> TranscriptionResult:
+        """
+        Transcribe an audio file.
+
+        Args:
+            audio_path: Path to the WAV file to transcribe
+            timeout: Maximum time in seconds to wait for transcription
+
+        Returns:
+            TranscriptionResult with text and metadata
+        """
+        whisper_cli = self.config.get_whisper_cli()
+        model_path = self.config.get_model_path()
+
+        if not whisper_cli or not whisper_cli.exists():
+            return TranscriptionResult(
+                text="",
+                duration_seconds=0,
+                model=self.config.model,
+                success=False,
+                error="whisper-cli not found. Run /voice-to-claude:setup first."
+            )
+
+        if not model_path or not model_path.exists():
+            return TranscriptionResult(
+                text="",
+                duration_seconds=0,
+                model=self.config.model,
+                success=False,
+                error=f"Model '{self.config.model}' not found at {model_path}. Run /voice-to-claude:setup first."
+            )
+
+        start_time = time.time()
+
+        try:
+            result = subprocess.run(
+                [
+                    str(whisper_cli),
+                    "-m", str(model_path),
+                    "-f", str(audio_path),
+                    "--no-timestamps",
+                    "-nt",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=timeout
+            )
+
+            elapsed = time.time() - start_time
+
+            if result.returncode != 0:
+                return TranscriptionResult(
+                    text="",
+                    duration_seconds=elapsed,
+                    model=self.config.model,
+                    success=False,
+                    error=f"Transcription failed: {result.stderr}"
+                )
+
+            # Clean up transcript (remove extra whitespace)
+            transcript = " ".join(result.stdout.strip().split())
+
+            if not transcript:
+                return TranscriptionResult(
+                    text="",
+                    duration_seconds=elapsed,
+                    model=self.config.model,
+                    success=False,
+                    error="No speech detected"
+                )
+
+            return TranscriptionResult(
+                text=transcript,
+                duration_seconds=elapsed,
+                model=self.config.model,
+                success=True
+            )
+
+        except subprocess.TimeoutExpired:
+            return TranscriptionResult(
+                text="",
+                duration_seconds=timeout,
+                model=self.config.model,
+                success=False,
+                error=f"Transcription timed out after {timeout}s"
+            )
+        except Exception as e:
+            return TranscriptionResult(
+                text="",
+                duration_seconds=time.time() - start_time,
+                model=self.config.model,
+                success=False,
+                error=f"Transcription error: {e}"
+            )
+
+    @staticmethod
+    def find_whisper_cli(plugin_root: Path) -> Optional[Path]:
+        """Find whisper-cli executable."""
+        locations = [
+            plugin_root / "whisper.cpp" / "build" / "bin" / "whisper-cli",
+            Path.home() / ".local" / "share" / "voice-to-claude" / "whisper.cpp" / "build" / "bin" / "whisper-cli",
+        ]
+
+        for loc in locations:
+            if loc.exists():
+                return loc
+
+        # Check if it's in PATH
+        result = subprocess.run(["which", "whisper-cli"], capture_output=True, text=True)
+        if result.returncode == 0:
+            return Path(result.stdout.strip())
+
+        return None
+
+    @staticmethod
+    def find_models_dir(whisper_cli: Path) -> Optional[Path]:
+        """Find Whisper models directory relative to whisper-cli."""
+        # Models are typically at whisper.cpp/models
+        # whisper-cli is at whisper.cpp/build/bin/whisper-cli
+        models_dir = whisper_cli.parent.parent.parent / "models"
+        if models_dir.exists():
+            return models_dir
+        return None
+
+    @staticmethod
+    def get_available_models(models_dir: Path) -> list:
+        """Get list of downloaded models."""
+        available = []
+        for model_name, model_info in WHISPER_MODELS.items():
+            model_path = models_dir / model_info["file"]
+            if model_path.exists():
+                available.append(model_name)
+        return available

--- a/plugins/voice-to-claude/src/voice_to_claude/transcriber.py
+++ b/plugins/voice-to-claude/src/voice_to_claude/transcriber.py
@@ -1,5 +1,6 @@
 """Whisper.cpp transcription functionality."""
 
+import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -132,10 +133,10 @@ class Transcriber:
             if loc.exists():
                 return loc
 
-        # Check if it's in PATH
-        result = subprocess.run(["which", "whisper-cli"], capture_output=True, text=True)
-        if result.returncode == 0:
-            return Path(result.stdout.strip())
+        # Check if it's in PATH (cross-platform)
+        found = shutil.which("whisper-cli")
+        if found:
+            return Path(found)
 
         return None
 

--- a/plugins/voice-to-claude/src/voice_to_claude/utils.py
+++ b/plugins/voice-to-claude/src/voice_to_claude/utils.py
@@ -1,0 +1,56 @@
+"""Cross-platform utilities for voice-to-claude."""
+
+import platform
+import shutil
+from typing import Optional
+
+# Detect OS once at import time
+IS_MACOS = platform.system() == "Darwin"
+IS_LINUX = platform.system() == "Linux"
+IS_WINDOWS = platform.system() == "Windows"
+
+
+def find_clipboard_command() -> Optional[list[str]]:
+    """Find the appropriate clipboard copy command for the current platform.
+
+    Returns:
+        Command list for piping text to clipboard, or None if unavailable.
+    """
+    if IS_MACOS:
+        if shutil.which("pbcopy"):
+            return ["pbcopy"]
+    elif IS_LINUX:
+        # Prefer xclip, fall back to xsel
+        if shutil.which("xclip"):
+            return ["xclip", "-selection", "clipboard"]
+        if shutil.which("xsel"):
+            return ["xsel", "--clipboard", "--input"]
+        # Wayland support
+        if shutil.which("wl-copy"):
+            return ["wl-copy"]
+    return None
+
+
+def find_sound_player() -> Optional[str]:
+    """Find the appropriate audio player for the current platform.
+
+    Returns:
+        Name of the audio player command, or None if unavailable.
+    """
+    if IS_MACOS:
+        return "afplay"
+    elif IS_LINUX:
+        for player in ("paplay", "aplay", "play"):
+            if shutil.which(player):
+                return player
+    return None
+
+
+def get_paste_key():
+    """Get the platform-appropriate paste modifier key.
+
+    Returns:
+        pynput Key for paste shortcut (Cmd on macOS, Ctrl on Linux).
+    """
+    from pynput.keyboard import Key
+    return Key.cmd if IS_MACOS else Key.ctrl

--- a/plugins/voice-to-claude/tests/conftest.py
+++ b/plugins/voice-to-claude/tests/conftest.py
@@ -1,0 +1,52 @@
+"""Shared test fixtures for voice-to-claude tests."""
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Ensure src is on the path for imports
+SRC_DIR = Path(__file__).resolve().parent.parent / "src"
+sys.path.insert(0, str(SRC_DIR))
+
+
+@pytest.fixture
+def tmp_config_dir(tmp_path):
+    """Provide a temporary config directory and patch defaults."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    config_file = config_dir / "config.json"
+    pid_file = config_dir / "daemon.pid"
+    log_file = config_dir / "daemon.log"
+
+    with patch("voice_to_claude.config.DEFAULT_CONFIG_DIR", config_dir), \
+         patch("voice_to_claude.config.DEFAULT_CONFIG_FILE", config_file), \
+         patch("voice_to_claude.config.DEFAULT_PID_FILE", pid_file), \
+         patch("voice_to_claude.config.DEFAULT_LOG_FILE", log_file):
+        yield {
+            "dir": config_dir,
+            "file": config_file,
+            "pid_file": pid_file,
+            "log_file": log_file,
+        }
+
+
+@pytest.fixture
+def sample_config_data():
+    """Return sample config data for testing."""
+    return {
+        "hotkey_ctrl": True,
+        "hotkey_alt": True,
+        "hotkey_shift": False,
+        "hotkey_cmd": False,
+        "model": "base",
+        "output_mode": "keyboard",
+        "sound_effects": True,
+        "max_recording_seconds": 60,
+        "whisper_cpp_path": "/usr/local/bin/whisper-cli",
+        "models_dir": "/usr/local/share/whisper/models",
+        "setup_complete": True,
+    }

--- a/plugins/voice-to-claude/tests/test_config.py
+++ b/plugins/voice-to-claude/tests/test_config.py
@@ -1,0 +1,148 @@
+"""Tests for voice_to_claude.config module."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from voice_to_claude.config import Config, WHISPER_MODELS, SAMPLE_RATE
+
+
+class TestConfigDefaults:
+    """Test Config default values."""
+
+    def test_default_hotkeys(self):
+        config = Config()
+        assert config.hotkey_ctrl is True
+        assert config.hotkey_alt is True
+        assert config.hotkey_shift is False
+        assert config.hotkey_cmd is False
+
+    def test_default_model(self):
+        config = Config()
+        assert config.model == "base"
+
+    def test_default_output_mode(self):
+        config = Config()
+        assert config.output_mode == "keyboard"
+
+    def test_default_sound_effects(self):
+        config = Config()
+        assert config.sound_effects is True
+
+    def test_default_setup_not_complete(self):
+        config = Config()
+        assert config.setup_complete is False
+
+    def test_default_paths_are_none(self):
+        config = Config()
+        assert config.whisper_cpp_path is None
+        assert config.models_dir is None
+
+
+class TestConfigHotkeyDescription:
+    """Test Config.get_hotkey_description."""
+
+    def test_default_hotkey(self):
+        config = Config()
+        assert config.get_hotkey_description() == "Ctrl+Alt"
+
+    def test_all_modifiers(self):
+        config = Config(hotkey_ctrl=True, hotkey_alt=True, hotkey_shift=True, hotkey_cmd=True)
+        assert config.get_hotkey_description() == "Ctrl+Alt+Shift+Cmd"
+
+    def test_single_modifier(self):
+        config = Config(hotkey_ctrl=False, hotkey_alt=False, hotkey_shift=True, hotkey_cmd=False)
+        assert config.get_hotkey_description() == "Shift"
+
+    def test_no_modifiers(self):
+        config = Config(hotkey_ctrl=False, hotkey_alt=False, hotkey_shift=False, hotkey_cmd=False)
+        assert config.get_hotkey_description() == "None"
+
+
+class TestConfigModelPath:
+    """Test Config.get_model_path."""
+
+    def test_with_valid_model_and_dir(self):
+        config = Config(models_dir="/models", model="base")
+        path = config.get_model_path()
+        assert path == Path("/models/ggml-base.bin")
+
+    def test_with_no_models_dir(self):
+        config = Config(models_dir=None, model="base")
+        assert config.get_model_path() is None
+
+    def test_with_invalid_model(self):
+        config = Config(models_dir="/models", model="nonexistent")
+        assert config.get_model_path() is None
+
+
+class TestConfigWhisperCli:
+    """Test Config.get_whisper_cli."""
+
+    def test_with_path(self):
+        config = Config(whisper_cpp_path="/usr/bin/whisper-cli")
+        assert config.get_whisper_cli() == Path("/usr/bin/whisper-cli")
+
+    def test_without_path(self):
+        config = Config(whisper_cpp_path=None)
+        assert config.get_whisper_cli() is None
+
+
+class TestConfigLoadSave:
+    """Test Config load and save round-trip."""
+
+    def test_save_and_load(self, tmp_config_dir):
+        config = Config(model="medium", output_mode="clipboard", setup_complete=True)
+        config.save()
+
+        loaded = Config.load()
+        assert loaded.model == "medium"
+        assert loaded.output_mode == "clipboard"
+        assert loaded.setup_complete is True
+
+    def test_load_missing_file(self, tmp_config_dir):
+        config = Config.load()
+        # Should return defaults
+        assert config.model == "base"
+        assert config.setup_complete is False
+
+    def test_load_corrupt_file(self, tmp_config_dir):
+        tmp_config_dir["file"].write_text("not json {{{")
+        config = Config.load()
+        # Should return defaults on parse error
+        assert config.model == "base"
+
+    def test_load_ignores_unknown_fields(self, tmp_config_dir):
+        data = {"model": "tiny", "unknown_field": "value", "setup_complete": True}
+        tmp_config_dir["file"].write_text(json.dumps(data))
+        config = Config.load()
+        assert config.model == "tiny"
+        assert config.setup_complete is True
+
+    def test_save_creates_directory(self, tmp_path):
+        nested_dir = tmp_path / "a" / "b" / "c"
+        config_file = nested_dir / "config.json"
+        with patch("voice_to_claude.config.DEFAULT_CONFIG_DIR", nested_dir), \
+             patch("voice_to_claude.config.DEFAULT_CONFIG_FILE", config_file):
+            config = Config(model="tiny")
+            config.save()
+            assert config_file.exists()
+
+
+class TestWhisperModels:
+    """Test whisper model definitions."""
+
+    def test_all_models_have_required_fields(self):
+        for name, info in WHISPER_MODELS.items():
+            assert "file" in info, f"Model {name} missing 'file'"
+            assert "size" in info, f"Model {name} missing 'size'"
+            assert "url" in info, f"Model {name} missing 'url'"
+            assert info["file"].endswith(".bin"), f"Model {name} file should be .bin"
+
+    def test_base_model_exists(self):
+        assert "base" in WHISPER_MODELS
+
+    def test_sample_rate(self):
+        assert SAMPLE_RATE == 16000

--- a/plugins/voice-to-claude/tests/test_daemon.py
+++ b/plugins/voice-to-claude/tests/test_daemon.py
@@ -1,0 +1,94 @@
+"""Tests for voice_to_claude.daemon module."""
+
+import os
+import signal
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from voice_to_claude.daemon import (
+    write_pid_file,
+    remove_pid_file,
+    read_pid_file,
+    is_daemon_running,
+    daemon_status,
+)
+
+
+class TestPidFile:
+    """Test PID file operations."""
+
+    def test_write_and_read(self, tmp_config_dir):
+        with patch("voice_to_claude.daemon.DEFAULT_PID_FILE", tmp_config_dir["pid_file"]), \
+             patch("voice_to_claude.daemon.ensure_config_dir"):
+            write_pid_file()
+            pid = read_pid_file()
+            assert pid == os.getpid()
+
+    def test_read_missing_file(self, tmp_config_dir):
+        with patch("voice_to_claude.daemon.DEFAULT_PID_FILE", tmp_config_dir["pid_file"]):
+            assert read_pid_file() is None
+
+    def test_read_corrupt_file(self, tmp_config_dir):
+        tmp_config_dir["pid_file"].write_text("not-a-number")
+        with patch("voice_to_claude.daemon.DEFAULT_PID_FILE", tmp_config_dir["pid_file"]):
+            assert read_pid_file() is None
+
+    def test_remove(self, tmp_config_dir):
+        tmp_config_dir["pid_file"].write_text("12345")
+        with patch("voice_to_claude.daemon.DEFAULT_PID_FILE", tmp_config_dir["pid_file"]):
+            remove_pid_file()
+            assert not tmp_config_dir["pid_file"].exists()
+
+    def test_remove_missing_file(self, tmp_config_dir):
+        with patch("voice_to_claude.daemon.DEFAULT_PID_FILE", tmp_config_dir["pid_file"]):
+            # Should not raise
+            remove_pid_file()
+
+
+class TestIsDaemonRunning:
+    """Test is_daemon_running function."""
+
+    def test_no_pid_file(self, tmp_config_dir):
+        with patch("voice_to_claude.daemon.DEFAULT_PID_FILE", tmp_config_dir["pid_file"]):
+            assert is_daemon_running() is False
+
+    def test_running_process(self, tmp_config_dir):
+        # Use our own PID (guaranteed to exist)
+        tmp_config_dir["pid_file"].write_text(str(os.getpid()))
+        with patch("voice_to_claude.daemon.DEFAULT_PID_FILE", tmp_config_dir["pid_file"]):
+            assert is_daemon_running() is True
+
+    def test_stale_pid_file(self, tmp_config_dir):
+        # Use a PID that almost certainly doesn't exist
+        tmp_config_dir["pid_file"].write_text("999999999")
+        with patch("voice_to_claude.daemon.DEFAULT_PID_FILE", tmp_config_dir["pid_file"]):
+            assert is_daemon_running() is False
+            # Should clean up stale PID file
+            assert not tmp_config_dir["pid_file"].exists()
+
+
+class TestDaemonStatus:
+    """Test daemon_status function."""
+
+    def test_status_when_stopped(self, tmp_config_dir):
+        with patch("voice_to_claude.daemon.DEFAULT_PID_FILE", tmp_config_dir["pid_file"]), \
+             patch("voice_to_claude.config.DEFAULT_CONFIG_FILE", tmp_config_dir["file"]):
+            status = daemon_status()
+
+            assert status["running"] is False
+            assert status["pid"] is None
+            assert status["setup_complete"] is False
+            assert status["model"] == "base"
+            assert status["hotkey"] == "Ctrl+Alt"
+            assert status["output_mode"] == "keyboard"
+
+    def test_status_when_running(self, tmp_config_dir):
+        tmp_config_dir["pid_file"].write_text(str(os.getpid()))
+        with patch("voice_to_claude.daemon.DEFAULT_PID_FILE", tmp_config_dir["pid_file"]), \
+             patch("voice_to_claude.config.DEFAULT_CONFIG_FILE", tmp_config_dir["file"]):
+            status = daemon_status()
+
+            assert status["running"] is True
+            assert status["pid"] == os.getpid()

--- a/plugins/voice-to-claude/tests/test_keyboard.py
+++ b/plugins/voice-to-claude/tests/test_keyboard.py
@@ -1,0 +1,98 @@
+"""Tests for voice_to_claude.keyboard module."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from voice_to_claude.keyboard import TextInjector
+
+
+class TestTextInjectorInject:
+    """Test TextInjector.inject."""
+
+    @patch("voice_to_claude.keyboard.Controller")
+    def test_inject_empty_text_returns_false(self, mock_controller):
+        injector = TextInjector(mode="keyboard")
+        assert injector.inject("") is False
+
+    @patch("voice_to_claude.keyboard.Controller")
+    def test_inject_keyboard_mode(self, mock_controller):
+        mock_instance = MagicMock()
+        mock_controller.return_value = mock_instance
+
+        injector = TextInjector(mode="keyboard")
+        result = injector.inject("hello")
+
+        assert result is True
+        mock_instance.type.assert_called_once_with("hello")
+
+    @patch("voice_to_claude.keyboard.Controller")
+    @patch("voice_to_claude.keyboard.find_clipboard_command", return_value=["pbcopy"])
+    @patch("subprocess.Popen")
+    def test_inject_clipboard_mode(self, mock_popen, mock_find_clip, mock_controller):
+        mock_process = MagicMock()
+        mock_process.returncode = 0
+        mock_popen.return_value = mock_process
+
+        injector = TextInjector(mode="clipboard")
+        result = injector.inject("hello")
+
+        assert result is True
+        mock_popen.assert_called_once()
+        mock_process.communicate.assert_called_once_with(b"hello")
+
+
+class TestTextInjectorClipboardFallback:
+    """Test clipboard fallback behavior."""
+
+    @patch("voice_to_claude.keyboard.Controller")
+    @patch("voice_to_claude.keyboard.find_clipboard_command", return_value=["pbcopy"])
+    @patch("subprocess.Popen")
+    def test_keyboard_failure_falls_back_to_clipboard(self, mock_popen, mock_find_clip, mock_controller):
+        mock_instance = MagicMock()
+        mock_instance.type.side_effect = Exception("keyboard unavailable")
+        mock_controller.return_value = mock_instance
+
+        mock_process = MagicMock()
+        mock_process.returncode = 0
+        mock_popen.return_value = mock_process
+
+        injector = TextInjector(mode="keyboard")
+        result = injector.inject("hello")
+
+        assert result is True
+        mock_popen.assert_called_once()
+
+
+class TestTextInjectorCopyToClipboard:
+    """Test TextInjector.copy_to_clipboard static method."""
+
+    @patch("voice_to_claude.keyboard.find_clipboard_command", return_value=["pbcopy"])
+    @patch("subprocess.Popen")
+    def test_copy_success(self, mock_popen, mock_find_clip):
+        mock_process = MagicMock()
+        mock_process.returncode = 0
+        mock_popen.return_value = mock_process
+
+        assert TextInjector.copy_to_clipboard("test") is True
+        mock_process.communicate.assert_called_once_with(b"test")
+
+    @patch("voice_to_claude.keyboard.find_clipboard_command", return_value=None)
+    def test_copy_no_clipboard_command(self, mock_find_clip):
+        assert TextInjector.copy_to_clipboard("test") is False
+
+    @patch("voice_to_claude.keyboard.find_clipboard_command", return_value=["pbcopy"])
+    @patch("subprocess.Popen", side_effect=Exception("fail"))
+    def test_copy_exception(self, mock_popen, mock_find_clip):
+        assert TextInjector.copy_to_clipboard("test") is False
+
+
+class TestClipboardNoCommand:
+    """Test behavior when no clipboard command is available."""
+
+    @patch("voice_to_claude.keyboard.Controller")
+    @patch("voice_to_claude.keyboard.find_clipboard_command", return_value=None)
+    def test_inject_clipboard_no_command(self, mock_find_clip, mock_controller):
+        injector = TextInjector(mode="clipboard")
+        result = injector.inject("hello")
+        assert result is False

--- a/plugins/voice-to-claude/tests/test_recorder.py
+++ b/plugins/voice-to-claude/tests/test_recorder.py
@@ -1,0 +1,105 @@
+"""Tests for voice_to_claude.recorder module."""
+
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import numpy as np
+import pytest
+
+from voice_to_claude.recorder import AudioRecorder, MicrophoneError, RecordingError
+from voice_to_claude.config import SAMPLE_RATE
+
+
+class TestAudioRecorderDuration:
+    """Test AudioRecorder.get_duration."""
+
+    def test_one_second(self):
+        recorder = AudioRecorder(sample_rate=SAMPLE_RATE)
+        audio = np.zeros(SAMPLE_RATE, dtype=np.float32)
+        assert recorder.get_duration(audio) == pytest.approx(1.0)
+
+    def test_half_second(self):
+        recorder = AudioRecorder(sample_rate=SAMPLE_RATE)
+        audio = np.zeros(SAMPLE_RATE // 2, dtype=np.float32)
+        assert recorder.get_duration(audio) == pytest.approx(0.5)
+
+    def test_zero_length(self):
+        recorder = AudioRecorder(sample_rate=SAMPLE_RATE)
+        audio = np.zeros(0, dtype=np.float32)
+        assert recorder.get_duration(audio) == pytest.approx(0.0)
+
+
+class TestAudioRecorderSaveToWav:
+    """Test AudioRecorder.save_to_wav."""
+
+    def test_creates_file(self, tmp_path):
+        recorder = AudioRecorder(sample_rate=SAMPLE_RATE)
+        audio = np.random.randn(SAMPLE_RATE).astype(np.float32) * 0.5
+        out_path = tmp_path / "test.wav"
+
+        result = recorder.save_to_wav(audio, path=out_path)
+        assert result == out_path
+        assert out_path.exists()
+        assert out_path.stat().st_size > 0
+
+    def test_creates_temp_file(self):
+        recorder = AudioRecorder(sample_rate=SAMPLE_RATE)
+        audio = np.random.randn(SAMPLE_RATE).astype(np.float32) * 0.5
+
+        result = recorder.save_to_wav(audio)
+        assert result.exists()
+        assert result.suffix == ".wav"
+        # Clean up
+        result.unlink()
+
+
+class TestAudioRecorderStartStop:
+    """Test AudioRecorder start/stop flow."""
+
+    def test_stop_without_start_returns_none(self):
+        recorder = AudioRecorder()
+        assert recorder.stop() is None
+
+    @patch("voice_to_claude.recorder.sd")
+    def test_start_sets_recording_flag(self, mock_sd):
+        mock_stream = MagicMock()
+        mock_sd.InputStream.return_value = mock_stream
+
+        recorder = AudioRecorder()
+        result = recorder.start()
+
+        assert result is True
+        assert recorder.is_recording is True
+        mock_stream.start.assert_called_once()
+
+    @patch("voice_to_claude.recorder.sd")
+    def test_start_while_already_recording(self, mock_sd):
+        recorder = AudioRecorder()
+        recorder.is_recording = True
+        result = recorder.start()
+        assert result is False
+
+
+class TestAudioRecorderCheckMicrophone:
+    """Test AudioRecorder.check_microphone."""
+
+    @patch("voice_to_claude.recorder.sd")
+    def test_microphone_available(self, mock_sd):
+        mock_sd.query_devices.return_value = [{"name": "mic"}]
+        mock_sd.query_devices.side_effect = None
+        assert AudioRecorder.check_microphone() is True
+
+    @patch("voice_to_claude.recorder.sd")
+    def test_microphone_unavailable(self, mock_sd):
+        mock_sd.query_devices.side_effect = Exception("No devices")
+        assert AudioRecorder.check_microphone() is False
+
+
+class TestExceptions:
+    """Test custom exception classes."""
+
+    def test_microphone_error_is_recording_error(self):
+        assert issubclass(MicrophoneError, RecordingError)
+
+    def test_recording_error_is_exception(self):
+        assert issubclass(RecordingError, Exception)

--- a/plugins/voice-to-claude/tests/test_transcriber.py
+++ b/plugins/voice-to-claude/tests/test_transcriber.py
@@ -1,0 +1,206 @@
+"""Tests for voice_to_claude.transcriber module."""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from voice_to_claude.config import Config, WHISPER_MODELS
+from voice_to_claude.transcriber import Transcriber, TranscriptionResult
+
+
+class TestTranscriptionResult:
+    """Test TranscriptionResult dataclass."""
+
+    def test_successful_result(self):
+        result = TranscriptionResult(
+            text="hello world",
+            duration_seconds=1.5,
+            model="base",
+            success=True,
+        )
+        assert result.text == "hello world"
+        assert result.success is True
+        assert result.error is None
+
+    def test_failed_result(self):
+        result = TranscriptionResult(
+            text="",
+            duration_seconds=0,
+            model="base",
+            success=False,
+            error="whisper-cli not found",
+        )
+        assert result.success is False
+        assert result.error == "whisper-cli not found"
+
+
+class TestTranscriberTranscribe:
+    """Test Transcriber.transcribe method."""
+
+    def test_missing_whisper_cli(self):
+        config = Config(whisper_cpp_path=None, models_dir="/models")
+        transcriber = Transcriber(config)
+        result = transcriber.transcribe(Path("/tmp/audio.wav"))
+        assert result.success is False
+        assert "whisper-cli not found" in result.error
+
+    def test_missing_model(self, tmp_path):
+        # whisper_cli exists but model doesn't
+        cli_path = tmp_path / "whisper-cli"
+        cli_path.touch()
+        config = Config(
+            whisper_cpp_path=str(cli_path),
+            models_dir=str(tmp_path / "models"),
+            model="base",
+        )
+        transcriber = Transcriber(config)
+        result = transcriber.transcribe(Path("/tmp/audio.wav"))
+        assert result.success is False
+        assert "not found" in result.error
+
+    def test_successful_transcription(self, tmp_path):
+        # Create fake whisper-cli and model
+        cli_path = tmp_path / "whisper-cli"
+        cli_path.touch()
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        model_file = models_dir / "ggml-base.bin"
+        model_file.touch()
+
+        config = Config(
+            whisper_cpp_path=str(cli_path),
+            models_dir=str(models_dir),
+            model="base",
+        )
+        transcriber = Transcriber(config)
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "  Hello, world!  \n"
+        mock_result.stderr = ""
+
+        with patch("subprocess.run", return_value=mock_result):
+            result = transcriber.transcribe(Path("/tmp/audio.wav"))
+
+        assert result.success is True
+        assert result.text == "Hello, world!"
+        assert result.model == "base"
+
+    def test_transcription_failure(self, tmp_path):
+        cli_path = tmp_path / "whisper-cli"
+        cli_path.touch()
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        (models_dir / "ggml-base.bin").touch()
+
+        config = Config(
+            whisper_cpp_path=str(cli_path),
+            models_dir=str(models_dir),
+            model="base",
+        )
+        transcriber = Transcriber(config)
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = "Error: invalid model"
+
+        with patch("subprocess.run", return_value=mock_result):
+            result = transcriber.transcribe(Path("/tmp/audio.wav"))
+
+        assert result.success is False
+        assert "Transcription failed" in result.error
+
+    def test_transcription_no_speech(self, tmp_path):
+        cli_path = tmp_path / "whisper-cli"
+        cli_path.touch()
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        (models_dir / "ggml-base.bin").touch()
+
+        config = Config(
+            whisper_cpp_path=str(cli_path),
+            models_dir=str(models_dir),
+            model="base",
+        )
+        transcriber = Transcriber(config)
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "   \n  \n"
+
+        with patch("subprocess.run", return_value=mock_result):
+            result = transcriber.transcribe(Path("/tmp/audio.wav"))
+
+        assert result.success is False
+        assert "No speech detected" in result.error
+
+    def test_transcription_timeout(self, tmp_path):
+        cli_path = tmp_path / "whisper-cli"
+        cli_path.touch()
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        (models_dir / "ggml-base.bin").touch()
+
+        config = Config(
+            whisper_cpp_path=str(cli_path),
+            models_dir=str(models_dir),
+            model="base",
+        )
+        transcriber = Transcriber(config)
+
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="whisper", timeout=5)):
+            result = transcriber.transcribe(Path("/tmp/audio.wav"), timeout=5)
+
+        assert result.success is False
+        assert "timed out" in result.error
+
+
+class TestTranscriberFindWhisperCli:
+    """Test Transcriber.find_whisper_cli static method."""
+
+    def test_finds_in_plugin_root(self, tmp_path):
+        cli_path = tmp_path / "whisper.cpp" / "build" / "bin" / "whisper-cli"
+        cli_path.parent.mkdir(parents=True)
+        cli_path.touch()
+
+        result = Transcriber.find_whisper_cli(tmp_path)
+        assert result == cli_path
+
+    def test_finds_in_home_dir(self, tmp_path):
+        home_cli = tmp_path / ".local" / "share" / "voice-to-claude" / "whisper.cpp" / "build" / "bin" / "whisper-cli"
+        home_cli.parent.mkdir(parents=True)
+        home_cli.touch()
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = Transcriber.find_whisper_cli(tmp_path / "nonexistent")
+
+        assert result == home_cli
+
+    def test_finds_in_path(self, tmp_path):
+        with patch("shutil.which", return_value="/usr/bin/whisper-cli"):
+            result = Transcriber.find_whisper_cli(tmp_path / "nonexistent")
+        assert result == Path("/usr/bin/whisper-cli")
+
+    def test_returns_none_when_not_found(self, tmp_path):
+        with patch("shutil.which", return_value=None):
+            result = Transcriber.find_whisper_cli(tmp_path / "nonexistent")
+        assert result is None
+
+
+class TestTranscriberGetAvailableModels:
+    """Test Transcriber.get_available_models."""
+
+    def test_finds_downloaded_models(self, tmp_path):
+        (tmp_path / "ggml-base.bin").touch()
+        (tmp_path / "ggml-tiny.bin").touch()
+
+        models = Transcriber.get_available_models(tmp_path)
+        assert "base" in models
+        assert "tiny" in models
+        assert "medium" not in models
+
+    def test_empty_dir(self, tmp_path):
+        models = Transcriber.get_available_models(tmp_path)
+        assert models == []

--- a/plugins/voice-to-claude/tests/test_utils.py
+++ b/plugins/voice-to-claude/tests/test_utils.py
@@ -1,0 +1,76 @@
+"""Tests for voice_to_claude.utils module."""
+
+from unittest.mock import patch
+
+import pytest
+
+from voice_to_claude.utils import (
+    find_clipboard_command,
+    find_sound_player,
+    IS_MACOS,
+    IS_LINUX,
+)
+
+
+class TestFindClipboardCommand:
+    """Test find_clipboard_command across platforms."""
+
+    @patch("voice_to_claude.utils.IS_MACOS", True)
+    @patch("voice_to_claude.utils.IS_LINUX", False)
+    @patch("shutil.which", return_value="/usr/bin/pbcopy")
+    def test_macos_pbcopy(self, mock_which):
+        result = find_clipboard_command()
+        assert result == ["pbcopy"]
+
+    @patch("voice_to_claude.utils.IS_MACOS", False)
+    @patch("voice_to_claude.utils.IS_LINUX", True)
+    @patch("shutil.which")
+    def test_linux_xclip(self, mock_which):
+        mock_which.side_effect = lambda cmd: "/usr/bin/xclip" if cmd == "xclip" else None
+        result = find_clipboard_command()
+        assert result == ["xclip", "-selection", "clipboard"]
+
+    @patch("voice_to_claude.utils.IS_MACOS", False)
+    @patch("voice_to_claude.utils.IS_LINUX", True)
+    @patch("shutil.which")
+    def test_linux_xsel_fallback(self, mock_which):
+        mock_which.side_effect = lambda cmd: "/usr/bin/xsel" if cmd == "xsel" else None
+        result = find_clipboard_command()
+        assert result == ["xsel", "--clipboard", "--input"]
+
+    @patch("voice_to_claude.utils.IS_MACOS", False)
+    @patch("voice_to_claude.utils.IS_LINUX", True)
+    @patch("shutil.which")
+    def test_linux_wl_copy_fallback(self, mock_which):
+        mock_which.side_effect = lambda cmd: "/usr/bin/wl-copy" if cmd == "wl-copy" else None
+        result = find_clipboard_command()
+        assert result == ["wl-copy"]
+
+    @patch("voice_to_claude.utils.IS_MACOS", False)
+    @patch("voice_to_claude.utils.IS_LINUX", True)
+    @patch("shutil.which", return_value=None)
+    def test_linux_no_clipboard(self, mock_which):
+        result = find_clipboard_command()
+        assert result is None
+
+
+class TestFindSoundPlayer:
+    """Test find_sound_player across platforms."""
+
+    @patch("voice_to_claude.utils.IS_MACOS", True)
+    @patch("voice_to_claude.utils.IS_LINUX", False)
+    def test_macos_afplay(self):
+        assert find_sound_player() == "afplay"
+
+    @patch("voice_to_claude.utils.IS_MACOS", False)
+    @patch("voice_to_claude.utils.IS_LINUX", True)
+    @patch("shutil.which")
+    def test_linux_paplay(self, mock_which):
+        mock_which.side_effect = lambda cmd: "/usr/bin/paplay" if cmd == "paplay" else None
+        assert find_sound_player() == "paplay"
+
+    @patch("voice_to_claude.utils.IS_MACOS", False)
+    @patch("voice_to_claude.utils.IS_LINUX", True)
+    @patch("shutil.which", return_value=None)
+    def test_linux_no_player(self, mock_which):
+        assert find_sound_player() is None


### PR DESCRIPTION
## Summary

Adds `voice-to-claude`, a Claude Code plugin for local push-to-talk voice dictation using whisper.cpp. All audio processing runs entirely on-device — no cloud APIs, no data sent externally.

Supports **macOS** (with Metal GPU acceleration on Apple Silicon) and **Linux** (CPU).

## What's included

- **Slash commands:** `/voice-to-claude:setup`, `/start`, `/stop`, `/status`, `/config`
- **Background daemon** with push-to-talk hotkey (Ctrl+Alt) and hooks integration
- **Local setup** that builds whisper.cpp, downloads models, and configures the plugin
- **Cross-platform support:** macOS (Metal GPU) and Linux (CPU), with platform-aware clipboard (pbcopy/xclip/xsel/wl-copy) and audio feedback
- **75 unit tests** (pytest) covering config, transcriber, recorder, keyboard, daemon, and platform utilities
- **Marketplace registration** in `.claude-plugin/marketplace.json`

## Why this is useful

Voice input speeds up coding and prompts with no cloud dependency. Especially fast on Apple Silicon with Metal acceleration, and works on Linux for broader accessibility.

## Architecture

```
Hold Ctrl+Alt → daemon captures audio via sounddevice
    → whisper.cpp transcribes locally (~1s for base model)
    → text injected into Claude Code input (keyboard or clipboard)
```

Key modules:
| Module | Purpose |
|--------|---------|
| `daemon.py` | Background hotkey listener, PID management, signal handling |
| `recorder.py` | Audio capture via sounddevice with WAV export |
| `transcriber.py` | whisper.cpp subprocess wrapper with timeout/error handling |
| `keyboard.py` | Text injection via keyboard simulation or clipboard paste |
| `sounds.py` | Platform-aware audio feedback (macOS system sounds / freedesktop) |
| `utils.py` | Cross-platform detection (clipboard, sound player, paste key) |
| `config.py` | Dataclass-based config with JSON persistence |

## Requirements

- **macOS:** Python 3.10+, cmake, Xcode Command Line Tools
- **Linux:** Python 3.10+, cmake, build-essential, portaudio19-dev, xclip (or xsel/wl-copy)
- ~200MB–3GB disk space depending on Whisper model

## Notes

- Privacy-first: all processing is local, no telemetry
- See plugin [README](plugins/voice-to-claude/README.md) for full install and troubleshooting docs
- Rebased onto latest upstream main as of Feb 13, 2026