### PR TITLE
fix(ralph-wiggum): handle empty PROMPT_PARTS array with set -u

### DIFF
--- a/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
+++ b/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
@@ -109,8 +109,8 @@ HELP_EOF
   esac
 done
 
-# Join all prompt parts with spaces
-PROMPT="${PROMPT_PARTS[*]}"
+# Join all prompt parts with spaces (use :- to handle empty array with set -u)
+PROMPT="${PROMPT_PARTS[*]:-}"
 
 # Validate prompt is non-empty
 if [[ -z "$PROMPT" ]]; then


### PR DESCRIPTION
## Summary
- Fixes crash when running `/ralph-loop` without arguments
- Adds default empty string (`:-`) to array expansion to handle `set -u`

## Problem
Running `/ralph-loop` without a prompt crashes with:
```
PROMPT_PARTS[*]: unbound variable
```

The script uses `set -u` (errexit on unset variables) which treats empty array expansion as an unset variable.

## Solution
Change line 113 from:
```bash
PROMPT="${PROMPT_PARTS[*]}"
```
To:
```bash
PROMPT="${PROMPT_PARTS[*]:-}"
```

This allows the empty case to proceed to the existing validation at line 116, which displays a helpful error message.

## Test plan
- [ ] Run `/ralph-loop` without arguments → should show "No prompt provided" error
- [ ] Run `/ralph-loop Build something` → should work as before

Fixes #18496