### PR TITLE
fix(code-review): allow re-reviews when new commits are pushed

### DIFF
--- a/plugins/code-review/commands/code-review.md
+++ b/plugins/code-review/commands/code-review.md
@@ -15,9 +15,11 @@ To do this, follow these steps precisely:
    - The pull request is closed
    - The pull request is a draft
    - The pull request does not need code review (e.g. automated PR, trivial change that is obviously correct)
-   - Claude has already commented on this PR (check `gh pr view <PR> --comments` for comments left by claude)
+   - Claude has already commented on this PR AND no new commits have been pushed since (check `gh pr view <PR> --comments` for comments left by claude, then compare the timestamp of the most recent Claude comment against the timestamp of the HEAD commit using `gh pr view <PR> --json commits`)
 
    If any condition is true, stop and do not proceed.
+
+   **Note on re-reviews**: If Claude previously commented but new commits have been pushed since, proceed with the review. This enables iterative PR workflows where authors push fixes and need updated feedback. If `--force` is provided as an argument, skip the "already commented" check entirely.
 
 Note: Still review Claude generated PR's.
 


### PR DESCRIPTION
## Summary
- Fixes the code-review plugin skipping reviews after new commits are pushed
- Adds smarter skip logic that checks if new commits exist since Claude's last comment
- Documents `--force` flag to bypass the check entirely

## Problem
The code-review plugin's pre-validation step skips the review entirely if Claude has previously commented on a PR. This means:

1. When a PR receives an initial review and the author pushes new commits to address feedback, the `synchronize` event triggers the workflow but the review is skipped
2. Even if all previous review comments are resolved, no re-review occurs
3. There is no way to force a re-review

This makes the plugin unusable for iterative PR workflows where authors push fixes and expect updated feedback.

## Solution
Updated the skip logic (step 1) to:
- Only skip if Claude has commented **AND** no new commits have been pushed since that comment
- Compare the timestamp of Claude's last comment against the HEAD commit timestamp
- Added documentation for `--force` flag to bypass the check entirely

## Test plan
- [ ] Run `/code-review` on a PR with no prior Claude comments → should review
- [ ] Run `/code-review` on a PR where Claude commented, no new commits → should skip
- [ ] Run `/code-review` on a PR where Claude commented, new commits pushed → should re-review
- [ ] Run `/code-review --force` on any PR → should review regardless of prior comments

Fixes #19618