### PR TITLE
fix: prevent ipset duplicate entry error in devcontainer firewall (#15611)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,10 +9,7 @@
       "ZSH_IN_DOCKER_VERSION": "1.2.0"
     }
   },
-  "runArgs": [
-    "--cap-add=NET_ADMIN",
-    "--cap-add=NET_RAW"
-  ],
+  "runArgs": ["--cap-add=NET_ADMIN", "--cap-add=NET_RAW"],
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -60,7 +60,7 @@ while read -r cidr; do
         exit 1
     fi
     echo "Adding GitHub range $cidr"
-    ipset add allowed-domains "$cidr"
+    ipset add -exist allowed-domains "$cidr"
 done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
 
 # Resolve and add other allowed domains
@@ -86,7 +86,7 @@ for domain in \
             exit 1
         fi
         echo "Adding $ip for $domain"
-        ipset add allowed-domains "$ip"
+        ipset add -exist allowed-domains "$ip"
     done < <(echo "$ips")
 done
 


### PR DESCRIPTION
Add -exist flag to ipset add commands to silently ignore duplicate IPs. This fixes the postStartCommand failure when DNS returns duplicate IPs for the same domain (e.g., marketplace.visualstudio.com).

Also small auto-format update.

Fixes #15611 

Example error log without this (scroll to end): 
[remoteContainers-2026-01-21T17-59-09.776Z copy.log](https://github.com/user-attachments/files/24777155/remoteContainers-2026-01-21T17-59-09.776Z.copy.log)
