### PR TITLE
fix: resolve typecheck errors in scripts

### DIFF
--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -1,11 +1,5 @@
 #!/usr/bin/env bun
 
-declare global {
-  var process: {
-    env: Record<string, string | undefined>;
-  };
-}
-
 interface GitHubIssue {
   number: number;
   title: string;
@@ -43,7 +37,7 @@ async function githubRequest<T>(endpoint: string, token: string, method: string 
     );
   }
 
-  return response.json();
+  return response.json() as T;
 }
 
 function extractDuplicateIssueNumber(commentBody: string): number | null {

--- a/scripts/backfill-duplicate-comments.ts
+++ b/scripts/backfill-duplicate-comments.ts
@@ -1,11 +1,5 @@
 #!/usr/bin/env bun
 
-declare global {
-  var process: {
-    env: Record<string, string | undefined>;
-  };
-}
-
 interface GitHubIssue {
   number: number;
   title: string;
@@ -41,7 +35,7 @@ async function githubRequest<T>(endpoint: string, token: string, method: string 
     );
   }
 
-  return response.json();
+  return response.json() as T;
 }
 
 async function triggerDedupeWorkflow(

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {},
+  "devDependencies": {
+    "bun-types": "^1.3.6"
+  }
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "types": ["bun-types"]
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
## Summary
- Add `tsconfig.json` with ES2022 target and bun-types for proper type checking
- Remove redundant global `process` declarations (already provided by bun-types)
- Fix `response.json()` return type with proper type assertion

## Test plan
- [x] Run `bun x tsc --noEmit` in scripts directory - passes with 0 errors

🤖 Generated with [Claude Code](https://claude.ai/code)