### PR TITLE
Use -exist flag when adding to allowed-domains

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -60,7 +60,7 @@ while read -r cidr; do
         exit 1
     fi
     echo "Adding GitHub range $cidr"
-    ipset add allowed-domains "$cidr"
+    ipset add -exist allowed-domains "$cidr"
 done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
 
 # Resolve and add other allowed domains
@@ -86,7 +86,7 @@ for domain in \
             exit 1
         fi
         echo "Adding $ip for $domain"
-        ipset add allowed-domains "$ip"
+        ipset add -exist allowed-domains "$ip"
     done < <(echo "$ips")
 done
 


### PR DESCRIPTION
Fixed. The -exist flag tells ipset add to silently ignore entries that already exist in the set.                                               
                                                                                                                                                 
  Root cause: The DNS lookup for marketplace.visualstudio.com returned the same IP (150.171.74.16) multiple times, and the script was using set  
  -e (exit on error), so the duplicate add caused the entire script to fail.                                                                     
                                                                                                                                                 
  Summary of changes:                                                                                                                            
  - Line 63: Added -exist flag to ipset add for GitHub IP ranges                                                                                 
  - Line 93: Added -exist flag to ipset add for domain IP addresses