### PR TITLE
feat: Add speakeasy-api/agent-skills to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -145,6 +145,17 @@
       },
       "source": "./plugins/security-guidance",
       "category": "security"
+    },
+    {
+      "name": "speakeasy",
+      "description": "SDK generation and OpenAPI tooling skills powered by the Speakeasy CLI. Includes validation, overlay creation, spec merging, and AI-powered suggestions for operation IDs.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Speakeasy",
+        "email": "support@speakeasy.com"
+      },
+      "source": "speakeasy-api/agent-skills",
+      "category": "development"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add Speakeasy Agent Skills plugin to the Claude Code marketplace

## Description
This PR adds the [speakeasy-api/agent-skills](https://github.com/speakeasy-api/agent-skills) plugin to the marketplace. 

The Speakeasy Agent Skills plugin provides 12 skills for SDK generation and OpenAPI tooling, including:
- `start-new-sdk-project` — Generate SDKs from OpenAPI specs
- `regenerate-sdk` — Regenerate after spec updates
- `validate-openapi-spec` — Run linting validation
- `get-ai-suggestions` — Improve operation ID naming
- `check-workspace-status` — View configured targets/sources
- `create-openapi-overlay` — Create customization overlays
- `apply-openapi-overlay` — Apply overlay files to specs
- `merge-openapi-specs` — Combine multiple specs
- `diagnose-generation-failure` — Debug generation errors
- `fix-validation-errors-with-overlays` — Fix lint errors via overlays
- `improve-operation-ids` — Rename SDK methods
- `configure-authentication` — Setup auth for CI/CD

## Test plan
- [ ] Verify marketplace.json is valid JSON
- [ ] Verify the plugin source reference is correct