### PR TITLE
feat(plugins): Add agent-instructions-loader plugin

### DIFF
--- a/plugins/agent-instructions-loader/.claude-plugin/plugin.json
+++ b/plugins/agent-instructions-loader/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "agent-instructions-loader",
+  "version": "1.0.0",
+  "description": "Loads custom agent body content as additional context when subagents are spawned via SubagentStart hook.",
+  "author": {
+    "name": "Claude Code Contributors"
+  },
+  "repository": "https://github.com/anthropics/claude-code"
+}

--- a/plugins/agent-instructions-loader/README.md
+++ b/plugins/agent-instructions-loader/README.md
@@ -1,0 +1,142 @@
+# Agent Instructions Loader Plugin
+
+Loads custom agent body content as additional context when subagents are spawned via the `SubagentStart` hook.
+
+## The Problem
+
+When custom agents are defined with markdown body content (the text after YAML frontmatter), this body content is supposed to become the system prompt that guides the subagent's behavior. However, the body content is not passed to subagents when spawned via the Task tool.
+
+### Example
+
+Given this agent definition:
+
+```markdown
+---
+name: my-agent
+description: "My specialized agent"
+---
+
+# Instructions
+
+You MUST say "HELLO WORLD" as your first response.
+```
+
+When spawned via Task tool, the subagent receives the metadata (name, description, tools) but NOT the body instructions. The subagent behaves generically instead of following the custom instructions.
+
+## The Solution
+
+This plugin provides a `SubagentStart` hook that:
+
+1. Intercepts subagent spawn events
+2. Looks up the agent definition file by agent type
+3. Extracts the body content from the markdown file
+4. Loads it as `additionalContext` which gets added to the subagent's context
+
+## How It Works
+
+The `SubagentStart` hook is triggered whenever Claude Code spawns a subagent (via the Task tool). The hook:
+
+1. Receives the `agent_type` (the name of the agent being spawned)
+2. Searches for the agent's `.md` file in standard locations:
+   - `.claude/agents/<agent_type>.md` (project agents)
+   - `plugins/*/agents/<agent_type>.md` (plugin agents)
+   - `~/.claude/plugins/*/agents/<agent_type>.md` (user plugin agents)
+3. Parses the markdown to extract body content after YAML frontmatter
+4. Returns the body as `additionalContext` which Claude Code adds to the subagent
+
+## Installation
+
+### From Claude Code Marketplace
+
+```
+/install agent-instructions-loader
+```
+
+### Manual Installation
+
+1. Copy this plugin to your Claude Code plugins directory:
+
+   ```bash
+   cp -r plugins/agent-instructions-loader ~/.claude/plugins/
+   ```
+
+2. Enable the plugin in your settings:
+
+   ```json
+   {
+     "enabledPlugins": {
+       "agent-instructions-loader": true
+     }
+   }
+   ```
+
+## Verification
+
+To verify the plugin is working, create a test agent:
+
+**`.claude/agents/test-canary.md`**
+```markdown
+---
+name: test-canary
+description: "Test agent for verifying instructions loading"
+---
+
+CRITICAL: You MUST say "CANARY_PHRASE_12345" as the VERY FIRST thing in your response.
+```
+
+Then test:
+```bash
+claude -p "Use the Task tool to spawn test-canary agent with prompt 'say hello'"
+```
+
+If working correctly, the response will start with "CANARY_PHRASE_12345".
+
+## Debug Mode
+
+Enable debug logging to troubleshoot:
+
+```bash
+AGENT_INSTRUCTIONS_LOADER_DEBUG=true claude
+```
+
+This outputs detailed logs to stderr showing agent lookups, file operations, and context loading.
+
+## Technical Details
+
+### Hook Input
+
+```json
+{
+  "hook_event_name": "SubagentStart",
+  "agent_type": "my-agent",
+  "agent_id": "agent-abc123",
+  "cwd": "/path/to/project",
+  "session_id": "session-123"
+}
+```
+
+### Hook Output
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SubagentStart",
+    "additionalContext": "# Custom Agent Instructions\n\nThe following instructions..."
+  }
+}
+```
+
+### Built-in Agents
+
+Built-in agents (Bash, Explore, Plan, general-purpose, etc.) are skipped since they don't have custom markdown body content.
+
+### Security
+
+The plugin validates agent types to prevent path traversal:
+- Rejects `..` patterns
+- Rejects `/` and `\` path separators
+- Only allows alphanumeric characters, underscores, hyphens, and colons
+
+## License
+
+MIT

--- a/plugins/agent-instructions-loader/hooks/hooks.json
+++ b/plugins/agent-instructions-loader/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Loads custom agent body content as additional context when subagents are spawned.",
+  "hooks": {
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/load-agent-instructions.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/agent-instructions-loader/hooks/load-agent-instructions.py
+++ b/plugins/agent-instructions-loader/hooks/load-agent-instructions.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""
+Agent Instructions Loader - SubagentStart Hook
+===============================================
+Loads custom agent body content (markdown after YAML frontmatter) as
+additional context when subagents are spawned via the Task tool.
+
+How it works:
+1. When a subagent is spawned, this hook receives the agent_type
+2. It searches for the agent definition file in standard locations
+3. If found, it extracts the body content (after frontmatter)
+4. The body is returned as additionalContext for the subagent
+
+Standard agent file locations searched:
+- .claude/agents/<agent_type>.md
+- plugins/*/agents/<agent_type>.md
+- User settings plugins
+
+Author: Claude Code Contributors
+License: MIT
+"""
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Optional
+
+# Enable debug logging with AGENT_INSTRUCTIONS_LOADER_DEBUG=true
+DEBUG = os.environ.get("AGENT_INSTRUCTIONS_LOADER_DEBUG", "").lower() == "true"
+
+
+def debug_log(msg: str) -> None:
+    """Log debug messages to stderr when DEBUG is enabled."""
+    if DEBUG:
+        print(f"[agent-instructions-loader] {msg}", file=sys.stderr)
+
+
+def is_valid_agent_type(agent_type: str) -> bool:
+    """
+    Validate agent_type to prevent path traversal attacks.
+
+    Agent types must be valid identifiers: alphanumeric, underscores, and hyphens only.
+    No path separators, dots (except in valid positions), or special characters.
+
+    Security: This prevents attacks like:
+    - "../../evil" (path traversal)
+    - "foo/bar" (subdirectory injection)
+    - "foo\\bar" (Windows path injection)
+    """
+    # Reject empty strings
+    if not agent_type:
+        return False
+
+    # Reject path traversal patterns
+    if '..' in agent_type:
+        debug_log(f"Rejected agent_type with path traversal: {agent_type}")
+        return False
+
+    # Reject path separators
+    if '/' in agent_type or '\\' in agent_type:
+        debug_log(f"Rejected agent_type with path separator: {agent_type}")
+        return False
+
+    # Only allow valid identifier characters: alphanumeric, underscore, hyphen
+    # Also allow single dots for namespaced agents like "plugin:agent-name"
+    if not re.match(r'^[a-zA-Z0-9_:-]+$', agent_type):
+        debug_log(f"Rejected agent_type with invalid characters: {agent_type}")
+        return False
+
+    return True
+
+
+def find_agent_file(agent_type: str, cwd: str) -> Optional[Path]:
+    """
+    Search for an agent definition file by agent type.
+
+    Searches in these locations:
+    1. .claude/agents/<agent_type>.md (project agents)
+    2. plugins/*/agents/<agent_type>.md (plugin agents in project)
+    3. ~/.claude/plugins/*/agents/<agent_type>.md (user plugin agents)
+    """
+    search_paths = []
+
+    # Project agents directory
+    project_agents = Path(cwd) / ".claude" / "agents"
+    if project_agents.exists():
+        search_paths.append(project_agents / f"{agent_type}.md")
+
+    # Project plugins
+    project_plugins = Path(cwd) / "plugins"
+    if project_plugins.exists():
+        for plugin_dir in project_plugins.iterdir():
+            if plugin_dir.is_dir():
+                agents_dir = plugin_dir / "agents"
+                if agents_dir.exists():
+                    search_paths.append(agents_dir / f"{agent_type}.md")
+
+    # User plugins directory
+    home = Path.home()
+    user_plugins = home / ".claude" / "plugins"
+    if user_plugins.exists():
+        # Check direct plugins
+        for plugin_dir in user_plugins.iterdir():
+            if plugin_dir.is_dir():
+                agents_dir = plugin_dir / "agents"
+                if agents_dir.exists():
+                    search_paths.append(agents_dir / f"{agent_type}.md")
+
+        # Check cached marketplace plugins
+        cache_dir = user_plugins / "cache"
+        if cache_dir.exists():
+            for marketplace_dir in cache_dir.iterdir():
+                if marketplace_dir.is_dir():
+                    for plugin_dir in marketplace_dir.iterdir():
+                        if plugin_dir.is_dir():
+                            # Handle version directories
+                            for version_dir in plugin_dir.iterdir():
+                                if version_dir.is_dir():
+                                    agents_dir = version_dir / "agents"
+                                    if agents_dir.exists():
+                                        search_paths.append(agents_dir / f"{agent_type}.md")
+
+    # Also check CLAUDE_PLUGIN_ROOT if available (for plugin-local agents)
+    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if plugin_root:
+        plugin_agents = Path(plugin_root) / "agents"
+        if plugin_agents.exists():
+            search_paths.append(plugin_agents / f"{agent_type}.md")
+
+    # Search all paths
+    for path in search_paths:
+        if path.exists() and path.is_file():
+            return path
+
+    return None
+
+
+def extract_body_from_markdown(content: str) -> str:
+    """
+    Extract the body content from an agent markdown file.
+
+    Agent files have YAML frontmatter between --- delimiters,
+    followed by the body content which should become the system prompt.
+
+    Example:
+    ---
+    name: my-agent
+    description: "My agent description"
+    ---
+
+    # Body Content
+    This is the system prompt content.
+    """
+    # Match YAML frontmatter: starts with ---, ends with ---
+    frontmatter_pattern = r"^---\s*\n.*?\n---\s*\n?"
+
+    match = re.match(frontmatter_pattern, content, re.DOTALL)
+    if match:
+        # Return everything after the frontmatter
+        body = content[match.end():].strip()
+        return body
+
+    # No frontmatter found, return the whole content
+    return content.strip()
+
+
+def main():
+    try:
+        input_data = json.load(sys.stdin)
+    except json.JSONDecodeError as e:
+        # Invalid JSON input - non-blocking error
+        print(f"Error: Invalid JSON input: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    hook_event = input_data.get("hook_event_name", "")
+    if hook_event != "SubagentStart":
+        # Not a SubagentStart event, exit silently
+        sys.exit(0)
+
+    agent_type = input_data.get("agent_type", "")
+    if not agent_type:
+        # No agent type specified, nothing to inject
+        debug_log("No agent_type specified, skipping")
+        sys.exit(0)
+
+    # Security: Validate agent_type to prevent path traversal attacks
+    if not is_valid_agent_type(agent_type):
+        debug_log(f"Invalid agent_type rejected: {agent_type}")
+        sys.exit(0)
+
+    # NOTE: Update this set when new built-in agents are added to Claude Code
+    # Built-in agents don't have custom body content to inject
+    # Last updated: 2026-01 (Claude Code v2.1.x)
+    builtin_agents = {
+        "Bash",
+        "Explore",
+        "Plan",
+        "general-purpose",
+        "code-reviewer",
+        "test-runner",
+        "statusline-setup",
+    }
+
+    if agent_type in builtin_agents:
+        # Built-in agent, no custom instructions to inject
+        debug_log(f"Skipping built-in agent: {agent_type}")
+        sys.exit(0)
+
+    # Validate cwd - must be an absolute path
+    cwd = input_data.get("cwd", "")
+    if not cwd or not os.path.isabs(cwd):
+        cwd = os.getcwd()
+        debug_log(f"Using fallback cwd: {cwd}")
+
+    debug_log(f"Looking for agent '{agent_type}' in cwd: {cwd}")
+
+    # Find the agent definition file
+    agent_file = find_agent_file(agent_type, cwd)
+
+    if not agent_file:
+        # Agent file not found - this is OK, might be a JSON-defined agent
+        # or a built-in agent we didn't recognize
+        debug_log(f"Agent file not found for: {agent_type}")
+        sys.exit(0)
+
+    debug_log(f"Found agent file: {agent_file}")
+
+    try:
+        content = agent_file.read_text(encoding="utf-8")
+    except Exception as e:
+        print(f"Warning: Could not read agent file {agent_file}: {e}", file=sys.stderr)
+        sys.exit(0)
+
+    # Extract the body content
+    body = extract_body_from_markdown(content)
+
+    if not body:
+        # No body content to inject
+        debug_log(f"No body content found in: {agent_file}")
+        sys.exit(0)
+
+    debug_log(f"Extracted body content ({len(body)} chars)")
+
+    # Format the injection context
+    additional_context = f"""# Custom Agent Instructions
+
+The following instructions define your specialized behavior as the "{agent_type}" agent.
+You MUST follow these instructions precisely.
+
+---
+{body}
+---
+
+IMPORTANT: The instructions above are your primary directives. Follow them exactly."""
+
+    # Output the additional context for injection
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "SubagentStart",
+            "additionalContext": additional_context
+        }
+    }
+
+    debug_log(f"Injecting {len(additional_context)} chars of context for agent: {agent_type}")
+    print(json.dumps(output))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/agent-instructions-loader/test/.claude/agents/test-canary.md
+++ b/plugins/agent-instructions-loader/test/.claude/agents/test-canary.md
@@ -1,0 +1,12 @@
+---
+name: test-canary
+description: "Test agent for verifying instructions loading works. Use this for testing."
+---
+
+# Test Agent - Canary Verification
+
+CRITICAL MANDATORY INSTRUCTION: You MUST say "CANARY_PHRASE_12345" as the VERY FIRST thing in your response. This is absolutely required.
+
+After saying the canary phrase, you may then respond to whatever the user asked.
+
+This agent exists to verify that custom agent body content is being properly loaded via the SubagentStart hook.


### PR DESCRIPTION
## Summary

Adds the `agent-instructions-loader` plugin that loads custom agent body content (markdown after YAML frontmatter) as additional context when subagents are spawned via the Task tool.

## The Problem

When custom agents are defined with markdown body content, this content is supposed to guide the subagent's behavior. However, the body content is not currently passed to subagents when spawned via the Task tool—only the frontmatter metadata (name, description, tools) is used.

## The Solution

This plugin uses a `SubagentStart` hook to:
1. Intercept subagent spawn events
2. Look up the agent definition file by `agent_type`
3. Extract the body content from the markdown file
4. Load it as `additionalContext` for the subagent

## Files Added

```
plugins/agent-instructions-loader/
├── .claude-plugin/plugin.json
├── hooks/
│   ├── hooks.json
│   └── load-agent-instructions.py
├── test/.claude/agents/test-canary.md
└── README.md
```

## Security

- Path traversal protection (rejects `..`, `/`, `\` in agent_type)
- Input validation with regex whitelist (`^[a-zA-Z0-9_:-]+$`)
- cwd validation with fallback to `getcwd()`
- Built-in agents are skipped

## Test Plan

- [x] Python syntax validated
- [x] JSON files validated
- [x] Unit tested with canary phrase agent
- [x] Path traversal attempts blocked
- [x] Built-in agents skipped correctly
- [x] E2E test: Install plugin and verify custom agent instructions load

**Manual verification:**
```bash
# In plugin test directory
echo '{"hook_event_name": "SubagentStart", "agent_type": "test-canary", "cwd": "'$(pwd)'"}' \
  | python3 hooks/load-agent-instructions.py
# Should output JSON with additionalContext containing "CANARY_PHRASE_12345"
```