### PR TITLE
fix(hookify): fix import errors on Mac by using relative imports

### DIFF
--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -7,7 +7,7 @@ from functools import lru_cache
 from typing import List, Dict, Any, Optional
 
 # Import from local module
-from hookify.core.config_loader import Rule, Condition
+from core.config_loader import Rule, Condition
 
 
 # Cache compiled regexes (max 128 patterns)
@@ -275,7 +275,7 @@ class RuleEngine:
 
 # For testing
 if __name__ == '__main__':
-    from hookify.core.config_loader import Condition, Rule
+    from core.config_loader import Condition, Rule
 
     # Test rule evaluation
     rule = Rule(

--- a/plugins/hookify/hooks/posttooluse.py
+++ b/plugins/hookify/hooks/posttooluse.py
@@ -19,8 +19,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)

--- a/plugins/hookify/hooks/pretooluse.py
+++ b/plugins/hookify/hooks/pretooluse.py
@@ -23,8 +23,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     # If imports fail, allow operation and log error
     error_msg = {"systemMessage": f"Hookify import error: {e}"}

--- a/plugins/hookify/hooks/stop.py
+++ b/plugins/hookify/hooks/stop.py
@@ -19,8 +19,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)

--- a/plugins/hookify/hooks/userpromptsubmit.py
+++ b/plugins/hookify/hooks/userpromptsubmit.py
@@ -19,8 +19,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)


### PR DESCRIPTION
## Summary

Fixes "No module named 'hookify'" error on Mac by changing from absolute to relative imports in the hookify plugin.

## Problem

The hookify plugin was failing on Mac with import errors:
```
ImportError: No module named 'hookify'
```

This occurred in all 4 hooks (PreToolUse, PostToolUse, UserPromptSubmit, Stop) and prevented the plugin from functioning.

## Root Cause

The plugin directory structure `hookify/0.1.0/core/` does not support absolute imports like `from hookify.core.*` because:
- `PLUGIN_ROOT` environment variable points to the `0.1.0/` directory
- Only `0.1.0/` is added to `sys.path`
- Python cannot resolve the `hookify` package since there's no `hookify` directory in sys.path

## Solution

Changed all imports from absolute to relative:

**Before:**
```python
from hookify.core.config_loader import load_rules
from hookify.core.rule_engine import RuleEngine
```

**After:**
```python
from core.config_loader import load_rules
from core.rule_engine import RuleEngine
```

## Files Changed

- `plugins/hookify/hooks/pretooluse.py`
- `plugins/hookify/hooks/posttooluse.py`
- `plugins/hookify/hooks/stop.py`
- `plugins/hookify/hooks/userpromptsubmit.py`
- `plugins/hookify/core/rule_engine.py`

## Testing

All 4 hooks tested successfully on Mac:
- ✅ PreToolUse - No import errors, returns valid JSON
- ✅ PostToolUse - No import errors, returns valid JSON
- ✅ UserPromptSubmit - No import errors, returns valid JSON
- ✅ Stop - No import errors, returns valid JSON

Manual test:
```bash
CLAUDE_PLUGIN_ROOT="~/.claude/plugins/cache/claude-code-plugins/hookify/0.1.0" \
python3 ~/.claude/plugins/cache/claude-code-plugins/hookify/0.1.0/hooks/pretooluse.py \
<<< '{"tool_name": "Bash"}'
# Output: {} (success, no errors)
```

## Impact

- Zero logic changes - only import paths modified
- All hookify functionality preserved (commands, agents, skills, rule evaluation)
- Compatible with existing plugin directory structure