### PR TITLE
fix(ci): refresh stale issues on human comments

### DIFF
--- a/.github/workflows/stale-issue-manager.yml
+++ b/.github/workflows/stale-issue-manager.yml
@@ -60,68 +60,71 @@ jobs:
                 // Skip pull requests
                 if (issue.pull_request) continue;
                 
-                // Check if updated more recently than 30 days ago
-                const updatedAt = new Date(issue.updated_at);
-                if (updatedAt > oneMonthAgo) {
-                  // Since issues are sorted by updated_at ascending, 
-                  // once we hit a recent issue, all remaining will be recent too
-                  hasMore = false;
-                  break;
-                }
-                
                 // Check if issue has autoclose label
                 const hasAutocloseLabel = issue.labels.some(label => 
                   typeof label === 'object' && label.name === 'autoclose'
                 );
                 
                 try {
-                  // Get comments to check for existing warning
-                  const { data: comments } = await github.rest.issues.listComments({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: issue.number,
-                    per_page: 100
-                  });
-                  
-                  // Find the last comment from github-actions bot
-                  const botComments = comments.filter(comment => 
-                    comment.user && comment.user.login === 'github-actions[bot]' &&
-                    comment.body && comment.body.includes('inactive for 30 days')
-                  );
-                  
-                  const lastBotComment = botComments[botComments.length - 1];
-                  
-                  if (lastBotComment) {
-                    // Check if the bot comment is older than 30 days (total 60 days of inactivity)
-                    const botCommentDate = new Date(lastBotComment.created_at);
-                    if (botCommentDate < oneMonthAgo) {
-                      // Close the issue - it's been stale for 60+ days
-                      console.log(`Closing issue #${issue.number} (stale for 60+ days): ${issue.title}`);
-                      
-                      // Post closing comment
-                      await github.rest.issues.createComment({
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        issue_number: issue.number,
-                        body: closingComment
-                      });
-                      
-                      // Close the issue
-                      await github.rest.issues.update({
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        issue_number: issue.number,
-                        state: 'closed',
-                        state_reason: 'not_planned'
-                      });
-                      
-                      totalClosed++;
+                  let lastHumanCommentAt = new Date(issue.created_at);
+                  let lastWarningCommentAt = null;
+
+                  if (issue.comments > 0) {
+                    // Get comments to check for human activity and existing warning
+                    const { data: comments } = await github.rest.issues.listComments({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: issue.number,
+                      per_page: 100
+                    });
+
+                    for (const comment of comments) {
+                      if (!comment.user || !comment.user.login) continue;
+
+                      if (comment.user.login === 'github-actions[bot]' &&
+                          comment.body && comment.body.includes('inactive for 30 days')) {
+                        const warningDate = new Date(comment.created_at);
+                        if (!lastWarningCommentAt || warningDate > lastWarningCommentAt) {
+                          lastWarningCommentAt = warningDate;
+                        }
+                      } else if (comment.user.login !== 'github-actions[bot]') {
+                        const commentDate = new Date(comment.created_at);
+                        if (commentDate > lastHumanCommentAt) {
+                          lastHumanCommentAt = commentDate;
+                        }
+                      }
                     }
-                    // If bot comment exists but is recent, issue already has warning
-                  } else if (updatedAt < oneMonthAgo) {
-                    // No bot warning yet, issue is 30+ days old
-                    console.log(`Warning issue #${issue.number} (stale for 30+ days): ${issue.title}`);
-                    
+                  }
+
+                  const warningIsCurrent = lastWarningCommentAt &&
+                    lastWarningCommentAt > lastHumanCommentAt;
+
+                  if (lastHumanCommentAt < twoMonthsAgo) {
+                    // Close the issue - it's been inactive for 60+ days
+                    console.log(`Closing issue #${issue.number} (inactive for 60+ days): ${issue.title}`);
+
+                    // Post closing comment
+                    await github.rest.issues.createComment({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: issue.number,
+                      body: closingComment
+                    });
+
+                    // Close the issue
+                    await github.rest.issues.update({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: issue.number,
+                      state: 'closed',
+                      state_reason: 'not_planned'
+                    });
+
+                    totalClosed++;
+                  } else if (lastHumanCommentAt < oneMonthAgo && !warningIsCurrent) {
+                    // No current warning yet, issue is 30+ days inactive
+                    console.log(`Warning issue #${issue.number} (inactive for 30+ days): ${issue.title}`);
+
                     // Post warning comment
                     await github.rest.issues.createComment({
                       owner: context.repo.owner,
@@ -129,9 +132,9 @@ jobs:
                       issue_number: issue.number,
                       body: warningComment
                     });
-                    
+
                     totalWarned++;
-                    
+
                     // Add autoclose label if not present
                     if (!hasAutocloseLabel) {
                       await github.rest.issues.addLabels({


### PR DESCRIPTION
## Description

The `manage-stale-issues.yml` workflow suggests that the issue -> "stale" warning -> closed flow is such that 30 days of inactivity leads to a warning, and 60 days of (consecutive) inactivity leads to a closure. For example, the bot says:

> This issue has been automatically closed due to 60 days of inactivity. If you're still experiencing this issue, please open a new issue with updated information.`

It also suggests that if an issue receives a warning, the user can effectively "dismiss" it by adding a keep-alive comment:

> If the issue is still occurring, please comment to let us know. 

Unfortunately, the logic of the workflow does not follow these statements, and a few users have opened issues reporting that their issue was closed prematurely. @marcindulak has been compiling a list of these issues as though preparing for a senate committee hearing. (#16497 )

## The Issue

The workflow does this:
- If an issue goes 30 days without any additional comments, it issues a warning that the issue has been inactive for 30 days ("inactive" means, for the bot, no new comments). It then asks users to let the bot know by commenting, or the issue will be closed automatically in 30 days.
- Each run, it checks whether last_updated (meaning last comment) occurred over 30 days ago.
  - If no, it skips. 
  - If yes, it checks whether there is a bot warning already.
    - If no, it posts warning message.
    - If yes, it posts closing message and closes issue. 
  
The problem is: if the last comment was by a human, all this does is affect the "last_updated is before 30-days-ago" check (if it is, it just bypasses the rest). It doesn't actually take into account "Oh, someone has commented since the first warning, so I guess this is not a stale issue." What it does is, effectively, restarts a 30-day "countdown timer", which opens up a second window of potential inactivity - and if there are no new comments, then it sees two 30-day periods of inactivity, and it closes the issue.

Another way to frame it is: an issue will be closed if it has two 30-day periods of no new comments - but those periods do _not_ have to be consecutive. So the bot's statement, "inactive for 60 days", which implies 60 days continuously, is inaccurate, or highly misleading at best.

This explains why if a user gets a warning on their thread, and then immediately comes to post "Yes this is still happening," it basically has no effect.

TL/DR: what, that was long?

## The Fix

In this PR, I propose a minimal change which basically sets the simple condition:

```
if (lastHumanCommentAt < twoMonthsAgo) {
  // Close the issue - it's been inactive for 60+ days
}
```

Because the intentions/design of the maintainers can only be inferred by the bot's messages and the code/comments, there is no uniquely correct fix. So, I just went with the natural interpretation - that 60 days of inactivity means 60 continuous days, and it checks by comparing the date against the last human comment, and not computing something on the basis of (a) a 30-day period of inactivity, and (b) a previous comment made by the bot.

EDIT: Fixes: #16497 