### PR TITLE
Corrected frontmatter, added metadata key to Writing Hookify Rules skill

### DIFF
--- a/plugins/hookify/skills/writing-rules/SKILL.md
+++ b/plugins/hookify/skills/writing-rules/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: Writing Hookify Rules
 description: This skill should be used when the user asks to "create a hookify rule", "write a hook rule", "configure hookify", "add a hookify rule", or needs guidance on hookify rule syntax and patterns.
-version: 0.1.0
+metadata:
+  version: 0.1.0
 ---
 
 # Writing Hookify Rules


### PR DESCRIPTION
The current iteration of the skill does not match frontmatter specifications put forth in https://agentskills.io/specification -- the `version` requires a `metadata` parent