### PR TITLE
feat(plugins): add verify-claims plugin for claim verification

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -25,6 +25,7 @@ Learn more in the [official plugins documentation](https://docs.claude.com/en/do
 | [pr-review-toolkit](./pr-review-toolkit/) | Comprehensive PR review agents specializing in comments, tests, error handling, type design, code quality, and code simplification | **Command:** `/pr-review-toolkit:review-pr` - Run with optional review aspects (comments, tests, errors, types, code, simplify, all)<br>**Agents:** `comment-analyzer`, `pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer`, `code-reviewer`, `code-simplifier` |
 | [ralph-wiggum](./ralph-wiggum/) | Interactive self-referential AI loops for iterative development. Claude works on the same task repeatedly until completion | **Commands:** `/ralph-loop`, `/cancel-ralph` - Start/stop autonomous iteration loops<br>**Hook:** Stop - Intercepts exit attempts to continue iteration |
 | [security-guidance](./security-guidance/) | Security reminder hook that warns about potential security issues when editing files | **Hook:** PreToolUse - Monitors 9 security patterns including command injection, XSS, eval usage, dangerous HTML, pickle deserialization, and os.system calls |
+| [verify-claims](./verify-claims/) | Automatically verifies Claude's claims about file creation, test results, lint status, and build success before task completion | **Command:** `/verify-claims:verify` - Manual verification trigger<br>**Hooks:** Stop (claim verification), PostToolUse (state tracking)<br>**Verifiers:** file_created, tests_pass, lint_clean, build_success, bug_fixed |
 
 ## Installation
 

--- a/plugins/verify-claims/.claude-plugin/plugin.json
+++ b/plugins/verify-claims/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "verify-claims",
+  "version": "1.0.0",
+  "description": "Verifies Claude's claims about file creation, test results, lint status, and build success before allowing task completion",
+  "author": {
+    "name": "augmnt",
+    "url": "https://augmnt.sh"
+  },
+  "license": "MIT",
+  "homepage": "https://augmnt.sh",
+  "repository": "https://github.com/anthropics/claude-code/tree/main/plugins/verify-claims",
+  "keywords": ["verification", "testing", "hooks", "quality-assurance", "fact-checking"]
+}

--- a/plugins/verify-claims/.github/workflows/test.yml
+++ b/plugins/verify-claims/.github/workflows/test.yml
@@ -1,0 +1,55 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[test]"
+
+      - name: Run tests with coverage
+        run: |
+          pytest tests/ -v --tb=short --cov=scripts --cov-report=xml --cov-report=term-missing
+
+      - name: Upload coverage reports
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v4
+        with:
+          file: ./coverage.xml
+          fail_ci_if_error: false
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Run linter
+        run: |
+          ruff check scripts/ tests/

--- a/plugins/verify-claims/.gitignore
+++ b/plugins/verify-claims/.gitignore
@@ -1,0 +1,83 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Session state files (these are runtime artifacts)
+verify_claims_state_*.json
+
+# Debug logs
+*.log

--- a/plugins/verify-claims/CHANGELOG.md
+++ b/plugins/verify-claims/CHANGELOG.md
@@ -1,0 +1,62 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2025-01-30
+
+### Added
+
+- Initial release of verify-claims plugin
+- **Stop Hook**: Intercepts task completion attempts and verifies claims
+- **PostToolUse Hook**: Tracks file writes and command executions
+- **Claim Parser**: Extracts verifiable claims from Claude's responses
+  - File creation claims
+  - Test passing claims
+  - Lint clean claims
+  - Build success claims
+  - Bug fix claims
+- **Verifiers**:
+  - `file_exists`: Verifies claimed files exist
+  - `test_runner`: Runs detected test suite
+  - `lint_checker`: Runs detected linter
+  - `build_checker`: Runs detected build command
+  - `git_diff`: Verifies code changes were made
+- **Framework Detection**: Auto-detects project type for:
+  - Node.js/npm projects
+  - Python (pytest) projects
+  - Rust/Cargo projects
+  - Go projects
+  - Ruby/RSpec projects
+  - Java/Maven/Gradle projects
+- **Configuration System**:
+  - Default configuration with sensible defaults
+  - Project-level overrides via `.claude/verify-claims.json`
+  - Configurable timeouts, thresholds, and commands
+- **Session State Management**:
+  - Tracks files written during session
+  - Tracks commands run and their results
+  - Stores verification history
+  - Automatic cleanup of old state files
+- **Safety Features**:
+  - Infinite loop prevention
+  - Max retry limits
+  - Confidence thresholds for claim detection
+- **Manual Verification**: `/verify` command for manual verification runs
+- **Debug Logging**: Optional debug logging to `~/.claude/logs/verify_claims.log`
+
+### Framework Support
+
+| Framework | Tests | Lint | Build |
+|-----------|-------|------|-------|
+| Node.js/npm | npm test | npm run lint / eslint | npm run build |
+| Python | pytest | ruff / flake8 / pylint | - |
+| Rust | cargo test | cargo clippy | cargo build |
+| Go | go test | golangci-lint | go build |
+| Ruby | rspec / rake | - | - |
+| Java | mvn test / gradle test | - | mvn compile / gradle build |
+| TypeScript | - | - | tsc --noEmit |
+
+[1.0.0]: https://github.com/augmnt/verify-claims/releases/tag/v1.0.0

--- a/plugins/verify-claims/LICENSE
+++ b/plugins/verify-claims/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 augmnt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/verify-claims/README.md
+++ b/plugins/verify-claims/README.md
@@ -1,0 +1,272 @@
+# verify-claims
+
+[![Tests](https://github.com/anthropics/claude-code/actions/workflows/test.yml/badge.svg)](https://github.com/anthropics/claude-code/actions/workflows/test.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
+[![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-purple.svg)](https://claude.ai/code)
+
+A Claude Code plugin that automatically verifies Claude's claims about code changes before allowing task completion.
+
+## Overview
+
+When Claude claims to have created files, fixed bugs, or ensured tests pass, this plugin intercepts the completion attempt and verifies those claims are actually true. If verification fails, completion is blocked and Claude must address the discrepancy.
+
+## Features
+
+- **Automatic Claim Detection**: Parses Claude's responses for verifiable claims
+- **Multi-Framework Support**: Auto-detects npm, pytest, cargo, go, and more
+- **Configurable Verification**: Override commands per-project
+- **Session State Tracking**: Remembers what files were written and commands run
+- **Infinite Loop Prevention**: Limits retries and detects active hooks
+
+## Installation
+
+### From GitHub
+
+```bash
+claude plugin install https://github.com/anthropics/claude-code/tree/main/plugins/verify-claims.git
+```
+
+### Manual Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/anthropics/claude-code/tree/main/plugins/verify-claims.git ~/.claude/plugins/verify-claims
+
+# Enable it in your Claude settings or use:
+claude --plugin-dir ~/.claude/plugins/verify-claims
+```
+
+## How It Works
+
+### Stop Hook
+
+When Claude attempts to complete a task, the Stop hook:
+
+1. Reads the last 3 assistant messages from the transcript
+2. Parses for verifiable claims using pattern matching
+3. Runs appropriate verifiers for each claim
+4. Blocks completion if any verification fails
+
+### PostToolUse Hook
+
+Tracks Write, Edit, and Bash tool uses to:
+
+- Record which files were created/modified
+- Track test/lint/build command results
+- Enable smarter verification decisions
+
+## Claim Types
+
+| Type | Example Phrases | Verification Method |
+|------|-----------------|---------------------|
+| `file_created` | "I created config.json" | `os.path.exists()` |
+| `tests_pass` | "All tests pass" | Run detected test command |
+| `lint_clean` | "No lint errors" | Run detected linter |
+| `build_success` | "Build succeeded" | Run detected build command |
+| `bug_fixed` | "Fixed the bug" | Check `git diff` for changes |
+
+## Configuration
+
+### Default Configuration
+
+Located at `config/default_config.json`:
+
+```json
+{
+  "verifiers": {
+    "file_created": { "enabled": true },
+    "tests_pass": { "enabled": true, "timeout": 60 },
+    "lint_clean": { "enabled": true, "timeout": 30 },
+    "build_success": { "enabled": true, "timeout": 120 },
+    "bug_fixed": { "enabled": true }
+  },
+  "behavior": {
+    "block_on_failure": true,
+    "max_retries": 3,
+    "confidence_threshold": 0.7,
+    "cleanup_days": 30
+  },
+  "debug": false
+}
+```
+
+### Project Overrides
+
+Create `.claude/verify-claims.json` in your project:
+
+```json
+{
+  "verifiers": {
+    "tests_pass": {
+      "command": "npm run test:unit -- --coverage"
+    },
+    "lint_clean": {
+      "command": "npm run lint:strict"
+    }
+  },
+  "behavior": {
+    "block_on_failure": false
+  }
+}
+```
+
+## Framework Detection
+
+The plugin auto-detects project type and appropriate commands:
+
+### Test Commands
+
+| Indicator | Command |
+|-----------|---------|
+| `package.json` with `test` script | `npm test` |
+| `pytest.ini` or `pyproject.toml` | `pytest` |
+| `Cargo.toml` | `cargo test` |
+| `go.mod` | `go test ./...` |
+| `Gemfile` + `spec/` | `bundle exec rspec` |
+
+### Lint Commands
+
+| Indicator | Command |
+|-----------|---------|
+| `package.json` with `lint` script | `npm run lint` |
+| `.eslintrc.*` | `npx eslint .` |
+| `ruff.toml` or `[tool.ruff]` | `ruff check .` |
+| `Cargo.toml` | `cargo clippy` |
+| `go.mod` | `golangci-lint run` |
+
+### Build Commands
+
+| Indicator | Command |
+|-----------|---------|
+| `package.json` with `build` script | `npm run build` |
+| `tsconfig.json` | `npx tsc --noEmit` |
+| `Cargo.toml` | `cargo build` |
+| `go.mod` | `go build ./...` |
+| `Makefile` | `make` |
+
+## Manual Verification
+
+Use the `/verify-claims:verify` command to manually run verifications:
+
+```
+/verify-claims:verify          # Verify all claims
+/verify-claims:verify tests    # Only run test verification
+/verify-claims:verify files    # Only check file existence
+```
+
+## Session State
+
+State is stored in `~/.claude/verify_claims_state_{session_id}.json`:
+
+```json
+{
+  "session_id": "abc123",
+  "files_written": [
+    {"path": "/project/src/file.ts", "tool": "Write", "timestamp": 1234567890}
+  ],
+  "commands_run": [
+    {"command": "npm test", "exit_code": 0, "is_test": true, "timestamp": 1234567890}
+  ],
+  "verification_results": [],
+  "verification_count": 0
+}
+```
+
+## Troubleshooting
+
+### Plugin Not Running
+
+Check that the plugin is properly installed:
+
+```bash
+ls -la ~/.claude/plugins/verify-claims/.claude-plugin/plugin.json
+```
+
+### Verification Always Failing
+
+1. Check debug logs at `~/.claude/logs/verify_claims.log`
+2. Enable debug mode in config: `"debug": true`
+3. Verify your project has the expected config files
+
+### Too Many False Positives
+
+Increase the confidence threshold:
+
+```json
+{
+  "behavior": {
+    "confidence_threshold": 0.85
+  }
+}
+```
+
+### Disable for Specific Project
+
+Create `.claude/verify-claims.json`:
+
+```json
+{
+  "behavior": {
+    "block_on_failure": false
+  }
+}
+```
+
+## Development
+
+### File Structure
+
+```
+verify-claims/
+├── .claude-plugin/
+│   └── plugin.json         # Plugin manifest
+├── hooks/
+│   └── hooks.json          # Hook definitions
+├── scripts/
+│   ├── verify_claims.py    # Main Stop hook
+│   ├── track_tool_use.py   # PostToolUse tracker
+│   ├── claim_parser.py     # Claim extraction
+│   ├── transcript_reader.py # JSONL parsing
+│   ├── verifiers/          # Verification modules
+│   └── utils/              # Shared utilities
+├── commands/
+│   └── verify.md           # Manual command
+├── config/
+│   └── default_config.json
+├── tests/                  # Test suite
+│   ├── test_claim_parser.py
+│   ├── test_transcript_reader.py
+│   ├── test_config.py
+│   ├── test_state.py
+│   └── test_verifiers.py
+└── README.md
+```
+
+### Running Tests
+
+```bash
+cd ~/.claude/plugins/verify-claims
+pip install -e ".[test]"
+pytest tests/
+```
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'feat: add amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
+
+## Author
+
+**augmnt**
+- Website: [augmnt.sh](https://augmnt.sh)
+- GitHub: [@augmnt](https://github.com/augmnt)
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/plugins/verify-claims/commands/verify.md
+++ b/plugins/verify-claims/commands/verify.md
@@ -1,0 +1,91 @@
+# verify
+
+Run manual verification of claims made in this session.
+
+## Usage
+
+```
+/verify-claims:verify [claim_type]
+```
+
+## Arguments
+
+- `claim_type` (optional): Specific claim type to verify. Options:
+  - `files` - Verify file creation claims
+  - `tests` - Run test verification
+  - `lint` - Run lint verification
+  - `build` - Run build verification
+  - `all` - Run all verifications (default)
+
+## Examples
+
+```
+/verify-claims:verify          # Verify all claims
+/verify-claims:verify tests    # Only run test verification
+/verify-claims:verify files    # Only check file existence
+```
+
+## Behavior
+
+When invoked, this command will:
+
+1. Parse recent assistant messages for verifiable claims
+2. Run appropriate verification checks
+3. Report results for each claim found
+
+### Claim Types Detected
+
+| Type | Patterns | Verification |
+|------|----------|--------------|
+| `file_created` | "I created...", "wrote to..." | Check file exists |
+| `tests_pass` | "tests pass", "all tests passing" | Run test suite |
+| `lint_clean` | "no lint errors" | Run linter |
+| `build_success` | "build succeeded" | Run build |
+| `bug_fixed` | "fixed the bug" | Check git diff |
+
+## Configuration
+
+Override verification commands in `.claude/verify-claims.json`:
+
+```json
+{
+  "verifiers": {
+    "tests_pass": { "command": "npm run test:unit" },
+    "lint_clean": { "command": "npm run lint:strict" }
+  }
+}
+```
+
+---
+
+**Instructions for Claude:**
+
+When the user invokes `/verify-claims:verify`, perform the following steps:
+
+1. Read the session transcript to get recent assistant messages
+2. Parse those messages for verifiable claims using these patterns:
+   - File creation: Look for mentions of creating/writing files
+   - Test claims: Look for "tests pass" or similar
+   - Lint claims: Look for "no lint errors" or similar
+   - Build claims: Look for "build succeeded" or similar
+   - Bug fix claims: Look for "fixed the bug" or similar
+
+3. For each claim found, run the appropriate verification:
+   - **file_created**: Check if the mentioned file exists using `ls -la`
+   - **tests_pass**: Run the project's test command (npm test, pytest, cargo test, etc.)
+   - **lint_clean**: Run the project's lint command (npm run lint, ruff, eslint, etc.)
+   - **build_success**: Run the project's build command (npm run build, cargo build, etc.)
+   - **bug_fixed**: Check `git diff` to confirm code changes were made
+
+4. Report results in a clear format:
+   ```
+   ## Verification Results
+
+   ✓ file_created: src/components/Button.tsx exists
+   ✓ tests_pass: All 42 tests passed (npm test)
+   ✗ lint_clean: 3 lint errors found
+   ```
+
+5. If any verifications fail, provide actionable next steps.
+
+**Note**: Only verify claims that were actually made. Don't run tests if no test-related claims were found.

--- a/plugins/verify-claims/hooks/hooks.json
+++ b/plugins/verify-claims/hooks/hooks.json
@@ -1,0 +1,28 @@
+{
+  "description": "Verification hooks for claim validation",
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/verify_claims.py",
+            "timeout": 120
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/track_tool_use.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/verify-claims/pyproject.toml
+++ b/plugins/verify-claims/pyproject.toml
@@ -1,0 +1,82 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "verify-claims"
+version = "1.0.0"
+description = "Claude Code plugin that verifies claims about file creation, tests, lint, and builds"
+readme = "README.md"
+license = {text = "MIT"}
+authors = [
+    {name = "augmnt", email = "hello@augmnt.sh"}
+]
+keywords = ["claude", "code", "plugin", "verification", "testing"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Quality Assurance",
+    "Topic :: Software Development :: Testing",
+]
+requires-python = ">=3.10"
+dependencies = []
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7.0.0",
+    "pytest-mock>=3.10.0",
+    "pytest-cov>=4.0.0",
+]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-mock>=3.10.0",
+    "pytest-cov>=4.0.0",
+    "ruff>=0.1.0",
+]
+
+[project.urls]
+Homepage = "https://augmnt.sh"
+Repository = "https://github.com/augmnt/verify-claims"
+Issues = "https://github.com/augmnt/verify-claims/issues"
+Changelog = "https://github.com/augmnt/verify-claims/blob/main/CHANGELOG.md"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["scripts*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_functions = ["test_*"]
+addopts = "-v --tb=short"
+
+[tool.coverage.run]
+source = ["scripts"]
+omit = [
+    "scripts/verifiers/test_runner.py",
+    "scripts/track_tool_use.py",
+    "scripts/verify_claims.py",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.:",
+    "raise NotImplementedError",
+]
+fail_under = 70
+show_missing = true
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "N", "UP", "B", "C4"]
+ignore = ["E501"]

--- a/plugins/verify-claims/scripts/claim_parser.py
+++ b/plugins/verify-claims/scripts/claim_parser.py
@@ -1,0 +1,182 @@
+"""Parse and extract claims from Claude's responses."""
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass
+class Claim:
+    """A claim extracted from Claude's response."""
+    claim_type: str
+    claim_text: str
+    confidence: float
+    extracted_value: str | None = None  # e.g., file path for file_created
+
+
+# Claim detection patterns with confidence weights
+# Note: For file_created patterns, we search on original text to preserve paths
+CLAIM_PATTERNS: dict[str, list[tuple[str, float]]] = {
+    "file_created": [
+        # High confidence - explicit creation statements
+        (r"(?:I've |I have |I )?(?:created|wrote|added|generated) (?:a )?(?:new )?(?:the )?(?:file )?(?:called |named )?[`'\"]?([^\s`'\",:]+\.[a-zA-Z0-9]+)[`'\"]?", 0.9),
+        (r"(?:created|wrote|written) (?:to )?(?:the )?(?:file )?[`'\"]?([^\s`'\",:]+\.[a-zA-Z0-9]+)[`'\"]?", 0.9),
+        # Medium confidence - references to files being done
+        (r"[`'\"]([^\s`'\"]+\.[a-zA-Z0-9]+)[`'\"]? (?:has been |is now )?(?:created|written|saved)", 0.8),
+        (r"saved (?:the )?(?:changes )?(?:to )?[`'\"]?([^\s`'\"]+\.[a-zA-Z0-9]+)[`'\"]?", 0.7),
+        # File written/created passively
+        (r"file [`'\"]?([^\s`'\",:]+\.[a-zA-Z0-9]+)[`'\"]? (?:was |has been )?(?:created|written|saved)", 0.85),
+    ],
+    "tests_pass": [
+        # High confidence - explicit pass statements
+        (r"(?:all )?tests? (?:are )?(?:now )?pass(?:ing|ed)?", 0.9),
+        (r"tests? (?:run |completed? )?successfully", 0.9),
+        (r"all (?:\d+ )?tests? pass(?:ed)?", 0.95),
+        # Medium confidence
+        (r"tests? (?:should )?(?:now )?work", 0.7),
+        (r"(?:the )?tests? (?:are )?(?:now )?green", 0.8),
+    ],
+    "lint_clean": [
+        # High confidence
+        (r"no (?:lint(?:ing)? )?(?:errors?|issues?|warnings?)", 0.9),
+        (r"lint(?:ing)? (?:is )?(?:now )?(?:clean|passing|passes)", 0.9),
+        (r"(?:all )?lint(?:ing)? (?:checks? )?pass(?:ed|ing)?", 0.9),
+        # Medium confidence
+        (r"code (?:is )?(?:now )?lint(?:-)?free", 0.8),
+        (r"(?:eslint|ruff|pylint|clippy) (?:shows? )?no (?:errors?|issues?)", 0.85),
+    ],
+    "build_success": [
+        # High confidence
+        (r"build (?:succeeded|successful(?:ly)?|completed? (?:successfully)?|passes)", 0.9),
+        (r"(?:compiled?|built) (?:successfully|without errors?)", 0.9),
+        (r"(?:the )?(?:project|app|code) (?:now )?builds?(?: successfully)?", 0.85),
+        # Medium confidence
+        (r"(?:npm|yarn|cargo|make|gradle) (?:run )?build (?:succeeded|passed|completed)", 0.9),
+        (r"no (?:build|compilation) errors?", 0.8),
+    ],
+    "bug_fixed": [
+        # High confidence
+        (r"(?:I've |I have |I )?(?:fixed|resolved|addressed|corrected) (?:the )?(?:bug|issue|problem|error)", 0.9),
+        (r"(?:the )?(?:bug|issue|problem|error) (?:is )?(?:now )?(?:fixed|resolved|addressed|corrected)", 0.9),
+        # Medium confidence
+        (r"(?:bug|issue|problem) (?:should be )?(?:now )?(?:fixed|resolved)", 0.75),
+        (r"(?:this )?(?:fix|change|update) (?:should )?(?:resolve|fix|address)", 0.7),
+    ],
+}
+
+
+def parse_claims(text: str, confidence_threshold: float = 0.7) -> list[Claim]:
+    """
+    Parse text for claims that can be verified.
+
+    Args:
+        text: Text content from Claude's response
+        confidence_threshold: Minimum confidence to include a claim
+
+    Returns:
+        List of Claim objects found in the text
+    """
+    claims = []
+
+    for claim_type, patterns in CLAIM_PATTERNS.items():
+        for pattern, confidence in patterns:
+            if confidence < confidence_threshold:
+                continue
+
+            # For file_created, search on original text to preserve file path case
+            # For other claims, use case-insensitive matching
+            search_text = text if claim_type == "file_created" else text.lower()
+            matches = re.finditer(pattern, search_text, re.IGNORECASE | re.MULTILINE)
+
+            for match in matches:
+                # Extract the matched claim text
+                claim_text = match.group(0)
+
+                # Extract any captured value (e.g., file path)
+                extracted_value = None
+                if match.groups():
+                    extracted_value = match.group(1)
+
+                # Avoid duplicate claims of the same type with same value
+                existing = [c for c in claims if c.claim_type == claim_type]
+                if claim_type == "file_created":
+                    # For files, check if extracted value already captured
+                    if extracted_value and any(c.extracted_value == extracted_value for c in existing):
+                        continue
+                else:
+                    # For other claims, just check we don't have the same type already
+                    if existing:
+                        continue
+
+                claims.append(Claim(
+                    claim_type=claim_type,
+                    claim_text=claim_text,
+                    confidence=confidence,
+                    extracted_value=extracted_value
+                ))
+
+    return claims
+
+
+def extract_file_paths(text: str) -> list[str]:
+    """
+    Extract file paths mentioned in text.
+
+    Args:
+        text: Text to search for file paths
+
+    Returns:
+        List of file paths found
+    """
+    paths = []
+
+    # Match paths in backticks or quotes
+    quoted_patterns = [
+        r'`([^\s`]+\.[a-zA-Z0-9]+)`',
+        r'"([^\s"]+\.[a-zA-Z0-9]+)"',
+        r"'([^\s']+\.[a-zA-Z0-9]+)'",
+    ]
+
+    for pattern in quoted_patterns:
+        matches = re.findall(pattern, text)
+        paths.extend(matches)
+
+    # Match Unix-style paths
+    unix_pattern = r'(?:^|[\s(])(/[^\s:,)]+\.[a-zA-Z0-9]+)'
+    paths.extend(re.findall(unix_pattern, text))
+
+    # Match relative paths
+    relative_pattern = r'(?:^|[\s(])(\./[^\s:,)]+\.[a-zA-Z0-9]+)'
+    paths.extend(re.findall(relative_pattern, text))
+
+    # Remove duplicates while preserving order
+    seen = set()
+    unique_paths = []
+    for path in paths:
+        if path not in seen:
+            seen.add(path)
+            unique_paths.append(path)
+
+    return unique_paths
+
+
+def get_claim_summary(claims: list[Claim]) -> dict[str, list[str]]:
+    """
+    Summarize claims by type.
+
+    Args:
+        claims: List of Claim objects
+
+    Returns:
+        Dictionary mapping claim types to extracted values or claim texts
+    """
+    summary: dict[str, list[str]] = {}
+
+    for claim in claims:
+        if claim.claim_type not in summary:
+            summary[claim.claim_type] = []
+
+        value = claim.extracted_value or claim.claim_text
+        if value not in summary[claim.claim_type]:
+            summary[claim.claim_type].append(value)
+
+    return summary

--- a/plugins/verify-claims/scripts/track_tool_use.py
+++ b/plugins/verify-claims/scripts/track_tool_use.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+PostToolUse hook handler for tracking file writes and command executions.
+
+This runs after Write, Edit, and Bash tool uses to maintain state about
+what files have been created and what commands have been run.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+# Add scripts directory to path for imports
+script_dir = Path(__file__).parent
+sys.path.insert(0, str(script_dir))
+
+from utils.logger import get_logger  # noqa: E402
+from utils.state import SessionState  # noqa: E402
+
+
+def read_hook_input() -> dict[str, Any]:
+    """Read the hook input from stdin."""
+    try:
+        input_data = sys.stdin.read()
+        if not input_data:
+            return {}
+        return json.loads(input_data)
+    except json.JSONDecodeError:
+        return {}
+
+
+def is_test_command(command: str) -> bool:
+    """Check if a command is running tests."""
+    test_patterns = [
+        r'\bnpm\s+test\b',
+        r'\bnpm\s+run\s+test',
+        r'\byarn\s+test\b',
+        r'\bpytest\b',
+        r'\bpython\s+-m\s+pytest\b',
+        r'\bcargo\s+test\b',
+        r'\bgo\s+test\b',
+        r'\brspec\b',
+        r'\bmocha\b',
+        r'\bjest\b',
+        r'\bvitest\b',
+    ]
+    command_lower = command.lower()
+    return any(re.search(p, command_lower) for p in test_patterns)
+
+
+def is_lint_command(command: str) -> bool:
+    """Check if a command is running a linter."""
+    lint_patterns = [
+        r'\bnpm\s+run\s+lint\b',
+        r'\byarn\s+lint\b',
+        r'\beslint\b',
+        r'\bruff\s+check\b',
+        r'\bpylint\b',
+        r'\bflake8\b',
+        r'\bmypy\b',
+        r'\bcargo\s+clippy\b',
+        r'\bgolangci-lint\b',
+        r'\brubocop\b',
+    ]
+    command_lower = command.lower()
+    return any(re.search(p, command_lower) for p in lint_patterns)
+
+
+def is_build_command(command: str) -> bool:
+    """Check if a command is building the project."""
+    build_patterns = [
+        r'\bnpm\s+run\s+build\b',
+        r'\byarn\s+build\b',
+        r'\bcargo\s+build\b',
+        r'\bgo\s+build\b',
+        r'\bmake\b',
+        r'\bmvn\s+compile\b',
+        r'\bgradle\s+build\b',
+        r'\btsc\b',
+        r'\bwebpack\b',
+        r'\bvite\s+build\b',
+    ]
+    command_lower = command.lower()
+    return any(re.search(p, command_lower) for p in build_patterns)
+
+
+def main() -> int:
+    """Main entry point for the track_tool_use hook."""
+    # Read hook input
+    hook_input = read_hook_input()
+
+    # Extract fields
+    session_id = hook_input.get("session_id", "unknown")
+    tool_name = hook_input.get("tool_name", "")
+    tool_input = hook_input.get("tool_input", {})
+    tool_output = hook_input.get("tool_output", {})
+
+    logger = get_logger(debug=False)
+
+    # Initialize session state
+    state = SessionState(session_id)
+
+    try:
+        if tool_name in ("Write", "Edit"):
+            # Track file operations
+            file_path = tool_input.get("file_path", "")
+            if file_path:
+                state.add_file_written(file_path, tool_name)
+                logger.debug(f"Tracked file write: {file_path}")
+
+        elif tool_name == "Bash":
+            # Track command executions
+            command = tool_input.get("command", "")
+            if command:
+                # Get exit code from output if available
+                exit_code = 0
+                if isinstance(tool_output, dict):
+                    exit_code = tool_output.get("exit_code", 0)
+                elif isinstance(tool_output, str):
+                    # Try to extract exit code from output string
+                    if "exit code" in tool_output.lower():
+                        try:
+                            match = re.search(r'exit code[:\s]+(\d+)', tool_output.lower())
+                            if match:
+                                exit_code = int(match.group(1))
+                        except (ValueError, AttributeError):
+                            pass
+
+                state.add_command_run(
+                    command=command,
+                    exit_code=exit_code,
+                    is_test=is_test_command(command),
+                    is_lint=is_lint_command(command),
+                    is_build=is_build_command(command)
+                )
+                logger.debug(f"Tracked command: {command[:50]}...")
+
+    except Exception as e:
+        logger.error(f"Error tracking tool use: {str(e)}")
+
+    # Always return success - tracking should never block tools
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/verify-claims/scripts/transcript_reader.py
+++ b/plugins/verify-claims/scripts/transcript_reader.py
@@ -1,0 +1,119 @@
+"""Read and parse Claude Code transcript JSONL files."""
+
+import json
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+
+
+def read_transcript(transcript_path: str) -> Generator[dict[str, Any], None, None]:
+    """
+    Read a transcript JSONL file and yield each message.
+
+    Args:
+        transcript_path: Path to the JSONL transcript file
+
+    Yields:
+        Dict representing each message in the transcript
+    """
+    path = Path(transcript_path)
+    if not path.exists():
+        return
+
+    with open(path, encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+def get_last_assistant_messages(transcript_path: str, count: int = 3) -> list[dict[str, Any]]:
+    """
+    Get the last N assistant messages from the transcript.
+
+    Args:
+        transcript_path: Path to the JSONL transcript file
+        count: Number of messages to retrieve
+
+    Returns:
+        List of assistant messages (most recent last)
+    """
+    assistant_messages = []
+
+    for message in read_transcript(transcript_path):
+        if message.get("type") == "assistant":
+            assistant_messages.append(message)
+
+    # Return last N messages
+    return assistant_messages[-count:] if len(assistant_messages) >= count else assistant_messages
+
+
+def extract_assistant_text(message: dict[str, Any]) -> str:
+    """
+    Extract text content from an assistant message.
+
+    Handles various message formats:
+    - Direct text content
+    - Content blocks with text type
+    - Nested message structures
+
+    Args:
+        message: Assistant message dictionary
+
+    Returns:
+        Combined text content from the message
+    """
+    text_parts = []
+
+    # Direct message field
+    if "message" in message:
+        msg = message["message"]
+        if isinstance(msg, str):
+            text_parts.append(msg)
+        elif isinstance(msg, dict):
+            # Check for content field
+            content = msg.get("content", [])
+            if isinstance(content, str):
+                text_parts.append(content)
+            elif isinstance(content, list):
+                for block in content:
+                    if isinstance(block, str):
+                        text_parts.append(block)
+                    elif isinstance(block, dict):
+                        if block.get("type") == "text":
+                            text_parts.append(block.get("text", ""))
+
+    # Direct content field
+    if "content" in message:
+        content = message["content"]
+        if isinstance(content, str):
+            text_parts.append(content)
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, str):
+                    text_parts.append(block)
+                elif isinstance(block, dict):
+                    if block.get("type") == "text":
+                        text_parts.append(block.get("text", ""))
+
+    return "\n".join(text_parts)
+
+
+def get_recent_assistant_text(transcript_path: str, message_count: int = 3) -> str:
+    """
+    Get combined text from the last N assistant messages.
+
+    Args:
+        transcript_path: Path to the JSONL transcript file
+        message_count: Number of recent messages to combine
+
+    Returns:
+        Combined text from recent assistant messages
+    """
+    messages = get_last_assistant_messages(transcript_path, message_count)
+    texts = [extract_assistant_text(msg) for msg in messages]
+    return "\n\n".join(texts)

--- a/plugins/verify-claims/scripts/utils/__init__.py
+++ b/plugins/verify-claims/scripts/utils/__init__.py
@@ -1,0 +1,6 @@
+# verify-claims utilities
+from .config import get_config_value, load_config
+from .logger import get_logger
+from .state import SessionState
+
+__all__ = ['load_config', 'get_config_value', 'SessionState', 'get_logger']

--- a/plugins/verify-claims/scripts/utils/config.py
+++ b/plugins/verify-claims/scripts/utils/config.py
@@ -1,0 +1,61 @@
+"""Configuration loading with project override support."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_config(cwd: str, plugin_root: str | None = None) -> dict[str, Any]:
+    """
+    Load configuration with project overrides.
+
+    Priority:
+    1. Project config: {cwd}/.claude/verify-claims.json
+    2. Default config: {plugin_root}/config/default_config.json
+    """
+    config = {}
+
+    # Load default config
+    if plugin_root:
+        default_path = Path(plugin_root) / "config" / "default_config.json"
+    else:
+        default_path = Path(__file__).parent.parent.parent / "config" / "default_config.json"
+
+    if default_path.exists():
+        with open(default_path) as f:
+            config = json.load(f)
+
+    # Load project overrides
+    project_config_path = Path(cwd) / ".claude" / "verify-claims.json"
+    if project_config_path.exists():
+        with open(project_config_path) as f:
+            project_config = json.load(f)
+        config = deep_merge(config, project_config)
+
+    return config
+
+
+def deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Deep merge override into base config."""
+    result = base.copy()
+
+    for key, value in override.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = deep_merge(result[key], value)
+        else:
+            result[key] = value
+
+    return result
+
+
+def get_config_value(config: dict[str, Any], *keys: str, default: Any = None) -> Any:
+    """Get nested config value with dot-path support."""
+    current = config
+
+    for key in keys:
+        if isinstance(current, dict) and key in current:
+            current = current[key]
+        else:
+            return default
+
+    return current

--- a/plugins/verify-claims/scripts/utils/logger.py
+++ b/plugins/verify-claims/scripts/utils/logger.py
@@ -1,0 +1,71 @@
+"""Debug logging for verify-claims plugin."""
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+class Logger:
+    """Simple logger that writes to stderr and optionally to a file."""
+
+    LOG_DIR = Path.home() / ".claude" / "logs"
+    LOG_FILE = "verify_claims.log"
+
+    def __init__(self, debug: bool = False, log_to_file: bool = True):
+        self.debug_enabled = debug
+        self.log_to_file = log_to_file
+        self._log_file_handle = None
+
+    def _get_timestamp(self) -> str:
+        return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    def _write(self, level: str, message: str) -> None:
+        """Write log message to stderr and optionally to file."""
+        formatted = f"[{self._get_timestamp()}] [{level}] {message}"
+
+        # Always write errors to stderr
+        if level == "ERROR":
+            print(formatted, file=sys.stderr)
+        elif self.debug_enabled:
+            print(formatted, file=sys.stderr)
+
+        # Write to log file if enabled
+        if self.log_to_file:
+            try:
+                self.LOG_DIR.mkdir(parents=True, exist_ok=True)
+                log_path = self.LOG_DIR / self.LOG_FILE
+                with open(log_path, 'a') as f:
+                    f.write(formatted + "\n")
+            except OSError:
+                pass
+
+    def debug(self, message: str) -> None:
+        """Log debug message (only if debug is enabled)."""
+        if self.debug_enabled:
+            self._write("DEBUG", message)
+
+    def info(self, message: str) -> None:
+        """Log info message."""
+        self._write("INFO", message)
+
+    def warning(self, message: str) -> None:
+        """Log warning message."""
+        self._write("WARN", message)
+
+    def error(self, message: str) -> None:
+        """Log error message."""
+        self._write("ERROR", message)
+
+
+# Global logger instance
+_logger: Logger | None = None
+
+
+def get_logger(debug: bool = False) -> Logger:
+    """Get or create the global logger instance."""
+    global _logger
+    if _logger is None:
+        _logger = Logger(debug=debug)
+    elif debug and not _logger.debug_enabled:
+        _logger.debug_enabled = True
+    return _logger

--- a/plugins/verify-claims/scripts/utils/state.py
+++ b/plugins/verify-claims/scripts/utils/state.py
@@ -1,0 +1,170 @@
+"""Session state management for tracking tool use and verification results."""
+
+import json
+import os
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class ToolUseRecord:
+    """Record of a tool use during the session."""
+    tool_name: str
+    timestamp: float
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class VerificationResult:
+    """Result of a claim verification."""
+    claim_type: str
+    claim_text: str
+    passed: bool
+    message: str
+    timestamp: float
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+class SessionState:
+    """Manages session-scoped state for verification tracking."""
+
+    STATE_DIR = Path.home() / ".claude"
+    STATE_PREFIX = "verify_claims_state_"
+
+    def __init__(self, session_id: str):
+        self.session_id = session_id
+        self.state_file = self.STATE_DIR / f"{self.STATE_PREFIX}{session_id}.json"
+        self._state = self._load_or_create()
+
+    def _load_or_create(self) -> dict[str, Any]:
+        """Load existing state or create new."""
+        if self.state_file.exists():
+            try:
+                with open(self.state_file) as f:
+                    return json.load(f)
+            except (json.JSONDecodeError, OSError):
+                pass
+
+        return {
+            "session_id": self.session_id,
+            "created_at": time.time(),
+            "files_written": [],
+            "commands_run": [],
+            "verification_results": [],
+            "verification_count": 0,
+            "stop_hook_active": False
+        }
+
+    def _save(self) -> None:
+        """Save state to file."""
+        self.STATE_DIR.mkdir(parents=True, exist_ok=True)
+        with open(self.state_file, 'w') as f:
+            json.dump(self._state, f, indent=2)
+
+    @property
+    def stop_hook_active(self) -> bool:
+        """Check if stop hook is currently active (prevents infinite loops)."""
+        return self._state.get("stop_hook_active", False)
+
+    @stop_hook_active.setter
+    def stop_hook_active(self, value: bool) -> None:
+        self._state["stop_hook_active"] = value
+        self._save()
+
+    @property
+    def verification_count(self) -> int:
+        """Number of verification attempts this session."""
+        return self._state.get("verification_count", 0)
+
+    def increment_verification_count(self) -> int:
+        """Increment and return the new verification count."""
+        self._state["verification_count"] = self.verification_count + 1
+        self._save()
+        return self._state["verification_count"]
+
+    def add_file_written(self, file_path: str, tool_name: str) -> None:
+        """Track a file that was written."""
+        self._state["files_written"].append({
+            "path": file_path,
+            "tool": tool_name,
+            "timestamp": time.time()
+        })
+        self._save()
+
+    def add_command_run(self, command: str, exit_code: int, is_test: bool = False,
+                        is_lint: bool = False, is_build: bool = False) -> None:
+        """Track a command that was run."""
+        self._state["commands_run"].append({
+            "command": command,
+            "exit_code": exit_code,
+            "is_test": is_test,
+            "is_lint": is_lint,
+            "is_build": is_build,
+            "timestamp": time.time()
+        })
+        self._save()
+
+    def add_verification_result(self, result: VerificationResult) -> None:
+        """Add a verification result."""
+        self._state["verification_results"].append(asdict(result))
+        self._save()
+
+    def get_files_written(self) -> list[dict[str, Any]]:
+        """Get all files written this session."""
+        return self._state.get("files_written", [])
+
+    def get_commands_run(self) -> list[dict[str, Any]]:
+        """Get all commands run this session."""
+        return self._state.get("commands_run", [])
+
+    def was_file_written(self, file_path: str) -> bool:
+        """Check if a file was written during this session."""
+        abs_path = os.path.abspath(file_path)
+        for record in self._state.get("files_written", []):
+            if os.path.abspath(record["path"]) == abs_path:
+                return True
+        return False
+
+    def last_test_passed(self) -> bool | None:
+        """Check if the last test command passed."""
+        for cmd in reversed(self._state.get("commands_run", [])):
+            if cmd.get("is_test"):
+                return cmd.get("exit_code") == 0
+        return None
+
+    def last_lint_passed(self) -> bool | None:
+        """Check if the last lint command passed."""
+        for cmd in reversed(self._state.get("commands_run", [])):
+            if cmd.get("is_lint"):
+                return cmd.get("exit_code") == 0
+        return None
+
+    def last_build_passed(self) -> bool | None:
+        """Check if the last build command passed."""
+        for cmd in reversed(self._state.get("commands_run", [])):
+            if cmd.get("is_build"):
+                return cmd.get("exit_code") == 0
+        return None
+
+    @classmethod
+    def cleanup_old_states(cls, max_age_days: int = 30) -> int:
+        """Remove state files older than max_age_days. Returns count removed."""
+        removed = 0
+        max_age_seconds = max_age_days * 24 * 60 * 60
+        now = time.time()
+
+        if not cls.STATE_DIR.exists():
+            return 0
+
+        for state_file in cls.STATE_DIR.glob(f"{cls.STATE_PREFIX}*.json"):
+            try:
+                mtime = state_file.stat().st_mtime
+                if now - mtime > max_age_seconds:
+                    state_file.unlink()
+                    removed += 1
+            except OSError:
+                pass
+
+        return removed

--- a/plugins/verify-claims/scripts/verifiers/__init__.py
+++ b/plugins/verify-claims/scripts/verifiers/__init__.py
@@ -1,0 +1,73 @@
+"""Verifiers for different claim types."""
+
+from typing import Any
+
+from .base import VerificationResult
+from .build_checker import verify_build_success
+from .file_exists import verify_file_exists
+from .git_diff import verify_changes_made
+from .lint_checker import verify_lint_clean
+from .test_runner import verify_tests_pass
+
+# Map claim types to verifier functions
+VERIFIERS = {
+    "file_created": verify_file_exists,
+    "tests_pass": verify_tests_pass,
+    "lint_clean": verify_lint_clean,
+    "build_success": verify_build_success,
+    "bug_fixed": verify_changes_made,
+}
+
+
+def verify_claim(claim_type: str, claim_value: str | None,
+                 cwd: str, config: dict[str, Any]) -> VerificationResult:
+    """
+    Verify a claim using the appropriate verifier.
+
+    Args:
+        claim_type: Type of claim (e.g., "file_created", "tests_pass")
+        claim_value: Extracted value from claim (e.g., file path)
+        cwd: Current working directory
+        config: Plugin configuration
+
+    Returns:
+        VerificationResult with pass/fail status and details
+    """
+    verifier = VERIFIERS.get(claim_type)
+
+    if verifier is None:
+        return VerificationResult(
+            passed=True,
+            message=f"No verifier for claim type: {claim_type}",
+            details={"skipped": True}
+        )
+
+    verifier_config = config.get("verifiers", {}).get(claim_type, {})
+
+    if not verifier_config.get("enabled", True):
+        return VerificationResult(
+            passed=True,
+            message=f"Verifier disabled for: {claim_type}",
+            details={"skipped": True, "reason": "disabled"}
+        )
+
+    try:
+        return verifier(claim_value, cwd, verifier_config)
+    except Exception as e:
+        return VerificationResult(
+            passed=False,
+            message=f"Verification error: {str(e)}",
+            details={"error": str(e), "claim_type": claim_type}
+        )
+
+
+__all__ = [
+    'VerificationResult',
+    'VERIFIERS',
+    'verify_claim',
+    'verify_file_exists',
+    'verify_tests_pass',
+    'verify_lint_clean',
+    'verify_build_success',
+    'verify_changes_made',
+]

--- a/plugins/verify-claims/scripts/verifiers/base.py
+++ b/plugins/verify-claims/scripts/verifiers/base.py
@@ -1,0 +1,12 @@
+"""Base types for verifiers."""
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class VerificationResult:
+    """Result of a verification check."""
+    passed: bool
+    message: str
+    details: dict[str, Any]

--- a/plugins/verify-claims/scripts/verifiers/build_checker.py
+++ b/plugins/verify-claims/scripts/verifiers/build_checker.py
@@ -1,0 +1,148 @@
+"""Verify build success claims by running builds."""
+
+import shlex
+import subprocess
+from typing import Any
+
+from .base import VerificationResult
+from .command_detection import file_exists, read_package_json
+
+
+def detect_build_command(cwd: str) -> tuple[str, str] | None:
+    """
+    Detect the appropriate build command for the project.
+
+    Args:
+        cwd: Current working directory
+
+    Returns:
+        Tuple of (command, build_tool_name) or None if not detected
+    """
+    # Node.js/npm projects
+    pkg = read_package_json(cwd)
+    if pkg:
+        scripts = pkg.get("scripts", {})
+        if "build" in scripts:
+            return ("npm run build", "npm")
+        if "compile" in scripts:
+            return ("npm run compile", "npm")
+
+    # TypeScript projects
+    if file_exists(cwd, "tsconfig.json"):
+        return ("npx tsc --noEmit", "typescript")
+
+    # Rust projects
+    if file_exists(cwd, "Cargo.toml"):
+        return ("cargo build", "cargo")
+
+    # Go projects
+    if file_exists(cwd, "go.mod"):
+        return ("go build ./...", "go")
+
+    # Java/Maven projects
+    if file_exists(cwd, "pom.xml"):
+        return ("mvn compile", "maven")
+
+    # Java/Gradle projects
+    if file_exists(cwd, "build.gradle", "build.gradle.kts"):
+        return ("./gradlew build", "gradle")
+
+    # Make projects
+    if file_exists(cwd, "Makefile"):
+        return ("make", "make")
+
+    # CMake projects
+    if file_exists(cwd, "CMakeLists.txt"):
+        return ("cmake --build .", "cmake")
+
+    return None
+
+
+def verify_build_success(claim_value: str | None, cwd: str,
+                         config: dict[str, Any]) -> VerificationResult:
+    """
+    Verify that the project builds successfully.
+
+    Args:
+        claim_value: Not used for build verification
+        cwd: Current working directory
+        config: Verifier configuration
+
+    Returns:
+        VerificationResult indicating if build succeeds
+    """
+    timeout = config.get("timeout", 120)
+    custom_command = config.get("command")
+
+    # Use custom command if specified
+    if custom_command:
+        build_command = custom_command
+        build_tool = "custom"
+    else:
+        # Auto-detect build command
+        detected = detect_build_command(cwd)
+        if detected is None:
+            return VerificationResult(
+                passed=True,
+                message="No build system detected, skipping verification",
+                details={"skipped": True, "reason": "no_build_system"}
+            )
+        build_command, build_tool = detected
+
+    try:
+        result = subprocess.run(
+            shlex.split(build_command),
+            shell=False,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout
+        )
+
+        if result.returncode == 0:
+            return VerificationResult(
+                passed=True,
+                message=f"Build succeeded ({build_tool})",
+                details={
+                    "command": build_command,
+                    "build_tool": build_tool,
+                    "exit_code": result.returncode
+                }
+            )
+        else:
+            # Extract build errors
+            output = result.stdout + result.stderr
+            output_tail = output[-1500:] if output else "No output"
+
+            return VerificationResult(
+                passed=False,
+                message=f"Build failed ({build_tool})",
+                details={
+                    "command": build_command,
+                    "build_tool": build_tool,
+                    "exit_code": result.returncode,
+                    "output_tail": output_tail
+                }
+            )
+
+    except subprocess.TimeoutExpired:
+        return VerificationResult(
+            passed=False,
+            message=f"Build timed out after {timeout}s",
+            details={
+                "command": build_command,
+                "build_tool": build_tool,
+                "timeout": timeout,
+                "error": "timeout"
+            }
+        )
+    except Exception as e:
+        return VerificationResult(
+            passed=False,
+            message=f"Failed to run build: {str(e)}",
+            details={
+                "command": build_command,
+                "build_tool": build_tool,
+                "error": str(e)
+            }
+        )

--- a/plugins/verify-claims/scripts/verifiers/command_detection.py
+++ b/plugins/verify-claims/scripts/verifiers/command_detection.py
@@ -1,0 +1,113 @@
+"""Shared command detection utilities for verifiers."""
+
+import json
+import os
+from typing import Any
+
+
+def read_package_json(cwd: str) -> dict[str, Any] | None:
+    """
+    Read and parse package.json if it exists.
+
+    Args:
+        cwd: Current working directory
+
+    Returns:
+        Parsed package.json contents or None
+    """
+    pkg_json = os.path.join(cwd, "package.json")
+    if os.path.exists(pkg_json):
+        try:
+            with open(pkg_json) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError):
+            pass
+    return None
+
+
+def read_pyproject_toml(cwd: str) -> str | None:
+    """
+    Read pyproject.toml contents if it exists.
+
+    Args:
+        cwd: Current working directory
+
+    Returns:
+        File contents as string or None
+    """
+    pyproject = os.path.join(cwd, "pyproject.toml")
+    if os.path.exists(pyproject):
+        try:
+            with open(pyproject) as f:
+                return f.read()
+        except OSError:
+            pass
+    return None
+
+
+def file_exists(cwd: str, *paths: str) -> bool:
+    """
+    Check if any of the given paths exist.
+
+    Args:
+        cwd: Current working directory
+        paths: Relative paths to check
+
+    Returns:
+        True if any path exists
+    """
+    return any(os.path.exists(os.path.join(cwd, p)) for p in paths)
+
+
+def detect_npm_script(cwd: str, *script_names: str) -> tuple[str, str] | None:
+    """
+    Detect an npm script from package.json.
+
+    Args:
+        cwd: Current working directory
+        script_names: Script names to look for (in priority order)
+
+    Returns:
+        Tuple of (npm command, "npm") or None
+    """
+    pkg = read_package_json(cwd)
+    if pkg:
+        scripts = pkg.get("scripts", {})
+        for name in script_names:
+            if name in scripts:
+                if name == "test" or name == "lint" or name == "build":
+                    return (f"npm {name}" if name in ("test",) else f"npm run {name}", "npm")
+                return (f"npm run {name}", "npm")
+    return None
+
+
+# Common project file detectors
+PROJECT_MARKERS = {
+    "npm": ["package.json"],
+    "python": ["pyproject.toml", "setup.py", "pytest.ini"],
+    "rust": ["Cargo.toml"],
+    "go": ["go.mod"],
+    "ruby": ["Gemfile"],
+    "java_maven": ["pom.xml"],
+    "java_gradle": ["build.gradle", "build.gradle.kts"],
+    "make": ["Makefile"],
+    "cmake": ["CMakeLists.txt"],
+    "typescript": ["tsconfig.json"],
+}
+
+
+def detect_project_type(cwd: str) -> list[str]:
+    """
+    Detect project types based on marker files.
+
+    Args:
+        cwd: Current working directory
+
+    Returns:
+        List of detected project types
+    """
+    detected = []
+    for project_type, markers in PROJECT_MARKERS.items():
+        if file_exists(cwd, *markers):
+            detected.append(project_type)
+    return detected

--- a/plugins/verify-claims/scripts/verifiers/file_exists.py
+++ b/plugins/verify-claims/scripts/verifiers/file_exists.py
@@ -1,0 +1,74 @@
+"""Verify file creation claims."""
+
+import os
+from typing import Any
+
+from .base import VerificationResult
+
+
+def verify_file_exists(file_path: str | None, cwd: str,
+                       config: dict[str, Any]) -> VerificationResult:
+    """
+    Verify that a claimed file was actually created.
+
+    Args:
+        file_path: Path to the file (relative or absolute)
+        cwd: Current working directory
+        config: Verifier configuration
+
+    Returns:
+        VerificationResult indicating if the file exists
+    """
+    if not file_path:
+        return VerificationResult(
+            passed=False,
+            message="No file path provided to verify",
+            details={"error": "missing_path"}
+        )
+
+    # Resolve relative paths
+    if not os.path.isabs(file_path):
+        full_path = os.path.join(cwd, file_path)
+    else:
+        full_path = file_path
+
+    # Normalize the path
+    full_path = os.path.normpath(full_path)
+
+    if os.path.exists(full_path):
+        # Check if it's a file (not a directory)
+        if os.path.isfile(full_path):
+            # Get file size for additional verification
+            size = os.path.getsize(full_path)
+            return VerificationResult(
+                passed=True,
+                message=f"File exists: {file_path}",
+                details={
+                    "path": full_path,
+                    "size": size,
+                    "is_file": True
+                }
+            )
+        else:
+            return VerificationResult(
+                passed=False,
+                message=f"Path exists but is not a file: {file_path}",
+                details={
+                    "path": full_path,
+                    "is_directory": os.path.isdir(full_path)
+                }
+            )
+    else:
+        # Check if parent directory exists (helps diagnose issues)
+        parent = os.path.dirname(full_path)
+        parent_exists = os.path.exists(parent)
+
+        return VerificationResult(
+            passed=False,
+            message=f"File does not exist: {file_path}",
+            details={
+                "path": full_path,
+                "parent_exists": parent_exists,
+                "cwd": cwd
+            }
+        )

--- a/plugins/verify-claims/scripts/verifiers/git_diff.py
+++ b/plugins/verify-claims/scripts/verifiers/git_diff.py
@@ -1,0 +1,146 @@
+"""Verify bug fix/change claims by checking git status."""
+
+import os
+import subprocess
+from typing import Any
+
+from .base import VerificationResult
+
+
+def verify_changes_made(claim_value: str | None, cwd: str,
+                        config: dict[str, Any]) -> VerificationResult:
+    """
+    Verify that changes were made to the codebase (for bug fix claims).
+
+    This checks that there are actual code changes that could constitute a fix.
+
+    Args:
+        claim_value: Not used for this verification
+        cwd: Current working directory
+        config: Verifier configuration
+
+    Returns:
+        VerificationResult indicating if changes were made
+    """
+    # Check if this is a git repository
+    git_dir = os.path.join(cwd, ".git")
+    if not os.path.exists(git_dir):
+        return VerificationResult(
+            passed=True,
+            message="Not a git repository, skipping change verification",
+            details={"skipped": True, "reason": "not_git_repo"}
+        )
+
+    try:
+        # Check for staged changes
+        staged_result = subprocess.run(
+            ["git", "diff", "--cached", "--name-only"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+        staged_files = [f for f in staged_result.stdout.strip().split('\n') if f]
+
+        # Check for unstaged changes
+        unstaged_result = subprocess.run(
+            ["git", "diff", "--name-only"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+        unstaged_files = [f for f in unstaged_result.stdout.strip().split('\n') if f]
+
+        # Check for untracked files (new files)
+        untracked_result = subprocess.run(
+            ["git", "ls-files", "--others", "--exclude-standard"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+        untracked_files = [f for f in untracked_result.stdout.strip().split('\n') if f]
+
+        # Filter to code files only
+        code_extensions = {'.py', '.js', '.ts', '.tsx', '.jsx', '.rs', '.go',
+                          '.java', '.c', '.cpp', '.h', '.hpp', '.rb', '.php',
+                          '.swift', '.kt', '.scala', '.vue', '.svelte'}
+
+        def is_code_file(f):
+            _, ext = os.path.splitext(f)
+            return ext.lower() in code_extensions
+
+        code_staged = [f for f in staged_files if is_code_file(f)]
+        code_unstaged = [f for f in unstaged_files if is_code_file(f)]
+        code_untracked = [f for f in untracked_files if is_code_file(f)]
+
+        all_code_changes = code_staged + code_unstaged + code_untracked
+        total_changes = len(staged_files) + len(unstaged_files) + len(untracked_files)
+
+        if all_code_changes:
+            return VerificationResult(
+                passed=True,
+                message=f"Code changes detected: {len(all_code_changes)} file(s)",
+                details={
+                    "staged_files": code_staged,
+                    "unstaged_files": code_unstaged,
+                    "new_files": code_untracked,
+                    "total_code_changes": len(all_code_changes)
+                }
+            )
+        elif total_changes > 0:
+            # Changes exist but not in code files
+            return VerificationResult(
+                passed=True,
+                message=f"Changes detected (non-code): {total_changes} file(s)",
+                details={
+                    "staged_files": staged_files,
+                    "unstaged_files": unstaged_files,
+                    "untracked_files": untracked_files,
+                    "note": "No code files changed, but other files modified"
+                }
+            )
+        else:
+            # Check if there are recent commits
+            log_result = subprocess.run(
+                ["git", "log", "-1", "--format=%H", "--since=5 minutes ago"],
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                timeout=10
+            )
+
+            if log_result.stdout.strip():
+                return VerificationResult(
+                    passed=True,
+                    message="Recent commit found (changes already committed)",
+                    details={
+                        "commit": log_result.stdout.strip()[:8],
+                        "note": "Changes were likely already committed"
+                    }
+                )
+
+            return VerificationResult(
+                passed=False,
+                message="No code changes detected for bug fix claim",
+                details={
+                    "staged_files": staged_files,
+                    "unstaged_files": unstaged_files,
+                    "untracked_files": untracked_files,
+                    "note": "Expected code changes for a bug fix claim"
+                }
+            )
+
+    except subprocess.TimeoutExpired:
+        return VerificationResult(
+            passed=False,
+            message="Git command timed out",
+            details={"error": "timeout"}
+        )
+    except Exception as e:
+        return VerificationResult(
+            passed=False,
+            message=f"Failed to check git status: {str(e)}",
+            details={"error": str(e)}
+        )

--- a/plugins/verify-claims/scripts/verifiers/lint_checker.py
+++ b/plugins/verify-claims/scripts/verifiers/lint_checker.py
@@ -1,0 +1,151 @@
+"""Verify lint clean claims by running linters."""
+
+import shlex
+import subprocess
+from typing import Any
+
+from .base import VerificationResult
+from .command_detection import (
+    file_exists,
+    read_package_json,
+    read_pyproject_toml,
+)
+
+
+def detect_lint_command(cwd: str) -> tuple[str, str] | None:
+    """
+    Detect the appropriate lint command for the project.
+
+    Args:
+        cwd: Current working directory
+
+    Returns:
+        Tuple of (command, linter_name) or None if not detected
+    """
+    # Node.js/npm projects
+    pkg = read_package_json(cwd)
+    if pkg:
+        scripts = pkg.get("scripts", {})
+        if "lint" in scripts:
+            return ("npm run lint", "npm")
+        # Check for eslint config
+        if file_exists(cwd, ".eslintrc.js", ".eslintrc.json", "eslint.config.js"):
+            return ("npx eslint .", "eslint")
+
+    # Python projects with ruff
+    if file_exists(cwd, "ruff.toml", ".ruff.toml"):
+        return ("ruff check .", "ruff")
+
+    # Python projects - check pyproject.toml for tools
+    content = read_pyproject_toml(cwd)
+    if content:
+        if "[tool.ruff" in content:
+            return ("ruff check .", "ruff")
+        if "[tool.flake8" in content or "[tool.pylint" in content:
+            return ("flake8 .", "flake8")
+
+    # Python with pylint or flake8 config
+    if file_exists(cwd, ".pylintrc"):
+        return ("pylint **/*.py", "pylint")
+    if file_exists(cwd, ".flake8"):
+        return ("flake8", "flake8")
+
+    # Rust projects
+    if file_exists(cwd, "Cargo.toml"):
+        return ("cargo clippy -- -D warnings", "clippy")
+
+    # Go projects
+    if file_exists(cwd, "go.mod"):
+        return ("golangci-lint run", "golangci-lint")
+
+    return None
+
+
+def verify_lint_clean(claim_value: str | None, cwd: str,
+                      config: dict[str, Any]) -> VerificationResult:
+    """
+    Verify that linting passes with no errors.
+
+    Args:
+        claim_value: Not used for lint verification
+        cwd: Current working directory
+        config: Verifier configuration
+
+    Returns:
+        VerificationResult indicating if lint passes
+    """
+    timeout = config.get("timeout", 30)
+    custom_command = config.get("command")
+
+    # Use custom command if specified
+    if custom_command:
+        lint_command = custom_command
+        linter = "custom"
+    else:
+        # Auto-detect lint command
+        detected = detect_lint_command(cwd)
+        if detected is None:
+            return VerificationResult(
+                passed=True,
+                message="No linter detected, skipping verification",
+                details={"skipped": True, "reason": "no_linter"}
+            )
+        lint_command, linter = detected
+
+    try:
+        result = subprocess.run(
+            shlex.split(lint_command),
+            shell=False,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout
+        )
+
+        if result.returncode == 0:
+            return VerificationResult(
+                passed=True,
+                message=f"Lint passed ({linter})",
+                details={
+                    "command": lint_command,
+                    "linter": linter,
+                    "exit_code": result.returncode
+                }
+            )
+        else:
+            # Extract lint errors
+            output = result.stdout + result.stderr
+            output_tail = output[-1000:] if output else "No output"
+
+            return VerificationResult(
+                passed=False,
+                message=f"Lint errors found ({linter})",
+                details={
+                    "command": lint_command,
+                    "linter": linter,
+                    "exit_code": result.returncode,
+                    "output_tail": output_tail
+                }
+            )
+
+    except subprocess.TimeoutExpired:
+        return VerificationResult(
+            passed=False,
+            message=f"Lint check timed out after {timeout}s",
+            details={
+                "command": lint_command,
+                "linter": linter,
+                "timeout": timeout,
+                "error": "timeout"
+            }
+        )
+    except Exception as e:
+        return VerificationResult(
+            passed=False,
+            message=f"Failed to run linter: {str(e)}",
+            details={
+                "command": lint_command,
+                "linter": linter,
+                "error": str(e)
+            }
+        )

--- a/plugins/verify-claims/scripts/verifiers/test_runner.py
+++ b/plugins/verify-claims/scripts/verifiers/test_runner.py
@@ -1,0 +1,162 @@
+"""Verify test passing claims by running tests."""
+
+import shlex
+import subprocess
+from typing import Any
+
+from .base import VerificationResult
+from .command_detection import (
+    file_exists,
+    read_package_json,
+    read_pyproject_toml,
+)
+
+
+def detect_test_command(cwd: str) -> tuple[str, str] | None:
+    """
+    Detect the appropriate test command for the project.
+
+    Args:
+        cwd: Current working directory
+
+    Returns:
+        Tuple of (command, framework_name) or None if not detected
+    """
+    # Node.js/npm projects
+    pkg = read_package_json(cwd)
+    if pkg:
+        scripts = pkg.get("scripts", {})
+        if "test" in scripts:
+            return ("npm test", "npm")
+        if "test:unit" in scripts:
+            return ("npm run test:unit", "npm")
+
+    # Python projects
+    if file_exists(cwd, "pytest.ini", "pyproject.toml", "setup.py"):
+        # Check for pytest
+        if file_exists(cwd, "pytest.ini"):
+            return ("pytest", "pytest")
+        # Check pyproject.toml for pytest
+        content = read_pyproject_toml(cwd)
+        if content and ("pytest" in content or "[tool.pytest" in content):
+            return ("pytest", "pytest")
+        # Default to pytest if tests directory exists
+        if file_exists(cwd, "tests"):
+            return ("pytest", "pytest")
+
+    # Rust projects
+    if file_exists(cwd, "Cargo.toml"):
+        return ("cargo test", "cargo")
+
+    # Go projects
+    if file_exists(cwd, "go.mod"):
+        return ("go test ./...", "go")
+
+    # Ruby projects
+    if file_exists(cwd, "Gemfile"):
+        if file_exists(cwd, "spec"):
+            return ("bundle exec rspec", "rspec")
+        if file_exists(cwd, "test"):
+            return ("bundle exec rake test", "rake")
+
+    # Java/Maven projects
+    if file_exists(cwd, "pom.xml"):
+        return ("mvn test", "maven")
+
+    # Java/Gradle projects
+    if file_exists(cwd, "build.gradle", "build.gradle.kts"):
+        return ("./gradlew test", "gradle")
+
+    return None
+
+
+def verify_tests_pass(claim_value: str | None, cwd: str,
+                      config: dict[str, Any]) -> VerificationResult:
+    """
+    Verify that tests pass by running the test suite.
+
+    Args:
+        claim_value: Not used for test verification
+        cwd: Current working directory
+        config: Verifier configuration
+
+    Returns:
+        VerificationResult indicating if tests pass
+    """
+    timeout = config.get("timeout", 60)
+    custom_command = config.get("command")
+
+    # Use custom command if specified
+    if custom_command:
+        test_command = custom_command
+        framework = "custom"
+    else:
+        # Auto-detect test command
+        detected = detect_test_command(cwd)
+        if detected is None:
+            return VerificationResult(
+                passed=True,
+                message="No test framework detected, skipping verification",
+                details={"skipped": True, "reason": "no_test_framework"}
+            )
+        test_command, framework = detected
+
+    try:
+        result = subprocess.run(
+            shlex.split(test_command),
+            shell=False,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout
+        )
+
+        if result.returncode == 0:
+            return VerificationResult(
+                passed=True,
+                message=f"Tests passed ({framework})",
+                details={
+                    "command": test_command,
+                    "framework": framework,
+                    "exit_code": result.returncode,
+                    "stdout_tail": result.stdout[-500:] if result.stdout else ""
+                }
+            )
+        else:
+            # Extract relevant failure info
+            output = result.stdout + result.stderr
+            # Get last 1000 chars which usually contains failure summary
+            output_tail = output[-1000:] if output else "No output"
+
+            return VerificationResult(
+                passed=False,
+                message=f"Tests failed ({framework})",
+                details={
+                    "command": test_command,
+                    "framework": framework,
+                    "exit_code": result.returncode,
+                    "output_tail": output_tail
+                }
+            )
+
+    except subprocess.TimeoutExpired:
+        return VerificationResult(
+            passed=False,
+            message=f"Test run timed out after {timeout}s",
+            details={
+                "command": test_command,
+                "framework": framework,
+                "timeout": timeout,
+                "error": "timeout"
+            }
+        )
+    except Exception as e:
+        return VerificationResult(
+            passed=False,
+            message=f"Failed to run tests: {str(e)}",
+            details={
+                "command": test_command,
+                "framework": framework,
+                "error": str(e)
+            }
+        )

--- a/plugins/verify-claims/scripts/verify_claims.py
+++ b/plugins/verify-claims/scripts/verify_claims.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+Main Stop hook handler for verify-claims plugin.
+
+Intercepts completion attempts, parses claims from transcript,
+verifies them, and blocks completion if verification fails.
+"""
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+# Add scripts directory to path for imports
+script_dir = Path(__file__).parent
+sys.path.insert(0, str(script_dir))
+
+from claim_parser import parse_claims  # noqa: E402
+from transcript_reader import get_recent_assistant_text  # noqa: E402
+from utils.config import get_config_value, load_config  # noqa: E402
+from utils.logger import get_logger  # noqa: E402
+from utils.state import SessionState  # noqa: E402
+from utils.state import VerificationResult as StateVerificationResult  # noqa: E402
+from verifiers import verify_claim  # noqa: E402
+
+
+def read_hook_input() -> dict[str, Any]:
+    """Read the hook input from stdin."""
+    try:
+        input_data = sys.stdin.read()
+        if not input_data:
+            return {}
+        return json.loads(input_data)
+    except json.JSONDecodeError:
+        return {}
+
+
+def output_decision(decision: str, reason: str = "") -> None:
+    """Output the hook decision as JSON to stdout."""
+    result = {"decision": decision}
+    if reason:
+        result["reason"] = reason
+    print(json.dumps(result))
+
+
+def main() -> int:
+    """Main entry point for the verify_claims hook."""
+    # Read hook input
+    hook_input = read_hook_input()
+
+    # Extract required fields
+    session_id = hook_input.get("session_id", "unknown")
+    transcript_path = hook_input.get("transcript_path")
+    cwd = hook_input.get("cwd", os.getcwd())
+
+    # Get plugin root from environment
+    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT", str(script_dir.parent))
+
+    # Load configuration
+    config = load_config(cwd, plugin_root)
+    debug = config.get("debug", False)
+    logger = get_logger(debug)
+
+    logger.info(f"Verify-claims hook started for session: {session_id}")
+
+    # Initialize session state
+    state = SessionState(session_id)
+
+    # Cleanup old state files periodically
+    cleanup_days = get_config_value(config, "behavior", "cleanup_days", default=30)
+    SessionState.cleanup_old_states(cleanup_days)
+
+    # Prevent infinite loops - check if we're already in a verification
+    if state.stop_hook_active:
+        logger.warning("Stop hook already active, allowing to prevent loop")
+        return 0
+
+    # Check max retries
+    max_retries = get_config_value(config, "behavior", "max_retries", default=3)
+    if state.verification_count >= max_retries:
+        logger.warning(f"Max retries ({max_retries}) reached, allowing completion")
+        return 0
+
+    # Mark hook as active
+    state.stop_hook_active = True
+
+    try:
+        # Increment verification count
+        count = state.increment_verification_count()
+        logger.info(f"Verification attempt {count}/{max_retries}")
+
+        # Read transcript if available
+        if not transcript_path or not os.path.exists(transcript_path):
+            logger.warning("No transcript path provided or file doesn't exist")
+            return 0
+
+        # Get recent assistant text
+        assistant_text = get_recent_assistant_text(transcript_path, message_count=3)
+        if not assistant_text:
+            logger.info("No assistant text found in transcript")
+            return 0
+
+        # Parse claims from the text
+        confidence_threshold = get_config_value(
+            config, "behavior", "confidence_threshold", default=0.7
+        )
+        claims = parse_claims(assistant_text, confidence_threshold)
+
+        if not claims:
+            logger.info("No verifiable claims found")
+            return 0
+
+        logger.info(f"Found {len(claims)} claims to verify")
+
+        # Verify each claim
+        failed_claims: list[dict[str, Any]] = []
+        passed_claims: list[dict[str, Any]] = []
+
+        for claim in claims:
+            logger.debug(f"Verifying claim: {claim.claim_type} - {claim.claim_text}")
+
+            result = verify_claim(
+                claim.claim_type,
+                claim.extracted_value,
+                cwd,
+                config
+            )
+
+            # Record result in state
+            state.add_verification_result(StateVerificationResult(
+                claim_type=claim.claim_type,
+                claim_text=claim.claim_text,
+                passed=result.passed,
+                message=result.message,
+                timestamp=time.time(),
+                details=result.details
+            ))
+
+            if result.passed:
+                logger.info(f"✓ Claim verified: {claim.claim_type}")
+                passed_claims.append({
+                    "type": claim.claim_type,
+                    "text": claim.claim_text,
+                    "message": result.message
+                })
+            else:
+                # Check if verification was skipped (not a real failure)
+                if result.details.get("skipped"):
+                    logger.info(f"○ Claim skipped: {claim.claim_type} - {result.message}")
+                    passed_claims.append({
+                        "type": claim.claim_type,
+                        "text": claim.claim_text,
+                        "message": result.message,
+                        "skipped": True
+                    })
+                else:
+                    logger.warning(f"✗ Claim failed: {claim.claim_type} - {result.message}")
+                    failed_claims.append({
+                        "type": claim.claim_type,
+                        "text": claim.claim_text,
+                        "message": result.message,
+                        "details": result.details
+                    })
+
+        # Determine if we should block
+        block_on_failure = get_config_value(
+            config, "behavior", "block_on_failure", default=True
+        )
+
+        if failed_claims and block_on_failure:
+            # Build failure message
+            failure_summary = []
+            for fc in failed_claims:
+                failure_summary.append(f"- {fc['type']}: {fc['message']}")
+
+            reason = "Claim verification failed:\n" + "\n".join(failure_summary)
+
+            if passed_claims:
+                passed_summary = [f"- {pc['type']}: {pc['message']}" for pc in passed_claims]
+                reason += "\n\nPassed verifications:\n" + "\n".join(passed_summary)
+
+            logger.warning(f"Blocking completion: {len(failed_claims)} failed claims")
+            output_decision("block", reason)
+            return 0
+
+        # All claims passed or blocking disabled
+        if passed_claims:
+            logger.info(f"All {len(passed_claims)} claims verified successfully")
+
+        return 0
+
+    except Exception as e:
+        logger.error(f"Verification error: {str(e)}")
+        # Don't block on internal errors
+        return 0
+
+    finally:
+        # Always clear the active flag
+        state.stop_hook_active = False
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/verify-claims/tests/__init__.py
+++ b/plugins/verify-claims/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests for verify-claims plugin

--- a/plugins/verify-claims/tests/conftest.py
+++ b/plugins/verify-claims/tests/conftest.py
@@ -1,0 +1,140 @@
+"""Pytest configuration and shared fixtures."""
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Add scripts directory to path for imports
+scripts_dir = Path(__file__).parent.parent / "scripts"
+sys.path.insert(0, str(scripts_dir))
+
+
+@pytest.fixture
+def temp_dir():
+    """Create a temporary directory for tests."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield tmpdir
+
+
+@pytest.fixture
+def temp_project_dir(temp_dir):
+    """Create a temporary project directory with common files."""
+    project_dir = Path(temp_dir) / "test_project"
+    project_dir.mkdir()
+    return str(project_dir)
+
+
+@pytest.fixture
+def npm_project(temp_project_dir):
+    """Create a mock npm project."""
+    package_json = {
+        "name": "test-project",
+        "version": "1.0.0",
+        "scripts": {
+            "test": "jest",
+            "lint": "eslint .",
+            "build": "tsc"
+        }
+    }
+    pkg_path = Path(temp_project_dir) / "package.json"
+    with open(pkg_path, 'w') as f:
+        json.dump(package_json, f)
+    return temp_project_dir
+
+
+@pytest.fixture
+def python_project(temp_project_dir):
+    """Create a mock Python project with pytest."""
+    pyproject = """
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+"""
+    pyproject_path = Path(temp_project_dir) / "pyproject.toml"
+    with open(pyproject_path, 'w') as f:
+        f.write(pyproject)
+
+    tests_dir = Path(temp_project_dir) / "tests"
+    tests_dir.mkdir()
+    return temp_project_dir
+
+
+@pytest.fixture
+def rust_project(temp_project_dir):
+    """Create a mock Rust project."""
+    cargo_toml = """
+[package]
+name = "test_project"
+version = "0.1.0"
+edition = "2021"
+"""
+    cargo_path = Path(temp_project_dir) / "Cargo.toml"
+    with open(cargo_path, 'w') as f:
+        f.write(cargo_toml)
+    return temp_project_dir
+
+
+@pytest.fixture
+def go_project(temp_project_dir):
+    """Create a mock Go project."""
+    go_mod = "module example.com/test\n\ngo 1.21\n"
+    gomod_path = Path(temp_project_dir) / "go.mod"
+    with open(gomod_path, 'w') as f:
+        f.write(go_mod)
+    return temp_project_dir
+
+
+@pytest.fixture
+def sample_transcript(temp_dir):
+    """Create a sample transcript JSONL file."""
+    transcript_path = Path(temp_dir) / "transcript.jsonl"
+    messages = [
+        {"type": "user", "message": "Create a config file"},
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "I've created the config.json file for you."}
+                ]
+            }
+        },
+        {"type": "user", "message": "Run the tests"},
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "All tests pass now. The build succeeded."}
+                ]
+            }
+        }
+    ]
+    with open(transcript_path, 'w') as f:
+        for msg in messages:
+            f.write(json.dumps(msg) + "\n")
+    return str(transcript_path)
+
+
+@pytest.fixture
+def default_config():
+    """Return default plugin configuration."""
+    return {
+        "verifiers": {
+            "file_created": {"enabled": True},
+            "tests_pass": {"enabled": True, "timeout": 60},
+            "lint_clean": {"enabled": True, "timeout": 30},
+            "build_success": {"enabled": True, "timeout": 120},
+            "bug_fixed": {"enabled": True}
+        },
+        "behavior": {
+            "block_on_failure": True,
+            "max_retries": 3,
+            "confidence_threshold": 0.7,
+            "cleanup_days": 30
+        },
+        "debug": False
+    }

--- a/plugins/verify-claims/tests/test_claim_parser.py
+++ b/plugins/verify-claims/tests/test_claim_parser.py
@@ -1,0 +1,232 @@
+"""Tests for claim_parser.py"""
+
+from claim_parser import Claim, extract_file_paths, get_claim_summary, parse_claims
+
+
+class TestParseClaims:
+    """Tests for the parse_claims function."""
+
+    def test_parse_file_created_claim(self):
+        """Test parsing file creation claims."""
+        text = "I've created the config.json file for you."
+        claims = parse_claims(text, confidence_threshold=0.7)
+
+        assert len(claims) >= 1
+        file_claims = [c for c in claims if c.claim_type == "file_created"]
+        assert len(file_claims) == 1
+        assert file_claims[0].extracted_value == "config.json"
+
+    def test_parse_file_created_with_path(self):
+        """Test parsing file creation with full path."""
+        text = "I wrote the file src/components/Button.tsx"
+        claims = parse_claims(text, confidence_threshold=0.7)
+
+        file_claims = [c for c in claims if c.claim_type == "file_created"]
+        assert len(file_claims) == 1
+        assert "Button.tsx" in file_claims[0].extracted_value
+
+    def test_parse_tests_pass_claim(self):
+        """Test parsing test passing claims."""
+        text = "All tests pass now."
+        claims = parse_claims(text, confidence_threshold=0.7)
+
+        test_claims = [c for c in claims if c.claim_type == "tests_pass"]
+        assert len(test_claims) == 1
+
+    def test_parse_tests_pass_variations(self):
+        """Test various ways of expressing tests passing."""
+        test_cases = [
+            "Tests are now passing",
+            "All 42 tests passed",
+            "The tests completed successfully",
+            "Tests should now work",
+        ]
+
+        for text in test_cases:
+            claims = parse_claims(text, confidence_threshold=0.7)
+            test_claims = [c for c in claims if c.claim_type == "tests_pass"]
+            assert len(test_claims) >= 1, f"Failed for: {text}"
+
+    def test_parse_lint_clean_claim(self):
+        """Test parsing lint clean claims."""
+        text = "No lint errors found."
+        claims = parse_claims(text, confidence_threshold=0.7)
+
+        lint_claims = [c for c in claims if c.claim_type == "lint_clean"]
+        assert len(lint_claims) == 1
+
+    def test_parse_lint_clean_variations(self):
+        """Test various ways of expressing lint clean."""
+        test_cases = [
+            "Linting is now clean",
+            "No linting issues",
+            "All lint checks pass",
+            "ESLint shows no errors",
+        ]
+
+        for text in test_cases:
+            claims = parse_claims(text, confidence_threshold=0.7)
+            lint_claims = [c for c in claims if c.claim_type == "lint_clean"]
+            assert len(lint_claims) >= 1, f"Failed for: {text}"
+
+    def test_parse_build_success_claim(self):
+        """Test parsing build success claims."""
+        text = "Build succeeded."
+        claims = parse_claims(text, confidence_threshold=0.7)
+
+        build_claims = [c for c in claims if c.claim_type == "build_success"]
+        assert len(build_claims) == 1
+
+    def test_parse_build_success_variations(self):
+        """Test various ways of expressing build success."""
+        test_cases = [
+            "The project builds successfully",
+            "Build completed successfully",
+            "Compiled without errors",
+            "npm run build succeeded",
+        ]
+
+        for text in test_cases:
+            claims = parse_claims(text, confidence_threshold=0.7)
+            build_claims = [c for c in claims if c.claim_type == "build_success"]
+            assert len(build_claims) >= 1, f"Failed for: {text}"
+
+    def test_parse_bug_fixed_claim(self):
+        """Test parsing bug fix claims."""
+        text = "I've fixed the bug in the login handler."
+        claims = parse_claims(text, confidence_threshold=0.7)
+
+        fix_claims = [c for c in claims if c.claim_type == "bug_fixed"]
+        assert len(fix_claims) == 1
+
+    def test_parse_bug_fixed_variations(self):
+        """Test various ways of expressing bug fixes."""
+        test_cases = [
+            "Fixed the issue",
+            "The problem is now resolved",
+            "I've addressed the error",
+            "Bug is fixed",
+        ]
+
+        for text in test_cases:
+            claims = parse_claims(text, confidence_threshold=0.7)
+            fix_claims = [c for c in claims if c.claim_type == "bug_fixed"]
+            assert len(fix_claims) >= 1, f"Failed for: {text}"
+
+    def test_parse_multiple_claims(self):
+        """Test parsing multiple claims in one text."""
+        text = """
+        I've created the config.json file.
+        All tests pass now.
+        The build succeeded.
+        """
+        claims = parse_claims(text, confidence_threshold=0.7)
+
+        claim_types = {c.claim_type for c in claims}
+        assert "file_created" in claim_types
+        assert "tests_pass" in claim_types
+        assert "build_success" in claim_types
+
+    def test_no_claims_in_neutral_text(self):
+        """Test that neutral text doesn't produce false positives."""
+        text = "Let me explain how the configuration system works."
+        claims = parse_claims(text, confidence_threshold=0.7)
+
+        # Should not have file_created claim just because "config" is mentioned
+        file_claims = [c for c in claims if c.claim_type == "file_created"]
+        assert len(file_claims) == 0
+
+    def test_confidence_threshold(self):
+        """Test that confidence threshold filters low-confidence claims."""
+        text = "Tests should now work."  # Lower confidence phrase
+
+        # With low threshold, should match
+        claims_low = parse_claims(text, confidence_threshold=0.5)
+        test_claims_low = [c for c in claims_low if c.claim_type == "tests_pass"]
+
+        # With high threshold, might not match
+        claims_high = parse_claims(text, confidence_threshold=0.95)
+        test_claims_high = [c for c in claims_high if c.claim_type == "tests_pass"]
+
+        assert len(test_claims_low) >= len(test_claims_high)
+
+    def test_duplicate_file_claims_deduplicated(self):
+        """Test that duplicate file claims are deduplicated."""
+        text = """
+        I created config.json.
+        The file config.json has been saved.
+        """
+        claims = parse_claims(text, confidence_threshold=0.7)
+
+        file_claims = [c for c in claims if c.claim_type == "file_created"]
+        file_values = [c.extracted_value for c in file_claims]
+        # Should only have one entry for config.json
+        assert file_values.count("config.json") == 1
+
+    def test_preserve_file_path_case(self):
+        """Test that file paths preserve their original case."""
+        text = "I created MyComponent.tsx"
+        claims = parse_claims(text, confidence_threshold=0.7)
+
+        file_claims = [c for c in claims if c.claim_type == "file_created"]
+        assert len(file_claims) >= 1
+        # The file path should preserve case
+        assert any("MyComponent.tsx" in (c.extracted_value or "") for c in file_claims)
+
+
+class TestExtractFilePaths:
+    """Tests for the extract_file_paths function."""
+
+    def test_extract_backtick_paths(self):
+        """Test extracting paths in backticks."""
+        text = "The file `src/config.json` was updated."
+        paths = extract_file_paths(text)
+        assert "src/config.json" in paths
+
+    def test_extract_quoted_paths(self):
+        """Test extracting paths in quotes."""
+        text = 'Created "src/utils/helper.ts" file.'
+        paths = extract_file_paths(text)
+        assert "src/utils/helper.ts" in paths
+
+    def test_extract_unix_paths(self):
+        """Test extracting Unix-style paths."""
+        text = "Modified /usr/local/config.json"
+        paths = extract_file_paths(text)
+        assert "/usr/local/config.json" in paths
+
+    def test_extract_relative_paths(self):
+        """Test extracting relative paths."""
+        text = "See ./src/index.ts for details."
+        paths = extract_file_paths(text)
+        assert "./src/index.ts" in paths
+
+    def test_deduplicate_paths(self):
+        """Test that duplicate paths are deduplicated."""
+        text = "`config.json` and `config.json` again"
+        paths = extract_file_paths(text)
+        assert paths.count("config.json") == 1
+
+
+class TestGetClaimSummary:
+    """Tests for the get_claim_summary function."""
+
+    def test_summarize_claims(self):
+        """Test summarizing claims by type."""
+        claims = [
+            Claim("file_created", "created config.json", 0.9, "config.json"),
+            Claim("file_created", "wrote utils.ts", 0.9, "utils.ts"),
+            Claim("tests_pass", "all tests pass", 0.9),
+        ]
+        summary = get_claim_summary(claims)
+
+        assert "file_created" in summary
+        assert len(summary["file_created"]) == 2
+        assert "config.json" in summary["file_created"]
+        assert "utils.ts" in summary["file_created"]
+        assert "tests_pass" in summary
+
+    def test_empty_claims(self):
+        """Test summary with no claims."""
+        summary = get_claim_summary([])
+        assert summary == {}

--- a/plugins/verify-claims/tests/test_command_detection.py
+++ b/plugins/verify-claims/tests/test_command_detection.py
@@ -1,0 +1,188 @@
+"""Tests for verifiers/command_detection.py"""
+
+import json
+from pathlib import Path
+
+from verifiers.command_detection import (
+    detect_project_type,
+    file_exists,
+    read_package_json,
+    read_pyproject_toml,
+)
+
+
+class TestReadPackageJson:
+    """Tests for the read_package_json function."""
+
+    def test_read_valid_package_json(self, temp_project_dir):
+        """Test reading a valid package.json file."""
+        pkg_data = {"name": "test", "version": "1.0.0", "scripts": {"test": "jest"}}
+        pkg_path = Path(temp_project_dir) / "package.json"
+        with open(pkg_path, 'w') as f:
+            json.dump(pkg_data, f)
+
+        result = read_package_json(temp_project_dir)
+        assert result == pkg_data
+
+    def test_read_nonexistent_package_json(self, temp_project_dir):
+        """Test reading when package.json doesn't exist."""
+        result = read_package_json(temp_project_dir)
+        assert result is None
+
+    def test_read_invalid_json(self, temp_project_dir):
+        """Test reading an invalid JSON file."""
+        pkg_path = Path(temp_project_dir) / "package.json"
+        with open(pkg_path, 'w') as f:
+            f.write("{invalid json")
+
+        result = read_package_json(temp_project_dir)
+        assert result is None
+
+
+class TestReadPyprojectToml:
+    """Tests for the read_pyproject_toml function."""
+
+    def test_read_valid_pyproject(self, temp_project_dir):
+        """Test reading a valid pyproject.toml file."""
+        content = """
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+"""
+        pyproject_path = Path(temp_project_dir) / "pyproject.toml"
+        with open(pyproject_path, 'w') as f:
+            f.write(content)
+
+        result = read_pyproject_toml(temp_project_dir)
+        assert result is not None
+        assert "[tool.pytest.ini_options]" in result
+        assert "[tool.ruff]" in result
+
+    def test_read_nonexistent_pyproject(self, temp_project_dir):
+        """Test reading when pyproject.toml doesn't exist."""
+        result = read_pyproject_toml(temp_project_dir)
+        assert result is None
+
+
+class TestFileExists:
+    """Tests for the file_exists function."""
+
+    def test_single_file_exists(self, temp_project_dir):
+        """Test checking for a single existing file."""
+        pkg_path = Path(temp_project_dir) / "package.json"
+        pkg_path.touch()
+
+        assert file_exists(temp_project_dir, "package.json") is True
+
+    def test_single_file_not_exists(self, temp_project_dir):
+        """Test checking for a single non-existing file."""
+        assert file_exists(temp_project_dir, "package.json") is False
+
+    def test_multiple_files_first_exists(self, temp_project_dir):
+        """Test checking for multiple files when first exists."""
+        pkg_path = Path(temp_project_dir) / "package.json"
+        pkg_path.touch()
+
+        assert file_exists(temp_project_dir, "package.json", "Cargo.toml") is True
+
+    def test_multiple_files_second_exists(self, temp_project_dir):
+        """Test checking for multiple files when second exists."""
+        cargo_path = Path(temp_project_dir) / "Cargo.toml"
+        cargo_path.touch()
+
+        assert file_exists(temp_project_dir, "package.json", "Cargo.toml") is True
+
+    def test_multiple_files_none_exist(self, temp_project_dir):
+        """Test checking for multiple files when none exist."""
+        assert file_exists(temp_project_dir, "package.json", "Cargo.toml") is False
+
+    def test_directory_as_path(self, temp_project_dir):
+        """Test checking for a directory."""
+        tests_dir = Path(temp_project_dir) / "tests"
+        tests_dir.mkdir()
+
+        assert file_exists(temp_project_dir, "tests") is True
+
+
+class TestDetectProjectType:
+    """Tests for the detect_project_type function."""
+
+    def test_detect_npm_project(self, temp_project_dir):
+        """Test detecting an npm project."""
+        pkg_path = Path(temp_project_dir) / "package.json"
+        pkg_path.touch()
+
+        types = detect_project_type(temp_project_dir)
+        assert "npm" in types
+
+    def test_detect_python_project(self, temp_project_dir):
+        """Test detecting a Python project."""
+        pyproject_path = Path(temp_project_dir) / "pyproject.toml"
+        pyproject_path.touch()
+
+        types = detect_project_type(temp_project_dir)
+        assert "python" in types
+
+    def test_detect_rust_project(self, temp_project_dir):
+        """Test detecting a Rust project."""
+        cargo_path = Path(temp_project_dir) / "Cargo.toml"
+        cargo_path.touch()
+
+        types = detect_project_type(temp_project_dir)
+        assert "rust" in types
+
+    def test_detect_go_project(self, temp_project_dir):
+        """Test detecting a Go project."""
+        gomod_path = Path(temp_project_dir) / "go.mod"
+        gomod_path.touch()
+
+        types = detect_project_type(temp_project_dir)
+        assert "go" in types
+
+    def test_detect_multiple_project_types(self, temp_project_dir):
+        """Test detecting multiple project types."""
+        (Path(temp_project_dir) / "package.json").touch()
+        (Path(temp_project_dir) / "pyproject.toml").touch()
+
+        types = detect_project_type(temp_project_dir)
+        assert "npm" in types
+        assert "python" in types
+
+    def test_detect_no_project_type(self, temp_project_dir):
+        """Test detecting no project type."""
+        types = detect_project_type(temp_project_dir)
+        assert types == []
+
+    def test_detect_java_maven_project(self, temp_project_dir):
+        """Test detecting a Maven project."""
+        pom_path = Path(temp_project_dir) / "pom.xml"
+        pom_path.touch()
+
+        types = detect_project_type(temp_project_dir)
+        assert "java_maven" in types
+
+    def test_detect_java_gradle_project(self, temp_project_dir):
+        """Test detecting a Gradle project."""
+        gradle_path = Path(temp_project_dir) / "build.gradle"
+        gradle_path.touch()
+
+        types = detect_project_type(temp_project_dir)
+        assert "java_gradle" in types
+
+    def test_detect_make_project(self, temp_project_dir):
+        """Test detecting a Make project."""
+        makefile_path = Path(temp_project_dir) / "Makefile"
+        makefile_path.touch()
+
+        types = detect_project_type(temp_project_dir)
+        assert "make" in types
+
+    def test_detect_typescript_project(self, temp_project_dir):
+        """Test detecting a TypeScript project."""
+        tsconfig_path = Path(temp_project_dir) / "tsconfig.json"
+        tsconfig_path.touch()
+
+        types = detect_project_type(temp_project_dir)
+        assert "typescript" in types

--- a/plugins/verify-claims/tests/test_config.py
+++ b/plugins/verify-claims/tests/test_config.py
@@ -1,0 +1,179 @@
+"""Tests for utils/config.py"""
+
+import json
+from pathlib import Path
+
+from utils.config import deep_merge, get_config_value, load_config
+
+
+class TestDeepMerge:
+    """Tests for the deep_merge function."""
+
+    def test_merge_simple_dicts(self):
+        """Test merging simple dictionaries."""
+        base = {"a": 1, "b": 2}
+        override = {"b": 3, "c": 4}
+        result = deep_merge(base, override)
+
+        assert result == {"a": 1, "b": 3, "c": 4}
+
+    def test_merge_nested_dicts(self):
+        """Test merging nested dictionaries."""
+        base = {
+            "verifiers": {
+                "tests_pass": {"enabled": True, "timeout": 60},
+                "lint_clean": {"enabled": True}
+            }
+        }
+        override = {
+            "verifiers": {
+                "tests_pass": {"timeout": 120}
+            }
+        }
+        result = deep_merge(base, override)
+
+        assert result["verifiers"]["tests_pass"]["enabled"] is True
+        assert result["verifiers"]["tests_pass"]["timeout"] == 120
+        assert result["verifiers"]["lint_clean"]["enabled"] is True
+
+    def test_override_replaces_non_dict(self):
+        """Test that non-dict values are replaced entirely."""
+        base = {"a": [1, 2, 3]}
+        override = {"a": [4, 5]}
+        result = deep_merge(base, override)
+
+        assert result["a"] == [4, 5]
+
+    def test_base_unchanged(self):
+        """Test that base dict is not mutated."""
+        base = {"a": 1}
+        override = {"a": 2}
+        deep_merge(base, override)
+
+        assert base["a"] == 1
+
+
+class TestGetConfigValue:
+    """Tests for the get_config_value function."""
+
+    def test_get_simple_value(self):
+        """Test getting a simple value."""
+        config = {"debug": True}
+        assert get_config_value(config, "debug") is True
+
+    def test_get_nested_value(self):
+        """Test getting a nested value."""
+        config = {
+            "behavior": {
+                "max_retries": 3
+            }
+        }
+        assert get_config_value(config, "behavior", "max_retries") == 3
+
+    def test_get_deeply_nested_value(self):
+        """Test getting a deeply nested value."""
+        config = {
+            "verifiers": {
+                "tests_pass": {
+                    "timeout": 60
+                }
+            }
+        }
+        assert get_config_value(config, "verifiers", "tests_pass", "timeout") == 60
+
+    def test_missing_key_returns_default(self):
+        """Test that missing keys return the default value."""
+        config = {"a": 1}
+        assert get_config_value(config, "b", default="default") == "default"
+
+    def test_missing_nested_key_returns_default(self):
+        """Test that missing nested keys return the default value."""
+        config = {"a": {"b": 1}}
+        assert get_config_value(config, "a", "c", default=None) is None
+
+    def test_default_is_none_by_default(self):
+        """Test that the default default is None."""
+        config = {}
+        assert get_config_value(config, "missing") is None
+
+
+class TestLoadConfig:
+    """Tests for the load_config function."""
+
+    def test_load_default_config(self, temp_project_dir, temp_dir):
+        """Test loading default configuration."""
+        # Create a plugin root with default config
+        plugin_root = Path(temp_dir) / "plugin"
+        config_dir = plugin_root / "config"
+        config_dir.mkdir(parents=True)
+
+        default_config = {
+            "verifiers": {
+                "tests_pass": {"enabled": True, "timeout": 60}
+            },
+            "debug": False
+        }
+        with open(config_dir / "default_config.json", 'w') as f:
+            json.dump(default_config, f)
+
+        config = load_config(temp_project_dir, str(plugin_root))
+
+        assert config["verifiers"]["tests_pass"]["enabled"] is True
+        assert config["verifiers"]["tests_pass"]["timeout"] == 60
+
+    def test_project_override(self, temp_project_dir, temp_dir):
+        """Test that project config overrides defaults."""
+        # Create plugin root with default config
+        plugin_root = Path(temp_dir) / "plugin"
+        config_dir = plugin_root / "config"
+        config_dir.mkdir(parents=True)
+
+        default_config = {
+            "verifiers": {
+                "tests_pass": {"enabled": True, "timeout": 60}
+            },
+            "debug": False
+        }
+        with open(config_dir / "default_config.json", 'w') as f:
+            json.dump(default_config, f)
+
+        # Create project override
+        project_claude_dir = Path(temp_project_dir) / ".claude"
+        project_claude_dir.mkdir()
+        project_config = {
+            "verifiers": {
+                "tests_pass": {"timeout": 120}
+            },
+            "debug": True
+        }
+        with open(project_claude_dir / "verify-claims.json", 'w') as f:
+            json.dump(project_config, f)
+
+        config = load_config(temp_project_dir, str(plugin_root))
+
+        # Default values should be preserved
+        assert config["verifiers"]["tests_pass"]["enabled"] is True
+        # Overridden values should be updated
+        assert config["verifiers"]["tests_pass"]["timeout"] == 120
+        assert config["debug"] is True
+
+    def test_missing_default_config(self, temp_project_dir, temp_dir):
+        """Test loading with missing default config."""
+        plugin_root = Path(temp_dir) / "plugin"
+        plugin_root.mkdir()
+
+        config = load_config(temp_project_dir, str(plugin_root))
+        assert config == {}
+
+    def test_missing_project_config(self, temp_project_dir, temp_dir):
+        """Test loading with missing project config."""
+        plugin_root = Path(temp_dir) / "plugin"
+        config_dir = plugin_root / "config"
+        config_dir.mkdir(parents=True)
+
+        default_config = {"debug": False}
+        with open(config_dir / "default_config.json", 'w') as f:
+            json.dump(default_config, f)
+
+        config = load_config(temp_project_dir, str(plugin_root))
+        assert config["debug"] is False

--- a/plugins/verify-claims/tests/test_integration.py
+++ b/plugins/verify-claims/tests/test_integration.py
@@ -1,0 +1,1300 @@
+"""
+Integration tests for verify-claims plugin.
+
+These tests run the hooks end-to-end using subprocess with mock JSON input,
+validating the complete verification flow including:
+- Hook input/output JSON format
+- Claim detection from transcripts
+- Verifier execution
+- Block/allow decisions
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# Plugin root directory
+PLUGIN_ROOT = Path(__file__).parent.parent
+SCRIPTS_DIR = PLUGIN_ROOT / "scripts"
+VERIFY_CLAIMS_SCRIPT = SCRIPTS_DIR / "verify_claims.py"
+TRACK_TOOL_USE_SCRIPT = SCRIPTS_DIR / "track_tool_use.py"
+
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+
+def create_transcript(
+    tmpdir: str, messages: list[dict[str, Any]], filename: str = "transcript.jsonl"
+) -> str:
+    """Create a JSONL transcript file with the given messages.
+
+    Args:
+        tmpdir: Directory to create the transcript in
+        messages: List of message dictionaries to write
+        filename: Name of the transcript file
+
+    Returns:
+        Path to the created transcript file
+    """
+    transcript_path = Path(tmpdir) / filename
+    with open(transcript_path, "w") as f:
+        for msg in messages:
+            f.write(json.dumps(msg) + "\n")
+    return str(transcript_path)
+
+
+def create_assistant_message(text: str) -> dict[str, Any]:
+    """Create an assistant message for the transcript.
+
+    Args:
+        text: The assistant's message text
+
+    Returns:
+        Transcript message dictionary
+    """
+    return {
+        "type": "assistant",
+        "message": {"content": [{"type": "text", "text": text}]},
+    }
+
+
+def create_user_message(text: str) -> dict[str, Any]:
+    """Create a user message for the transcript.
+
+    Args:
+        text: The user's message text
+
+    Returns:
+        Transcript message dictionary
+    """
+    return {"type": "user", "message": text}
+
+
+def run_verify_claims_hook(
+    session_id: str, transcript_path: str, cwd: str, timeout: int = 30
+) -> dict[str, Any]:
+    """Run the verify_claims Stop hook and return parsed output.
+
+    Args:
+        session_id: Unique session identifier
+        transcript_path: Path to the transcript JSONL file
+        cwd: Working directory for verification
+        timeout: Subprocess timeout in seconds
+
+    Returns:
+        Dictionary with 'decision' and optionally 'reason' keys,
+        or empty dict if no JSON output
+    """
+    hook_input = {
+        "session_id": session_id,
+        "transcript_path": transcript_path,
+        "cwd": cwd,
+    }
+
+    env = os.environ.copy()
+    env["CLAUDE_PLUGIN_ROOT"] = str(PLUGIN_ROOT)
+
+    result = subprocess.run(
+        [sys.executable, str(VERIFY_CLAIMS_SCRIPT)],
+        input=json.dumps(hook_input),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=env,
+    )
+
+    # Parse JSON output if any
+    stdout = result.stdout.strip()
+    if stdout:
+        try:
+            return json.loads(stdout)
+        except json.JSONDecodeError:
+            return {"raw_output": stdout}
+
+    return {}
+
+
+def run_track_tool_use_hook(
+    session_id: str,
+    tool_name: str,
+    tool_input: dict[str, Any],
+    tool_output: Any = None,
+) -> int:
+    """Run the track_tool_use PostToolUse hook.
+
+    Args:
+        session_id: Unique session identifier
+        tool_name: Name of the tool (Write, Edit, Bash)
+        tool_input: Tool input parameters
+        tool_output: Tool output (optional)
+
+    Returns:
+        Exit code of the hook
+    """
+    hook_input = {
+        "session_id": session_id,
+        "tool_name": tool_name,
+        "tool_input": tool_input,
+        "tool_output": tool_output or {},
+    }
+
+    env = os.environ.copy()
+    env["CLAUDE_PLUGIN_ROOT"] = str(PLUGIN_ROOT)
+
+    result = subprocess.run(
+        [sys.executable, str(TRACK_TOOL_USE_SCRIPT)],
+        input=json.dumps(hook_input),
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env=env,
+    )
+
+    return result.returncode
+
+
+def assert_verification_passed(output: dict[str, Any]) -> None:
+    """Assert that verification passed (no block decision).
+
+    Args:
+        output: Hook output dictionary
+    """
+    assert output.get("decision") != "block", (
+        f"Expected verification to pass, but got blocked: {output.get('reason', 'no reason')}"
+    )
+
+
+def assert_verification_blocked(
+    output: dict[str, Any], expected_claim_type: str | None = None
+) -> None:
+    """Assert that verification blocked with correct claim type.
+
+    Args:
+        output: Hook output dictionary
+        expected_claim_type: Expected claim type in the failure reason
+    """
+    assert output.get("decision") == "block", (
+        f"Expected verification to block, but got: {output}"
+    )
+    assert "reason" in output, "Block decision should include a reason"
+
+    if expected_claim_type:
+        assert expected_claim_type in output["reason"], (
+            f"Expected '{expected_claim_type}' in reason, got: {output['reason']}"
+        )
+
+
+def create_npm_project(tmpdir: str) -> None:
+    """Create a minimal npm project structure.
+
+    Args:
+        tmpdir: Directory to create the project in
+    """
+    package_json = {
+        "name": "test-project",
+        "version": "1.0.0",
+        "scripts": {
+            "test": "echo 'All tests passed' && exit 0",
+            "lint": "echo 'No lint errors' && exit 0",
+            "build": "echo 'Build succeeded' && exit 0",
+        },
+    }
+    pkg_path = Path(tmpdir) / "package.json"
+    with open(pkg_path, "w") as f:
+        json.dump(package_json, f)
+
+
+def create_npm_project_failing_tests(tmpdir: str) -> None:
+    """Create an npm project with failing tests.
+
+    Args:
+        tmpdir: Directory to create the project in
+    """
+    package_json = {
+        "name": "test-project",
+        "version": "1.0.0",
+        "scripts": {
+            "test": "echo 'FAIL: Test failed' && exit 1",
+            "lint": "echo 'No lint errors' && exit 0",
+        },
+    }
+    pkg_path = Path(tmpdir) / "package.json"
+    with open(pkg_path, "w") as f:
+        json.dump(package_json, f)
+
+
+def create_npm_project_failing_lint(tmpdir: str) -> None:
+    """Create an npm project with failing lint.
+
+    Args:
+        tmpdir: Directory to create the project in
+    """
+    package_json = {
+        "name": "test-project",
+        "version": "1.0.0",
+        "scripts": {
+            "test": "echo 'Tests passed' && exit 0",
+            "lint": "echo 'error: lint error found' && exit 1",
+        },
+    }
+    pkg_path = Path(tmpdir) / "package.json"
+    with open(pkg_path, "w") as f:
+        json.dump(package_json, f)
+
+
+def create_npm_project_failing_build(tmpdir: str) -> None:
+    """Create an npm project with failing build.
+
+    Args:
+        tmpdir: Directory to create the project in
+    """
+    package_json = {
+        "name": "test-project",
+        "version": "1.0.0",
+        "scripts": {
+            "build": "echo 'error: Build failed' && exit 1",
+        },
+    }
+    pkg_path = Path(tmpdir) / "package.json"
+    with open(pkg_path, "w") as f:
+        json.dump(package_json, f)
+
+
+def create_python_project(tmpdir: str) -> None:
+    """Create a minimal Python project structure.
+
+    Args:
+        tmpdir: Directory to create the project in
+    """
+    pyproject = """
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+"""
+    pyproject_path = Path(tmpdir) / "pyproject.toml"
+    with open(pyproject_path, "w") as f:
+        f.write(pyproject)
+
+    tests_dir = Path(tmpdir) / "tests"
+    tests_dir.mkdir()
+
+
+def create_git_repo(tmpdir: str, with_changes: bool = False) -> None:
+    """Initialize a git repository.
+
+    Args:
+        tmpdir: Directory to initialize git in
+        with_changes: Whether to create uncommitted changes
+    """
+    # Initialize git repo
+    subprocess.run(
+        ["git", "init"], cwd=tmpdir, capture_output=True, check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=tmpdir,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=tmpdir,
+        capture_output=True,
+        check=True,
+    )
+
+    # Create initial commit
+    readme = Path(tmpdir) / "README.md"
+    readme.write_text("# Test Project\n")
+    subprocess.run(
+        ["git", "add", "README.md"], cwd=tmpdir, capture_output=True, check=True
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "Initial commit"],
+        cwd=tmpdir,
+        capture_output=True,
+        check=True,
+    )
+
+    if with_changes:
+        # Create uncommitted changes
+        code_file = Path(tmpdir) / "main.py"
+        code_file.write_text("print('Hello World')\n")
+
+
+def create_config_file(
+    tmpdir: str, config: dict[str, Any], filename: str = "verify-claims.json"
+) -> None:
+    """Create a project-specific config file.
+
+    Args:
+        tmpdir: Project directory
+        config: Configuration dictionary
+        filename: Config filename
+    """
+    claude_dir = Path(tmpdir) / ".claude"
+    claude_dir.mkdir(exist_ok=True)
+    config_path = claude_dir / filename
+    with open(config_path, "w") as f:
+        json.dump(config, f)
+
+
+def cleanup_session_state(session_id: str) -> None:
+    """Remove session state file if it exists.
+
+    Args:
+        session_id: Session ID to clean up
+    """
+    state_file = Path.home() / ".claude" / f"verify_claims_state_{session_id}.json"
+    if state_file.exists():
+        state_file.unlink()
+
+
+# ============================================================================
+# Test Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def integration_temp_dir():
+    """Create a temporary directory for integration tests."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield tmpdir
+
+
+@pytest.fixture
+def unique_session_id():
+    """Generate a unique session ID for each test."""
+    import uuid
+    session_id = f"test-{uuid.uuid4().hex[:8]}"
+    yield session_id
+    # Cleanup session state after test
+    cleanup_session_state(session_id)
+
+
+# ============================================================================
+# file_created Claim Tests
+# ============================================================================
+
+
+class TestFileCreatedClaims:
+    """Tests for file_created claim verification."""
+
+    def test_file_created_claim_passes(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: Create file, make claim -> verification passes."""
+        # Setup: Create the file
+        test_file = Path(integration_temp_dir) / "config.json"
+        test_file.write_text('{"key": "value"}')
+
+        # Create transcript with claim
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Create a config file"),
+                create_assistant_message("I've created the config.json file for you."),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir
+        )
+
+        # Assert: Should pass
+        assert_verification_passed(output)
+
+    def test_file_created_claim_fails(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: Don't create file, make claim -> verification blocks."""
+        # Setup: Don't create the file
+
+        # Create transcript with claim
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Create a config file"),
+                create_assistant_message("I've created the config.json file for you."),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir
+        )
+
+        # Assert: Should block
+        assert_verification_blocked(output, "file_created")
+
+    def test_file_created_directory_not_file(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: Create directory, claim file created -> verification blocks."""
+        # Setup: Create a directory instead of file
+        dir_path = Path(integration_temp_dir) / "config.json"
+        dir_path.mkdir()
+
+        # Create transcript with claim
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Create config file"),
+                create_assistant_message("I've created config.json."),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir
+        )
+
+        # Assert: Should block (is directory, not file)
+        assert_verification_blocked(output, "file_created")
+
+    def test_file_created_nested_path(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: Create nested file, make claim -> verification passes."""
+        # Setup: Create nested directory structure
+        nested_dir = Path(integration_temp_dir) / "src" / "utils"
+        nested_dir.mkdir(parents=True)
+        test_file = nested_dir / "helper.ts"
+        test_file.write_text("export const helper = () => {};")
+
+        # Create transcript with claim
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Create a helper utility"),
+                create_assistant_message(
+                    "I've created the src/utils/helper.ts file with the utility function."
+                ),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir
+        )
+
+        # Assert: Should pass
+        assert_verification_passed(output)
+
+    def test_multiple_file_claims(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: Multiple file claims, all exist -> verification passes."""
+        # Setup: Create multiple files
+        (Path(integration_temp_dir) / "file1.py").write_text("# file 1")
+        (Path(integration_temp_dir) / "file2.py").write_text("# file 2")
+
+        # Create transcript with claims
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Create two files"),
+                create_assistant_message(
+                    "I've created file1.py and file2.py for you."
+                ),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir
+        )
+
+        # Assert: Should pass
+        assert_verification_passed(output)
+
+    def test_partial_file_claims_fail(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: Multiple file claims (separate statements), one missing -> verification blocks."""
+        # Setup: Create only one file
+        (Path(integration_temp_dir) / "file1.py").write_text("# file 1")
+        # file2.py is NOT created
+
+        # Create transcript with claims - use separate claim statements for each file
+        # The regex captures one file per match, so we need separate sentences
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Create two files"),
+                create_assistant_message(
+                    "I've created file1.py with the first module. "
+                    "I also created file2.py with the second module."
+                ),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir
+        )
+
+        # Assert: Should block because file2.py doesn't exist
+        assert_verification_blocked(output, "file_created")
+
+
+# ============================================================================
+# tests_pass Claim Tests
+# ============================================================================
+
+
+class TestTestsPassClaims:
+    """Tests for tests_pass claim verification."""
+
+    def test_tests_pass_claim_with_passing_tests(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: NPM project with passing tests -> verification passes."""
+        # Setup: Create npm project with passing tests
+        create_npm_project(integration_temp_dir)
+
+        # Create transcript with claim
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Run the tests"),
+                create_assistant_message("All tests pass now."),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir, timeout=60
+        )
+
+        # Assert: Should pass
+        assert_verification_passed(output)
+
+    def test_tests_pass_claim_with_failing_tests(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: NPM project with failing tests -> verification blocks."""
+        # Setup: Create npm project with failing tests
+        create_npm_project_failing_tests(integration_temp_dir)
+
+        # Create transcript with claim
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Run the tests"),
+                create_assistant_message("All tests pass now."),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir, timeout=60
+        )
+
+        # Assert: Should block
+        assert_verification_blocked(output, "tests_pass")
+
+    def test_tests_pass_no_test_framework_skips(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: No test framework detected -> verification skips (passes)."""
+        # Setup: Empty project with no test framework
+
+        # Create transcript with claim
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Run the tests"),
+                create_assistant_message("All tests pass."),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir
+        )
+
+        # Assert: Should pass (skipped)
+        assert_verification_passed(output)
+
+    def test_tests_pass_custom_command(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: Custom test command in config is used."""
+        # Setup: Create project with custom config
+        create_config_file(
+            integration_temp_dir,
+            {
+                "verifiers": {
+                    "tests_pass": {
+                        "enabled": True,
+                        "command": "echo 'Custom tests passed' && exit 0",
+                    }
+                }
+            },
+        )
+
+        # Create transcript with claim
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Run tests"),
+                create_assistant_message("All tests pass."),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir, timeout=60
+        )
+
+        # Assert: Should pass
+        assert_verification_passed(output)
+
+
+# ============================================================================
+# lint_clean Claim Tests
+# ============================================================================
+
+
+class TestLintCleanClaims:
+    """Tests for lint_clean claim verification."""
+
+    def test_lint_clean_claim_passes(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: Project with no lint errors -> verification passes."""
+        # Setup: Create npm project with passing lint
+        create_npm_project(integration_temp_dir)
+
+        # Create transcript with claim
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Check lint"),
+                create_assistant_message("No lint errors found."),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir, timeout=60
+        )
+
+        # Assert: Should pass
+        assert_verification_passed(output)
+
+    def test_lint_clean_claim_fails(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: Project with lint errors -> verification blocks."""
+        # Setup: Create npm project with failing lint
+        create_npm_project_failing_lint(integration_temp_dir)
+
+        # Create transcript with claim
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Check lint"),
+                create_assistant_message("No lint errors found."),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir, timeout=60
+        )
+
+        # Assert: Should block
+        assert_verification_blocked(output, "lint_clean")
+
+    def test_lint_clean_no_linter_skips(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: No linter detected -> verification skips (passes)."""
+        # Setup: Empty project with no linter
+
+        # Create transcript with claim
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Check lint"),
+                create_assistant_message("Lint is clean."),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir
+        )
+
+        # Assert: Should pass (skipped)
+        assert_verification_passed(output)
+
+
+# ============================================================================
+# build_success Claim Tests
+# ============================================================================
+
+
+class TestBuildSuccessClaims:
+    """Tests for build_success claim verification."""
+
+    def test_build_success_claim_passes(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: Successful build -> verification passes."""
+        # Setup: Create npm project with passing build
+        create_npm_project(integration_temp_dir)
+
+        # Create transcript with claim
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Build the project"),
+                create_assistant_message("Build succeeded with no errors."),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir, timeout=60
+        )
+
+        # Assert: Should pass
+        assert_verification_passed(output)
+
+    def test_build_success_claim_fails(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: Failed build -> verification blocks."""
+        # Setup: Create npm project with failing build
+        create_npm_project_failing_build(integration_temp_dir)
+
+        # Create transcript with claim
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Build the project"),
+                create_assistant_message("Build succeeded."),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir, timeout=60
+        )
+
+        # Assert: Should block
+        assert_verification_blocked(output, "build_success")
+
+    def test_build_success_no_build_system_skips(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: No build system detected -> verification skips (passes)."""
+        # Setup: Empty project with no build system
+
+        # Create transcript with claim
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Build it"),
+                create_assistant_message("Build succeeded."),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir
+        )
+
+        # Assert: Should pass (skipped)
+        assert_verification_passed(output)
+
+
+# ============================================================================
+# bug_fixed Claim Tests
+# ============================================================================
+
+
+class TestBugFixedClaims:
+    """Tests for bug_fixed claim verification."""
+
+    def test_bug_fixed_with_git_changes(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: Git repo with uncommitted changes -> verification passes."""
+        # Setup: Create git repo with changes
+        create_git_repo(integration_temp_dir, with_changes=True)
+
+        # Create transcript with claim
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Fix the bug"),
+                create_assistant_message("I've fixed the bug in the code."),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir
+        )
+
+        # Assert: Should pass
+        assert_verification_passed(output)
+
+    def test_bug_fixed_no_changes(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: Git repo with no recent changes -> verification blocks."""
+        # Setup: Create git repo with an old commit (no recent commits)
+        # We need to create the commit with a date in the past to avoid
+        # the "recent commits" check in the verifier
+        #
+        # IMPORTANT: Create the git repo in a subdirectory, and put the
+        # transcript OUTSIDE it. Otherwise the transcript file shows up
+        # as an untracked file and the verifier thinks there are changes.
+
+        git_repo_dir = Path(integration_temp_dir) / "repo"
+        git_repo_dir.mkdir()
+
+        # Initialize git repo
+        subprocess.run(
+            ["git", "init"], cwd=git_repo_dir, capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=git_repo_dir,
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=git_repo_dir,
+            capture_output=True,
+            check=True,
+        )
+
+        # Create initial commit with an old date
+        readme = git_repo_dir / "README.md"
+        readme.write_text("# Test Project\n")
+        subprocess.run(
+            ["git", "add", "README.md"], cwd=git_repo_dir, capture_output=True, check=True
+        )
+
+        # Set both author and committer dates to the past
+        old_date = "2020-01-01T00:00:00"
+        env = {**os.environ, "GIT_AUTHOR_DATE": old_date, "GIT_COMMITTER_DATE": old_date}
+        subprocess.run(
+            ["git", "commit", "-m", "Initial commit"],
+            cwd=git_repo_dir,
+            capture_output=True,
+            check=True,
+            env=env,
+        )
+
+        # Create transcript OUTSIDE the git repo
+        transcript = create_transcript(
+            integration_temp_dir,  # Parent dir, not inside repo
+            [
+                create_user_message("Fix the bug"),
+                create_assistant_message("I've fixed the bug."),
+            ],
+        )
+
+        # Run verification (cwd is the git repo)
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, str(git_repo_dir)
+        )
+
+        # Assert: Should block because no code changes and no recent commits
+        assert_verification_blocked(output, "bug_fixed")
+
+    def test_bug_fixed_not_git_repo_skips(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: Not a git repo -> verification skips (passes)."""
+        # Setup: No git repo (just empty directory)
+
+        # Create transcript with claim
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Fix the bug"),
+                create_assistant_message("I've fixed the bug."),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir
+        )
+
+        # Assert: Should pass (skipped because not a git repo)
+        assert_verification_passed(output)
+
+    def test_bug_fixed_with_staged_changes(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: Git repo with staged changes -> verification passes."""
+        # Setup: Create git repo and stage changes
+        create_git_repo(integration_temp_dir)
+
+        # Add a new file and stage it
+        code_file = Path(integration_temp_dir) / "fix.py"
+        code_file.write_text("# Bug fix\n")
+        subprocess.run(
+            ["git", "add", "fix.py"],
+            cwd=integration_temp_dir,
+            capture_output=True,
+            check=True,
+        )
+
+        # Create transcript with claim
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Fix the bug"),
+                create_assistant_message("I've fixed the bug."),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir
+        )
+
+        # Assert: Should pass
+        assert_verification_passed(output)
+
+    def test_bug_fixed_with_untracked_code_file(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: Git repo with new untracked code file -> verification passes."""
+        # Setup: Create git repo
+        create_git_repo(integration_temp_dir)
+
+        # Add an untracked Python file (code extension)
+        code_file = Path(integration_temp_dir) / "new_feature.py"
+        code_file.write_text("def new_feature(): pass\n")
+
+        # Create transcript with claim
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Fix the bug"),
+                create_assistant_message("I've fixed the issue."),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir
+        )
+
+        # Assert: Should pass
+        assert_verification_passed(output)
+
+
+# ============================================================================
+# Configuration Tests
+# ============================================================================
+
+
+class TestConfiguration:
+    """Tests for configuration handling."""
+
+    def test_block_on_failure_disabled(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: block_on_failure=false -> verification doesn't block."""
+        # Setup: Create config with block_on_failure=false
+        create_config_file(
+            integration_temp_dir,
+            {"behavior": {"block_on_failure": False}},
+        )
+
+        # Don't create the claimed file
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Create file"),
+                create_assistant_message("I've created config.json."),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir
+        )
+
+        # Assert: Should NOT block even though file doesn't exist
+        assert_verification_passed(output)
+
+    def test_verifier_disabled(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: Disabled verifier is skipped."""
+        # Setup: Create config with file_created disabled
+        create_config_file(
+            integration_temp_dir,
+            {"verifiers": {"file_created": {"enabled": False}}},
+        )
+
+        # Don't create the claimed file
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Create file"),
+                create_assistant_message("I've created config.json."),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir
+        )
+
+        # Assert: Should pass (verifier disabled)
+        assert_verification_passed(output)
+
+    def test_max_retries_respected(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: After max_retries, verification allows completion."""
+        # Setup: Config with max_retries=2
+        create_config_file(
+            integration_temp_dir,
+            {"behavior": {"max_retries": 2}},
+        )
+
+        # Don't create the claimed file
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Create file"),
+                create_assistant_message("I've created config.json."),
+            ],
+        )
+
+        # Run verification 3 times (exceeds max_retries=2)
+        for _ in range(3):
+            output = run_verify_claims_hook(
+                unique_session_id, transcript, integration_temp_dir
+            )
+
+        # Assert: After max retries, should allow through
+        assert_verification_passed(output)
+
+
+# ============================================================================
+# Edge Cases and Error Handling
+# ============================================================================
+
+
+class TestEdgeCases:
+    """Tests for edge cases and error handling."""
+
+    def test_no_claims_in_transcript(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: No verifiable claims -> verification passes."""
+        # Create transcript with no claims
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Hello"),
+                create_assistant_message("Hello! How can I help you today?"),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir
+        )
+
+        # Assert: Should pass (no claims to verify)
+        assert_verification_passed(output)
+
+    def test_empty_transcript(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: Empty transcript -> verification passes."""
+        # Create empty transcript
+        transcript = create_transcript(integration_temp_dir, [])
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir
+        )
+
+        # Assert: Should pass
+        assert_verification_passed(output)
+
+    def test_missing_transcript(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: Missing transcript file -> verification passes."""
+        # Run verification with non-existent transcript
+        output = run_verify_claims_hook(
+            unique_session_id,
+            "/nonexistent/transcript.jsonl",
+            integration_temp_dir,
+        )
+
+        # Assert: Should pass (graceful handling)
+        assert_verification_passed(output)
+
+    def test_combined_claims_partial_pass(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: Multiple claim types, some fail -> verification blocks."""
+        # Setup: Create npm project with passing tests but missing file
+        create_npm_project(integration_temp_dir)
+        # Don't create the claimed config.json file
+
+        # Create transcript with multiple claims
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Create config and run tests"),
+                create_assistant_message(
+                    "I've created config.json and all tests pass now."
+                ),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir, timeout=60
+        )
+
+        # Assert: Should block due to missing file
+        assert_verification_blocked(output, "file_created")
+
+
+# ============================================================================
+# PostToolUse Hook Tests
+# ============================================================================
+
+
+class TestTrackToolUseHook:
+    """Tests for the PostToolUse tracking hook."""
+
+    def test_track_file_write(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: Write tool use is tracked."""
+        # Run the tracking hook
+        result = run_track_tool_use_hook(
+            unique_session_id,
+            "Write",
+            {"file_path": f"{integration_temp_dir}/test.py"},
+            {"success": True},
+        )
+
+        # Assert: Should succeed
+        assert result == 0
+
+    def test_track_bash_command(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: Bash command is tracked."""
+        # Run the tracking hook
+        result = run_track_tool_use_hook(
+            unique_session_id,
+            "Bash",
+            {"command": "npm test"},
+            {"exit_code": 0},
+        )
+
+        # Assert: Should succeed
+        assert result == 0
+
+    def test_track_edit_tool(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: Edit tool use is tracked."""
+        # Run the tracking hook
+        result = run_track_tool_use_hook(
+            unique_session_id,
+            "Edit",
+            {"file_path": f"{integration_temp_dir}/config.json"},
+            {"success": True},
+        )
+
+        # Assert: Should succeed
+        assert result == 0
+
+
+# ============================================================================
+# Block Decision Output Format Tests
+# ============================================================================
+
+
+class TestBlockDecisionFormat:
+    """Tests for correct block decision JSON output format."""
+
+    def test_block_decision_has_correct_structure(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: Block decision has correct JSON structure."""
+        # Don't create the claimed file
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Create file"),
+                create_assistant_message("I've created config.json."),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir
+        )
+
+        # Assert: Correct structure
+        assert "decision" in output
+        assert output["decision"] == "block"
+        assert "reason" in output
+        assert isinstance(output["reason"], str)
+        assert len(output["reason"]) > 0
+
+    def test_block_reason_contains_claim_details(
+        self, integration_temp_dir, unique_session_id
+    ):
+        """Test: Block reason contains useful claim details."""
+        # Don't create the claimed file
+        transcript = create_transcript(
+            integration_temp_dir,
+            [
+                create_user_message("Create file"),
+                create_assistant_message("I've created config.json."),
+            ],
+        )
+
+        # Run verification
+        output = run_verify_claims_hook(
+            unique_session_id, transcript, integration_temp_dir
+        )
+
+        # Assert: Reason is descriptive
+        reason = output.get("reason", "")
+        assert "file_created" in reason
+        assert "config.json" in reason.lower() or "does not exist" in reason.lower()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/plugins/verify-claims/tests/test_logger.py
+++ b/plugins/verify-claims/tests/test_logger.py
@@ -1,0 +1,247 @@
+"""Tests for utils/logger.py"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import utils.logger as logger_module
+from utils.logger import Logger, get_logger
+
+
+class TestLogger:
+    """Tests for the Logger class."""
+
+    def setup_method(self):
+        """Reset global logger state before each test."""
+        logger_module._logger = None
+
+    def test_init_default_values(self):
+        """Test Logger initialization with default values."""
+        log = Logger()
+        assert log.debug_enabled is False
+        assert log.log_to_file is True
+
+    def test_init_custom_values(self):
+        """Test Logger initialization with custom values."""
+        log = Logger(debug=True, log_to_file=False)
+        assert log.debug_enabled is True
+        assert log.log_to_file is False
+
+    def test_get_timestamp_format(self):
+        """Test that timestamp has expected format."""
+        log = Logger()
+        timestamp = log._get_timestamp()
+        # Should be in format YYYY-MM-DD HH:MM:SS
+        assert len(timestamp) == 19
+        assert timestamp[4] == '-'
+        assert timestamp[7] == '-'
+        assert timestamp[10] == ' '
+        assert timestamp[13] == ':'
+        assert timestamp[16] == ':'
+
+    def test_debug_message_when_disabled(self, capsys):
+        """Test that debug messages are not printed when debug is disabled."""
+        log = Logger(debug=False, log_to_file=False)
+        log.debug("test message")
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        assert captured.out == ""
+
+    def test_debug_message_when_enabled(self, capsys):
+        """Test that debug messages are printed when debug is enabled."""
+        log = Logger(debug=True, log_to_file=False)
+        log.debug("test debug message")
+        captured = capsys.readouterr()
+        assert "[DEBUG]" in captured.err
+        assert "test debug message" in captured.err
+
+    def test_info_message_when_debug_disabled(self, capsys):
+        """Test that info messages are not printed when debug is disabled."""
+        log = Logger(debug=False, log_to_file=False)
+        log.info("test info message")
+        captured = capsys.readouterr()
+        # Info messages should not be printed to stderr when debug is off
+        assert captured.err == ""
+
+    def test_info_message_when_debug_enabled(self, capsys):
+        """Test that info messages are printed when debug is enabled."""
+        log = Logger(debug=True, log_to_file=False)
+        log.info("test info message")
+        captured = capsys.readouterr()
+        assert "[INFO]" in captured.err
+        assert "test info message" in captured.err
+
+    def test_warning_message_when_debug_disabled(self, capsys):
+        """Test that warning messages are not printed when debug is disabled."""
+        log = Logger(debug=False, log_to_file=False)
+        log.warning("test warning message")
+        captured = capsys.readouterr()
+        # Warning messages should not be printed to stderr when debug is off
+        assert captured.err == ""
+
+    def test_warning_message_when_debug_enabled(self, capsys):
+        """Test that warning messages are printed when debug is enabled."""
+        log = Logger(debug=True, log_to_file=False)
+        log.warning("test warning message")
+        captured = capsys.readouterr()
+        assert "[WARN]" in captured.err
+        assert "test warning message" in captured.err
+
+    def test_error_message_always_printed(self, capsys):
+        """Test that error messages are always printed regardless of debug setting."""
+        log = Logger(debug=False, log_to_file=False)
+        log.error("test error message")
+        captured = capsys.readouterr()
+        assert "[ERROR]" in captured.err
+        assert "test error message" in captured.err
+
+    def test_error_message_with_debug_enabled(self, capsys):
+        """Test error messages with debug enabled."""
+        log = Logger(debug=True, log_to_file=False)
+        log.error("test error message")
+        captured = capsys.readouterr()
+        assert "[ERROR]" in captured.err
+        assert "test error message" in captured.err
+
+    def test_write_to_file(self, temp_dir):
+        """Test that messages are written to log file."""
+        log_dir = Path(temp_dir) / "logs"
+        log_file = "test.log"
+
+        with patch.object(Logger, 'LOG_DIR', log_dir):
+            with patch.object(Logger, 'LOG_FILE', log_file):
+                log = Logger(debug=True, log_to_file=True)
+                log.info("file test message")
+
+                log_path = log_dir / log_file
+                assert log_path.exists()
+                content = log_path.read_text()
+                assert "[INFO]" in content
+                assert "file test message" in content
+
+    def test_write_to_file_creates_directory(self, temp_dir):
+        """Test that log directory is created if it doesn't exist."""
+        log_dir = Path(temp_dir) / "nested" / "logs"
+        log_file = "test.log"
+
+        with patch.object(Logger, 'LOG_DIR', log_dir):
+            with patch.object(Logger, 'LOG_FILE', log_file):
+                log = Logger(debug=True, log_to_file=True)
+                log.info("create dir test")
+
+                assert log_dir.exists()
+
+    def test_write_to_file_handles_os_error(self, capsys):
+        """Test that OSError when writing to file is handled gracefully."""
+        log = Logger(debug=True, log_to_file=True)
+
+        with patch.object(Logger, 'LOG_DIR', Path("/nonexistent/readonly/path")):
+            # This should not raise an exception
+            log.info("should not fail")
+            captured = capsys.readouterr()
+            assert "[INFO]" in captured.err
+
+    def test_log_to_file_disabled(self, temp_dir):
+        """Test that messages are not written to file when disabled."""
+        log_dir = Path(temp_dir) / "logs"
+        log_file = "test.log"
+
+        with patch.object(Logger, 'LOG_DIR', log_dir):
+            with patch.object(Logger, 'LOG_FILE', log_file):
+                log = Logger(debug=True, log_to_file=False)
+                log.info("should not be in file")
+
+                log_path = log_dir / log_file
+                assert not log_path.exists()
+
+
+class TestGetLogger:
+    """Tests for the get_logger function."""
+
+    def setup_method(self):
+        """Reset global logger state before each test."""
+        logger_module._logger = None
+
+    def test_get_logger_creates_new_instance(self):
+        """Test that get_logger creates a new logger if none exists."""
+        log = get_logger()
+        assert log is not None
+        assert isinstance(log, Logger)
+
+    def test_get_logger_returns_same_instance(self):
+        """Test that get_logger returns the same instance on subsequent calls."""
+        log1 = get_logger()
+        log2 = get_logger()
+        assert log1 is log2
+
+    def test_get_logger_with_debug_false(self):
+        """Test get_logger with debug=False."""
+        log = get_logger(debug=False)
+        assert log.debug_enabled is False
+
+    def test_get_logger_with_debug_true(self):
+        """Test get_logger with debug=True."""
+        log = get_logger(debug=True)
+        assert log.debug_enabled is True
+
+    def test_get_logger_upgrades_debug_setting(self):
+        """Test that calling get_logger with debug=True enables debug on existing logger."""
+        log1 = get_logger(debug=False)
+        assert log1.debug_enabled is False
+
+        log2 = get_logger(debug=True)
+        assert log2 is log1
+        assert log1.debug_enabled is True
+
+    def test_get_logger_does_not_downgrade_debug(self):
+        """Test that calling get_logger with debug=False doesn't disable debug."""
+        log1 = get_logger(debug=True)
+        assert log1.debug_enabled is True
+
+        log2 = get_logger(debug=False)
+        assert log2 is log1
+        # Debug should remain True
+        assert log1.debug_enabled is True
+
+
+class TestLoggerIntegration:
+    """Integration tests for logger functionality."""
+
+    def setup_method(self):
+        """Reset global logger state before each test."""
+        logger_module._logger = None
+
+    def test_all_log_levels(self, capsys, temp_dir):
+        """Test all log levels in sequence."""
+        log_dir = Path(temp_dir) / "logs"
+
+        with patch.object(Logger, 'LOG_DIR', log_dir):
+            log = Logger(debug=True, log_to_file=True)
+
+            log.debug("debug msg")
+            log.info("info msg")
+            log.warning("warning msg")
+            log.error("error msg")
+
+            captured = capsys.readouterr()
+            assert "[DEBUG]" in captured.err
+            assert "[INFO]" in captured.err
+            assert "[WARN]" in captured.err
+            assert "[ERROR]" in captured.err
+
+            # Check file content
+            log_path = log_dir / Logger.LOG_FILE
+            content = log_path.read_text()
+            assert "debug msg" in content
+            assert "info msg" in content
+            assert "warning msg" in content
+            assert "error msg" in content
+
+    def test_log_message_format(self, capsys):
+        """Test that log messages have the correct format."""
+        log = Logger(debug=True, log_to_file=False)
+        log.info("format test")
+
+        captured = capsys.readouterr()
+        # Format: [YYYY-MM-DD HH:MM:SS] [LEVEL] message
+        assert captured.err.startswith('[')
+        assert '] [INFO] format test' in captured.err

--- a/plugins/verify-claims/tests/test_state.py
+++ b/plugins/verify-claims/tests/test_state.py
@@ -1,0 +1,216 @@
+"""Tests for utils/state.py"""
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+from utils.state import SessionState, ToolUseRecord, VerificationResult
+
+
+class TestSessionState:
+    """Tests for the SessionState class."""
+
+    @pytest.fixture
+    def session_state(self, temp_dir, monkeypatch):
+        """Create a session state with a temporary directory."""
+        # Override the STATE_DIR to use temp directory
+        test_state_dir = Path(temp_dir)
+        monkeypatch.setattr(SessionState, 'STATE_DIR', test_state_dir)
+        return SessionState("test_session_123")
+
+    def test_create_new_state(self, session_state):
+        """Test creating a new session state."""
+        assert session_state.session_id == "test_session_123"
+        assert session_state.verification_count == 0
+        assert session_state.stop_hook_active is False
+
+    def test_state_persists_to_file(self, session_state):
+        """Test that state is persisted to file."""
+        session_state.stop_hook_active = True
+
+        # Read the state file directly
+        with open(session_state.state_file) as f:
+            saved_state = json.load(f)
+
+        assert saved_state["stop_hook_active"] is True
+
+    def test_load_existing_state(self, temp_dir, monkeypatch):
+        """Test loading an existing state file."""
+        test_state_dir = Path(temp_dir)
+        monkeypatch.setattr(SessionState, 'STATE_DIR', test_state_dir)
+
+        # Create state and modify it
+        state1 = SessionState("existing_session")
+        state1.increment_verification_count()
+        state1.add_file_written("/path/to/file.py", "Write")
+
+        # Create a new state object for the same session
+        state2 = SessionState("existing_session")
+
+        assert state2.verification_count == 1
+        assert len(state2.get_files_written()) == 1
+
+    def test_increment_verification_count(self, session_state):
+        """Test incrementing verification count."""
+        assert session_state.verification_count == 0
+
+        count = session_state.increment_verification_count()
+        assert count == 1
+        assert session_state.verification_count == 1
+
+        count = session_state.increment_verification_count()
+        assert count == 2
+        assert session_state.verification_count == 2
+
+    def test_add_file_written(self, session_state):
+        """Test adding written files."""
+        session_state.add_file_written("/project/src/main.py", "Write")
+        session_state.add_file_written("/project/src/utils.py", "Edit")
+
+        files = session_state.get_files_written()
+        assert len(files) == 2
+        assert files[0]["path"] == "/project/src/main.py"
+        assert files[0]["tool"] == "Write"
+        assert files[1]["path"] == "/project/src/utils.py"
+        assert files[1]["tool"] == "Edit"
+        assert "timestamp" in files[0]
+
+    def test_was_file_written(self, session_state):
+        """Test checking if a file was written."""
+        session_state.add_file_written("/project/src/main.py", "Write")
+
+        assert session_state.was_file_written("/project/src/main.py") is True
+        assert session_state.was_file_written("/project/src/other.py") is False
+
+    def test_add_command_run(self, session_state):
+        """Test adding command runs."""
+        session_state.add_command_run("npm test", exit_code=0, is_test=True)
+        session_state.add_command_run("npm run lint", exit_code=1, is_lint=True)
+        session_state.add_command_run("npm run build", exit_code=0, is_build=True)
+
+        commands = session_state.get_commands_run()
+        assert len(commands) == 3
+        assert commands[0]["command"] == "npm test"
+        assert commands[0]["is_test"] is True
+        assert commands[1]["is_lint"] is True
+        assert commands[2]["is_build"] is True
+
+    def test_last_test_passed(self, session_state):
+        """Test checking if last test passed."""
+        assert session_state.last_test_passed() is None  # No tests run
+
+        session_state.add_command_run("npm test", exit_code=0, is_test=True)
+        assert session_state.last_test_passed() is True
+
+        session_state.add_command_run("npm test", exit_code=1, is_test=True)
+        assert session_state.last_test_passed() is False
+
+    def test_last_lint_passed(self, session_state):
+        """Test checking if last lint passed."""
+        assert session_state.last_lint_passed() is None
+
+        session_state.add_command_run("npm run lint", exit_code=0, is_lint=True)
+        assert session_state.last_lint_passed() is True
+
+    def test_last_build_passed(self, session_state):
+        """Test checking if last build passed."""
+        assert session_state.last_build_passed() is None
+
+        session_state.add_command_run("npm run build", exit_code=0, is_build=True)
+        assert session_state.last_build_passed() is True
+
+    def test_add_verification_result(self, session_state):
+        """Test adding verification results."""
+        result = VerificationResult(
+            claim_type="tests_pass",
+            claim_text="all tests pass",
+            passed=True,
+            message="Tests passed",
+            timestamp=time.time(),
+            details={"framework": "pytest"}
+        )
+        session_state.add_verification_result(result)
+
+        # Load state and check
+        with open(session_state.state_file) as f:
+            state = json.load(f)
+
+        assert len(state["verification_results"]) == 1
+        assert state["verification_results"][0]["claim_type"] == "tests_pass"
+        assert state["verification_results"][0]["passed"] is True
+
+    def test_stop_hook_active_property(self, session_state):
+        """Test stop_hook_active property."""
+        assert session_state.stop_hook_active is False
+
+        session_state.stop_hook_active = True
+        assert session_state.stop_hook_active is True
+
+        session_state.stop_hook_active = False
+        assert session_state.stop_hook_active is False
+
+
+class TestSessionStateCleanup:
+    """Tests for session state cleanup functionality."""
+
+    def test_cleanup_old_states(self, temp_dir, monkeypatch):
+        """Test cleaning up old state files."""
+        test_state_dir = Path(temp_dir)
+        monkeypatch.setattr(SessionState, 'STATE_DIR', test_state_dir)
+
+        # Create some state files with old timestamps
+        old_file = test_state_dir / "verify_claims_state_old.json"
+        new_file = test_state_dir / "verify_claims_state_new.json"
+
+        with open(old_file, 'w') as f:
+            json.dump({"session_id": "old"}, f)
+        with open(new_file, 'w') as f:
+            json.dump({"session_id": "new"}, f)
+
+        # Set old file's mtime to 35 days ago
+        old_time = time.time() - (35 * 24 * 60 * 60)
+        os.utime(old_file, (old_time, old_time))
+
+        # Run cleanup with 30 day threshold
+        removed = SessionState.cleanup_old_states(max_age_days=30)
+
+        assert removed == 1
+        assert not old_file.exists()
+        assert new_file.exists()
+
+    def test_cleanup_nonexistent_directory(self, temp_dir, monkeypatch):
+        """Test cleanup when state directory doesn't exist."""
+        nonexistent_dir = Path(temp_dir) / "nonexistent"
+        monkeypatch.setattr(SessionState, 'STATE_DIR', nonexistent_dir)
+
+        removed = SessionState.cleanup_old_states(max_age_days=30)
+        assert removed == 0
+
+
+class TestDataClasses:
+    """Tests for data classes."""
+
+    def test_tool_use_record(self):
+        """Test ToolUseRecord dataclass."""
+        record = ToolUseRecord(
+            tool_name="Write",
+            timestamp=time.time(),
+            details={"path": "/test/file.py"}
+        )
+        assert record.tool_name == "Write"
+        assert "path" in record.details
+
+    def test_verification_result(self):
+        """Test VerificationResult dataclass."""
+        result = VerificationResult(
+            claim_type="file_created",
+            claim_text="created config.json",
+            passed=True,
+            message="File exists",
+            timestamp=time.time(),
+            details={"size": 1024}
+        )
+        assert result.passed is True
+        assert result.claim_type == "file_created"

--- a/plugins/verify-claims/tests/test_transcript_reader.py
+++ b/plugins/verify-claims/tests/test_transcript_reader.py
@@ -1,0 +1,188 @@
+"""Tests for transcript_reader.py"""
+
+import json
+from pathlib import Path
+
+from transcript_reader import (
+    extract_assistant_text,
+    get_last_assistant_messages,
+    get_recent_assistant_text,
+    read_transcript,
+)
+
+
+class TestReadTranscript:
+    """Tests for the read_transcript function."""
+
+    def test_read_valid_transcript(self, sample_transcript):
+        """Test reading a valid transcript file."""
+        messages = list(read_transcript(sample_transcript))
+        assert len(messages) == 4
+        assert messages[0]["type"] == "user"
+        assert messages[1]["type"] == "assistant"
+
+    def test_read_nonexistent_file(self, temp_dir):
+        """Test reading a non-existent file."""
+        messages = list(read_transcript(f"{temp_dir}/nonexistent.jsonl"))
+        assert messages == []
+
+    def test_read_empty_file(self, temp_dir):
+        """Test reading an empty file."""
+        empty_file = Path(temp_dir) / "empty.jsonl"
+        empty_file.touch()
+        messages = list(read_transcript(str(empty_file)))
+        assert messages == []
+
+    def test_skip_invalid_json_lines(self, temp_dir):
+        """Test that invalid JSON lines are skipped."""
+        transcript_path = Path(temp_dir) / "mixed.jsonl"
+        with open(transcript_path, 'w') as f:
+            f.write('{"type": "user", "message": "hello"}\n')
+            f.write('invalid json line\n')
+            f.write('{"type": "assistant", "message": "hi"}\n')
+
+        messages = list(read_transcript(str(transcript_path)))
+        assert len(messages) == 2
+
+    def test_skip_empty_lines(self, temp_dir):
+        """Test that empty lines are skipped."""
+        transcript_path = Path(temp_dir) / "with_blanks.jsonl"
+        with open(transcript_path, 'w') as f:
+            f.write('{"type": "user", "message": "hello"}\n')
+            f.write('\n')
+            f.write('   \n')
+            f.write('{"type": "assistant", "message": "hi"}\n')
+
+        messages = list(read_transcript(str(transcript_path)))
+        assert len(messages) == 2
+
+
+class TestGetLastAssistantMessages:
+    """Tests for the get_last_assistant_messages function."""
+
+    def test_get_last_messages(self, sample_transcript):
+        """Test getting last N assistant messages."""
+        messages = get_last_assistant_messages(sample_transcript, count=2)
+        assert len(messages) == 2
+        for msg in messages:
+            assert msg["type"] == "assistant"
+
+    def test_get_more_messages_than_exist(self, sample_transcript):
+        """Test requesting more messages than available."""
+        messages = get_last_assistant_messages(sample_transcript, count=10)
+        # Sample transcript has 2 assistant messages
+        assert len(messages) == 2
+
+    def test_empty_transcript(self, temp_dir):
+        """Test with empty transcript."""
+        empty_file = Path(temp_dir) / "empty.jsonl"
+        empty_file.touch()
+        messages = get_last_assistant_messages(str(empty_file), count=3)
+        assert messages == []
+
+
+class TestExtractAssistantText:
+    """Tests for the extract_assistant_text function."""
+
+    def test_extract_from_content_blocks(self):
+        """Test extracting text from content blocks."""
+        message = {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "Hello"},
+                    {"type": "text", "text": "World"}
+                ]
+            }
+        }
+        text = extract_assistant_text(message)
+        assert "Hello" in text
+        assert "World" in text
+
+    def test_extract_from_direct_string_content(self):
+        """Test extracting from direct string content."""
+        message = {
+            "type": "assistant",
+            "content": "Direct text content"
+        }
+        text = extract_assistant_text(message)
+        assert "Direct text content" in text
+
+    def test_extract_from_string_message(self):
+        """Test extracting from string message field."""
+        message = {
+            "type": "assistant",
+            "message": "Simple string message"
+        }
+        text = extract_assistant_text(message)
+        assert "Simple string message" in text
+
+    def test_extract_from_list_content(self):
+        """Test extracting from list content with strings."""
+        message = {
+            "type": "assistant",
+            "content": ["First part", "Second part"]
+        }
+        text = extract_assistant_text(message)
+        assert "First part" in text
+        assert "Second part" in text
+
+    def test_extract_empty_message(self):
+        """Test extracting from message with no text."""
+        message = {
+            "type": "assistant",
+            "message": {}
+        }
+        text = extract_assistant_text(message)
+        assert text == ""
+
+    def test_ignore_non_text_blocks(self):
+        """Test that non-text blocks are ignored."""
+        message = {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "Visible"},
+                    {"type": "tool_use", "id": "123"},
+                    {"type": "text", "text": "Also visible"}
+                ]
+            }
+        }
+        text = extract_assistant_text(message)
+        assert "Visible" in text
+        assert "Also visible" in text
+        assert "tool_use" not in text
+
+
+class TestGetRecentAssistantText:
+    """Tests for the get_recent_assistant_text function."""
+
+    def test_get_combined_text(self, sample_transcript):
+        """Test getting combined text from recent messages."""
+        text = get_recent_assistant_text(sample_transcript, message_count=3)
+        # Should contain text from assistant messages
+        assert "config.json" in text or "tests pass" in text
+
+    def test_empty_on_missing_file(self, temp_dir):
+        """Test empty result for missing file."""
+        text = get_recent_assistant_text(f"{temp_dir}/missing.jsonl", message_count=3)
+        assert text == ""
+
+    def test_respects_message_count(self, temp_dir):
+        """Test that message count is respected."""
+        transcript_path = Path(temp_dir) / "multi.jsonl"
+        messages = [
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "Message 1"}]}},
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "Message 2"}]}},
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "Message 3"}]}},
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "Message 4"}]}},
+        ]
+        with open(transcript_path, 'w') as f:
+            for msg in messages:
+                f.write(json.dumps(msg) + "\n")
+
+        text = get_recent_assistant_text(str(transcript_path), message_count=2)
+        # Should only contain last 2 messages
+        assert "Message 3" in text
+        assert "Message 4" in text
+        assert "Message 1" not in text

--- a/plugins/verify-claims/tests/test_verifiers.py
+++ b/plugins/verify-claims/tests/test_verifiers.py
@@ -1,0 +1,382 @@
+"""Tests for verifiers."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from verifiers import verify_claim
+from verifiers.build_checker import detect_build_command, verify_build_success
+from verifiers.file_exists import verify_file_exists
+from verifiers.git_diff import verify_changes_made
+from verifiers.lint_checker import detect_lint_command, verify_lint_clean
+from verifiers.test_runner import detect_test_command, verify_tests_pass
+
+
+class TestVerifyFileExists:
+    """Tests for the file exists verifier."""
+
+    def test_file_exists(self, temp_project_dir):
+        """Test verification when file exists."""
+        # Create a test file
+        test_file = Path(temp_project_dir) / "config.json"
+        test_file.write_text('{"key": "value"}')
+
+        result = verify_file_exists("config.json", temp_project_dir, {})
+
+        assert result.passed is True
+        assert "exists" in result.message.lower()
+        assert result.details["is_file"] is True
+
+    def test_file_not_exists(self, temp_project_dir):
+        """Test verification when file doesn't exist."""
+        result = verify_file_exists("nonexistent.json", temp_project_dir, {})
+
+        assert result.passed is False
+        assert "does not exist" in result.message.lower()
+
+    def test_absolute_path(self, temp_project_dir):
+        """Test verification with absolute path."""
+        test_file = Path(temp_project_dir) / "abs_test.json"
+        test_file.write_text("{}")
+
+        result = verify_file_exists(str(test_file), temp_project_dir, {})
+        assert result.passed is True
+
+    def test_nested_path(self, temp_project_dir):
+        """Test verification with nested path."""
+        nested_dir = Path(temp_project_dir) / "src" / "components"
+        nested_dir.mkdir(parents=True)
+        test_file = nested_dir / "Button.tsx"
+        test_file.write_text("export default Button;")
+
+        result = verify_file_exists("src/components/Button.tsx", temp_project_dir, {})
+        assert result.passed is True
+
+    def test_directory_not_file(self, temp_project_dir):
+        """Test that directories don't pass file verification."""
+        dir_path = Path(temp_project_dir) / "src"
+        dir_path.mkdir()
+
+        result = verify_file_exists("src", temp_project_dir, {})
+        assert result.passed is False
+        assert "not a file" in result.message.lower()
+
+    def test_missing_path_parameter(self, temp_project_dir):
+        """Test verification with missing path."""
+        result = verify_file_exists(None, temp_project_dir, {})
+        assert result.passed is False
+        assert "no file path" in result.message.lower()
+
+    def test_empty_path_parameter(self, temp_project_dir):
+        """Test verification with empty path."""
+        result = verify_file_exists("", temp_project_dir, {})
+        assert result.passed is False
+
+
+class TestDetectTestCommand:
+    """Tests for test command detection."""
+
+    def test_detect_npm_test(self, npm_project):
+        """Test detection of npm test command."""
+        command, framework = detect_test_command(npm_project)
+        assert command == "npm test"
+        assert framework == "npm"
+
+    def test_detect_pytest(self, python_project):
+        """Test detection of pytest command."""
+        command, framework = detect_test_command(python_project)
+        assert command == "pytest"
+        assert framework == "pytest"
+
+    def test_detect_cargo_test(self, rust_project):
+        """Test detection of cargo test command."""
+        command, framework = detect_test_command(rust_project)
+        assert command == "cargo test"
+        assert framework == "cargo"
+
+    def test_detect_go_test(self, go_project):
+        """Test detection of go test command."""
+        command, framework = detect_test_command(go_project)
+        assert command == "go test ./..."
+        assert framework == "go"
+
+    def test_no_test_framework(self, temp_project_dir):
+        """Test when no test framework is detected."""
+        result = detect_test_command(temp_project_dir)
+        assert result is None
+
+
+class TestVerifyTestsPass:
+    """Tests for the test runner verifier."""
+
+    def test_skips_when_no_framework(self, temp_project_dir):
+        """Test that verification is skipped when no test framework detected."""
+        result = verify_tests_pass(None, temp_project_dir, {})
+
+        assert result.passed is True
+        assert result.details.get("skipped") is True
+        assert "no test framework" in result.message.lower()
+
+    def test_uses_custom_command(self, temp_project_dir):
+        """Test that custom command is used when specified."""
+        config = {"command": "echo 'tests pass'"}
+
+        with patch('verifiers.test_runner.subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            verify_tests_pass(None, temp_project_dir, config)
+
+        mock_run.assert_called_once()
+        call_args = mock_run.call_args
+        # Command is now passed as a list via shlex.split() for security
+        assert call_args[0][0] == ["echo", "tests pass"]
+
+    def test_handles_test_failure(self, npm_project):
+        """Test handling of test failures."""
+        with patch('verifiers.test_runner.subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1,
+                stdout="FAIL: test_something",
+                stderr=""
+            )
+            result = verify_tests_pass(None, npm_project, {})
+
+        assert result.passed is False
+        assert "failed" in result.message.lower()
+
+    def test_handles_timeout(self, npm_project):
+        """Test handling of test timeout."""
+        import subprocess
+
+        with patch('verifiers.test_runner.subprocess.run') as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired("npm test", 60)
+            result = verify_tests_pass(None, npm_project, {"timeout": 60})
+
+        assert result.passed is False
+        assert "timed out" in result.message.lower()
+
+
+class TestDetectLintCommand:
+    """Tests for lint command detection."""
+
+    def test_detect_npm_lint(self, npm_project):
+        """Test detection of npm lint command."""
+        command, linter = detect_lint_command(npm_project)
+        assert command == "npm run lint"
+        assert linter == "npm"
+
+    def test_detect_ruff(self, temp_project_dir):
+        """Test detection of ruff linter."""
+        ruff_config = Path(temp_project_dir) / "ruff.toml"
+        ruff_config.write_text("[lint]\nselect = ['E', 'F']\n")
+
+        command, linter = detect_lint_command(temp_project_dir)
+        assert command == "ruff check ."
+        assert linter == "ruff"
+
+    def test_detect_cargo_clippy(self, rust_project):
+        """Test detection of cargo clippy."""
+        command, linter = detect_lint_command(rust_project)
+        assert "clippy" in command
+        assert linter == "clippy"
+
+    def test_no_linter_detected(self, temp_project_dir):
+        """Test when no linter is detected."""
+        result = detect_lint_command(temp_project_dir)
+        assert result is None
+
+
+class TestVerifyLintClean:
+    """Tests for the lint checker verifier."""
+
+    def test_skips_when_no_linter(self, temp_project_dir):
+        """Test that verification is skipped when no linter detected."""
+        result = verify_lint_clean(None, temp_project_dir, {})
+
+        assert result.passed is True
+        assert result.details.get("skipped") is True
+
+    def test_lint_passes(self, npm_project):
+        """Test when lint passes."""
+        with patch('verifiers.lint_checker.subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            result = verify_lint_clean(None, npm_project, {})
+
+        assert result.passed is True
+        assert "passed" in result.message.lower()
+
+    def test_lint_fails(self, npm_project):
+        """Test when lint fails."""
+        with patch('verifiers.lint_checker.subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1,
+                stdout="src/index.ts:10 error",
+                stderr=""
+            )
+            result = verify_lint_clean(None, npm_project, {})
+
+        assert result.passed is False
+        assert "error" in result.message.lower()
+
+
+class TestDetectBuildCommand:
+    """Tests for build command detection."""
+
+    def test_detect_npm_build(self, npm_project):
+        """Test detection of npm build command."""
+        # Add build script to package.json
+        pkg_path = Path(npm_project) / "package.json"
+        with open(pkg_path) as f:
+            pkg = json.load(f)
+        pkg["scripts"]["build"] = "tsc"
+        with open(pkg_path, 'w') as f:
+            json.dump(pkg, f)
+
+        command, tool = detect_build_command(npm_project)
+        assert command == "npm run build"
+        assert tool == "npm"
+
+    def test_detect_cargo_build(self, rust_project):
+        """Test detection of cargo build."""
+        command, tool = detect_build_command(rust_project)
+        assert command == "cargo build"
+        assert tool == "cargo"
+
+    def test_detect_go_build(self, go_project):
+        """Test detection of go build."""
+        command, tool = detect_build_command(go_project)
+        assert command == "go build ./..."
+        assert tool == "go"
+
+    def test_detect_typescript(self, temp_project_dir):
+        """Test detection of TypeScript compilation."""
+        tsconfig = Path(temp_project_dir) / "tsconfig.json"
+        tsconfig.write_text('{"compilerOptions": {}}')
+
+        command, tool = detect_build_command(temp_project_dir)
+        assert "tsc" in command
+        assert tool == "typescript"
+
+
+class TestVerifyBuildSuccess:
+    """Tests for the build checker verifier."""
+
+    def test_skips_when_no_build_system(self, temp_project_dir):
+        """Test that verification is skipped when no build system detected."""
+        result = verify_build_success(None, temp_project_dir, {})
+
+        assert result.passed is True
+        assert result.details.get("skipped") is True
+
+    def test_build_succeeds(self, rust_project):
+        """Test when build succeeds."""
+        with patch('verifiers.build_checker.subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            result = verify_build_success(None, rust_project, {})
+
+        assert result.passed is True
+        assert "succeeded" in result.message.lower()
+
+    def test_build_fails(self, rust_project):
+        """Test when build fails."""
+        with patch('verifiers.build_checker.subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1,
+                stdout="error[E0308]: mismatched types",
+                stderr=""
+            )
+            result = verify_build_success(None, rust_project, {})
+
+        assert result.passed is False
+        assert "failed" in result.message.lower()
+
+
+class TestVerifyChangesMade:
+    """Tests for the git diff verifier."""
+
+    def test_skips_non_git_repo(self, temp_project_dir):
+        """Test that verification is skipped for non-git repos."""
+        result = verify_changes_made(None, temp_project_dir, {})
+
+        assert result.passed is True
+        assert result.details.get("skipped") is True
+        assert "not a git repository" in result.message.lower()
+
+    def test_detects_changes(self, temp_project_dir):
+        """Test detection of code changes in a git repo."""
+        # Initialize git repo
+        git_dir = Path(temp_project_dir) / ".git"
+        git_dir.mkdir()
+
+        with patch('verifiers.git_diff.subprocess.run') as mock_run:
+            # Simulate having unstaged changes
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout=""),  # staged
+                MagicMock(returncode=0, stdout="src/main.py\n"),  # unstaged
+                MagicMock(returncode=0, stdout=""),  # untracked
+            ]
+            result = verify_changes_made(None, temp_project_dir, {})
+
+        assert result.passed is True
+        assert "changes detected" in result.message.lower()
+
+    def test_no_changes_detected(self, temp_project_dir):
+        """Test when no changes are detected."""
+        git_dir = Path(temp_project_dir) / ".git"
+        git_dir.mkdir()
+
+        with patch('verifiers.git_diff.subprocess.run') as mock_run:
+            # Simulate no changes
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout=""),  # staged
+                MagicMock(returncode=0, stdout=""),  # unstaged
+                MagicMock(returncode=0, stdout=""),  # untracked
+                MagicMock(returncode=0, stdout=""),  # recent commits
+            ]
+            result = verify_changes_made(None, temp_project_dir, {})
+
+        assert result.passed is False
+        assert "no code changes" in result.message.lower()
+
+
+class TestVerifyClaim:
+    """Tests for the main verify_claim function."""
+
+    def test_routes_to_correct_verifier(self, temp_project_dir):
+        """Test that claims are routed to correct verifiers."""
+        # Create a test file
+        test_file = Path(temp_project_dir) / "test.txt"
+        test_file.write_text("content")
+
+        config = {"verifiers": {"file_created": {"enabled": True}}}
+        result = verify_claim("file_created", "test.txt", temp_project_dir, config)
+
+        assert result.passed is True
+
+    def test_unknown_claim_type_skipped(self, temp_project_dir):
+        """Test that unknown claim types are skipped."""
+        config = {}
+        result = verify_claim("unknown_type", None, temp_project_dir, config)
+
+        assert result.passed is True
+        assert result.details.get("skipped") is True
+
+    def test_disabled_verifier_skipped(self, temp_project_dir):
+        """Test that disabled verifiers are skipped."""
+        config = {"verifiers": {"tests_pass": {"enabled": False}}}
+        result = verify_claim("tests_pass", None, temp_project_dir, config)
+
+        assert result.passed is True
+        assert result.details.get("skipped") is True
+        assert result.details.get("reason") == "disabled"
+
+    def test_handles_verifier_exceptions(self, temp_project_dir):
+        """Test that verifier exceptions are handled gracefully."""
+        config = {"verifiers": {"file_created": {"enabled": True}}}
+
+        # Pass an invalid path that might cause issues
+        with patch('verifiers.file_exists.os.path.exists') as mock_exists:
+            mock_exists.side_effect = PermissionError("Access denied")
+            result = verify_claim("file_created", "/some/path", temp_project_dir, config)
+
+        assert result.passed is False
+        assert "error" in result.message.lower()


### PR DESCRIPTION
## Summary

- **Add verify-claims plugin**: Automatically verifies Claude's claims about code changes before allowing task completion
- **Intercept Stop hook**: When Claude claims success, the plugin validates those claims are actually true
- **Update plugins/README.md**: Add verify-claims to the official plugin directory listing

## What This Plugin Does

When Claude claims to have:
- Created files → Verifies they exist on disk
- Fixed bugs → Checks git diff for actual changes
- Tests pass → Runs the detected test command
- Lint is clean → Runs the detected linter
- Build succeeds → Runs the detected build command

If verification fails, task completion is blocked and Claude must address the discrepancy.

## Features

- **Multi-framework support**: Auto-detects npm, pytest, cargo, go, rspec, maven, gradle
- **Configurable**: Per-project overrides via `.claude/verify-claims.json`
- **Session state tracking**: Remembers files written and commands run
- **Infinite loop prevention**: Retry limits and active hook detection

## Files Added

```
plugins/verify-claims/
├── .claude-plugin/plugin.json
├── commands/verify.md
├── hooks/hooks.json
├── scripts/
│   ├── verify_claims.py     # Stop hook
│   ├── track_tool_use.py    # PostToolUse hook
│   ├── claim_parser.py      # Claim extraction
│   ├── transcript_reader.py # JSONL parsing
│   ├── verifiers/           # Verification modules
│   └── utils/               # Shared utilities
├── tests/                   # 183 tests, 70% coverage
├── README.md
├── CHANGELOG.md
└── LICENSE (MIT)
```

## Test Plan

- [x] All 183 tests pass (`pytest tests/ -v`)
- [x] Linting passes (`ruff check scripts/ tests/`)
- [x] CI configured for Python 3.10-3.13
- [ ] Manual testing with `claude --plugin-dir ./plugins/verify-claims`