### PR TITLE
docs: add examples/settings

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -1,0 +1,31 @@
+# Settings Examples
+
+Example Claude Code settings files, primarily intended for organization-wide deployments. Use these are starting points — adjust them to fit your needs.
+
+These may be applied at any level of the [settings hierarchy](https://code.claude.com/docs/en/settings#settings-files), though certain properties only take effect if specified in enterprise settings (e.g. `strictKnownMarketplaces`, `allowManagedHooksOnly`, `allowManagedPermissionRulesOnly`).
+
+
+## Configuration Examples
+
+> [!WARNING]
+> These examples are community-maintained snippets which may be unsupported or incorrect. You are responsible for the correctness of your own settings configuration.
+
+| Setting | [`settings-lax.json`](./settings-lax.json) | [`settings-strict.json`](./settings-strict.json) | [`settings-bash-sandbox.json`](./settings-bash-sandbox.json) |
+|---------|:---:|:---:|:---:|
+| Disable `--dangerously-skip-permissions` | ✅ | ✅ | |
+| Block plugin marketplaces | ✅ | ✅ | |
+| Block user and project-defined permission `allow` / `ask` / `deny` | | ✅ | ✅ |
+| Block user and project-defined hooks | | ✅ | |
+| Deny web fetch and search tools | | ✅ | |
+| Bash tool requires approval | | ✅ | |
+| Bash tool must run inside of sandbox | | | ✅ |
+
+## Tips
+- Consider merging snippets of the above examples to reach your desired configuration
+- Settings files must be valid JSON
+- Before deploying configuration files to your organization, test them locally by applying to `managed-settings.json`, `settings.json` or `settings.local.json`
+- The `sandbox` property only applies to the `Bash` tool; it does not apply to other tools (like Read, Write, WebSearch, WebFetch, MCPs), hooks, or internal commands
+
+## Full Documentation
+
+See https://code.claude.com/docs/en/settings for complete documentation on all available managed settings.

--- a/examples/settings/settings-bash-sandbox.json
+++ b/examples/settings/settings-bash-sandbox.json
@@ -1,0 +1,16 @@
+{
+  "allowManagedPermissionRulesOnly": true,
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": false,
+    "allowUnsandboxedCommands": false,
+    "excludedCommands": [],
+    "network": {
+      "allowUnixSockets": [],
+      "allowLocalBinding": false,
+      "httpProxyPort": null,
+      "socksProxyPort": null
+    },
+    "enableWeakerNestedSandbox": false
+  }
+}

--- a/examples/settings/settings-bash-sandbox.json
+++ b/examples/settings/settings-bash-sandbox.json
@@ -7,7 +7,9 @@
     "excludedCommands": [],
     "network": {
       "allowUnixSockets": [],
+      "allowAllUnixSockets": false,
       "allowLocalBinding": false,
+      "allowedDomains": [],
       "httpProxyPort": null,
       "socksProxyPort": null
     },

--- a/examples/settings/settings-lax.json
+++ b/examples/settings/settings-lax.json
@@ -1,0 +1,6 @@
+{
+  "permissions": {
+    "disableBypassPermissionsMode": "disable"
+  },
+  "strictKnownMarketplaces": []
+}

--- a/examples/settings/settings-strict.json
+++ b/examples/settings/settings-strict.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "disableBypassPermissionsMode": "disable",
+    "ask": [
+      "Bash"
+    ],
+    "deny": [
+      "WebSearch",
+      "WebFetch"
+    ]
+  },
+  "allowManagedPermissionRulesOnly": true,
+  "allowManagedHooksOnly": true,
+  "strictKnownMarketplaces": []
+}

--- a/examples/settings/settings-strict.json
+++ b/examples/settings/settings-strict.json
@@ -17,7 +17,9 @@
     "excludedCommands": [],
     "network": {
       "allowUnixSockets": [],
+      "allowAllUnixSockets": false,
       "allowLocalBinding": false,
+      "allowedDomains": [],
       "httpProxyPort": null,
       "socksProxyPort": null
     },

--- a/examples/settings/settings-strict.json
+++ b/examples/settings/settings-strict.json
@@ -11,5 +11,16 @@
   },
   "allowManagedPermissionRulesOnly": true,
   "allowManagedHooksOnly": true,
-  "strictKnownMarketplaces": []
+  "strictKnownMarketplaces": [],
+  "sandbox": {
+    "autoAllowBashIfSandboxed": false,
+    "excludedCommands": [],
+    "network": {
+      "allowUnixSockets": [],
+      "allowLocalBinding": false,
+      "httpProxyPort": null,
+      "socksProxyPort": null
+    },
+    "enableWeakerNestedSandbox": false
+  }
 }


### PR DESCRIPTION
Add `examples/settings` with three sample settings files, and a human-readable description of them.