### PR TITLE
fix(commit-commands): Add git diff, branch, log to allowed-tools

### DIFF
--- a/plugins/commit-commands/commands/commit.md
+++ b/plugins/commit-commands/commands/commit.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git, Bash(git diff:*), Bash(git branch:*), Bash(git log:*) commit:*)
 description: Create a git commit
 ---
 


### PR DESCRIPTION
This PR updates [plugins/commit-commands/commands/commit.md] to include `git diff`, `git branch`, and `git log` in the `allowed-tools` list.

**Reasoning:**
These commands are already referenced in the `Context` section of the prompt. Explicitly allowing them enables the agent to run these commands if needed (e.g., if context is truncated or for verification), preventing potential permission errors.