### PR TITLE
feat(plugins): Add audit-trail plugin for compliance logging

### DIFF
--- a/plugins/audit-trail/.claude-plugin/plugin.json
+++ b/plugins/audit-trail/.claude-plugin/plugin.json
@@ -2,31 +2,8 @@
   "name": "audit-trail",
   "version": "1.0.0",
   "description": "Comprehensive audit logging for Claude Code tool usage. Logs all tool calls with timestamps, inputs, and results to JSONL files for debugging, compliance, and security review.",
-  "author": "Steven Elliott",
-  "homepage": "https://github.com/stevenelliottjr/claude-code",
-  "keywords": ["audit", "logging", "compliance", "security", "debugging", "HIPAA", "SOC2"],
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": ".*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 $CLAUDE_PLUGIN_ROOT/hooks/pretooluse.py"
-          }
-        ]
-      }
-    ],
-    "PostToolUse": [
-      {
-        "matcher": ".*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 $CLAUDE_PLUGIN_ROOT/hooks/posttooluse.py"
-          }
-        ]
-      }
-    ]
+  "author": {
+    "name": "Steven Elliott",
+    "email": "elliotts@uswa.net"
   }
 }

--- a/plugins/audit-trail/.claude-plugin/plugin.json
+++ b/plugins/audit-trail/.claude-plugin/plugin.json
@@ -1,0 +1,32 @@
+{
+  "name": "audit-trail",
+  "version": "1.0.0",
+  "description": "Comprehensive audit logging for Claude Code tool usage. Logs all tool calls with timestamps, inputs, and results to JSONL files for debugging, compliance, and security review.",
+  "author": "Steven Elliott",
+  "homepage": "https://github.com/stevenelliottjr/claude-code",
+  "keywords": ["audit", "logging", "compliance", "security", "debugging", "HIPAA", "SOC2"],
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PLUGIN_ROOT/hooks/pretooluse.py"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PLUGIN_ROOT/hooks/posttooluse.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/audit-trail/README.md
+++ b/plugins/audit-trail/README.md
@@ -1,0 +1,219 @@
+# Audit Trail Plugin for Claude Code
+
+Comprehensive audit logging for Claude Code tool usage. Provides an immutable record of all AI agent actions for debugging, compliance, and security review.
+
+## Why Audit Logging?
+
+Claude Code executes powerful operations: writing files, running commands, making network requests. In production environments, you need to answer questions like:
+
+- **Debugging**: "What did Claude change last session that broke the build?"
+- **Compliance**: "Can we demonstrate what the AI agent accessed for our SOC 2 audit?"
+- **Security**: "Did any session access sensitive files or run unexpected commands?"
+- **Accountability**: "What exactly happened during this automated workflow?"
+
+This plugin addresses [Issue #16622](https://github.com/anthropics/claude-code/issues/16622) by providing visibility into Claude Code's actions through structured audit logs.
+
+## Features
+
+- **Comprehensive Logging**: Records all tool calls (Bash, Read, Write, Edit, WebFetch, etc.)
+- **Pre and Post Capture**: Logs both the request (before) and result (after) for each tool
+- **Automatic Categorization**: Tools are categorized (execution, file_read, file_write, network, etc.)
+- **Sensitive Data Redaction**: Automatically masks passwords, API keys, and tokens
+- **Daily Log Rotation**: Logs stored in daily JSONL files for easy management
+- **Zero-Block Design**: Audit failures never block operations
+- **Compliance Ready**: Structured format suitable for SOC 2, HIPAA, and similar requirements
+
+## Installation
+
+### Option 1: Via Plugin Directory
+
+Copy the `audit-trail` folder to your Claude Code plugins directory:
+
+```bash
+cp -r audit-trail ~/.claude/plugins/
+```
+
+### Option 2: Via Settings
+
+Add to your `.claude/settings.json`:
+
+```json
+{
+  "plugins": [
+    "/path/to/audit-trail"
+  ]
+}
+```
+
+## Usage
+
+Once installed, the plugin automatically logs all tool usage. No configuration required.
+
+### View Audit Logs
+
+Use the `/audit` command to query logs:
+
+```
+/audit
+```
+
+Or manually inspect the JSONL files:
+
+```bash
+# Today's logs
+cat ~/.claude/audit/audit-$(date +%Y-%m-%d).jsonl | jq '.'
+
+# Recent activity
+tail -10 ~/.claude/audit/audit-*.jsonl | jq '.'
+```
+
+### Common Queries
+
+```bash
+# Count tool usage by type
+cat ~/.claude/audit/audit-*.jsonl | jq -r '.tool.name' | sort | uniq -c | sort -rn
+
+# Find all file modifications
+cat ~/.claude/audit/audit-*.jsonl | jq 'select(.tool.category == "file_write")'
+
+# Find all Bash commands run
+cat ~/.claude/audit/audit-*.jsonl | jq 'select(.tool.name == "Bash") | .tool.command'
+
+# Find errors
+cat ~/.claude/audit/audit-*.jsonl | jq 'select(.result.status == "error")'
+
+# Activity by session
+cat ~/.claude/audit/audit-*.jsonl | jq -s 'group_by(.session_id) | map({session: .[0].session_id, count: length})'
+```
+
+## Log Format
+
+Each audit record is a JSON object with this structure:
+
+```json
+{
+  "timestamp": "2026-02-02T18:30:45.123456+00:00",
+  "timestamp_unix": 1770156645.123456,
+  "event_type": "pre_tool_use",
+  "session_id": "a1b2c3d4e5f6",
+  "tool": {
+    "name": "Bash",
+    "category": "execution",
+    "command": "npm test"
+  },
+  "request": {
+    "command": "npm test",
+    "timeout": 60000
+  },
+  "context": {
+    "cwd": "/home/user/project",
+    "user": "developer",
+    "config_dir": "~/.claude"
+  }
+}
+```
+
+### Event Types
+
+- `pre_tool_use`: Logged before tool execution (captures intent)
+- `post_tool_use`: Logged after tool execution (captures result)
+
+### Tool Categories
+
+| Category | Tools |
+|----------|-------|
+| `execution` | Bash |
+| `file_read` | Read |
+| `file_write` | Write, Edit, MultiEdit |
+| `file_search` | Glob, Grep |
+| `network` | WebFetch, WebSearch |
+| `agent` | Task |
+| `interaction` | AskUserQuestion |
+
+## Configuration
+
+### Custom Audit Directory
+
+Set `CLAUDE_CONFIG_DIR` to change where logs are stored:
+
+```bash
+export CLAUDE_CONFIG_DIR=~/.claude-work
+# Logs will be in ~/.claude-work/audit/
+```
+
+### Log Retention
+
+Logs are stored in daily files. Implement your own retention policy:
+
+```bash
+# Delete logs older than 90 days
+find ~/.claude/audit -name "audit-*.jsonl" -mtime +90 -delete
+```
+
+## Compliance Use Cases
+
+### SOC 2 Type II
+
+The audit trail provides evidence of:
+- Access controls (who accessed what)
+- Change management (what was modified)
+- System operations (commands executed)
+
+### HIPAA
+
+For healthcare environments:
+- Track access to files containing PHI
+- Maintain audit logs for required retention period
+- Demonstrate access monitoring controls
+
+### Financial Services (SOX, GLBA)
+
+- Document automated processes
+- Maintain change audit trail
+- Support segregation of duties review
+
+## Privacy Considerations
+
+The plugin automatically redacts values for keys containing:
+- password, secret, token, api_key, credential, private_key, auth
+
+For additional privacy:
+- File contents from Read operations are not logged (only metadata)
+- Large outputs are truncated
+- You can post-process logs to remove additional sensitive data
+
+## Troubleshooting
+
+### Logs not appearing
+
+1. Check plugin is loaded: Look for audit-trail in active plugins
+2. Verify directory exists: `ls ~/.claude/audit/`
+3. Check permissions: `touch ~/.claude/audit/test.txt`
+
+### Hook errors
+
+Errors are logged to stderr but never block operations. Check:
+```bash
+# Recent errors in Claude Code debug logs
+grep -i "audit" ~/.claude/debug/*.log
+```
+
+## Contributing
+
+This plugin was created to address [Issue #16622](https://github.com/anthropics/claude-code/issues/16622). Contributions welcome:
+
+- Additional query commands
+- Export formats (CSV, SQL)
+- Log analysis tools
+- Integration with SIEM systems
+
+## License
+
+MIT License
+
+## Author
+
+Steven Elliott - CIO with expertise in compliance (HIPAA, SOC 2, ERISA) and AI transformation in regulated environments.
+
+- GitHub: [@stevenelliottjr](https://github.com/stevenelliottjr)
+- LinkedIn: [/in/stevenelliottjr](https://linkedin.com/in/stevenelliottjr)

--- a/plugins/audit-trail/commands/audit.md
+++ b/plugins/audit-trail/commands/audit.md
@@ -1,0 +1,77 @@
+---
+name: audit
+description: Query and analyze Claude Code audit logs for debugging and compliance review
+allowed-tools: Bash(python3:*), Bash(cat:*), Bash(head:*), Bash(tail:*), Bash(wc:*), Bash(jq:*), Read(*)
+---
+
+# Audit Log Query
+
+You are an audit log analyzer for Claude Code. Help the user query and understand their audit logs.
+
+## Audit Log Location
+
+Audit logs are stored in `~/.claude/audit/` (or `$CLAUDE_CONFIG_DIR/audit/` if configured).
+Files are named `audit-YYYY-MM-DD.jsonl` with one JSON record per line.
+
+## Record Structure
+
+Each audit record contains:
+- `timestamp`: ISO 8601 timestamp
+- `event_type`: "pre_tool_use" or "post_tool_use"
+- `session_id`: Session identifier
+- `tool.name`: Tool that was called (Bash, Read, Write, etc.)
+- `tool.category`: Category (execution, file_read, file_write, network, etc.)
+- `request`: Tool input (sanitized for sensitive data)
+- `result`: Tool result summary (post_tool_use only)
+- `context.cwd`: Working directory
+
+## Common Queries
+
+When the user asks to see audit logs, use these approaches:
+
+### Show recent activity
+```bash
+tail -20 ~/.claude/audit/audit-$(date +%Y-%m-%d).jsonl | jq '.'
+```
+
+### Count tool usage by type
+```bash
+cat ~/.claude/audit/audit-*.jsonl | jq -r '.tool.name' | sort | uniq -c | sort -rn
+```
+
+### Find all file writes
+```bash
+cat ~/.claude/audit/audit-*.jsonl | jq 'select(.tool.category == "file_write")'
+```
+
+### Find all Bash commands
+```bash
+cat ~/.claude/audit/audit-*.jsonl | jq 'select(.tool.name == "Bash") | {time: .timestamp, cmd: .tool.command}'
+```
+
+### Show activity in a time range
+```bash
+cat ~/.claude/audit/audit-2026-02-02.jsonl | jq 'select(.timestamp > "2026-02-02T10:00:00")'
+```
+
+### Find errors
+```bash
+cat ~/.claude/audit/audit-*.jsonl | jq 'select(.result.status == "error")'
+```
+
+### Generate compliance summary
+```bash
+cat ~/.claude/audit/audit-*.jsonl | jq -s 'group_by(.tool.category) | map({category: .[0].tool.category, count: length})'
+```
+
+## Instructions
+
+1. First check if audit logs exist: `ls -la ~/.claude/audit/`
+2. Ask the user what they want to find (specific files, commands, time range, errors, etc.)
+3. Construct appropriate jq queries to extract the information
+4. Present results in a clear, readable format
+5. For compliance reports, summarize findings with counts and categories
+
+## Privacy Note
+
+Audit logs may contain file paths and command snippets. Be careful when sharing or exporting logs - review for sensitive information first.

--- a/plugins/audit-trail/hooks/hooks.json
+++ b/plugins/audit-trail/hooks/hooks.json
@@ -1,0 +1,27 @@
+{
+  "description": "Audit trail plugin - comprehensive logging of all tool usage for debugging and compliance",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/posttooluse.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/audit-trail/hooks/posttooluse.py
+++ b/plugins/audit-trail/hooks/posttooluse.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""PostToolUse audit hook for comprehensive tool result logging.
+
+This hook logs all tool results AFTER execution, capturing:
+- Timestamp
+- Session ID
+- Tool name and result status
+- Execution duration (when paired with PreToolUse)
+- Output summary (truncated for large outputs)
+
+Logs are written to ~/.claude/audit/<date>.jsonl in append mode.
+
+Author: Steven Elliott
+License: MIT
+"""
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+import hashlib
+
+
+def get_audit_dir() -> Path:
+    """Get or create the audit log directory."""
+    config_dir = os.environ.get('CLAUDE_CONFIG_DIR', os.path.expanduser('~/.claude'))
+    audit_dir = Path(config_dir) / 'audit'
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    return audit_dir
+
+
+def get_session_id() -> str:
+    """Extract or generate a session identifier."""
+    session_id = os.environ.get('CLAUDE_SESSION_ID', '')
+    if not session_id:
+        cwd = os.getcwd()
+        session_id = hashlib.md5(f"{cwd}-{datetime.now().date()}".encode()).hexdigest()[:12]
+    return session_id
+
+
+def categorize_tool(tool_name: str) -> str:
+    """Categorize tool for filtering and reporting."""
+    categories = {
+        'Bash': 'execution',
+        'Read': 'file_read',
+        'Write': 'file_write',
+        'Edit': 'file_write',
+        'MultiEdit': 'file_write',
+        'Glob': 'file_search',
+        'Grep': 'file_search',
+        'WebFetch': 'network',
+        'WebSearch': 'network',
+        'Task': 'agent',
+        'AskUserQuestion': 'interaction',
+    }
+    return categories.get(tool_name, 'other')
+
+
+def summarize_output(output: any, max_length: int = 500) -> str:
+    """Create a summary of tool output for logging."""
+    if output is None:
+        return "[no output]"
+
+    if isinstance(output, str):
+        if len(output) <= max_length:
+            return output
+        return output[:max_length] + f"... [truncated, {len(output)} chars total]"
+
+    if isinstance(output, dict):
+        # For dicts, create a summary
+        summary = json.dumps(output, ensure_ascii=False)
+        if len(summary) <= max_length:
+            return summary
+        return summary[:max_length] + f"... [truncated]"
+
+    return str(output)[:max_length]
+
+
+def determine_result_status(input_data: dict) -> str:
+    """Determine if the tool execution was successful."""
+    tool_result = input_data.get('tool_result', {})
+
+    # Check for error indicators
+    if isinstance(tool_result, dict):
+        if tool_result.get('is_error', False):
+            return 'error'
+        if 'error' in str(tool_result).lower()[:100]:
+            return 'possible_error'
+
+    # Check if there's output
+    if tool_result:
+        return 'success'
+
+    return 'unknown'
+
+
+def create_audit_record(input_data: dict, event_type: str) -> dict:
+    """Create a structured audit record for post-tool-use."""
+    now = datetime.now(timezone.utc)
+    tool_name = input_data.get('tool_name', 'unknown')
+    tool_input = input_data.get('tool_input', {})
+    tool_result = input_data.get('tool_result', {})
+
+    record = {
+        "timestamp": now.isoformat(),
+        "timestamp_unix": now.timestamp(),
+        "event_type": event_type,
+        "session_id": get_session_id(),
+        "tool": {
+            "name": tool_name,
+            "category": categorize_tool(tool_name),
+        },
+        "result": {
+            "status": determine_result_status(input_data),
+            "output_summary": summarize_output(tool_result),
+        },
+        "context": {
+            "cwd": os.getcwd(),
+        }
+    }
+
+    # Add tool-specific result info
+    if tool_name == 'Bash':
+        record["tool"]["command"] = tool_input.get('command', '')[:200]
+        # Check for exit code in result
+        result_str = str(tool_result)
+        if 'exit code' in result_str.lower():
+            record["result"]["has_exit_code"] = True
+
+    elif tool_name in ['Write', 'Edit']:
+        record["tool"]["file_path"] = tool_input.get('file_path', '')
+        record["result"]["file_modified"] = True
+
+    elif tool_name == 'Read':
+        record["tool"]["file_path"] = tool_input.get('file_path', '')
+        # Don't log file contents for privacy
+        record["result"]["output_summary"] = f"[file read: {len(str(tool_result))} chars]"
+
+    return record
+
+
+def write_audit_log(record: dict) -> None:
+    """Append audit record to daily JSONL file."""
+    audit_dir = get_audit_dir()
+    date_str = datetime.now().strftime('%Y-%m-%d')
+    log_file = audit_dir / f"audit-{date_str}.jsonl"
+
+    with open(log_file, 'a', encoding='utf-8') as f:
+        f.write(json.dumps(record, ensure_ascii=False) + '\n')
+
+
+def main():
+    """Main entry point for PostToolUse audit hook."""
+    try:
+        # Read input from stdin
+        input_data = json.load(sys.stdin)
+
+        # Create and write audit record
+        record = create_audit_record(input_data, "post_tool_use")
+        write_audit_log(record)
+
+        # Output empty JSON to allow operation to proceed
+        print(json.dumps({}), file=sys.stdout)
+
+    except Exception as e:
+        # On any error, log to stderr but allow operation
+        print(f"Audit hook error: {e}", file=sys.stderr)
+        print(json.dumps({}), file=sys.stdout)
+
+    finally:
+        # Always exit 0
+        sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/audit-trail/hooks/pretooluse.py
+++ b/plugins/audit-trail/hooks/pretooluse.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""PreToolUse audit hook for comprehensive tool usage logging.
+
+This hook logs all tool calls BEFORE execution, capturing:
+- Timestamp
+- Session ID
+- Tool name and category
+- Tool input/arguments
+- Request context
+
+Logs are written to ~/.claude/audit/<date>.jsonl in append mode.
+
+For compliance environments (HIPAA, SOC2, ERISA), this provides
+an immutable audit trail of all AI agent actions.
+
+Author: Steven Elliott
+License: MIT
+"""
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+import hashlib
+
+
+def get_audit_dir() -> Path:
+    """Get or create the audit log directory."""
+    # Respect CLAUDE_CONFIG_DIR if set, otherwise use ~/.claude
+    config_dir = os.environ.get('CLAUDE_CONFIG_DIR', os.path.expanduser('~/.claude'))
+    audit_dir = Path(config_dir) / 'audit'
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    return audit_dir
+
+
+def get_session_id() -> str:
+    """Extract or generate a session identifier."""
+    # Try to get from environment or generate from timestamp
+    session_id = os.environ.get('CLAUDE_SESSION_ID', '')
+    if not session_id:
+        # Generate a session ID from the current working directory and time
+        cwd = os.getcwd()
+        session_id = hashlib.md5(f"{cwd}-{datetime.now().date()}".encode()).hexdigest()[:12]
+    return session_id
+
+
+def categorize_tool(tool_name: str) -> str:
+    """Categorize tool for filtering and reporting."""
+    categories = {
+        'Bash': 'execution',
+        'Read': 'file_read',
+        'Write': 'file_write',
+        'Edit': 'file_write',
+        'MultiEdit': 'file_write',
+        'Glob': 'file_search',
+        'Grep': 'file_search',
+        'WebFetch': 'network',
+        'WebSearch': 'network',
+        'Task': 'agent',
+        'AskUserQuestion': 'interaction',
+    }
+    return categories.get(tool_name, 'other')
+
+
+def sanitize_sensitive_data(data: dict) -> dict:
+    """Remove or mask potentially sensitive information.
+
+    In compliance environments, we want to log WHAT happened
+    but may need to redact sensitive content.
+    """
+    sensitive_patterns = [
+        'password', 'secret', 'token', 'api_key', 'apikey',
+        'credential', 'private_key', 'auth'
+    ]
+
+    def redact_value(key: str, value) -> any:
+        key_lower = key.lower()
+        for pattern in sensitive_patterns:
+            if pattern in key_lower:
+                if isinstance(value, str):
+                    return f"[REDACTED-{len(value)} chars]"
+                return "[REDACTED]"
+        return value
+
+    if isinstance(data, dict):
+        return {k: redact_value(k, sanitize_sensitive_data(v)) for k, v in data.items()}
+    elif isinstance(data, list):
+        return [sanitize_sensitive_data(item) for item in data]
+    return data
+
+
+def create_audit_record(input_data: dict, event_type: str) -> dict:
+    """Create a structured audit record."""
+    now = datetime.now(timezone.utc)
+    tool_name = input_data.get('tool_name', 'unknown')
+    tool_input = input_data.get('tool_input', {})
+
+    # Create the audit record
+    record = {
+        "timestamp": now.isoformat(),
+        "timestamp_unix": now.timestamp(),
+        "event_type": event_type,
+        "session_id": get_session_id(),
+        "tool": {
+            "name": tool_name,
+            "category": categorize_tool(tool_name),
+        },
+        "request": sanitize_sensitive_data(tool_input),
+        "context": {
+            "cwd": os.getcwd(),
+            "user": os.environ.get('USER', 'unknown'),
+            "config_dir": os.environ.get('CLAUDE_CONFIG_DIR', '~/.claude'),
+        }
+    }
+
+    # Add specific fields based on tool type
+    if tool_name == 'Bash':
+        record["tool"]["command"] = tool_input.get('command', '')[:500]  # Truncate long commands
+    elif tool_name in ['Read', 'Write', 'Edit']:
+        record["tool"]["file_path"] = tool_input.get('file_path', '')
+    elif tool_name == 'WebFetch':
+        record["tool"]["url"] = tool_input.get('url', '')
+
+    return record
+
+
+def write_audit_log(record: dict) -> None:
+    """Append audit record to daily JSONL file."""
+    audit_dir = get_audit_dir()
+    date_str = datetime.now().strftime('%Y-%m-%d')
+    log_file = audit_dir / f"audit-{date_str}.jsonl"
+
+    with open(log_file, 'a', encoding='utf-8') as f:
+        f.write(json.dumps(record, ensure_ascii=False) + '\n')
+
+
+def main():
+    """Main entry point for PreToolUse audit hook."""
+    try:
+        # Read input from stdin
+        input_data = json.load(sys.stdin)
+
+        # Create and write audit record
+        record = create_audit_record(input_data, "pre_tool_use")
+        write_audit_log(record)
+
+        # Output empty JSON to allow operation to proceed
+        # We never block operations - this is observational only
+        print(json.dumps({}), file=sys.stdout)
+
+    except Exception as e:
+        # On any error, log to stderr but allow operation
+        print(f"Audit hook error: {e}", file=sys.stderr)
+        print(json.dumps({}), file=sys.stdout)
+
+    finally:
+        # Always exit 0 - never block operations due to audit failures
+        sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

This PR adds a new **audit-trail** plugin that addresses [Issue #16622](https://github.com/anthropics/claude-code/issues/16622) by providing comprehensive audit logging for all Claude Code tool usage.

### Why This Plugin?

Claude Code executes powerful operations (file writes, bash commands, network requests), but there's currently no built-in way to track what happened in a session. This creates challenges for:

- **Debugging**: "What did Claude change that broke the build?"
- **Compliance**: SOC 2, HIPAA, and similar frameworks require audit trails
- **Security review**: Monitoring for unexpected file access or command execution
- **Accountability**: Understanding AI agent actions in production

### Features

- **PreToolUse hook**: Logs tool requests before execution (captures intent)
- **PostToolUse hook**: Logs results after execution (captures outcome)
- **Automatic sensitive data redaction**: Masks passwords, API keys, tokens
- **Daily JSONL rotation**: Logs stored in `~/.claude/audit/audit-YYYY-MM-DD.jsonl`
- **`/audit` command**: Query and analyze logs with jq
- **Zero-block design**: Audit failures never stop operations
- **Tool categorization**: Organizes by type (execution, file_read, file_write, network, etc.)

### Log Format

```json
{
  "timestamp": "2026-02-02T18:30:45.123456+00:00",
  "event_type": "pre_tool_use",
  "session_id": "a1b2c3d4e5f6",
  "tool": {
    "name": "Bash",
    "category": "execution",
    "command": "npm test"
  },
  "request": { "command": "npm test" },
  "context": { "cwd": "/home/user/project" }
}
```

### Use Cases

1. **SOC 2 Type II audits**: Evidence of access controls and change management
2. **HIPAA compliance**: Track access to files containing PHI
3. **Debugging sessions**: "Show me all file writes from yesterday"
4. **Security review**: "Find all Bash commands that matched pattern X"

## Test plan

- [x] Python syntax validation (`python3 -m py_compile`)
- [ ] Manual testing: Install plugin and verify logs appear in `~/.claude/audit/`
- [ ] Verify `/audit` command loads and can query logs
- [ ] Test sensitive data redaction with mock API keys
- [ ] Confirm zero-block behavior (introduce error, verify operations continue)

## About the Author

I'm a CIO with 19 years of experience implementing AI in regulated environments (HIPAA, SOC 2, ERISA). This plugin addresses a real gap I've encountered deploying AI coding tools in enterprise settings.

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)