### PR TITLE
Install Claude with the recommended command instead of npm in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -79,7 +79,7 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
   -x
 
 # Install Claude
-RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
+RUN curl -fsSL https://claude.ai/install.sh | TARGET=${CLAUDE_CODE_VERSION} bash
 
 
 # Copy and set up firewall script


### PR DESCRIPTION
I'm not sure if this makes a huge difference, other than suppressing the warning you get when using an npm installed Claude Code. According to the docs, npm installation is deprecated though:

    https://code.claude.com/docs/en/setup#npm-installation-deprecated

The install.sh script understands a TARGET environment variable, rather than a CLAUDE_CODE_VERSION variable, so we have to reexport the var.