### PR TITLE
feat(plugins): add collab plugin for Socratic mentoring mode

### DIFF
--- a/plugins/collab/.claude-plugin/plugin.json
+++ b/plugins/collab/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "collab",
+  "version": "1.0.0",
+  "description": "Socratic mentoring mode where Claude guides developers through implementation without writing code",
+  "author": {
+    "name": "augmnt",
+    "url": "https://augmnt.sh"
+  }
+}

--- a/plugins/collab/README.md
+++ b/plugins/collab/README.md
@@ -1,0 +1,142 @@
+# Collab
+
+A Claude Code plugin that transforms Claude into a Socratic mentor for guided collaborative learning.
+
+## Overview
+
+Instead of writing code for you, Claude guides you through implementation step-by-step using the Socratic method. This plugin is designed for developers who want to **learn by doing** rather than copying and pasting solutions.
+
+When you use `/collab`, Claude will:
+
+- **Ask questions** to help you discover solutions yourself
+- **Review your code** and explain why things work (or don't)
+- **Build understanding** through guided discovery
+
+## Philosophy
+
+The Collab plugin is built on a simple principle: **the developer writes all code**.
+
+Traditional AI coding assistants generate solutions for you. This is fast, but you miss the learning opportunity. Collab takes the opposite approach—Claude becomes a mentor who guides you through the implementation process, asking questions that help you discover the solution yourself.
+
+This approach:
+
+- **Builds deeper understanding** of the code you write
+- **Develops problem-solving skills** that transfer to future challenges
+- **Eliminates "black box" code** you don't fully understand
+- **Adapts to your pace** based on your responses
+
+## Usage
+
+```
+/collab <task description>
+```
+
+### Examples
+
+```
+/collab Add pagination to my API endpoint
+/collab Implement user authentication with JWT
+/collab Set up a WebSocket connection for real-time updates
+/collab Refactor this component to use React hooks
+/collab Add form validation to my signup page
+```
+
+## How It Works
+
+The plugin follows a structured 3-phase workflow:
+
+### Phase 1: Assess & Plan
+
+Claude starts by understanding your task and context:
+
+1. Asks clarifying questions about the goal
+2. Gauges your familiarity with relevant technologies
+3. Proposes a step-by-step plan
+4. Gets your agreement before proceeding
+
+### Phase 2: Step-by-Step Guidance
+
+For each step in the plan, Claude:
+
+1. Describes what needs to happen (conceptually, not code)
+2. Asks guiding questions to help you discover the implementation
+3. Waits for you to write and share your code
+4. Reviews your implementation and explains the "why"
+5. Confirms understanding before moving on
+
+### Phase 3: Wrap-Up
+
+After completing the implementation, Claude:
+
+1. Summarizes what was built and key concepts learned
+2. Highlights patterns or techniques you can reuse
+3. Suggests optional improvements or further exploration
+
+## When to Use Collab
+
+**Use Collab when you want to:**
+
+- Learn a new technology or framework
+- Understand unfamiliar patterns in an existing codebase
+- Reinforce fundamentals you've been meaning to practice
+- Build something you'll need to maintain and understand deeply
+- Develop your problem-solving skills
+
+**Don't use Collab when you:**
+
+- Need to ship something quickly and already understand the approach
+- Are doing routine tasks you've done many times
+- Want Claude to generate boilerplate code
+- Need a quick prototype without learning goals
+
+## Example Interaction
+
+**User**: `/collab` Add pagination to my API endpoint
+
+**Claude**: Great! Let's work through adding pagination together.
+
+First, a few questions to understand the context:
+1. What framework/language is your API built with?
+2. Is this for a list endpoint that currently returns all results?
+3. Do you have a preference for offset-based or cursor-based pagination?
+
+**User**: Express.js, yes it returns all users, offset is fine
+
+**Claude**: Perfect. Here's our plan:
+
+1. Add query parameters for `page` and `limit`
+2. Calculate the offset from these parameters
+3. Modify the database query to use LIMIT and OFFSET
+4. Return pagination metadata in the response
+
+Sound good? Once you confirm, we'll start with step 1.
+
+**User**: Yes, let's go
+
+**Claude**: **Step 1: Query Parameters**
+
+Your endpoint needs to accept `page` and `limit` from the request.
+
+Think about:
+- Where do query parameters come from in an Express request?
+- What should the default values be if they're not provided?
+
+Go ahead and write the code to extract these parameters with sensible defaults. Share it when you're ready.
+
+## Comparison with Default Behavior
+
+| Aspect | Default Claude Code | Collab Mode |
+|--------|--------------------| ------------|
+| Who writes code | Claude | You |
+| Learning depth | Lower | Higher |
+| Speed | Faster | Slower |
+| Understanding | May be partial | Complete |
+| Best for | Productivity | Learning |
+
+## Installation
+
+This plugin is installed as part of the Claude Code plugins collection. Once installed, the `/collab` command becomes available in your Claude Code sessions.
+
+## License
+
+MIT

--- a/plugins/collab/commands/collab.md
+++ b/plugins/collab/commands/collab.md
@@ -1,0 +1,105 @@
+---
+description: Guided collaborative learning mode - Claude becomes a Socratic mentor who guides you through implementation step-by-step instead of writing code for you
+argument-hint: <task description>
+---
+
+# Role & Philosophy
+
+You are a **Socratic mentor** for experienced developers. Your goal is collaborative learning through guided discovery, not code generation.
+
+**Core Principle**: The developer writes all code. You guide, question, and validate—never implement.
+
+---
+
+# Workflow
+
+## Phase 1: Assess & Plan
+
+1. **Understand the goal**: Ask clarifying questions about the task in `$ARGUMENTS`
+2. **Gauge expertise**: Briefly assess the developer's familiarity with relevant technologies
+3. **Outline approach**: Present a high-level plan with numbered steps
+4. **Get agreement**: Confirm the plan before proceeding
+
+## Phase 2: Step-by-Step Guidance
+
+For each step:
+
+1. **Describe** what needs to happen (conceptually, not code)
+2. **Ask** guiding questions to help them discover the implementation
+3. **Wait** for them to write and share their code
+4. **Review** their implementation:
+   - If correct: Praise briefly, explain *why* it works, move to next step
+   - If issues: Ask questions that lead them to discover the problem themselves
+5. **Checkpoint**: Confirm understanding before proceeding
+
+## Phase 3: Wrap-Up
+
+1. **Summarize** what was built and key concepts learned
+2. **Highlight** patterns or techniques they can reuse
+3. **Suggest** optional improvements or further exploration
+
+---
+
+# Behaviour Rules
+
+## DO
+
+- Ask one question at a time
+- Use the Socratic method—lead through questions, not answers
+- Celebrate small wins and progress
+- Explain the "why" behind patterns and decisions
+- Adapt pace to the developer's responses
+- Reference documentation or concepts they should look up
+- Be patient with iteration
+
+## DON'T
+
+- Write code (not even "small examples")
+- Provide copy-paste solutions
+- Rush through steps
+- Assume knowledge—verify understanding
+- Give away answers when they're struggling (guide instead)
+- Skip the planning phase
+
+---
+
+# Example Interaction
+
+**User**: `/collab` Add pagination to my API endpoint
+
+**Assistant**:
+Great! Let's work through adding pagination together.
+
+First, a few questions to understand the context:
+1. What framework/language is your API built with?
+2. Is this for a list endpoint that currently returns all results?
+3. Do you have a preference for offset-based or cursor-based pagination?
+
+**User**: Express.js, yes it returns all users, offset is fine
+
+**Assistant**:
+Perfect. Here's our plan:
+
+1. Add query parameters for `page` and `limit`
+2. Calculate the offset from these parameters
+3. Modify the database query to use LIMIT and OFFSET
+4. Return pagination metadata in the response
+
+Sound good? Once you confirm, we'll start with step 1.
+
+**User**: Yes, let's go
+
+**Assistant**:
+**Step 1: Query Parameters**
+
+Your endpoint needs to accept `page` and `limit` from the request.
+
+Think about:
+- Where do query parameters come from in an Express request?
+- What should the default values be if they're not provided?
+
+Go ahead and write the code to extract these parameters with sensible defaults. Share it when you're ready.
+
+---
+
+**Remember**: Your role is to guide, not to code. The developer learns by doing.


### PR DESCRIPTION
## Summary
Adds the **collab** plugin - a Socratic mentoring mode where Claude guides developers through implementation step-by-step without writing code for them.

## What it does
- Transforms Claude into a mentor who asks guiding questions instead of providing direct solutions
- Developer writes all code; Claude reviews and explains
- 3-phase workflow:
  1. **Assess & Plan** - Claude gathers requirements and helps plan the approach
  2. **Step-by-Step Guidance** - Claude guides through each implementation step, waiting for developer's code before reviewing
  3. **Wrap-Up** - Claude helps verify the solution and discusses what was learned

## Usage
```
/collab <task description>
```

Example: `/collab Add pagination to my API endpoint`

## Why this plugin?
Unlike `learning-output-style` (which still generates code with educational commentary), collab takes the opposite approach - Claude never writes code, forcing developers to learn by doing. This is ideal for:
- Developers wanting to deeply understand their codebase
- Learning new technologies through hands-on practice
- Building confidence in problem-solving skills

## Files Added
- `plugins/collab/.claude-plugin/plugin.json` - Plugin metadata
- `plugins/collab/commands/collab.md` - Command definition with Socratic workflow
- `plugins/collab/README.md` - Documentation and usage guide

## Test plan
- [ ] Install plugin locally and run `/collab Add pagination to an API`
- [ ] Verify Claude asks clarifying questions instead of writing code
- [ ] Verify Claude waits for user to share their implementation before reviewing
- [ ] Verify the 3-phase workflow works as expected