### PR TITLE
feat(plugin): Add windows-null-redirect-fix plugin to prevent null file creation

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -25,6 +25,7 @@ Learn more in the [official plugins documentation](https://docs.claude.com/en/do
 | [pr-review-toolkit](./pr-review-toolkit/) | Comprehensive PR review agents specializing in comments, tests, error handling, type design, code quality, and code simplification | **Command:** `/pr-review-toolkit:review-pr` - Run with optional review aspects (comments, tests, errors, types, code, simplify, all)<br>**Agents:** `comment-analyzer`, `pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer`, `code-reviewer`, `code-simplifier` |
 | [ralph-wiggum](./ralph-wiggum/) | Interactive self-referential AI loops for iterative development. Claude works on the same task repeatedly until completion | **Commands:** `/ralph-loop`, `/cancel-ralph` - Start/stop autonomous iteration loops<br>**Hook:** Stop - Intercepts exit attempts to continue iteration |
 | [security-guidance](./security-guidance/) | Security reminder hook that warns about potential security issues when editing files | **Hook:** PreToolUse - Monitors 9 security patterns including command injection, XSS, eval usage, dangerous HTML, pickle deserialization, and os.system calls |
+| [windows-null-redirect-fix](./windows-null-redirect-fix/) | Prevents creation of literal 'nul' files on Windows by detecting incorrect null device redirections in bash commands (fixes [#23343](https://github.com/anthropics/claude-code/issues/23343)) | **Hook:** PreToolUse - Detects `> nul` patterns and suggests `/dev/null` for Git Bash/MSYS compatibility |
 
 ## Installation
 

--- a/plugins/windows-null-redirect-fix/.claude-plugin/plugin.json
+++ b/plugins/windows-null-redirect-fix/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "windows-null-redirect-fix",
+  "version": "1.0.0",
+  "description": "Prevents creation of 'nul' files on Windows by detecting and fixing incorrect null device redirections in bash commands. Addresses issue #23343.",
+  "author": {
+    "name": "Community Contributor",
+    "email": "contributor@example.com"
+  }
+}

--- a/plugins/windows-null-redirect-fix/README.md
+++ b/plugins/windows-null-redirect-fix/README.md
@@ -1,0 +1,134 @@
+# Windows Null Redirect Fix Plugin
+
+Prevents the creation of literal `nul` files on Windows by detecting and blocking incorrect null device redirections in bash commands.
+
+**Fixes:** [GitHub Issue #23343](https://github.com/anthropics/claude-code/issues/23343)
+
+## Problem
+
+On Windows, when Claude Code executes bash commands through Git Bash/MSYS, using `nul` for output redirection creates a literal file named `nul` instead of discarding the output as intended.
+
+### Why This Happens
+
+Different shells on Windows use different null devices:
+
+| Shell Context | Null Device |
+|---------------|-------------|
+| Windows CMD | `NUL` |
+| PowerShell | `$null` |
+| Git Bash/MSYS | `/dev/null` |
+
+When Git Bash encounters bare `nul` (not `/dev/null`), it treats it as a regular filename.
+
+### Why This Is Problematic
+
+1. **Reserved Name**: `NUL` is a reserved device name on Windows
+2. **Difficult to Delete**: Files named `nul` can be difficult or impossible to delete via Windows Explorer
+3. **Software Issues**: May cause problems with backup software, antivirus scanners, and sync tools
+4. **Edge Cases**: Confuses Windows applications that expect `NUL` to be a device name
+
+## Solution
+
+This plugin adds a `PreToolUse` hook that:
+
+1. Detects bash commands containing `nul` redirections (e.g., `> nul`, `2> nul`, `&> nul`)
+2. Blocks execution and provides a helpful error message
+3. Suggests the correct `/dev/null` syntax
+
+## Installation
+
+### Option 1: Project-level installation
+
+Add to your project's `.claude/settings.json`:
+
+```json
+{
+  "plugins": [
+    {
+      "path": "/path/to/claude-code/plugins/windows-null-redirect-fix"
+    }
+  ]
+}
+```
+
+### Option 2: User-level installation
+
+Add to your user settings at `~/.claude/settings.json`:
+
+```json
+{
+  "plugins": [
+    {
+      "path": "/path/to/claude-code/plugins/windows-null-redirect-fix"
+    }
+  ]
+}
+```
+
+## Usage
+
+Once installed, the hook automatically runs on Windows whenever Claude Code attempts to execute a bash command. No manual intervention is required.
+
+### Example
+
+If Claude tries to run:
+
+```bash
+some_command > nul 2>&1
+```
+
+The hook will block execution and display:
+
+```
+⚠️ Windows Null Device Warning (Issue #23343)
+
+Detected '> nul' redirection in bash command.
+
+On Windows with Git Bash/MSYS, using 'nul' creates a literal file named 'nul' 
+instead of discarding output.
+
+✅ Suggested fix: Use '/dev/null' instead of 'nul'
+
+Fixed command:
+  some_command > /dev/null 2>&1
+```
+
+## Detected Patterns
+
+The hook detects these redirection patterns:
+
+- `> nul` → `> /dev/null`
+- `1> nul` → `1> /dev/null`
+- `2> nul` → `2> /dev/null`
+- `&> nul` → `&> /dev/null`
+- `>> nul` → `>> /dev/null`
+- `2>> nul` → `2>> /dev/null`
+- `> nul 2>&1` → `> /dev/null 2>&1`
+
+Also detects uppercase `NUL` variants commonly used in Windows CMD.
+
+## Requirements
+
+- Python 3.6+
+- Windows operating system (hook is a no-op on other platforms)
+
+## Files
+
+```
+windows-null-redirect-fix/
+├── .claude-plugin/
+│   └── plugin.json          # Plugin metadata
+├── hooks/
+│   ├── hooks.json           # Hook configuration
+│   └── windows_null_redirect_hook.py  # Main hook script
+└── README.md                # This file
+```
+
+## Contributing
+
+This plugin was created to address [Issue #23343](https://github.com/anthropics/claude-code/issues/23343). 
+If you encounter issues or have suggestions for improvement, please open an issue or submit a pull request.
+
+## License
+
+This plugin is part of the Claude Code repository and is subject to the same license terms.

--- a/plugins/windows-null-redirect-fix/hooks/hooks.json
+++ b/plugins/windows-null-redirect-fix/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Hook to detect and fix incorrect null device redirections on Windows (nul vs /dev/null)",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/windows_null_redirect_hook.py"
+          }
+        ],
+        "matcher": "Bash"
+      }
+    ]
+  }
+}

--- a/plugins/windows-null-redirect-fix/hooks/windows_null_redirect_hook.py
+++ b/plugins/windows-null-redirect-fix/hooks/windows_null_redirect_hook.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+Claude Code Hook: Windows Null Redirect Fix
+============================================
+This hook runs as a PreToolUse hook for the Bash tool on Windows.
+It detects when bash commands incorrectly use 'nul' for output redirection
+and blocks execution with a helpful message to use '/dev/null' instead.
+
+Issue: https://github.com/anthropics/claude-code/issues/23343
+
+Background:
+- On Windows CMD: NUL is the null device
+- On PowerShell: $null is the null device
+- On Git Bash/MSYS: /dev/null is the null device
+- Using bare 'nul' in Git Bash creates a file named 'nul' instead of discarding output
+
+This is problematic because:
+1. NUL is a reserved device name on Windows
+2. Files named 'nul' can be difficult to delete via Windows Explorer
+3. May cause issues with backup software, antivirus scanners, and sync tools
+4. Confuses Windows applications that expect these to be device names
+
+Solution:
+In Git Bash contexts on Windows, always use /dev/null for output redirection.
+"""
+
+import json
+import os
+import re
+import sys
+from typing import Optional, Tuple
+
+# Patterns that indicate incorrect null device usage in bash on Windows
+# These patterns match common redirection to 'nul' which should be '/dev/null'
+NUL_REDIRECT_PATTERNS = [
+    # Standard output redirection to nul
+    (r'>\s*nul\b', '> /dev/null'),
+    (r'1>\s*nul\b', '1> /dev/null'),
+    # Standard error redirection to nul
+    (r'2>\s*nul\b', '2> /dev/null'),
+    # Both stdout and stderr to nul
+    (r'&>\s*nul\b', '&> /dev/null'),
+    (r'>\s*nul\s+2>&1', '> /dev/null 2>&1'),
+    (r'2>&1\s*>\s*nul', '2>&1 > /dev/null'),
+    # Append redirections
+    (r'>>\s*nul\b', '>> /dev/null'),
+    (r'2>>\s*nul\b', '2>> /dev/null'),
+]
+
+# Also catch Windows CMD style with NUL (case insensitive)
+NUL_PATTERNS_CASE_INSENSITIVE = [
+    (r'>\s*NUL\b', '> /dev/null'),
+    (r'2>\s*NUL\b', '2> /dev/null'),
+    (r'&>\s*NUL\b', '&> /dev/null'),
+]
+
+
+def is_windows() -> bool:
+    """Check if running on Windows."""
+    return os.name == 'nt' or 'windows' in os.environ.get('OS', '').lower()
+
+
+def detect_nul_redirect(command: str) -> Optional[Tuple[str, str]]:
+    """
+    Detect if the command uses 'nul' redirection that should be '/dev/null'.
+    
+    Returns:
+        Tuple of (matched_pattern, suggested_fix) if found, None otherwise
+    """
+    # Check case-sensitive patterns first
+    for pattern, fix in NUL_REDIRECT_PATTERNS:
+        match = re.search(pattern, command)
+        if match:
+            return (match.group(), fix)
+    
+    # Check case-insensitive patterns (for CMD-style NUL)
+    for pattern, fix in NUL_PATTERNS_CASE_INSENSITIVE:
+        match = re.search(pattern, command, re.IGNORECASE)
+        if match:
+            return (match.group(), fix)
+    
+    return None
+
+
+def suggest_fixed_command(command: str) -> str:
+    """
+    Return the command with nul redirections fixed to /dev/null.
+    """
+    fixed = command
+    
+    # Apply all pattern fixes
+    for pattern, fix in NUL_REDIRECT_PATTERNS:
+        fixed = re.sub(pattern, fix, fixed)
+    
+    for pattern, fix in NUL_PATTERNS_CASE_INSENSITIVE:
+        fixed = re.sub(pattern, fix, fixed, flags=re.IGNORECASE)
+    
+    return fixed
+
+
+def main():
+    # Only run on Windows
+    if not is_windows():
+        sys.exit(0)
+    
+    try:
+        input_data = json.load(sys.stdin)
+    except json.JSONDecodeError as e:
+        print(f"Error: Invalid JSON input: {e}", file=sys.stderr)
+        sys.exit(1)
+    
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Bash":
+        sys.exit(0)
+    
+    tool_input = input_data.get("tool_input", {})
+    command = tool_input.get("command", "")
+    
+    if not command:
+        sys.exit(0)
+    
+    # Check for nul redirect patterns
+    detection = detect_nul_redirect(command)
+    
+    if detection:
+        matched, suggested = detection
+        fixed_command = suggest_fixed_command(command)
+        
+        error_message = f"""⚠️ Windows Null Device Warning (Issue #23343)
+
+Detected '{matched}' redirection in bash command.
+
+On Windows with Git Bash/MSYS, using 'nul' creates a literal file named 'nul' 
+instead of discarding output. This file:
+- Uses a reserved Windows device name
+- Can be difficult to delete via Windows Explorer
+- May cause issues with backup/sync software
+
+✅ Suggested fix: Use '/dev/null' instead of 'nul'
+
+Original command:
+  {command}
+
+Fixed command:
+  {fixed_command}
+
+Context:
+- Windows CMD uses: NUL
+- PowerShell uses: $null  
+- Git Bash/MSYS uses: /dev/null
+
+For more information, see: https://github.com/anthropics/claude-code/issues/23343
+"""
+        print(error_message, file=sys.stderr)
+        # Exit code 2 blocks tool call and shows stderr to Claude
+        sys.exit(2)
+    
+    # Allow command to proceed
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
This PR adds a new plugin that addresses issue #23343 - Windows reserved filename 'nul' being created instead of properly redirecting to the null device.

## Problem
On Windows with Git Bash/MSYS, using `nul` for output redirection creates a literal file named `nul` instead of discarding output. This is problematic because:
- `NUL` is a reserved device name on Windows
- Files named `nul` can be difficult to delete via Windows Explorer
- May cause issues with backup software, antivirus scanners, and sync tools

## Solution
Added a `PreToolUse` hook plugin that:
- Detects bash commands with `nul` redirections (e.g., `> nul`, `2> nul`, `&> nul`)
- Blocks execution and suggests using `/dev/null` instead
- Only runs on Windows (no-op on other platforms)

## Files Added
- `plugins/windows-null-redirect-fix/.claude-plugin/plugin.json`
- `plugins/windows-null-redirect-fix/hooks/hooks.json`
- `plugins/windows-null-redirect-fix/hooks/windows_null_redirect_hook.py`
- `plugins/windows-null-redirect-fix/README.md`

Fixes #23343
