### PR TITLE
chore: add Bedrock Guardrails settings example

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -20,6 +20,10 @@ These may be applied at any level of the [settings hierarchy](https://code.claud
 | Bash tool requires approval | | ✅ | |
 | Bash tool must run inside of sandbox | | | ✅ |
 
+### AWS Bedrock Guardrails
+
+[`settings-bedrock-guardrails.json`](./settings-bedrock-guardrails.json) — Configures Claude Code to use AWS Bedrock with [Bedrock Guardrails](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html). Set `BEDROCK_GUARDRAIL_IDENTIFIER` to your guardrail ID or ARN and `BEDROCK_GUARDRAIL_VERSION` to the version (e.g. `"1"` or `"DRAFT"`). Requires `@anthropic-ai/bedrock-sdk` with guardrail support (see [anthropic-sdk-typescript](https://github.com/anthropics/anthropic-sdk-typescript/tree/main/packages/bedrock-sdk)).
+
 ## Tips
 - Consider merging snippets of the above examples to reach your desired configuration
 - Settings files must be valid JSON

--- a/examples/settings/settings-bedrock-guardrails.json
+++ b/examples/settings/settings-bedrock-guardrails.json
@@ -1,0 +1,9 @@
+{
+  "env": {
+    "CLAUDE_CODE_USE_BEDROCK": "1",
+    "AWS_REGION": "us-east-1",
+    "BEDROCK_GUARDRAIL_IDENTIFIER": "your-guardrail-id",
+    "BEDROCK_GUARDRAIL_VERSION": "1",
+    "BEDROCK_TRACE": "ENABLED"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `examples/settings/settings-bedrock-guardrails.json` showing env var configuration for Bedrock Guardrails
- Updates `examples/settings/README.md` with a Bedrock Guardrails section

## Context

Configures `BEDROCK_GUARDRAIL_IDENTIFIER`, `BEDROCK_GUARDRAIL_VERSION`, and `BEDROCK_TRACE` env vars which are read by `@anthropic-ai/bedrock-sdk` and sent as `X-Amzn-Bedrock-GuardrailIdentifier`, `X-Amzn-Bedrock-GuardrailVersion`, and `X-Amzn-Bedrock-Trace` headers on Bedrock invoke requests.

Depends on SDK support from anthropics/anthropic-sdk-typescript#899.

Ref: #23322

## Test plan
- [x] JSON is valid
- [x] README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)