### PR TITLE
fix(plugins): Add cross-platform hook wrappers for Windows compatibility

### DIFF
--- a/plugins/explanatory-output-style/hooks-handlers/run-hook.cmd
+++ b/plugins/explanatory-output-style/hooks-handlers/run-hook.cmd
@@ -1,0 +1,34 @@
+:; # Cross-platform hook wrapper (polyglot: cmd.exe + bash)
+:; # On Windows: invokes Git Bash explicitly to avoid WSL bash.exe
+:; # On Unix/macOS: passes through to bash natively
+:;
+:; # --- Unix/macOS execution path ---
+:; SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+:; exec bash "$SCRIPT_DIR/$1" "${@:2}"
+:; exit $?
+
+@echo off
+REM --- Windows execution path ---
+set "SCRIPT_DIR=%~dp0"
+set "HOOK_SCRIPT=%SCRIPT_DIR%%~1"
+
+if exist "C:\Program Files\Git\bin\bash.exe" (
+    "C:\Program Files\Git\bin\bash.exe" "%HOOK_SCRIPT%" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %errorlevel%
+)
+if exist "C:\Program Files (x86)\Git\bin\bash.exe" (
+    "C:\Program Files (x86)\Git\bin\bash.exe" "%HOOK_SCRIPT%" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %errorlevel%
+)
+
+for /f "tokens=*" %%i in ('where git 2^>nul') do (
+    for %%j in ("%%~dpi..") do (
+        if exist "%%~fj\bin\bash.exe" (
+            "%%~fj\bin\bash.exe" "%HOOK_SCRIPT%" %2 %3 %4 %5 %6 %7 %8 %9
+            exit /b %errorlevel%
+        )
+    )
+)
+
+echo ERROR: Git Bash not found. Install Git for Windows. >&2
+exit /b 1

--- a/plugins/explanatory-output-style/hooks/hooks.json
+++ b/plugins/explanatory-output-style/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks-handlers/session-start.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks-handlers/run-hook.cmd session-start.sh"
           }
         ]
       }

--- a/plugins/learning-output-style/hooks-handlers/run-hook.cmd
+++ b/plugins/learning-output-style/hooks-handlers/run-hook.cmd
@@ -1,0 +1,34 @@
+:; # Cross-platform hook wrapper (polyglot: cmd.exe + bash)
+:; # On Windows: invokes Git Bash explicitly to avoid WSL bash.exe
+:; # On Unix/macOS: passes through to bash natively
+:;
+:; # --- Unix/macOS execution path ---
+:; SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+:; exec bash "$SCRIPT_DIR/$1" "${@:2}"
+:; exit $?
+
+@echo off
+REM --- Windows execution path ---
+set "SCRIPT_DIR=%~dp0"
+set "HOOK_SCRIPT=%SCRIPT_DIR%%~1"
+
+if exist "C:\Program Files\Git\bin\bash.exe" (
+    "C:\Program Files\Git\bin\bash.exe" "%HOOK_SCRIPT%" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %errorlevel%
+)
+if exist "C:\Program Files (x86)\Git\bin\bash.exe" (
+    "C:\Program Files (x86)\Git\bin\bash.exe" "%HOOK_SCRIPT%" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %errorlevel%
+)
+
+for /f "tokens=*" %%i in ('where git 2^>nul') do (
+    for %%j in ("%%~dpi..") do (
+        if exist "%%~fj\bin\bash.exe" (
+            "%%~fj\bin\bash.exe" "%HOOK_SCRIPT%" %2 %3 %4 %5 %6 %7 %8 %9
+            exit /b %errorlevel%
+        )
+    )
+)
+
+echo ERROR: Git Bash not found. Install Git for Windows. >&2
+exit /b 1

--- a/plugins/learning-output-style/hooks/hooks.json
+++ b/plugins/learning-output-style/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks-handlers/session-start.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks-handlers/run-hook.cmd session-start.sh"
           }
         ]
       }

--- a/plugins/plugin-dev/skills/hook-development/examples/cross-platform-hook.cmd
+++ b/plugins/plugin-dev/skills/hook-development/examples/cross-platform-hook.cmd
@@ -1,0 +1,56 @@
+:; # ============================================================================
+:; # Cross-Platform Hook Wrapper (Polyglot: cmd.exe + bash)
+:; # ============================================================================
+:; #
+:; # PURPOSE:
+:; #   Ensures hook .sh scripts work on Windows even when WSL is installed.
+:; #   On Windows, `bash` in PATH often resolves to WSL's bash.exe instead of
+:; #   Git Bash, causing hooks to fail. This wrapper explicitly invokes Git Bash.
+:; #
+:; # USAGE:
+:; #   In hooks.json, replace direct .sh references:
+:; #     BEFORE: "command": "${CLAUDE_PLUGIN_ROOT}/hooks/my-hook.sh"
+:; #     AFTER:  "command": "${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd my-hook.sh"
+:; #
+:; # HOW IT WORKS:
+:; #   Lines starting with `:;` are valid labels in cmd.exe (ignored) and valid
+:; #   no-ops in bash. When bash runs this file, it executes the commands after
+:; #   `:;` and `exec`s the target script. When cmd.exe runs it, it skips the
+:; #   `:;` labels and executes the @echo off section below.
+:; #
+:; # COPY THIS FILE into your plugin's hooks directory and rename to run-hook.cmd
+:; # ============================================================================
+:;
+:; # --- Unix/macOS execution path ---
+:; SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+:; exec bash "$SCRIPT_DIR/$1" "${@:2}"
+:; exit $?
+
+@echo off
+REM --- Windows execution path ---
+REM Resolve the hook script path relative to this .cmd file
+set "SCRIPT_DIR=%~dp0"
+set "HOOK_SCRIPT=%SCRIPT_DIR%%~1"
+
+REM Try standard Git for Windows installation paths
+if exist "C:\Program Files\Git\bin\bash.exe" (
+    "C:\Program Files\Git\bin\bash.exe" "%HOOK_SCRIPT%" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %errorlevel%
+)
+if exist "C:\Program Files (x86)\Git\bin\bash.exe" (
+    "C:\Program Files (x86)\Git\bin\bash.exe" "%HOOK_SCRIPT%" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %errorlevel%
+)
+
+REM Fallback: locate bash via Git's installation directory
+for /f "tokens=*" %%i in ('where git 2^>nul') do (
+    for %%j in ("%%~dpi..") do (
+        if exist "%%~fj\bin\bash.exe" (
+            "%%~fj\bin\bash.exe" "%HOOK_SCRIPT%" %2 %3 %4 %5 %6 %7 %8 %9
+            exit /b %errorlevel%
+        )
+    )
+)
+
+echo ERROR: Git Bash not found. Install Git for Windows from https://git-scm.com >&2
+exit /b 1

--- a/plugins/ralph-wiggum/hooks/hooks.json
+++ b/plugins/ralph-wiggum/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd stop-hook.sh"
           }
         ]
       }

--- a/plugins/ralph-wiggum/hooks/run-hook.cmd
+++ b/plugins/ralph-wiggum/hooks/run-hook.cmd
@@ -1,0 +1,34 @@
+:; # Cross-platform hook wrapper (polyglot: cmd.exe + bash)
+:; # On Windows: invokes Git Bash explicitly to avoid WSL bash.exe
+:; # On Unix/macOS: passes through to bash natively
+:;
+:; # --- Unix/macOS execution path ---
+:; SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+:; exec bash "$SCRIPT_DIR/$1" "${@:2}"
+:; exit $?
+
+@echo off
+REM --- Windows execution path ---
+set "SCRIPT_DIR=%~dp0"
+set "HOOK_SCRIPT=%SCRIPT_DIR%%~1"
+
+if exist "C:\Program Files\Git\bin\bash.exe" (
+    "C:\Program Files\Git\bin\bash.exe" "%HOOK_SCRIPT%" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %errorlevel%
+)
+if exist "C:\Program Files (x86)\Git\bin\bash.exe" (
+    "C:\Program Files (x86)\Git\bin\bash.exe" "%HOOK_SCRIPT%" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %errorlevel%
+)
+
+for /f "tokens=*" %%i in ('where git 2^>nul') do (
+    for %%j in ("%%~dpi..") do (
+        if exist "%%~fj\bin\bash.exe" (
+            "%%~fj\bin\bash.exe" "%HOOK_SCRIPT%" %2 %3 %4 %5 %6 %7 %8 %9
+            exit /b %errorlevel%
+        )
+    )
+)
+
+echo ERROR: Git Bash not found. Install Git for Windows. >&2
+exit /b 1


### PR DESCRIPTION
## Summary

- **Add polyglot `.cmd` wrappers** to 3 official plugins (`explanatory-output-style`, `learning-output-style`, `ralph-wiggum`) that ensure hook `.sh` scripts execute correctly on Windows when WSL is installed
- **Update `hooks.json`** in each plugin to route through the wrapper instead of calling `.sh` scripts directly
- **Document the pattern** in `plugin-dev` skill (SKILL.md, patterns.md) with a copyable example for plugin developers

## Problem

On Windows with WSL installed (extremely common due to Docker Desktop), `bash` in PATH resolves to `C:\Windows\System32\bash.exe` (WSL) instead of Git Bash. Claude Code detects `.sh` in hook commands and auto-prepends `bash`, causing all plugin hooks to fail:

```
WSL ERROR: CreateProcessCommon: execvpe(/bin/bash) failed: No such file or directory
```

Claude Code correctly identifies Git Bash at startup (`Using bash path: "C:\Program Files\Git\bin\bash.exe"`) but uses generic `bash` for hook execution.

## Solution

A polyglot `.cmd` file that works in both cmd.exe and bash:
- Lines starting with `:;` are labels in cmd.exe (ignored) and no-ops in bash
- **Bash path**: `exec`s the target `.sh` script natively
- **cmd.exe path**: explicitly invokes Git Bash at standard installation paths with fallback discovery via `where git`

No changes to the core binary needed. Existing `.sh` scripts remain unchanged.

## Test Plan

- [x] Run each `.cmd` wrapper via `cmd /c` on Windows — produces valid JSON output
- [x] Run each `.cmd` wrapper via `bash` on Unix-like shell — passes through correctly
- [x] Verify no behavior change for existing Unix/macOS users (polyglot passthrough)
- [x] Start Claude Code with the modified plugins — no SessionStart hook error

## References

- Fixes #23556
- Related: #22700 (bash not in PATH), #21468 (superpowers fails on Windows)
- Related: PR #19084 (ralph-wiggum `.cmd` wrapper — narrow scope, same approach)