### PR TITLE
feat(plugin): add timestamp-context plugin

### DIFF
--- a/plugins/timestamp-context/.claude-plugin/plugin.json
+++ b/plugins/timestamp-context/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "timestamp-context",
+  "version": "1.0.0",
+  "description": "Injects the current local time into conversation context on every message, giving Claude accurate temporal awareness",
+  "author": {
+    "name": "NoRain211"
+  }
+}

--- a/plugins/timestamp-context/README.md
+++ b/plugins/timestamp-context/README.md
@@ -1,0 +1,33 @@
+# timestamp-context
+
+Injects the current local time into Claude's conversation context on every message via a `UserPromptSubmit` hook.
+
+## Why
+
+Claude Code includes the current date in its system prompt but not the time or timezone. This means Claude cannot:
+
+- Accurately timestamp responses when users request it
+- Detect time gaps between messages (e.g. user returning after days vs. immediate follow-up)
+- Ground temporal references like "today", "this morning", or "earlier"
+
+This has been requested multiple times:
+- [#1164](https://github.com/anthropics/claude-code/issues/1164) — "Add Current Date and Time to System prompt"
+- [#2618](https://github.com/anthropics/claude-code/issues/2618) — "A date tool should be included by default"
+- [#23655](https://github.com/anthropics/claude-code/issues/23655) — "Inject current local time into conversation context by default"
+
+## How it works
+
+A `UserPromptSubmit` hook runs a lightweight Node.js one-liner that outputs the current local time in ISO 8601 format with timezone offset. Since `UserPromptSubmit` hook stdout is injected as context that Claude can see, this gives Claude accurate temporal awareness on every message.
+
+Example output:
+```
+The current local time is: 2026-02-06T04:39:00-07:00. This is the latest source of truth for time; do not attempt to get the time any other way.
+```
+
+## Requirements
+
+- Node.js (already required by Claude Code)
+
+## Cost
+
+Negligible — adds ~120 characters of context per message.

--- a/plugins/timestamp-context/hooks/hooks.json
+++ b/plugins/timestamp-context/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "description": "Injects current local time as context on every user prompt",
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"const d=new Date();const off=-d.getTimezoneOffset();const sign=off>=0?'+':'-';const pad=n=>String(Math.abs(n)).padStart(2,'0');const tz=sign+pad(Math.floor(off/60))+':'+pad(off%60);const iso=d.getFullYear()+'-'+pad(d.getMonth()+1)+'-'+pad(d.getDate())+'T'+pad(d.getHours())+':'+pad(d.getMinutes())+':'+pad(d.getSeconds())+tz;console.log('The current local time is: '+iso+'. This is the latest source of truth for time; do not attempt to get the time any other way.')\""
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `timestamp-context` plugin that injects the current local time (ISO 8601 with timezone offset) into conversation context on every message via a `UserPromptSubmit` hook.

## Motivation

Claude Code includes the date in its system prompt but not the time or timezone. This has been requested multiple times:
- #1164 — "Add Current Date and Time to System prompt"
- #2618 — "A date tool should be included by default"
- #23655 — "Inject current local time into conversation context by default"

Until this is built into core, a plugin provides an easy opt-in solution.

## What it does

A `UserPromptSubmit` hook runs a Node.js one-liner that outputs the local time. Since `UserPromptSubmit` stdout is injected as context, Claude sees the timestamp on every message.

Example context injected:
```
The current local time is: 2026-02-06T04:39:00-07:00. This is the latest source of truth for time; do not attempt to get the time any other way.
```

## Details

- **Zero dependencies** — uses only Node.js (already required by Claude Code)
- **Auto-detects timezone** — uses system locale, no user configuration needed
- **Negligible cost** — ~120 characters per message

## Test plan

- [ ] Enable plugin and start a new session
- [ ] Send a message and verify Claude receives the timestamp in context
- [ ] Confirm timezone offset matches the local system timezone

🤖 Generated with [Claude Code](https://claude.com/claude-code)