### PR TITLE
fix: Replace deprecated npm install with native installer in Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,8 +3,6 @@ FROM node:20
 ARG TZ
 ENV TZ="$TZ"
 
-ARG CLAUDE_CODE_VERSION=latest
-
 # Install basic development tools and iptables/ipset
 RUN apt-get update && apt-get install -y --no-install-recommends \
   less \
@@ -28,8 +26,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Ensure default node user has access to /usr/local/share
-RUN mkdir -p /usr/local/share/npm-global && \
-  chown -R node:node /usr/local/share
+RUN chown -R node:node /usr/local/share
 
 ARG USERNAME=node
 
@@ -57,9 +54,8 @@ RUN ARCH=$(dpkg --print-architecture) && \
 # Set up non-root user
 USER node
 
-# Install global packages
-ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
-ENV PATH=$PATH:/usr/local/share/npm-global/bin
+# Add Claude Code to PATH
+ENV PATH=$PATH:/home/node/.local/bin
 
 # Set the default shell to zsh rather than sh
 ENV SHELL=/bin/zsh
@@ -78,8 +74,8 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
   -a "export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
   -x
 
-# Install Claude
-RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
+# Install Claude Code using native installer
+RUN curl -fsSL https://claude.ai/install.sh | bash
 
 
 # Copy and set up firewall script

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,6 @@
     "dockerfile": "Dockerfile",
     "args": {
       "TZ": "${localEnv:TZ:America/Los_Angeles}",
-      "CLAUDE_CODE_VERSION": "latest",
       "GIT_DELTA_VERSION": "0.18.2",
       "ZSH_IN_DOCKER_VERSION": "1.2.0"
     }

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -66,6 +66,7 @@ done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
 # Resolve and add other allowed domains
 for domain in \
     "registry.npmjs.org" \
+    "claude.ai" \
     "api.anthropic.com" \
     "sentry.io" \
     "statsig.anthropic.com" \
@@ -86,7 +87,7 @@ for domain in \
             exit 1
         fi
         echo "Adding $ip for $domain"
-        ipset add allowed-domains "$ip"
+        ipset add allowed-domains "$ip" -exist
     done < <(echo "$ips")
 done
 


### PR DESCRIPTION
## Summary
- Replaced deprecated `npm install -g @anthropic-ai/claude-code` with native installer (`curl -fsSL https://claude.ai/install.sh | bash`) in the devcontainer Dockerfile
- Removed unused `CLAUDE_CODE_VERSION` build arg and npm-global directory setup
- Updated PATH to point to `~/.local/bin` where the native installer places the binary
- Added `claude.ai` to the firewall allowlist in `init-firewall.sh`
- Added `-exist` flag to `ipset add` to gracefully handle duplicate IPs (claude.ai and api.anthropic.com resolve to the same IP)

Fixes #19985

## Test plan
- [ ] Rebuild devcontainer in VS Code and verify `claude` command is available
- [ ] Verify firewall script completes without errors
- [ ] Verify Claude Code functions correctly inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)