### PR TITLE
feat(plugin): add destructive-command-guard plugin

### DIFF
--- a/plugins/destructive-command-guard/.claude-plugin/plugin.json
+++ b/plugins/destructive-command-guard/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "destructive-command-guard",
+  "version": "1.0.0",
+  "description": "PreToolUse hook that blocks self-destructive Bash commands and warns about edits to CLAUDE.md and policy files"
+}

--- a/plugins/destructive-command-guard/README.md
+++ b/plugins/destructive-command-guard/README.md
@@ -31,7 +31,7 @@ Or add to your project's `.claude/settings.json`:
 | Docker mass ops | `docker system prune`, `docker volume prune`, `docker container prune`, `docker network prune`, `docker builder prune`, `docker image prune -a`, `docker rm -f $(docker ps -aq)`, `docker volume rm $(docker volume ls -q)`, `docker compose down -v` | Mass removal of containers, volumes, images, networks |
 | Git destructive | `git clean -fdx` (without `-n`), `git checkout -- .`, `git reset --hard` (no target), `git push --force`, `git branch -D`, `git stash clear`, `git stash drop` (no ref) | Loss of uncommitted changes, remote history, branches, stashes |
 | Indirect execution | `eval "..."`, `sh -c "..."`, `bash -c "..."`, `... \| sh`, `base64 ... \| bash` | Bypasses all other checks |
-| Alternative deletion | `find / -delete`, `find ~ -delete` | Equivalent to mass `rm` |
+| Alternative deletion | `find / -delete`, `find ~ -delete`, `find / -exec rm`, `find / \| xargs rm` | Equivalent to mass `rm` |
 
 ### Allowed commands (not blocked)
 

--- a/plugins/destructive-command-guard/README.md
+++ b/plugins/destructive-command-guard/README.md
@@ -29,7 +29,7 @@ Or add to your project's `.claude/settings.json`:
 | Variable expansion | `rm -rf $(pwd)`, `rm -rf $DIR` | Unvalidatable dynamic targets |
 | Path traversal | `rm -rf /./`, `rm -rf //`, `rm -rf /../..` | Normalized to dangerous paths |
 | Docker mass ops | `docker system prune`, `docker volume prune`, `docker container prune`, `docker network prune`, `docker builder prune`, `docker image prune -a`, `docker rm -f $(docker ps -aq)`, `docker volume rm $(docker volume ls -q)`, `docker compose down -v` | Mass removal of containers, volumes, images, networks |
-| Git destructive | `git clean -fdx` (without `-n`), `git checkout -- .`, `git reset --hard` (no target), `git push --force`, `git branch -D`, `git stash clear`, `git stash drop` (no ref) | Loss of uncommitted changes, remote history, branches, stashes |
+| Git destructive | `git clean -fdx` (without `-n`), `git checkout -- .`, `git restore .`, `git restore --staged .`, `git reset --hard` (no target), `git push --force`, `git branch -D`, `git stash clear`, `git stash drop` (no ref) | Loss of uncommitted changes, remote history, branches, stashes |
 | Indirect execution | `eval "..."`, `sh -c "..."`, `bash -c "..."`, `... \| sh`, `base64 ... \| bash` | Bypasses all other checks |
 | Alternative deletion | `find / -delete`, `find ~ -delete`, `find / -exec rm`, `find / \| xargs rm` | Equivalent to mass `rm` |
 
@@ -47,6 +47,7 @@ Or add to your project's `.claude/settings.json`:
 | `git reset --hard abc1234` | Has an explicit commit target |
 | `git push` | Normal push (no force) |
 | `git push --force-with-lease` | Safe force push with protection |
+| `git restore src/file.py` | Targets a specific file |
 | `git branch -d` | Safe delete (warns if unmerged) |
 | `git stash drop stash@{0}` | Removes a single specific stash |
 | `find ./src -name '*.pyc' -delete` | Scoped to a specific directory |

--- a/plugins/destructive-command-guard/README.md
+++ b/plugins/destructive-command-guard/README.md
@@ -28,8 +28,8 @@ Or add to your project's `.claude/settings.json`:
 | System paths | `rm -rf /etc`, `/usr`, `/var`, `/home`, `/boot`, `/opt`, `/bin`, `/sbin`, `/lib`, `/Users`, `/Applications`, `/System`, `/Library` | Critical system directories |
 | Variable expansion | `rm -rf $(pwd)`, `rm -rf $DIR` | Unvalidatable dynamic targets |
 | Path traversal | `rm -rf /./`, `rm -rf //`, `rm -rf /../..` | Normalized to dangerous paths |
-| Docker mass ops | `docker system prune`, `docker volume prune`, `docker container prune`, `docker network prune`, `docker builder prune`, `docker image prune -a`, `docker rm -f $(docker ps -aq)`, `docker compose down -v` | Mass removal of containers, volumes, images, networks |
-| Git destructive | `git clean -fdx` (without `-n`), `git checkout -- .`, `git reset --hard` (no target), `git push --force`, `git branch -D`, `git stash clear` | Loss of uncommitted changes, remote history, branches |
+| Docker mass ops | `docker system prune`, `docker volume prune`, `docker container prune`, `docker network prune`, `docker builder prune`, `docker image prune -a`, `docker rm -f $(docker ps -aq)`, `docker volume rm $(docker volume ls -q)`, `docker compose down -v` | Mass removal of containers, volumes, images, networks |
+| Git destructive | `git clean -fdx` (without `-n`), `git checkout -- .`, `git reset --hard` (no target), `git push --force`, `git branch -D`, `git stash clear`, `git stash drop` (no ref) | Loss of uncommitted changes, remote history, branches, stashes |
 | Indirect execution | `eval "..."`, `sh -c "..."`, `bash -c "..."`, `... \| sh`, `base64 ... \| bash` | Bypasses all other checks |
 | Alternative deletion | `find / -delete`, `find ~ -delete` | Equivalent to mass `rm` |
 
@@ -41,6 +41,7 @@ Or add to your project's `.claude/settings.json`:
 | `rm -rf /tmp/build` | Targets a temporary path |
 | `rm file.txt` | No recursive force flags |
 | `docker rm my-container` | Targets a specific container |
+| `docker volume rm my-data-vol` | Targets a specific named volume |
 | `docker image prune` (without `-a`) | Only removes dangling images |
 | `git clean -n` / `git clean -ndx` | Dry-run mode (preview only) |
 | `git reset --hard abc1234` | Has an explicit commit target |

--- a/plugins/destructive-command-guard/README.md
+++ b/plugins/destructive-command-guard/README.md
@@ -1,0 +1,79 @@
+# destructive-command-guard
+
+A PreToolUse hook plugin for Claude Code that blocks self-destructive Bash commands and warns about edits to agent policy files.
+
+Addresses issues [#23871](https://github.com/anthropics/claude-code/issues/23871) and [#23870](https://github.com/anthropics/claude-code/issues/23870).
+
+## Installation
+
+```bash
+claude --plugin-dir ./plugins/destructive-command-guard
+```
+
+Or add to your project's `.claude/settings.json`:
+
+```json
+{
+  "plugins": ["./plugins/destructive-command-guard"]
+}
+```
+
+## What it does
+
+### Blocked Bash commands (exit code 2)
+
+| Category | Blocked patterns | Why |
+|----------|-----------------|-----|
+| Mass deletion | `rm -rf /`, `rm -rf ~`, `rm -rf $HOME`, `rm -rf .`, `rm -rf ..`, `rm -rf *` | Irreversible deletion of root, home, or working directory |
+| Docker mass removal | `docker rm -f $(docker ps -aq)`, `docker system prune`, `docker volume prune`, `docker compose down -v` | Removes all containers, volumes, or system data |
+| Git destructive | `git clean -fdx`, `git checkout -- .`, `git reset --hard` (no target) | Loss of uncommitted changes and untracked files |
+
+### Allowed commands (not blocked)
+
+| Command | Why it's safe |
+|---------|--------------|
+| `rm -rf node_modules` | Targets a specific, regenerable directory |
+| `rm -rf /tmp/build` | Targets a temporary path |
+| `rm file.txt` | No recursive force flags |
+| `docker rm my-container` | Targets a specific container |
+| `docker stop my-container` | Targets a specific container |
+| `git clean -n` | Dry-run mode (preview only) |
+| `git clean -ndx` | Dry-run mode (preview only) |
+| `git reset --hard abc1234` | Has an explicit commit target |
+
+### Protected file warnings (systemMessage, once per session)
+
+| File pattern | Why it's protected |
+|-------------|-------------------|
+| `CLAUDE.md` (any path) | Agent behavior policy file |
+| `.claude/settings.json` | Agent permissions and settings |
+| `.claude/settings.local.json` | Local agent settings |
+| `hooks/hooks.json` | Plugin hook configuration |
+
+File edit warnings are non-blocking (exit code 0 with `systemMessage` JSON). They appear once per file per session.
+
+## Configuration
+
+### Disable the guard
+
+Set the environment variable:
+
+```bash
+export ENABLE_DESTRUCTIVE_GUARD=0
+```
+
+### Session state
+
+Warning state is stored in `~/.claude/destructive_guard_state_{session_id}.json`. Old state files (>30 days) are cleaned up automatically.
+
+## How it works
+
+The hook intercepts `PreToolUse` events for `Bash`, `Write`, `Edit`, and `MultiEdit` tools:
+
+1. **Bash commands**: Parses the command, splits multi-command chains (`&&`, `;`, `|`), and checks each part against destructive patterns. Blocked commands return exit code 2 with an error message on stderr.
+
+2. **File edits**: Checks the target file path against protected patterns. If matched, outputs a one-time warning as a `systemMessage` JSON on stdout (exit code 0).
+
+## Dependencies
+
+Python 3.7+ (stdlib only, no external packages).

--- a/plugins/destructive-command-guard/hooks/destructive_command_guard.py
+++ b/plugins/destructive-command-guard/hooks/destructive_command_guard.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+"""
+Destructive Command Guard Hook for Claude Code
+
+PreToolUse hook that:
+- BLOCKS dangerous Bash commands (rm -rf /, docker system prune, git clean -fdx, etc.)
+- WARNS about edits to policy files (CLAUDE.md, .claude/settings.json, hooks.json)
+
+Exit codes:
+  0 - allow (or warn via JSON on stdout)
+  2 - block (message on stderr)
+"""
+
+import json
+import os
+import random
+import re
+import sys
+from datetime import datetime
+
+
+# --- Konfiguracja ---
+
+STATE_FILE_PREFIX = "destructive_guard_state_"
+DEBUG_LOG_FILE = "/tmp/destructive-guard-log.txt"
+
+
+def debug_log(message):
+    """Zapis logu debugowego z timestampem."""
+    try:
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+        with open(DEBUG_LOG_FILE, "a") as f:
+            f.write(f"[{timestamp}] {message}\n")
+    except Exception:
+        pass
+
+
+# --- Session state (wzorzec z security-guidance) ---
+
+
+def get_state_file(session_id):
+    """Sciezka do pliku stanu sesji."""
+    return os.path.expanduser(f"~/.claude/{STATE_FILE_PREFIX}{session_id}.json")
+
+
+def cleanup_old_state_files():
+    """Usuwa pliki stanu starsze niz 30 dni."""
+    try:
+        state_dir = os.path.expanduser("~/.claude")
+        if not os.path.exists(state_dir):
+            return
+        current_time = datetime.now().timestamp()
+        thirty_days_ago = current_time - (30 * 24 * 60 * 60)
+        for filename in os.listdir(state_dir):
+            if filename.startswith(STATE_FILE_PREFIX) and filename.endswith(".json"):
+                file_path = os.path.join(state_dir, filename)
+                try:
+                    if os.path.getmtime(file_path) < thirty_days_ago:
+                        os.remove(file_path)
+                except (OSError, IOError):
+                    pass
+    except Exception:
+        pass
+
+
+def load_state(session_id):
+    """Wczytaj zbiór juz wyswietlonych ostrzezen."""
+    state_file = get_state_file(session_id)
+    if os.path.exists(state_file):
+        try:
+            with open(state_file, "r") as f:
+                return set(json.load(f))
+        except (json.JSONDecodeError, IOError):
+            return set()
+    return set()
+
+
+def save_state(session_id, shown_warnings):
+    """Zapisz zbiór wyswietlonych ostrzezen."""
+    state_file = get_state_file(session_id)
+    try:
+        os.makedirs(os.path.dirname(state_file), exist_ok=True)
+        with open(state_file, "w") as f:
+            json.dump(list(shown_warnings), f)
+    except IOError:
+        pass
+
+
+# --- Parsery komend Bash ---
+
+
+def _split_commands(command):
+    """Rozdziela polecenie na czesci po &&, ;, | (uproszczony split)."""
+    parts = re.split(r"\s*(?:&&|;|\|)\s*", command)
+    return [p.strip() for p in parts if p.strip()]
+
+
+def _parse_rm_flags_and_targets(args_str):
+    """Parsuje flagi i targety z argumentow rm.
+
+    Obsluguje: -rf, -r -f, -rfv, --recursive --force, itp.
+    Zwraca (flags: set, targets: list).
+    """
+    tokens = args_str.split()
+    flags = set()
+    targets = []
+    for token in tokens:
+        if token == "--":
+            # Wszystko po -- to targety
+            idx = tokens.index(token)
+            targets.extend(tokens[idx + 1:])
+            break
+        if token.startswith("--"):
+            flag_name = token.lstrip("-")
+            if flag_name == "recursive":
+                flags.add("r")
+            elif flag_name == "force":
+                flags.add("f")
+            else:
+                flags.add(flag_name)
+        elif token.startswith("-") and not token.startswith("--"):
+            for char in token[1:]:
+                flags.add(char)
+        else:
+            targets.append(token)
+    return flags, targets
+
+
+# Sciezki niebezpieczne dla rm -rf (normalizowane)
+_DANGEROUS_RM_TARGETS = {
+    "/",
+    "/*",
+    "~",
+    "~/",
+    "~/*",
+    "$HOME",
+    "$HOME/",
+    "$HOME/*",
+    "${HOME}",
+    "${HOME}/",
+    "${HOME}/*",
+    ".",
+    "./",
+    "./*",
+    "..",
+    "../",
+    "../*",
+    "*",
+}
+
+
+def check_rm_dangerous(command):
+    """Sprawdza czy komenda rm jest niebezpieczna.
+
+    Blokuje: rm -rf /, rm -rf ~, rm -rf ., rm -rf .., rm -rf *
+    Przepuszcza: rm -rf node_modules, rm -rf /tmp/build, rm file.txt
+    """
+    for part in _split_commands(command):
+        tokens = part.split()
+        if not tokens or tokens[0] != "rm":
+            continue
+        args_str = " ".join(tokens[1:])
+        flags, targets = _parse_rm_flags_and_targets(args_str)
+
+        # Blokujemy tylko gdy sa flagi -r i -f (lub kombinacje typu -rf)
+        has_recursive = "r" in flags or "R" in flags
+        has_force = "f" in flags
+        if not (has_recursive and has_force):
+            continue
+
+        for target in targets:
+            normalized = target.rstrip("/") if target not in ("/", "~/") else target
+            if target in _DANGEROUS_RM_TARGETS or normalized in _DANGEROUS_RM_TARGETS:
+                return (
+                    f"BLOCKED: 'rm -rf {target}' would cause irreversible data loss. "
+                    f"This command targets a critical path ({target}). "
+                    f"If you need to remove specific files, use a more targeted command."
+                )
+    return None
+
+
+# Wzorce docker niebezpiecznych komend
+_DOCKER_DANGEROUS_PATTERNS = [
+    # docker rm/stop/kill z subshell $(docker ps ...)
+    (
+        r"docker\s+(?:rm|stop|kill)\s+.*\$\(docker\s+ps",
+        "BLOCKED: Mass Docker container removal/stop/kill via subshell. "
+        "Remove containers individually by name instead.",
+    ),
+    # docker system prune (z lub bez -f/--force, z lub bez -a/--all)
+    (
+        r"docker\s+system\s+prune",
+        "BLOCKED: 'docker system prune' removes all unused data (containers, images, networks). "
+        "Use targeted cleanup commands instead.",
+    ),
+    # docker volume prune
+    (
+        r"docker\s+volume\s+prune",
+        "BLOCKED: 'docker volume prune' removes all unused volumes and their data. "
+        "Remove specific volumes by name instead.",
+    ),
+    # docker compose down -v (usuwa woluminy)
+    (
+        r"docker[\s-]compose\s+down\s+(?:.*\s)?-v\b",
+        "BLOCKED: 'docker compose down -v' removes all associated volumes. "
+        "Use 'docker compose down' without -v to preserve volume data.",
+    ),
+    (
+        r"docker[\s-]compose\s+down\s+(?:.*\s)?--volumes\b",
+        "BLOCKED: 'docker compose down --volumes' removes all associated volumes. "
+        "Use 'docker compose down' without --volumes to preserve volume data.",
+    ),
+]
+
+
+def check_docker_dangerous(command):
+    """Sprawdza czy komenda docker jest niebezpieczna.
+
+    Blokuje: docker rm -f $(docker ps -aq), docker system prune, docker volume prune,
+             docker compose down -v
+    Przepuszcza: docker rm my-container, docker stop my-container
+    """
+    for part in _split_commands(command):
+        for pattern, message in _DOCKER_DANGEROUS_PATTERNS:
+            if re.search(pattern, part):
+                return message
+    return None
+
+
+def check_git_dangerous(command):
+    """Sprawdza czy komenda git jest niebezpieczna.
+
+    Blokuje: git clean -fdx (bez -n/--dry-run), git checkout -- ., git reset --hard (bez targetu)
+    Przepuszcza: git clean -n, git clean -ndx, git reset --hard abc1234
+    """
+    for part in _split_commands(command):
+        tokens = part.split()
+        if not tokens or tokens[0] != "git":
+            continue
+
+        if len(tokens) < 2:
+            continue
+
+        subcommand = tokens[1]
+
+        # git clean -fdx (bez dry-run)
+        if subcommand == "clean":
+            args_str = " ".join(tokens[2:])
+            # Sprawdz czy jest dry-run (-n lub --dry-run)
+            has_dry_run = bool(re.search(r"(?:^|\s)-[a-zA-Z]*n", args_str)) or \
+                          "--dry-run" in args_str
+            if has_dry_run:
+                continue
+            # Sprawdz czy sa niebezpieczne flagi (-f z -d lub -x)
+            all_short_flags = set()
+            for token in tokens[2:]:
+                if token.startswith("-") and not token.startswith("--"):
+                    for char in token[1:]:
+                        all_short_flags.add(char)
+            has_force = "f" in all_short_flags
+            has_dirs_or_ignored = "d" in all_short_flags or "x" in all_short_flags or \
+                                  "X" in all_short_flags
+            if has_force and has_dirs_or_ignored:
+                return (
+                    "BLOCKED: 'git clean -fdx' permanently deletes untracked files and directories. "
+                    "Use 'git clean -ndx' (dry-run) first to preview what would be deleted."
+                )
+
+        # git checkout -- . (odrzuca wszystkie lokalne zmiany)
+        # Obsluguje: -- ., -- ./, -- ./*
+        if subcommand == "checkout":
+            rest = " ".join(tokens[2:])
+            if re.search(r"--\s+\.(?:[/\s*]|$)", rest):
+                return (
+                    "BLOCKED: 'git checkout -- .' discards all uncommitted changes. "
+                    "Use 'git stash' to save changes, or checkout specific files."
+                )
+
+        # git reset --hard (bez explicit commit hash)
+        if subcommand == "reset":
+            rest_tokens = tokens[2:]
+            if "--hard" in rest_tokens:
+                # Sprawdz czy po --hard jest explicit target (commit hash, branch, HEAD~N)
+                hard_idx = rest_tokens.index("--hard")
+                # Tokeny ktore nie sa flagami
+                non_flag_tokens = [
+                    t for t in rest_tokens
+                    if not t.startswith("-") and t != "--hard"
+                ]
+                if not non_flag_tokens:
+                    return (
+                        "BLOCKED: 'git reset --hard' without a target resets to HEAD, "
+                        "discarding all uncommitted changes. "
+                        "Specify an explicit commit (e.g., 'git reset --hard abc1234') "
+                        "or use 'git stash' first."
+                    )
+
+    return None
+
+
+# --- Ochrona plikow konfiguracyjnych ---
+# Decyzja projektowa: edycje chronionych plikow sa ostrzegane (exit 0 + systemMessage),
+# a NIE blokowane (exit 2). Uzytkownik moze celowo chciec zmodyfikowac CLAUDE.md
+# lub settings - blokowanie utrudnialoby uzywanie agenta. Ostrzezenie informuje
+# agenta o wrazliwosci pliku. Destrukcyjne komendy Bash sa blokowane (exit 2),
+# bo sa nieodwracalne.
+
+_PROTECTED_FILE_PATTERNS = [
+    (
+        r"(?:^|/)CLAUDE\.md$",
+        "policy_file_claude_md",
+        "You are about to modify CLAUDE.md, which defines agent behavior policies. "
+        "Ensure this change is intentional and reviewed.",
+    ),
+    (
+        r"(?:^|/)\.claude/settings\.json$",
+        "settings_file",
+        "You are about to modify .claude/settings.json, which controls agent permissions. "
+        "Ensure this change is intentional and reviewed.",
+    ),
+    (
+        r"(?:^|/)\.claude/settings\.local\.json$",
+        "settings_local_file",
+        "You are about to modify .claude/settings.local.json (local agent settings). "
+        "Ensure this change is intentional and reviewed.",
+    ),
+    (
+        r"(?:^|/)hooks/hooks\.json$",
+        "hooks_config_file",
+        "You are about to modify hooks/hooks.json, which configures plugin hooks. "
+        "Ensure this change is intentional and reviewed.",
+    ),
+]
+
+
+def check_file_protection(file_path):
+    """Sprawdza czy plik jest chroniony (CLAUDE.md, settings, hooks.json).
+
+    Zwraca (warning_key, message) lub (None, None).
+    """
+    if not file_path:
+        return None, None
+    for pattern, key, message in _PROTECTED_FILE_PATTERNS:
+        if re.search(pattern, file_path):
+            return key, message
+    return None, None
+
+
+# --- Glowna logika ---
+
+
+def handle_bash(tool_input):
+    """Obsluga narzedzia Bash - sprawdza komende pod katem destrukcyjnych operacji."""
+    command = tool_input.get("command", "")
+    if not command:
+        return None
+
+    # Sprawdz kolejno kazda kategorie
+    result = check_rm_dangerous(command)
+    if result:
+        return result
+
+    result = check_docker_dangerous(command)
+    if result:
+        return result
+
+    result = check_git_dangerous(command)
+    if result:
+        return result
+
+    return None
+
+
+def handle_file_edit(tool_name, tool_input, session_id):
+    """Obsluga narzedzi Write/Edit/MultiEdit - ostrzezenie przy edycji chronionych plikow.
+
+    Zwraca (should_warn: bool, message: str).
+    Warning jest wyswietlany tylko raz na sesje per plik.
+    """
+    file_path = tool_input.get("file_path", "")
+    if not file_path:
+        return False, ""
+
+    warning_key, message = check_file_protection(file_path)
+    if not warning_key:
+        return False, ""
+
+    # Sprawdz czy juz ostrzegano w tej sesji
+    shown_warnings = load_state(session_id)
+    full_key = f"{file_path}-{warning_key}"
+    if full_key in shown_warnings:
+        return False, ""
+
+    # Zapisz ostrzezenie
+    shown_warnings.add(full_key)
+    save_state(session_id, shown_warnings)
+    return True, message
+
+
+def main():
+    # Sprawdz env var wylaczajacy guard
+    if os.environ.get("ENABLE_DESTRUCTIVE_GUARD", "1") == "0":
+        sys.exit(0)
+
+    # Periodyczny cleanup starych plikow stanu (10% szans)
+    if random.random() < 0.1:
+        cleanup_old_state_files()
+
+    # Wczytaj dane wejsciowe z stdin
+    try:
+        raw_input_data = sys.stdin.read()
+        input_data = json.loads(raw_input_data)
+    except json.JSONDecodeError as e:
+        debug_log(f"JSON decode error: {e}")
+        sys.exit(0)
+
+    session_id = input_data.get("session_id", "default")
+    tool_name = input_data.get("tool_name", "")
+    tool_input = input_data.get("tool_input", {})
+
+    # Obsluga Bash - blokowanie destrukcyjnych komend
+    if tool_name == "Bash":
+        block_message = handle_bash(tool_input)
+        if block_message:
+            print(block_message, file=sys.stderr)
+            sys.exit(2)
+        sys.exit(0)
+
+    # Obsluga Write/Edit/MultiEdit - ostrzezenia o chronionych plikach
+    if tool_name in ("Write", "Edit", "MultiEdit"):
+        should_warn, message = handle_file_edit(tool_name, tool_input, session_id)
+        if should_warn:
+            # Wyslij warning jako systemMessage (exit 0, JSON na stdout)
+            warning_output = json.dumps({"systemMessage": message})
+            print(warning_output)
+            sys.exit(0)
+        sys.exit(0)
+
+    # Inne narzedzia - przepusc
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/destructive-command-guard/hooks/destructive_command_guard.py
+++ b/plugins/destructive-command-guard/hooks/destructive_command_guard.py
@@ -655,10 +655,10 @@ def check_bash_file_modification(command):
         for pattern_template in _BASH_FILE_MOD_PATTERNS:
             pattern = pattern_template.format(name=escaped_name)
             if re.search(pattern, command):
-                # Find the appropriate warning message
-                for _, _, msg in _PROTECTED_FILE_PATTERNS:
-                    if name.split("/")[-1] in msg or name in msg:
-                        return msg
+                # Use check_file_protection for consistent message lookup
+                _, message = check_file_protection(name)
+                if message:
+                    return message
                 return (
                     f"You are about to modify {name} via Bash command. "
                     "Ensure this change is intentional and reviewed."

--- a/plugins/destructive-command-guard/hooks/destructive_command_guard.py
+++ b/plugins/destructive-command-guard/hooks/destructive_command_guard.py
@@ -3,12 +3,17 @@
 Destructive Command Guard Hook for Claude Code
 
 PreToolUse hook that:
-- BLOCKS dangerous Bash commands (rm -rf /, docker system prune, git clean -fdx, etc.)
+- BLOCKS dangerous Bash commands (mass deletion, Docker mass ops, destructive git,
+  indirect execution, alternative deletion tools, file modification via Bash)
 - WARNS about edits to policy files (CLAUDE.md, .claude/settings.json, hooks.json)
 
 Exit codes:
   0 - allow (or warn via JSON on stdout)
   2 - block (message on stderr)
+
+Security model:
+  Blocklist approach -- first line of defense against accidental destructive commands.
+  Not a sandbox. Cannot prevent all obfuscation vectors, but catches common patterns.
 """
 
 import json
@@ -16,18 +21,22 @@ import os
 import random
 import re
 import sys
+import tempfile
 from datetime import datetime
 
 
 # --- Konfiguracja ---
 
 STATE_FILE_PREFIX = "destructive_guard_state_"
-DEBUG_LOG_FILE = "/tmp/destructive-guard-log.txt"
+# Log w katalogu uzytkownika, nie w /tmp (ochrona przed symlink attacks)
+CLAUDE_DIR = os.path.expanduser("~/.claude")
+DEBUG_LOG_FILE = os.path.join(CLAUDE_DIR, "destructive-guard-log.txt")
 
 
 def debug_log(message):
-    """Zapis logu debugowego z timestampem."""
+    """Zapis logu debugowego z timestampem do katalogu uzytkownika."""
     try:
+        os.makedirs(CLAUDE_DIR, mode=0o700, exist_ok=True)
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
         with open(DEBUG_LOG_FILE, "a") as f:
             f.write(f"[{timestamp}] {message}\n")
@@ -35,25 +44,32 @@ def debug_log(message):
         pass
 
 
-# --- Session state (wzorzec z security-guidance) ---
+# --- Session state ---
+
+
+def _sanitize_session_id(session_id):
+    """Walidacja session_id - zapobieganie path traversal (CWE-22)."""
+    if not session_id or not re.match(r"^[a-zA-Z0-9_.-]+$", session_id):
+        return "default_safe"
+    return session_id
 
 
 def get_state_file(session_id):
-    """Sciezka do pliku stanu sesji."""
-    return os.path.expanduser(f"~/.claude/{STATE_FILE_PREFIX}{session_id}.json")
+    """Sciezka do pliku stanu sesji (z sanityzacja)."""
+    safe_id = _sanitize_session_id(session_id)
+    return os.path.join(CLAUDE_DIR, f"{STATE_FILE_PREFIX}{safe_id}.json")
 
 
 def cleanup_old_state_files():
     """Usuwa pliki stanu starsze niz 30 dni."""
     try:
-        state_dir = os.path.expanduser("~/.claude")
-        if not os.path.exists(state_dir):
+        if not os.path.exists(CLAUDE_DIR):
             return
         current_time = datetime.now().timestamp()
         thirty_days_ago = current_time - (30 * 24 * 60 * 60)
-        for filename in os.listdir(state_dir):
+        for filename in os.listdir(CLAUDE_DIR):
             if filename.startswith(STATE_FILE_PREFIX) and filename.endswith(".json"):
-                file_path = os.path.join(state_dir, filename)
+                file_path = os.path.join(CLAUDE_DIR, filename)
                 try:
                     if os.path.getmtime(file_path) < thirty_days_ago:
                         os.remove(file_path)
@@ -64,7 +80,7 @@ def cleanup_old_state_files():
 
 
 def load_state(session_id):
-    """Wczytaj zbiór juz wyswietlonych ostrzezen."""
+    """Wczytaj zbior juz wyswietlonych ostrzezen."""
     state_file = get_state_file(session_id)
     if os.path.exists(state_file):
         try:
@@ -76,12 +92,23 @@ def load_state(session_id):
 
 
 def save_state(session_id, shown_warnings):
-    """Zapisz zbiór wyswietlonych ostrzezen."""
+    """Atomowy zapis stanu (tempfile + os.replace, POSIX atomic)."""
     state_file = get_state_file(session_id)
     try:
-        os.makedirs(os.path.dirname(state_file), exist_ok=True)
-        with open(state_file, "w") as f:
-            json.dump(list(shown_warnings), f)
+        os.makedirs(os.path.dirname(state_file), mode=0o700, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(
+            dir=os.path.dirname(state_file), suffix=".tmp", text=True
+        )
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(list(shown_warnings), f)
+            os.replace(tmp_path, state_file)
+        except Exception:
+            # Sprzatanie pliku tymczasowego w razie bledu
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
     except IOError:
         pass
 
@@ -90,9 +117,27 @@ def save_state(session_id, shown_warnings):
 
 
 def _split_commands(command):
-    """Rozdziela polecenie na czesci po &&, ;, | (uproszczony split)."""
+    """Rozdziela polecenie na czesci po &&, ;, | (uproszczony split).
+
+    Nie obsluguje zagniezdzenych cudzyslow -- to ograniczenie blocklist approach.
+    """
     parts = re.split(r"\s*(?:&&|;|\|)\s*", command)
     return [p.strip() for p in parts if p.strip()]
+
+
+def _normalize_path(path):
+    """Normalizacja sciezki -- lapie warianty /./  //  /../.. itp."""
+    cleaned = path
+    # Usun podwojne slashe
+    while "//" in cleaned:
+        cleaned = cleaned.replace("//", "/")
+    # Usun /./ sekwencje
+    while "/./" in cleaned:
+        cleaned = cleaned.replace("/./", "/")
+    # Jesli zawiera parent traversal (..) -- podejrzane
+    if "/.." in cleaned or cleaned.startswith(".."):
+        return "/"
+    return cleaned.rstrip("/") or "/"
 
 
 def _parse_rm_flags_and_targets(args_str):
@@ -104,12 +149,14 @@ def _parse_rm_flags_and_targets(args_str):
     tokens = args_str.split()
     flags = set()
     targets = []
-    for token in tokens:
+    end_of_flags = False
+    for i, token in enumerate(tokens):
+        if end_of_flags:
+            targets.append(token)
+            continue
         if token == "--":
-            # Wszystko po -- to targety
-            idx = tokens.index(token)
-            targets.extend(tokens[idx + 1:])
-            break
+            end_of_flags = True
+            continue
         if token.startswith("--"):
             flag_name = token.lstrip("-")
             if flag_name == "recursive":
@@ -126,33 +173,29 @@ def _parse_rm_flags_and_targets(args_str):
     return flags, targets
 
 
-# Sciezki niebezpieczne dla rm -rf (normalizowane)
+# Sciezki niebezpieczne dla rm -rf
 _DANGEROUS_RM_TARGETS = {
-    "/",
-    "/*",
-    "~",
-    "~/",
-    "~/*",
-    "$HOME",
-    "$HOME/",
-    "$HOME/*",
-    "${HOME}",
-    "${HOME}/",
-    "${HOME}/*",
-    ".",
-    "./",
-    "./*",
-    "..",
-    "../",
-    "../*",
+    "/", "/*",
+    "~", "~/", "~/*",
+    "$HOME", "$HOME/", "$HOME/*",
+    "${HOME}", "${HOME}/", "${HOME}/*",
+    ".", "./", "./*",
+    "..", "../", "../*",
     "*",
+}
+
+# Sciezki systemowe -- rowniez niebezpieczne dla rm -rf
+_DANGEROUS_SYSTEM_PATHS = {
+    "/etc", "/usr", "/var", "/home", "/opt", "/boot",
+    "/bin", "/sbin", "/lib", "/lib64", "/srv", "/root",
+    "/System", "/Applications", "/Library", "/Users",
 }
 
 
 def check_rm_dangerous(command):
     """Sprawdza czy komenda rm jest niebezpieczna.
 
-    Blokuje: rm -rf /, rm -rf ~, rm -rf ., rm -rf .., rm -rf *
+    Blokuje: rm -rf /, ~, ., .., *, /etc, /usr, /var, /home, zmienne, subshells
     Przepuszcza: rm -rf node_modules, rm -rf /tmp/build, rm file.txt
     """
     for part in _split_commands(command):
@@ -162,24 +205,143 @@ def check_rm_dangerous(command):
         args_str = " ".join(tokens[1:])
         flags, targets = _parse_rm_flags_and_targets(args_str)
 
-        # Blokujemy tylko gdy sa flagi -r i -f (lub kombinacje typu -rf)
         has_recursive = "r" in flags or "R" in flags
         has_force = "f" in flags
         if not (has_recursive and has_force):
             continue
 
+        # Sprawdz backticki w calym args_str (split rozbija je na wiele tokenow)
+        if "`" in args_str:
+            return (
+                "BLOCKED: 'rm -rf' with backtick command substitution is not allowed. "
+                "Specify the target path directly so it can be validated."
+            )
+
         for target in targets:
-            normalized = target.rstrip("/") if target not in ("/", "~/") else target
-            if target in _DANGEROUS_RM_TARGETS or normalized in _DANGEROUS_RM_TARGETS:
+            # Sprawdz command substitution / variable expansion
+            if re.search(r"\$\(.*\)|`.*`", target):
+                return (
+                    "BLOCKED: 'rm -rf' with command substitution is not allowed. "
+                    "Specify the target path directly so it can be validated."
+                )
+            if re.search(r"\$\{?\w+\}?", target) and target not in _DANGEROUS_RM_TARGETS:
+                # Zmienna ktora nie jest na liscie znanych -- podejrzane
+                return (
+                    f"BLOCKED: 'rm -rf' with variable expansion ({target}) is not allowed. "
+                    "Specify the target path directly so it can be validated."
+                )
+
+            # Normalizacja sciezki
+            normalized = _normalize_path(target)
+            raw_stripped = target.rstrip("/") or "/"
+
+            # Sprawdz literalne niebezpieczne targety
+            if (target in _DANGEROUS_RM_TARGETS
+                    or raw_stripped in _DANGEROUS_RM_TARGETS
+                    or normalized in _DANGEROUS_RM_TARGETS):
                 return (
                     f"BLOCKED: 'rm -rf {target}' would cause irreversible data loss. "
                     f"This command targets a critical path ({target}). "
-                    f"If you need to remove specific files, use a more targeted command."
+                    "If you need to remove specific files, use a more targeted command."
                 )
+
+            # Sprawdz sciezki systemowe
+            if normalized in _DANGEROUS_SYSTEM_PATHS or raw_stripped in _DANGEROUS_SYSTEM_PATHS:
+                return (
+                    f"BLOCKED: 'rm -rf {target}' targets a critical system directory. "
+                    "Removing system directories causes irreversible damage."
+                )
+            # Sprawdz czy target z /* jest sciezka systemowa
+            if target.endswith("/*"):
+                base = target[:-2].rstrip("/") or "/"
+                if base in _DANGEROUS_SYSTEM_PATHS:
+                    return (
+                        f"BLOCKED: 'rm -rf {target}' targets contents of a critical system directory."
+                    )
+
     return None
 
 
-# Wzorce docker niebezpiecznych komend
+# --- Indirect execution / obfuscation ---
+
+
+def check_indirect_execution(command):
+    """Blokuje posrednie wykonanie komend (eval, sh -c, pipe do shell, base64).
+
+    Zapobiega obejsciu guardu przez zawijanie komend w eval/sh/bash.
+    """
+    for part in _split_commands(command):
+        tokens = part.split()
+        if not tokens:
+            continue
+
+        cmd = tokens[0]
+
+        # eval z argumentami
+        if cmd == "eval" and len(tokens) > 1:
+            return (
+                "BLOCKED: 'eval' executes arbitrary strings as commands, bypassing safety checks. "
+                "Run the command directly instead."
+            )
+
+        # sh -c / bash -c / zsh -c
+        if cmd in ("sh", "bash", "zsh") and "-c" in tokens:
+            return (
+                f"BLOCKED: '{cmd} -c' executes arbitrary strings as commands, "
+                "bypassing safety checks. Run the command directly instead."
+            )
+
+    # Pipe do shell: ... | sh, ... | bash, ... | zsh
+    if re.search(r"\|\s*(?:sh|bash|zsh)\s*$", command):
+        return (
+            "BLOCKED: Piping output to a shell interpreter bypasses safety checks. "
+            "Run the command directly instead."
+        )
+
+    # base64 decode piped do shell
+    if re.search(r"base64\s+.*\|\s*(?:sh|bash|zsh)", command):
+        return (
+            "BLOCKED: Decoding and piping to shell is a common obfuscation technique. "
+            "Run the command directly instead."
+        )
+
+    return None
+
+
+# --- Alternative deletion tools ---
+
+
+def check_alternative_deletion(command):
+    """Blokuje alternatywne narzedzia usuwania na sciezkach systemowych.
+
+    Blokuje: find / -delete, find ~ -delete, shred na sciezkach systemowych
+    Przepuszcza: find ./src -name '*.pyc' -delete (specyficzna sciezka)
+    """
+    for part in _split_commands(command):
+        tokens = part.split()
+        if not tokens:
+            continue
+
+        # find <path> ... -delete
+        if tokens[0] == "find" and "-delete" in tokens:
+            if len(tokens) >= 2:
+                target = tokens[1]
+                normalized = _normalize_path(target)
+                all_dangerous = _DANGEROUS_RM_TARGETS | _DANGEROUS_SYSTEM_PATHS | {
+                    "$HOME", "${HOME}", "~"
+                }
+                if normalized in all_dangerous or target in all_dangerous:
+                    return (
+                        f"BLOCKED: 'find {target} -delete' would cause irreversible data loss. "
+                        "Use a more specific path."
+                    )
+
+    return None
+
+
+# --- Docker ---
+
+
 _DOCKER_DANGEROUS_PATTERNS = [
     # docker rm/stop/kill z subshell $(docker ps ...)
     (
@@ -187,7 +349,13 @@ _DOCKER_DANGEROUS_PATTERNS = [
         "BLOCKED: Mass Docker container removal/stop/kill via subshell. "
         "Remove containers individually by name instead.",
     ),
-    # docker system prune (z lub bez -f/--force, z lub bez -a/--all)
+    # docker rm/stop/kill z backticks `docker ps ...`
+    (
+        r"docker\s+(?:rm|stop|kill)\s+.*`docker\s+ps",
+        "BLOCKED: Mass Docker container removal/stop/kill via subshell. "
+        "Remove containers individually by name instead.",
+    ),
+    # docker system prune
     (
         r"docker\s+system\s+prune",
         "BLOCKED: 'docker system prune' removes all unused data (containers, images, networks). "
@@ -199,7 +367,36 @@ _DOCKER_DANGEROUS_PATTERNS = [
         "BLOCKED: 'docker volume prune' removes all unused volumes and their data. "
         "Remove specific volumes by name instead.",
     ),
-    # docker compose down -v (usuwa woluminy)
+    # docker container prune
+    (
+        r"docker\s+container\s+prune",
+        "BLOCKED: 'docker container prune' removes all stopped containers. "
+        "Remove specific containers by name instead.",
+    ),
+    # docker image prune -a (usun WSZYSTKIE nieuzywane obrazy)
+    (
+        r"docker\s+image\s+prune\s+(?:.*\s)?-a",
+        "BLOCKED: 'docker image prune -a' removes all unused images. "
+        "Remove specific images by name/tag instead.",
+    ),
+    (
+        r"docker\s+image\s+prune\s+(?:.*\s)?--all",
+        "BLOCKED: 'docker image prune --all' removes all unused images. "
+        "Remove specific images by name/tag instead.",
+    ),
+    # docker network prune
+    (
+        r"docker\s+network\s+prune",
+        "BLOCKED: 'docker network prune' removes all unused networks. "
+        "Remove specific networks by name instead.",
+    ),
+    # docker builder prune
+    (
+        r"docker\s+builder\s+prune",
+        "BLOCKED: 'docker builder prune' removes all build cache. "
+        "Use targeted cleanup instead.",
+    ),
+    # docker compose down -v / --volumes
     (
         r"docker[\s-]compose\s+down\s+(?:.*\s)?-v\b",
         "BLOCKED: 'docker compose down -v' removes all associated volumes. "
@@ -216,9 +413,10 @@ _DOCKER_DANGEROUS_PATTERNS = [
 def check_docker_dangerous(command):
     """Sprawdza czy komenda docker jest niebezpieczna.
 
-    Blokuje: docker rm -f $(docker ps -aq), docker system prune, docker volume prune,
-             docker compose down -v
-    Przepuszcza: docker rm my-container, docker stop my-container
+    Blokuje: docker system/volume/container/network/builder prune,
+             docker rm/stop/kill z subshell, docker compose down -v
+    Przepuszcza: docker rm my-container, docker stop my-container,
+                 docker image prune (bez -a)
     """
     for part in _split_commands(command):
         for pattern, message in _DOCKER_DANGEROUS_PATTERNS:
@@ -227,31 +425,34 @@ def check_docker_dangerous(command):
     return None
 
 
+# --- Git ---
+
+
 def check_git_dangerous(command):
     """Sprawdza czy komenda git jest niebezpieczna.
 
-    Blokuje: git clean -fdx (bez -n/--dry-run), git checkout -- ., git reset --hard (bez targetu)
-    Przepuszcza: git clean -n, git clean -ndx, git reset --hard abc1234
+    Blokuje: git clean -fd/-fx/-fdx (bez dry-run), git checkout -- .,
+             git reset --hard (bez targetu), git push --force,
+             git branch -D, git stash drop/clear
+    Przepuszcza: git clean -n, git reset --hard abc1234, git push,
+                 git branch -d, git stash
     """
     for part in _split_commands(command):
         tokens = part.split()
         if not tokens or tokens[0] != "git":
             continue
-
         if len(tokens) < 2:
             continue
 
         subcommand = tokens[1]
 
-        # git clean -fdx (bez dry-run)
+        # git clean (bez dry-run, z force + dirs/ignored)
         if subcommand == "clean":
             args_str = " ".join(tokens[2:])
-            # Sprawdz czy jest dry-run (-n lub --dry-run)
             has_dry_run = bool(re.search(r"(?:^|\s)-[a-zA-Z]*n", args_str)) or \
                           "--dry-run" in args_str
             if has_dry_run:
                 continue
-            # Sprawdz czy sa niebezpieczne flagi (-f z -d lub -x)
             all_short_flags = set()
             for token in tokens[2:]:
                 if token.startswith("-") and not token.startswith("--"):
@@ -266,8 +467,7 @@ def check_git_dangerous(command):
                     "Use 'git clean -ndx' (dry-run) first to preview what would be deleted."
                 )
 
-        # git checkout -- . (odrzuca wszystkie lokalne zmiany)
-        # Obsluguje: -- ., -- ./, -- ./*
+        # git checkout -- . / ./ / ./*
         if subcommand == "checkout":
             rest = " ".join(tokens[2:])
             if re.search(r"--\s+\.(?:[/\s*]|$)", rest):
@@ -276,13 +476,10 @@ def check_git_dangerous(command):
                     "Use 'git stash' to save changes, or checkout specific files."
                 )
 
-        # git reset --hard (bez explicit commit hash)
+        # git reset --hard (bez explicit targetu)
         if subcommand == "reset":
             rest_tokens = tokens[2:]
             if "--hard" in rest_tokens:
-                # Sprawdz czy po --hard jest explicit target (commit hash, branch, HEAD~N)
-                hard_idx = rest_tokens.index("--hard")
-                # Tokeny ktore nie sa flagami
                 non_flag_tokens = [
                     t for t in rest_tokens
                     if not t.startswith("-") and t != "--hard"
@@ -295,6 +492,45 @@ def check_git_dangerous(command):
                         "or use 'git stash' first."
                     )
 
+        # git push --force / -f (nadpisuje historie remote)
+        if subcommand == "push":
+            rest_tokens = tokens[2:]
+            if "--force" in rest_tokens or "-f" in rest_tokens:
+                return (
+                    "BLOCKED: 'git push --force' overwrites remote history and can cause data loss "
+                    "for other collaborators. Use 'git push --force-with-lease' for safer force push."
+                )
+            # Sprawdz sklejone flagi np. -uf
+            for token in rest_tokens:
+                if token.startswith("-") and not token.startswith("--") and "f" in token[1:]:
+                    return (
+                        "BLOCKED: 'git push -f' overwrites remote history and can cause data loss "
+                        "for other collaborators. Use 'git push --force-with-lease' instead."
+                    )
+
+        # git branch -D (force delete)
+        if subcommand == "branch":
+            rest_tokens = tokens[2:]
+            if "-D" in rest_tokens:
+                return (
+                    "BLOCKED: 'git branch -D' force-deletes a branch even if not merged. "
+                    "Use 'git branch -d' which will warn if the branch is not fully merged."
+                )
+
+        # git stash drop / clear (utrata zapisanych zmian)
+        if subcommand == "stash":
+            if len(tokens) >= 3:
+                stash_action = tokens[2]
+                if stash_action == "clear":
+                    return (
+                        "BLOCKED: 'git stash clear' permanently deletes all stashed changes. "
+                        "Use 'git stash drop' to remove specific stash entries."
+                    )
+                if stash_action == "drop" and len(tokens) == 3:
+                    # 'git stash drop' bez argumentu -- dropuje ostatni stash
+                    # Przepuszczamy, bo to pojedynczy stash, nie catastrophic
+                    pass
+
     return None
 
 
@@ -304,6 +540,14 @@ def check_git_dangerous(command):
 # lub settings - blokowanie utrudnialoby uzywanie agenta. Ostrzezenie informuje
 # agenta o wrazliwosci pliku. Destrukcyjne komendy Bash sa blokowane (exit 2),
 # bo sa nieodwracalne.
+
+# Nazwy chronionych plikow (do regex matching)
+_PROTECTED_FILE_NAMES = [
+    "CLAUDE.md",
+    ".claude/settings.json",
+    ".claude/settings.local.json",
+    "hooks/hooks.json",
+]
 
 _PROTECTED_FILE_PATTERNS = [
     (
@@ -346,29 +590,85 @@ def check_file_protection(file_path):
     return None, None
 
 
+def check_bash_file_modification(command):
+    """Sprawdza czy komenda Bash modyfikuje chronione pliki.
+
+    Lapie: echo > CLAUDE.md, sed -i CLAUDE.md, mv/cp/tee/truncate/dd
+    Nie blokuje -- wyswietla warning (return message string lub None).
+    """
+    # Wzorce modyfikacji plikow w Bash
+    _BASH_FILE_MOD_PATTERNS = [
+        r"(?:>|>>)\s*\S*{name}",          # echo "x" > CLAUDE.md, >> append
+        r"tee\s+(?:-a\s+)?\S*{name}",     # tee CLAUDE.md, tee -a CLAUDE.md
+        r"sed\s+-i\S*\s+.*\S*{name}",     # sed -i 's/.../.../' CLAUDE.md
+        r"mv\s+\S+\s+\S*{name}",          # mv something CLAUDE.md
+        r"cp\s+\S+\s+\S*{name}",          # cp something CLAUDE.md
+        r"truncate\s+.*\S*{name}",         # truncate -s 0 CLAUDE.md
+        r"dd\s+.*of=\S*{name}",           # dd if=... of=CLAUDE.md
+    ]
+
+    for name in _PROTECTED_FILE_NAMES:
+        # Escape regex special chars w nazwie pliku
+        escaped_name = re.escape(name)
+        for pattern_template in _BASH_FILE_MOD_PATTERNS:
+            pattern = pattern_template.format(name=escaped_name)
+            if re.search(pattern, command):
+                # Znajdz odpowiedni warning message
+                for _, _, msg in _PROTECTED_FILE_PATTERNS:
+                    if name.split("/")[-1] in msg or name in msg:
+                        return msg
+                return (
+                    f"You are about to modify {name} via Bash command. "
+                    "Ensure this change is intentional and reviewed."
+                )
+
+    return None
+
+
 # --- Glowna logika ---
 
 
 def handle_bash(tool_input):
-    """Obsluga narzedzia Bash - sprawdza komende pod katem destrukcyjnych operacji."""
+    """Obsluga narzedzia Bash - sprawdza komende pod katem destrukcyjnych operacji.
+
+    Zwraca (block_message, warn_message) -- block_message powoduje exit 2,
+    warn_message powoduje systemMessage (exit 0).
+    """
     command = tool_input.get("command", "")
     if not command:
-        return None
+        return None, None
 
-    # Sprawdz kolejno kazda kategorie
+    # 1. Indirect execution (eval, sh -c, pipe to shell)
+    result = check_indirect_execution(command)
+    if result:
+        return result, None
+
+    # 2. rm -rf na niebezpiecznych sciezkach
     result = check_rm_dangerous(command)
     if result:
-        return result
+        return result, None
 
+    # 3. Alternatywne narzedzia usuwania (find -delete)
+    result = check_alternative_deletion(command)
+    if result:
+        return result, None
+
+    # 4. Docker destrukcyjne komendy
     result = check_docker_dangerous(command)
     if result:
-        return result
+        return result, None
 
+    # 5. Git destrukcyjne komendy
     result = check_git_dangerous(command)
     if result:
-        return result
+        return result, None
 
-    return None
+    # 6. Modyfikacja chronionych plikow przez Bash (warning, nie block)
+    warn = check_bash_file_modification(command)
+    if warn:
+        return None, warn
+
+    return None, None
 
 
 def handle_file_edit(tool_name, tool_input, session_id):
@@ -385,13 +685,11 @@ def handle_file_edit(tool_name, tool_input, session_id):
     if not warning_key:
         return False, ""
 
-    # Sprawdz czy juz ostrzegano w tej sesji
     shown_warnings = load_state(session_id)
     full_key = f"{file_path}-{warning_key}"
     if full_key in shown_warnings:
         return False, ""
 
-    # Zapisz ostrzezenie
     shown_warnings.add(full_key)
     save_state(session_id, shown_warnings)
     return True, message
@@ -418,25 +716,34 @@ def main():
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input", {})
 
-    # Obsluga Bash - blokowanie destrukcyjnych komend
+    # Obsluga Bash
     if tool_name == "Bash":
-        block_message = handle_bash(tool_input)
+        block_message, warn_message = handle_bash(tool_input)
         if block_message:
             print(block_message, file=sys.stderr)
             sys.exit(2)
+        if warn_message:
+            # Warning o modyfikacji chronionego pliku przez Bash
+            # Raz na sesje per warning
+            shown_warnings = load_state(session_id)
+            warn_key = f"bash-{warn_message[:50]}"
+            if warn_key not in shown_warnings:
+                shown_warnings.add(warn_key)
+                save_state(session_id, shown_warnings)
+                warning_output = json.dumps({"systemMessage": warn_message})
+                print(warning_output)
         sys.exit(0)
 
-    # Obsluga Write/Edit/MultiEdit - ostrzezenia o chronionych plikach
+    # Obsluga Write/Edit/MultiEdit
     if tool_name in ("Write", "Edit", "MultiEdit"):
         should_warn, message = handle_file_edit(tool_name, tool_input, session_id)
         if should_warn:
-            # Wyslij warning jako systemMessage (exit 0, JSON na stdout)
             warning_output = json.dumps({"systemMessage": message})
             print(warning_output)
             sys.exit(0)
         sys.exit(0)
 
-    # Inne narzedzia - przepusc
+    # Inne narzedzia -- przepusc
     sys.exit(0)
 
 

--- a/plugins/destructive-command-guard/hooks/destructive_command_guard.py
+++ b/plugins/destructive-command-guard/hooks/destructive_command_guard.py
@@ -116,10 +116,89 @@ def save_state(session_id, shown_warnings):
 # --- Bash command parsers ---
 
 
+def _strip_quoted_content(command):
+    """Replace content inside quoted strings with empty placeholders.
+
+    Handles single-quoted ('...'), double-quoted ("...") with backslash escapes,
+    and heredocs (<<EOF...EOF, <<'EOF'...EOF).
+    Returns the command with quoted content neutralized so that text arguments
+    (e.g., gh pr comment --body "text with rm -rf") do not trigger false positives.
+    """
+    result = []
+    i = 0
+    length = len(command)
+    while i < length:
+        c = command[i]
+
+        # Heredoc: <<EOF or <<'EOF' or <<-EOF or <<"EOF"
+        if c == '<' and i + 1 < length and command[i + 1] == '<':
+            # Capture the heredoc delimiter
+            j = i + 2
+            # Skip optional '-' (for <<-EOF indented heredocs)
+            if j < length and command[j] == '-':
+                j += 1
+            # Skip whitespace between << and delimiter
+            while j < length and command[j] in (' ', '\t'):
+                j += 1
+            # Extract delimiter (may be quoted: 'EOF', "EOF", or bare EOF)
+            quote_char = None
+            if j < length and command[j] in ("'", '"'):
+                quote_char = command[j]
+                j += 1
+            delim_start = j
+            while j < length and command[j] not in (' ', '\t', '\n', '\r', "'", '"'):
+                j += 1
+            delimiter = command[delim_start:j]
+            if quote_char and j < length and command[j] == quote_char:
+                j += 1
+            if delimiter:
+                # Find the end: delimiter on its own line
+                end_marker = '\n' + delimiter
+                end_pos = command.find(end_marker, j)
+                if end_pos != -1:
+                    # Keep the <<DELIM part, skip the body
+                    result.append(command[i:j])
+                    i = end_pos + len(end_marker)
+                    continue
+            # No valid heredoc found, treat as normal characters
+            result.append(command[i:j])
+            i = j
+            continue
+
+        # Single-quoted string: preserve quotes, remove content
+        if c == "'":
+            end = command.find("'", i + 1)
+            if end != -1:
+                result.append("''")
+                i = end + 1
+                continue
+
+        # Double-quoted string: preserve quotes, remove content (handle backslash escapes)
+        if c == '"':
+            j = i + 1
+            while j < length:
+                if command[j] == '\\' and j + 1 < length:
+                    j += 2  # skip escaped character
+                elif command[j] == '"':
+                    break
+                else:
+                    j += 1
+            if j < length:
+                result.append('""')
+                i = j + 1
+                continue
+
+        result.append(c)
+        i += 1
+
+    return ''.join(result)
+
+
 def _split_commands(command):
     """Split command into parts by &&, ||, ;, |, and newlines (simplified split).
 
-    Does not handle nested quotes -- this is a limitation of the blocklist approach.
+    Callers should pre-strip quoted content via _strip_quoted_content() to avoid
+    false splits on operators inside quoted strings and heredoc bodies.
     """
     parts = re.split(r"\s*(?:&&|\|\||;|\|)\s*|[\r\n]+", command)
     return [p.strip() for p in parts if p.strip()]
@@ -707,33 +786,40 @@ def handle_bash(tool_input):
     if not command:
         return None, None
 
+    # Strip quoted content (single/double quotes, heredocs) to prevent false
+    # positives when dangerous patterns appear inside text arguments, e.g.:
+    #   gh pr comment --body "text about rm -rf"
+    #   git commit -m "fix: block git reset --hard"
+    # All checks below operate on the stripped version.
+    safe_command = _strip_quoted_content(command)
+
     # 1. Indirect execution (eval, sh -c, pipe to shell)
-    result = check_indirect_execution(command)
+    result = check_indirect_execution(safe_command)
     if result:
         return result, None
 
     # 2. rm -rf on dangerous paths
-    result = check_rm_dangerous(command)
+    result = check_rm_dangerous(safe_command)
     if result:
         return result, None
 
     # 3. Alternative deletion tools (find -delete)
-    result = check_alternative_deletion(command)
+    result = check_alternative_deletion(safe_command)
     if result:
         return result, None
 
     # 4. Docker destructive commands
-    result = check_docker_dangerous(command)
+    result = check_docker_dangerous(safe_command)
     if result:
         return result, None
 
     # 5. Git destructive commands
-    result = check_git_dangerous(command)
+    result = check_git_dangerous(safe_command)
     if result:
         return result, None
 
     # 6. Protected file modification via Bash (warning, not block)
-    warn = check_bash_file_modification(command)
+    warn = check_bash_file_modification(safe_command)
     if warn:
         return None, warn
 

--- a/plugins/destructive-command-guard/hooks/hooks.json
+++ b/plugins/destructive-command-guard/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "Blocks self-destructive Bash commands and warns about edits to CLAUDE.md and policy files",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/destructive_command_guard.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/plugin-dev/skills/command-development/references/interactive-commands.md
+++ b/plugins/plugin-dev/skills/command-development/references/interactive-commands.md
@@ -314,24 +314,39 @@ Use AskUserQuestion with multiple questions in one call:
 **Question 1:**
 - question: "Which programming language?"
 - header: "Language"
-- options: Python, TypeScript, Go, Rust
+- options:
+  - Python (General-purpose, great for data and scripting)
+  - TypeScript (Typed JavaScript, ideal for web applications)
+  - Go (Fast compiled language, great for services)
+  - Rust (Memory-safe systems language, maximum performance)
 
 **Question 2:**
 - question: "Which test framework?"
 - header: "Testing"
-- options: Jest, PyTest, Go Test, Cargo Test
+- options:
+  - Jest (JavaScript/TypeScript testing with snapshots)
+  - PyTest (Python testing with fixtures and plugins)
+  - Go Test (Built-in Go testing framework)
+  - Cargo Test (Rust built-in test runner)
   (Adapt based on language from Q1)
 
 **Question 3:**
 - question: "Which CI/CD platform?"
 - header: "CI/CD"
-- options: GitHub Actions, GitLab CI, CircleCI
+- options:
+  - GitHub Actions (Native GitHub integration, YAML workflows)
+  - GitLab CI (Built-in GitLab pipelines)
+  - CircleCI (Cloud CI with Docker support)
 
 **Question 4:**
 - question: "Which features do you need?"
 - header: "Features"
 - multiSelect: true
-- options: Linting, Type checking, Code coverage, Security scanning
+- options:
+  - Linting (Static code analysis and style enforcement)
+  - Type checking (Compile-time type verification)
+  - Code coverage (Track test coverage metrics)
+  - Security scanning (Detect vulnerabilities in dependencies)
 
 Process all answers together to generate cohesive configuration.
 ```
@@ -522,10 +537,10 @@ If "Guided":
 Question: "Which features do you want to enable?"
 multiSelect: true
 Options:
-  - Logging
-  - Metrics
-  - Alerts
-  - Backups
+  - Logging (Detailed operation logs)
+  - Metrics (Performance monitoring)
+  - Alerts (Error notifications)
+  - Backups (Automatic backups)
 
 Reason: User might want any combination
 ```
@@ -822,10 +837,10 @@ Question: "Which features do you need?"
 Header: "Features"
 multiSelect: true
 Options:
-  - Authentication
-  - Authorization
-  - Rate Limiting
-  - Caching
+  - Authentication (User identity verification and login)
+  - Authorization (Access control and permissions)
+  - Rate Limiting (Request throttling and quotas)
+  - Caching (Response and data caching layer)
 ```
 
 ### Pattern: Environment Configuration


### PR DESCRIPTION
## Summary

- Add `destructive-command-guard` plugin -- a PreToolUse hook that blocks irreversible Bash commands and warns about edits to agent policy files
- Blocks dangerous mass-deletion (root, home, cwd, system paths), mass Docker operations, destructive git commands, indirect execution, and alternative deletion tools
- Warns (once per session via `systemMessage`) on edits to `CLAUDE.md`, `.claude/settings.json`, `.claude/settings.local.json`, `hooks/hooks.json`
- Supports multi-command chain splitting, env var disable (`ENABLE_DESTRUCTIVE_GUARD=0`), and session-scoped state with 30-day auto-cleanup

Closes #23871, closes #23870

## Related issues

This plugin addresses or mitigates multiple open reports of destructive agent behavior:

| Issue | Description | Coverage |
|-------|------------|----------|
| #23871 | Agent lacks detection for self-destructive operations | **Direct fix** -- blocks mass deletion, Docker, git destructive |
| #23870 | Agent can overwrite/delete CLAUDE.md and policy files | **Direct fix** -- warns on policy file edits |
| #23010 | Plan mode missing permission prompt for destructive rm | Blocks the rm pattern regardless of mode |
| #22638 | Claude ignored CLAUDE.md, executed `git stash drop` causing data loss | Blocks `git stash drop` without specific ref |
| #18290 | Destructive `git checkout` without confirmation | Blocks `git checkout -- .` pattern |
| #14944 | `docker volume rm` without confirmation, Supabase data loss | Blocks mass `docker volume rm $(docker volume ls -q)` |
| #17908 | CLAUDE.md rules for destructive ops not reliably followed | Plugin enforces rules at tool level, independent of model compliance |
| #13904 | Destructive `git reset --hard` during test restructuring | Blocks `git reset --hard` without explicit target |
| #19874 | Plan mode has no tool-level enforcement | Plugin operates at PreToolUse level, enforced regardless of mode |
| #17296 | Dangerous destructive model behavior | Provides blocklist-based safety net |
| #24196 | **HIGH-PRIORITY** Unauthorized `rm -rf` in chained command caused data loss | Blocks chained rm -rf via multi-command splitting (&&, ;) |
| #24319 | Newline in command string caused `rm -rf` to delete project directory | Command splitter handles `\n` separators, checks each part independently |

**Not covered** (out of scope for this plugin):
- SQL destructive operations via MCP (#13325) -- requires database-specific tooling
- Single-file `git checkout <file>` (#18290 partial) -- cannot distinguish from branch switching without filesystem context

## Security hardening

- Session ID sanitization (CWE-22 path traversal prevention)
- Debug logs in `~/.claude/` not `/tmp` (CWE-377 symlink attack prevention)
- Atomic state writes via `tempfile` + `os.replace` (race condition mitigation)
- Indirect execution detection (eval, sh -c, bash -c, pipe-to-shell, base64 decode)
- Path normalization (catches `//`, `/./`, `/../..`)
- Command splitter handles `||`, newlines, `&&`, `;`, `|`
- Adversarial review + two rounds of Gemini cross-verification applied

## Test plan

- [x] 102 automated tests passing (rm, Docker, git, file protection, indirect execution, find -exec, xargs, env var, session ID)
- [ ] Verify blocked commands return exit code 2 in live session
- [ ] Verify allowed commands return exit code 0 in live session
- [ ] Verify protected file edits emit systemMessage on first occurrence, silent on repeat
- [ ] Install plugin via `claude --plugin-dir ./plugins/destructive-command-guard` and test end-to-end
