### PR TITLE
fix: handle unescaped Windows path backslashes in hookify plugin

### DIFF
--- a/plugins/hookify/hooks/__init__.py
+++ b/plugins/hookify/hooks/__init__.py
@@ -1,0 +1,39 @@
+"""Shared utilities for hookify hook executors."""
+
+import json
+import re
+import sys
+
+
+# Regex to find backslashes NOT followed by a valid JSON escape character.
+# Valid JSON escapes: " \ / b f n r t u
+_INVALID_ESCAPE_RE = re.compile(r'\\(?!["\\/bfnrtu])')
+
+
+def safe_json_load(stream=None):
+    """Read JSON from a stream, tolerating unescaped backslashes in Windows paths.
+
+    On Windows, Claude Code may pass file paths with unescaped backslashes
+    (e.g. C:\\Users\\...) which are invalid JSON. This function attempts a
+    normal parse first, and falls back to escaping lone backslashes on failure.
+
+    Args:
+        stream: File-like object to read from. Defaults to sys.stdin.
+
+    Returns:
+        Parsed JSON data as a dict.
+
+    Raises:
+        json.JSONDecodeError: If JSON is still invalid after repair.
+    """
+    if stream is None:
+        stream = sys.stdin
+
+    raw = stream.read()
+
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        # Escape lone backslashes that aren't part of valid JSON escape sequences
+        repaired = _INVALID_ESCAPE_RE.sub(r'\\\\', raw)
+        return json.loads(repaired)

--- a/plugins/hookify/hooks/posttooluse.py
+++ b/plugins/hookify/hooks/posttooluse.py
@@ -21,6 +21,7 @@ if PLUGIN_ROOT:
 try:
     from hookify.core.config_loader import load_rules
     from hookify.core.rule_engine import RuleEngine
+    from hookify.hooks import safe_json_load
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)
@@ -30,8 +31,8 @@ except ImportError as e:
 def main():
     """Main entry point for PostToolUse hook."""
     try:
-        # Read input from stdin
-        input_data = json.load(sys.stdin)
+        # Read input from stdin (with Windows path backslash tolerance)
+        input_data = safe_json_load(sys.stdin)
 
         # Determine event type based on tool
         tool_name = input_data.get('tool_name', '')

--- a/plugins/hookify/hooks/pretooluse.py
+++ b/plugins/hookify/hooks/pretooluse.py
@@ -25,6 +25,7 @@ if PLUGIN_ROOT:
 try:
     from hookify.core.config_loader import load_rules
     from hookify.core.rule_engine import RuleEngine
+    from hookify.hooks import safe_json_load
 except ImportError as e:
     # If imports fail, allow operation and log error
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
@@ -35,8 +36,8 @@ except ImportError as e:
 def main():
     """Main entry point for PreToolUse hook."""
     try:
-        # Read input from stdin
-        input_data = json.load(sys.stdin)
+        # Read input from stdin (with Windows path backslash tolerance)
+        input_data = safe_json_load(sys.stdin)
 
         # Determine event type for filtering
         # For PreToolUse, we use tool_name to determine "bash" vs "file" event

--- a/plugins/hookify/hooks/stop.py
+++ b/plugins/hookify/hooks/stop.py
@@ -21,6 +21,7 @@ if PLUGIN_ROOT:
 try:
     from hookify.core.config_loader import load_rules
     from hookify.core.rule_engine import RuleEngine
+    from hookify.hooks import safe_json_load
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)
@@ -30,8 +31,8 @@ except ImportError as e:
 def main():
     """Main entry point for Stop hook."""
     try:
-        # Read input from stdin
-        input_data = json.load(sys.stdin)
+        # Read input from stdin (with Windows path backslash tolerance)
+        input_data = safe_json_load(sys.stdin)
 
         # Load stop rules
         rules = load_rules(event='stop')

--- a/plugins/hookify/hooks/userpromptsubmit.py
+++ b/plugins/hookify/hooks/userpromptsubmit.py
@@ -21,6 +21,7 @@ if PLUGIN_ROOT:
 try:
     from hookify.core.config_loader import load_rules
     from hookify.core.rule_engine import RuleEngine
+    from hookify.hooks import safe_json_load
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)
@@ -30,8 +31,8 @@ except ImportError as e:
 def main():
     """Main entry point for UserPromptSubmit hook."""
     try:
-        # Read input from stdin
-        input_data = json.load(sys.stdin)
+        # Read input from stdin (with Windows path backslash tolerance)
+        input_data = safe_json_load(sys.stdin)
 
         # Load user prompt rules
         rules = load_rules(event='prompt')


### PR DESCRIPTION
## Summary

- Add `safe_json_load()` helper to `plugins/hookify/hooks/__init__.py` that tolerates unescaped backslashes in Windows file paths
- Update all four hook executors (`pretooluse.py`, `posttooluse.py`, `stop.py`, `userpromptsubmit.py`) to use it

On Windows, Claude Code passes JSON to hook stdin containing file paths with unescaped backslashes (e.g. `C:\Users\username\file.txt`). Python's `json.loads()` rejects these because sequences like `\U` are invalid JSON escapes. The fix attempts normal parsing first, then falls back to escaping lone backslashes that aren't part of valid JSON escape sequences (`\"`, `\`, `\/`, `\b`, `\f`, `\n`, `\r`, `\t`, `\u`).

**Note:** The root cause is in Claude Code's hook invocation code (which should properly escape backslashes before serializing to JSON). This PR is a defensive workaround in the plugin so hookify works on Windows until the upstream fix lands.

## Test plan

- [ ] Verify valid JSON (Unix paths, no backslashes) still parses normally
- [ ] Verify already-escaped Windows paths (`C:\Users\...`) parse correctly
- [ ] Verify unescaped Windows paths (`C:\Users\...`) are repaired and parsed
- [ ] Verify valid JSON escapes (`\n`, `\t`, `\"`) are not mangled
- [ ] Verify mixed valid/broken escapes are handled correctly
- [ ] Test on Windows with hookify plugin enabled and any hookify rule configured

Fixes #20015

🤖 Generated with [Claude Code](https://claude.com/claude-code)