### PR TITLE
docs: fix agents field type in plugin manifest reference

### DIFF
--- a/plugins/plugin-dev/skills/plugin-structure/references/manifest-reference.md
+++ b/plugins/plugin-dev/skills/plugin-structure/references/manifest-reference.md
@@ -243,13 +243,13 @@ Additional directories or files containing command definitions.
 
 #### agents
 
-**Type**: String or Array of strings
+**Type**: Array of strings
 **Default**: `["./agents"]`
-**Example**: `"./specialized-agents"`
+**Example**: `["./specialized-agents"]`
 
 Additional directories or files containing agent definitions.
 
-**Format**: Same as `commands` field
+> **Note**: Only the array format is supported. String values (e.g. `"./agents/"`) will cause plugin installation to silently fail.
 
 **Use cases**:
 - Grouping agents by specialization
@@ -512,7 +512,7 @@ Full configuration with all features:
     "./commands",
     "./admin-commands"
   ],
-  "agents": "./specialized-agents",
+  "agents": ["./specialized-agents"],
   "hooks": "./config/hooks.json",
   "mcpServers": "./.mcp.json"
 }


### PR DESCRIPTION
## Summary

- Update `agents` field type from "String or Array of strings" to "Array of strings" in `manifest-reference.md`
- Fix the "Complete Plugin" example to use array syntax: `["./specialized-agents"]`
- Add warning note that string values cause silent installation failure

The `agents` field in `plugin.json` only accepts an array of strings. Using the string form (e.g. `"./agents/"`) causes plugin installation to silently fail with no error surfaced to the user. Multiple community reports confirm only the array format works.

## Test plan

- [ ] Verify `manifest-reference.md` shows `agents` type as "Array of strings"
- [ ] Verify all `agents` examples in the repo use array syntax
- [ ] Confirm no other docs files reference the string form for `agents`

Fixes #21598

🤖 Generated with [Claude Code](https://claude.com/claude-code)