### PR TITLE
fix: hookify Python 3.8 compat and cwd-independent rule loading

### DIFF
--- a/plugins/hookify/core/config_loader.py
+++ b/plugins/hookify/core/config_loader.py
@@ -4,6 +4,8 @@
 Loads and parses .claude/hookify.*.local.md files.
 """
 
+from __future__ import annotations
+
 import os
 import sys
 import glob
@@ -207,7 +209,10 @@ def load_rules(event: Optional[str] = None) -> List[Rule]:
     rules = []
 
     # Find all hookify.*.local.md files
-    pattern = os.path.join('.claude', 'hookify.*.local.md')
+    # Use CLAUDE_PROJECT_DIR (set by Claude Code) so rules are found
+    # regardless of the current working directory.
+    project_dir = os.environ.get('CLAUDE_PROJECT_DIR', os.getcwd())
+    pattern = os.path.join(project_dir, '.claude', 'hookify.*.local.md')
     files = glob.glob(pattern)
 
     for file_path in files:


### PR DESCRIPTION
## Summary

Two fixes for the hookify plugin in `config_loader.py`:

- **Python 3.8 compatibility**: Add `from __future__ import annotations` to fix `TypeError: 'type' object is not subscriptable` on Python 3.8 (Ubuntu 20.04 default). The `tuple[Dict, str]` return type syntax requires Python 3.9+; the future import enables it on 3.7+.
- **cwd-independent rule loading**: Use `CLAUDE_PROJECT_DIR` env var instead of relative path for `.claude/hookify.*.local.md` discovery. Previously, rules were only found when the cwd happened to be the project root; now they're found from any working directory.

## Test plan

- [ ] Verify hookify loads on Python 3.8 without `TypeError`
- [ ] Verify hookify rules are discovered when cwd is a subdirectory of the project
- [ ] Verify hookify rules still work normally when `CLAUDE_PROJECT_DIR` is set (standard Claude Code behavior)
- [ ] Verify fallback to `os.getcwd()` when `CLAUDE_PROJECT_DIR` is unset

Fixes #14588
Fixes #20749

🤖 Generated with [Claude Code](https://claude.com/claude-code)