### PR TITLE
fix: remove non-existent $schema URL from marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "claude-code-plugins",
   "version": "1.0.0",
   "description": "Bundled plugins for Claude Code including Agent SDK development tools, PR review toolkit, and commit workflows",


### PR DESCRIPTION
## Summary

- Remove the `$schema` reference to `https://anthropic.com/claude-code/marketplace.schema.json` from `.claude-plugin/marketplace.json`

The URL returns a 404 (Anthropic's website, not a JSON schema endpoint). IDEs that validate JSON schemas show a persistent error for anyone who opens this file. Removing the dead reference eliminates the spurious warning.

If a real marketplace schema is published in the future, the `$schema` field can be re-added pointing to the live URL.

## Test plan

- [ ] Verify `marketplace.json` is still valid JSON after the change
- [ ] Verify no IDE schema validation errors when opening the file

Fixes #9686

🤖 Generated with [Claude Code](https://claude.com/claude-code)