### PR TITLE
fix: replace jq dependency with python3 in ralph-wiggum stop hook

### DIFF
--- a/plugins/ralph-wiggum/README.md
+++ b/plugins/ralph-wiggum/README.md
@@ -32,6 +32,10 @@ This creates a **self-referential feedback loop** where:
 - Each iteration sees modified files and git history
 - Claude autonomously improves by reading its own past work in files
 
+## Requirements
+
+- **Python 3** — used by the stop hook for JSON parsing (available on virtually all systems)
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Summary

- Replace all 3 `jq` calls in `stop-hook.sh` with `python3` equivalents
- Add Requirements section to README.md documenting the `python3` dependency

The ralph-wiggum stop hook uses `jq` for JSON parsing, but `jq` is not available by default on Windows/Git Bash, causing `command not found` errors. Python 3 is far more universally available and handles JSON natively via `json` module.

Replacements:
1. **Line 58**: `jq -r '.transcript_path'` → `python3 -c "import sys,json; print(json.load(sys.stdin).get('transcript_path',''))"`
2. **Lines 90-95**: Complex `.message.content` extraction → equivalent Python with error handling
3. **Lines 167-174**: `jq -n --arg` JSON construction → `python3 -c "import json; print(json.dumps(...))"` with proper escaping via `sys.argv`

## Test plan

- [ ] Verify stop hook correctly extracts transcript path from hook input JSON
- [ ] Verify stop hook correctly parses assistant message text from JSONL transcript
- [ ] Verify stop hook outputs valid JSON with decision/reason/systemMessage fields
- [ ] Verify ralph-loop iteration cycle works end-to-end (start → iterate → complete)
- [ ] Test on Windows/Git Bash where jq is not installed

Fixes #14817

🤖 Generated with [Claude Code](https://claude.com/claude-code)