### PR TITLE
fix: Add parseInt validation and remove unused environment variable

### DIFF
--- a/.github/workflows/auto-close-duplicates.yml
+++ b/.github/workflows/auto-close-duplicates.yml
@@ -28,4 +28,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
           GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}
-          STATSIG_API_KEY: ${{ secrets.STATSIG_API_KEY }}

--- a/scripts/backfill-duplicate-comments.ts
+++ b/scripts/backfill-duplicate-comments.ts
@@ -89,9 +89,32 @@ Environment Variables:
   const owner = "anthropics";
   const repo = "claude-code";
   const dryRun = process.env.DRY_RUN !== "false";
+
+  // Parse and validate issue number range
   const maxIssueNumber = parseInt(process.env.MAX_ISSUE_NUMBER || "4050", 10);
   const minIssueNumber = parseInt(process.env.MIN_ISSUE_NUMBER || "1", 10);
-  
+
+  if (isNaN(maxIssueNumber)) {
+    throw new Error(
+      `MAX_ISSUE_NUMBER must be a valid number. Got: "${process.env.MAX_ISSUE_NUMBER}"`
+    );
+  }
+  if (isNaN(minIssueNumber)) {
+    throw new Error(
+      `MIN_ISSUE_NUMBER must be a valid number. Got: "${process.env.MIN_ISSUE_NUMBER}"`
+    );
+  }
+  if (minIssueNumber < 1) {
+    throw new Error(
+      `MIN_ISSUE_NUMBER must be at least 1. Got: ${minIssueNumber}`
+    );
+  }
+  if (maxIssueNumber <= minIssueNumber) {
+    throw new Error(
+      `MAX_ISSUE_NUMBER must be greater than MIN_ISSUE_NUMBER. Got: MIN=${minIssueNumber}, MAX=${maxIssueNumber}`
+    );
+  }
+
   console.log(`[DEBUG] Repository: ${owner}/${repo}`);
   console.log(`[DEBUG] Dry run mode: ${dryRun}`);
   console.log(`[DEBUG] Looking at issues between #${minIssueNumber} and #${maxIssueNumber}`);


### PR DESCRIPTION
## Summary
This PR includes two bug fixes for the scripts:

1. **Add NaN validation for parseInt operations** in `backfill-duplicate-comments.ts`
   - Previously, invalid environment variable values (e.g., `MAX_ISSUE_NUMBER="invalid"`) would silently become `NaN`, causing unexpected script behavior
   - Now validates that parsed numbers are valid and within reasonable ranges
   - Throws descriptive error messages for invalid inputs

2. **Remove unused `STATSIG_API_KEY`** from `auto-close-duplicates.yml` workflow
   - The environment variable was set but never used by the `auto-close-duplicates.ts` script
   - Removes confusion about unused configuration

## Changes

### `scripts/backfill-duplicate-comments.ts`
- Added validation after `parseInt()` operations to ensure values are not `NaN`
- Added validation to ensure `MIN_ISSUE_NUMBER` is at least 1
- Added validation to ensure `MAX_ISSUE_NUMBER` is greater than `MIN_ISSUE_NUMBER`
- Error messages now include the invalid value for easier debugging

### `.github/workflows/auto-close-duplicates.yml`
- Removed `STATSIG_API_KEY` environment variable (unused)

## Test plan
- [x] Script now throws descriptive errors for invalid `MAX_ISSUE_NUMBER` or `MIN_ISSUE_NUMBER` values
- [x] Script validates that `MIN_ISSUE_NUMBER >= 1`
- [x] Script validates that `MAX_ISSUE_NUMBER > MIN_ISSUE_NUMBER`
- [x] Workflow configuration no longer includes unused environment variable

## Example Error Messages
```
MAX_ISSUE_NUMBER must be a valid number. Got: "invalid"
MIN_ISSUE_NUMBER must be at least 1. Got: 0
MAX_ISSUE_NUMBER must be greater than MIN_ISSUE_NUMBER. Got: MIN=100, MAX=50
```

🤖 Generated with [Claude Code](https://claude.ai/code)