### PR TITLE
fix: Python 3.8 compatibility in hookify config_loader

### DIFF
--- a/plugins/hookify/core/config_loader.py
+++ b/plugins/hookify/core/config_loader.py
@@ -8,7 +8,7 @@ import os
 import sys
 import glob
 import re
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Tuple
 from dataclasses import dataclass, field
 
 
@@ -84,7 +84,7 @@ class Rule:
         )
 
 
-def extract_frontmatter(content: str) -> tuple[Dict[str, Any], str]:
+def extract_frontmatter(content: str) -> Tuple[Dict[str, Any], str]:
     """Extract YAML frontmatter and message body from markdown.
 
     Returns (frontmatter_dict, message_body).


### PR DESCRIPTION
## WHAT

The extract_frontmatter function in core/config_loader.py uses tuple[Dict[str, Any], str] (lowercase tuple) as a return type annotation. This PEP 585 syntax is only supported in Python 3.9+. On systems running Python 3.8, importing the module raises TypeError: 'type' object is not subscriptable, which crashes every hook execution, those PreToolUse, PostToolUse, and Stop all fail on every tool call, spamming errors throughout the session. The fix just adds Tuple to the typing imports and replaces the lowercase tuple annotation with Tuple, restoring compatibility with Python 3.8+.

---

<img width="645" height="152" alt="Screenshot from 2026-02-08 22-01-00" src="https://github.com/user-attachments/assets/2da9eefc-df9e-4e03-8531-df6a97830d25" />
