### PR TITLE
fix(hookify): make file rules match Write tool content

### DIFF
--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -233,11 +233,9 @@ class RuleEngine:
                 return tool_input.get('command', '')
 
         elif tool_name in ['Write', 'Edit']:
-            if field == 'content':
-                # Write uses 'content', Edit has 'new_string'
-                return tool_input.get('content') or tool_input.get('new_string', '')
-            elif field == 'new_text' or field == 'new_string':
-                return tool_input.get('new_string', '')
+            if field in ['content', 'new_text', 'new_string']:
+                # new_text maps to Write content and Edit new_string.
+                return tool_input.get('new_string') or tool_input.get('content', '')
             elif field == 'old_text' or field == 'old_string':
                 return tool_input.get('old_string', '')
             elif field == 'file_path':


### PR DESCRIPTION
## Summary
Fixes hookify file-rule matching so rules targeting `new_text` (including legacy `event: file` + `pattern`) also match `Write` tool payloads.

Before this change, `Write` operations used `tool_input.content`, but `new_text` resolution only looked at `new_string`, so file rules could miss new-file writes.

## Changes
- For `Write`/`Edit`, `content` / `new_text` / `new_string` now resolve consistently from:
  - `new_string` _(Edit)_, (or)
  - `content` _(Write)_.

## Test Plan
- [x] Sanity check:
  - File rule with `pattern: console\.log\(` matches:
    - `Write` input using `tool_input.content`
    - `Edit` input using `tool_input.new_string`
  - Negative control with non-matching content returns no match.

<img width="1624" height="997" alt="Screenshot 2026-02-09 at 08 47 26" src="https://github.com/user-attachments/assets/47263c59-ffd5-4e0b-bf7a-86a7ef90df2f" />


## Risk
Low. Change is limited to `Write`/`Edit` field mapping for file-rule evaluation and does not alter unrelated hook events.