### PR TITLE
docs: add configuration file reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,33 @@ For more installation options, uninstall steps, and troubleshooting, see the [se
 
 2. Navigate to your project directory and run `claude`.
 
+## Configuration
+
+Claude Code uses several configuration files, each serving a distinct purpose. The two most commonly encountered are:
+
+| File | Purpose | Editing |
+|------|---------|---------|
+| `~/.claude.json` | **Application state** — OAuth tokens, MCP server registrations (local/user scope), theme, notifications, per-project state, and caches | Managed by Claude Code. Avoid manual edits. |
+| `~/.claude/settings.json` | **User settings** — permissions, model selection, language, hooks, environment variables, and plugin configuration | User-editable. This is where your preferences go. |
+
+**Why two files?** `~/.claude.json` is a runtime state file that Claude Code reads and writes automatically (session tokens, caches, MCP server registrations added via `claude mcp add`). `~/.claude/settings.json` is your configuration file — settings you consciously choose and can safely edit by hand. Separating state from configuration keeps the user-editable file clean and predictable.
+
+Beyond these two, Claude Code supports a full hierarchy of settings and memory files:
+
+| File | Scope | Purpose |
+|------|-------|---------|
+| `~/.claude/settings.json` | User | Personal settings across all projects |
+| `.claude/settings.json` | Project | Team-shared settings (committed to git) |
+| `.claude/settings.local.json` | Local | Personal project overrides (git-ignored) |
+| `.mcp.json` | Project | Project-scoped MCP servers (committed to git) |
+| `CLAUDE.md` / `.claude/CLAUDE.md` | Project | Team-shared memory and instructions |
+| `~/.claude/CLAUDE.md` | User | Personal memory across all projects |
+| `CLAUDE.local.md` | Local | Personal project memory (git-ignored) |
+
+Settings follow a precedence order: **Managed** (IT-deployed) > **Command line** > **Local** > **Project** > **User**. More specific scopes override less specific ones.
+
+For full details, see the [settings documentation](https://code.claude.com/docs/en/settings) and [memory documentation](https://code.claude.com/docs/en/memory).
+
 ## Plugins
 
 This repository includes several Claude Code plugins that extend functionality with custom commands and agents. See the [plugins directory](./plugins/README.md) for detailed documentation on available plugins.


### PR DESCRIPTION
## Summary

Closes #24005

- Adds a **Configuration** section to README.md documenting the file hierarchy and scope precedence
- Explains the architectural distinction between `~/.claude.json` (application state managed by Claude Code) and `~/.claude/settings.json` (user-editable configuration)
- Includes a quick-reference table for all config and memory file locations
- Links to the official settings and memory documentation for full details

## Context

Users frequently encounter both `~/.claude.json` and `~/.claude/settings.json` without understanding why they exist separately or which one to edit. The official docs cover individual settings well, but the README — where most users land first — had no configuration reference at all.

The key insight documented: `~/.claude.json` is a **runtime state file** (OAuth tokens, caches, MCP registrations) that Claude Code manages automatically, while `~/.claude/settings.json` is the **user configuration file** meant for manual editing. Separating state from configuration keeps the user-editable file clean and predictable.

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm all links to official docs resolve (settings, memory pages)
- [ ] Review table formatting across different viewport widths