### PR TITLE
fix(plugin-dev): add marketplace.json entry example in create-plugin

### DIFF
--- a/plugins/plugin-dev/commands/create-plugin.md
+++ b/plugins/plugin-dev/commands/create-plugin.md
@@ -317,7 +317,15 @@ Guide the user through creating a complete, high-quality Claude Code plugin from
    - For settings: Provide configuration templates
 
 2. **Add marketplace entry** (if publishing):
-   - Show user how to add to marketplace.json
+   - Show user how to add to marketplace.json:
+     ```json
+     {
+       "name": "plugin-name",
+       "description": "Brief plugin description",
+       "source": "./plugins/plugin-name",
+       "category": "development"
+     }
+     ```
    - Help draft marketplace description
    - Suggest category and tags
 


### PR DESCRIPTION
## Summary

The create-plugin command (Phase 8) tells Claude to "show user how to add to marketplace.json" but provides no example. Without one, Claude infers the field name `path` instead of the correct `source`.

This adds an explicit marketplace.json entry example with the canonical format, preventing the issue.

The problem can be verified by searching GitHub for `.claude-plugin/marketplace.json` files that use `path` instead of `source`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)