### PR TITLE
Fix exit codes for duplicate automation scripts

### DIFF
--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -271,7 +271,10 @@ async function autoCloseDuplicates(): Promise<void> {
   );
 }
 
-autoCloseDuplicates().catch(console.error);
+autoCloseDuplicates().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
 
 // Make it a module
 export {};

--- a/scripts/backfill-duplicate-comments.ts
+++ b/scripts/backfill-duplicate-comments.ts
@@ -207,7 +207,10 @@ Environment Variables:
   );
 }
 
-backfillDuplicateComments().catch(console.error);
+backfillDuplicateComments().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
 
 // Make it a module
 export {};


### PR DESCRIPTION
## Problem

The duplicate automation scripts currently exit with code `0` even when fatal errors occur (e.g., missing `GITHUB_TOKEN`). This masks failures in CI/CD pipelines and violates the fail-fast principle.

## Solution

Updated top-level `.catch()` handlers in both scripts to set `process.exitCode = 1` on errors while preserving error logging.

## Verification

```bash
bun run scripts/auto-close-duplicates.ts; echo $?
# Before: prints error, exits 0
# After: prints error, exits 1
```

Success path behavior unchanged—only failure signaling is fixed.