### PR TITLE
feat(plugin): add sound-notification plugin

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -25,6 +25,7 @@ Learn more in the [official plugins documentation](https://docs.claude.com/en/do
 | [pr-review-toolkit](./pr-review-toolkit/) | Comprehensive PR review agents specializing in comments, tests, error handling, type design, code quality, and code simplification | **Command:** `/pr-review-toolkit:review-pr` - Run with optional review aspects (comments, tests, errors, types, code, simplify, all)<br>**Agents:** `comment-analyzer`, `pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer`, `code-reviewer`, `code-simplifier` |
 | [ralph-wiggum](./ralph-wiggum/) | Interactive self-referential AI loops for iterative development. Claude works on the same task repeatedly until completion | **Commands:** `/ralph-loop`, `/cancel-ralph` - Start/stop autonomous iteration loops<br>**Hook:** Stop - Intercepts exit attempts to continue iteration |
 | [security-guidance](./security-guidance/) | Security reminder hook that warns about potential security issues when editing files | **Hook:** PreToolUse - Monitors 9 security patterns including command injection, XSS, eval usage, dangerous HTML, pickle deserialization, and os.system calls |
+| [sound-notification](./sound-notification/) | Play audio notifications on task completion and permission prompts | **Hooks:** Stop - Plays sound on task completion, PreToolUse - Plays sound on permission prompts |
 
 ## Installation
 

--- a/plugins/sound-notification/.claude-plugin/plugin.json
+++ b/plugins/sound-notification/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "sound-notification",
+  "version": "1.0.0",
+  "description": "Play sound notifications on task completion and permission prompts to alert users during long-running operations",
+  "author": {
+    "name": "Community"
+  }
+}

--- a/plugins/sound-notification/README.md
+++ b/plugins/sound-notification/README.md
@@ -1,0 +1,53 @@
+# Sound Notification Plugin
+
+Play audio notifications when Claude Code completes a task or needs user attention. Useful when running long operations while multitasking.
+
+## Features
+
+- **Task completion sound** — plays when Claude Code finishes a session (`Stop` hook)
+- **Permission prompt sound** — plays when Claude Code asks a question (`PreToolUse` on `AskUserQuestion`)
+- Cross-platform support (macOS, Linux, Windows via WSL)
+
+## Installation
+
+Add to your project or user settings:
+
+```json
+{
+  "plugins": ["<path-to>/sound-notification"]
+}
+```
+
+## Default Sounds
+
+| Event | macOS | Linux/Windows |
+|-------|-------|---------------|
+| Task complete | Glass (`/System/Library/Sounds/Glass.aiff`) | Terminal bell |
+| Permission prompt | Ping (`/System/Library/Sounds/Ping.aiff`) | Terminal bell |
+
+## Configuration
+
+Override defaults with environment variables:
+
+```bash
+# Disable all sounds
+export CLAUDE_SOUND_DISABLED=1
+
+# Use custom sound files
+export CLAUDE_SOUND_COMPLETE="/path/to/complete.wav"
+export CLAUDE_SOUND_PERMISSION="/path/to/attention.wav"
+```
+
+## Platform Support
+
+| Platform | Audio Backend |
+|----------|--------------|
+| macOS | `afplay` (built-in) |
+| Linux | `paplay` (PulseAudio) or `aplay` (ALSA) |
+| Windows (WSL) | `powershell.exe` SoundPlayer |
+| Fallback | Terminal bell (`\a`) |
+
+## Related Issues
+
+- [#15795](https://github.com/anthropics/claude-code/issues/15795) — Audio notifications for permission prompts and task completion
+- [#25267](https://github.com/anthropics/claude-code/issues/25267) — Add native sound notification/chime for task completion

--- a/plugins/sound-notification/hooks/hooks.json
+++ b/plugins/sound-notification/hooks/hooks.json
@@ -1,0 +1,26 @@
+{
+  "description": "Play sound notifications on task completion and permission prompts",
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/play-sound.sh complete"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/play-sound.sh permission"
+          }
+        ],
+        "matcher": "AskUserQuestion"
+      }
+    ]
+  }
+}

--- a/plugins/sound-notification/hooks/play-sound.sh
+++ b/plugins/sound-notification/hooks/play-sound.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Play a notification sound when Claude Code completes a task or needs attention.
+# Usage: play-sound.sh [complete|permission]
+#
+# Configuration via environment variables:
+#   CLAUDE_SOUND_DISABLED=1       - Disable all sounds
+#   CLAUDE_SOUND_COMPLETE=<path>  - Custom sound file for task completion
+#   CLAUDE_SOUND_PERMISSION=<path> - Custom sound file for permission prompts
+
+set -euo pipefail
+
+EVENT_TYPE="${1:-complete}"
+
+if [ "${CLAUDE_SOUND_DISABLED:-}" = "1" ]; then
+  exit 0
+fi
+
+play_sound() {
+  local sound_file="$1"
+
+  if [ "$(uname)" = "Darwin" ]; then
+    afplay "$sound_file" &>/dev/null &
+  elif command -v paplay &>/dev/null; then
+    paplay "$sound_file" &>/dev/null &
+  elif command -v aplay &>/dev/null; then
+    aplay -q "$sound_file" &>/dev/null &
+  elif command -v powershell.exe &>/dev/null; then
+    powershell.exe -c "(New-Object Media.SoundPlayer '$sound_file').PlaySync()" &>/dev/null &
+  fi
+}
+
+play_bell() {
+  printf '\a'
+}
+
+case "$EVENT_TYPE" in
+  complete)
+    if [ -n "${CLAUDE_SOUND_COMPLETE:-}" ] && [ -f "${CLAUDE_SOUND_COMPLETE}" ]; then
+      play_sound "$CLAUDE_SOUND_COMPLETE"
+    elif [ "$(uname)" = "Darwin" ]; then
+      play_sound "/System/Library/Sounds/Glass.aiff"
+    else
+      play_bell
+    fi
+    ;;
+  permission)
+    if [ -n "${CLAUDE_SOUND_PERMISSION:-}" ] && [ -f "${CLAUDE_SOUND_PERMISSION}" ]; then
+      play_sound "$CLAUDE_SOUND_PERMISSION"
+    elif [ "$(uname)" = "Darwin" ]; then
+      play_sound "/System/Library/Sounds/Ping.aiff"
+    else
+      play_bell
+    fi
+    ;;
+esac


### PR DESCRIPTION
## Summary

- Adds a `sound-notification` plugin that plays audio alerts on **task completion** (Stop hook) and **permission prompts** (PreToolUse on AskUserQuestion)
- Cross-platform support: macOS (`afplay`), Linux (`paplay`/`aplay`), Windows WSL (`powershell.exe`), with terminal bell fallback
- Configurable via environment variables (`CLAUDE_SOUND_DISABLED`, `CLAUDE_SOUND_COMPLETE`, `CLAUDE_SOUND_PERMISSION`)

## Motivation

This is one of the most requested features — users running long tasks need an audible cue when Claude Code finishes or needs attention. Currently users resort to custom hooks for this basic need.

Closes #15795, closes #25267

## Test plan

- [ ] Install plugin on macOS, verify Glass sound plays on session end
- [ ] Install plugin on macOS, verify Ping sound plays on AskUserQuestion
- [ ] Set `CLAUDE_SOUND_DISABLED=1`, verify no sound plays
- [ ] Set `CLAUDE_SOUND_COMPLETE` to custom .wav, verify custom sound plays
- [ ] Test on Linux with PulseAudio (`paplay`)
- [ ] Test fallback terminal bell when no audio backend available

🤖 Generated with [Claude Code](https://claude.com/claude-code)