### PR TITLE
Fix sweep script crashing on locked issues

### DIFF
--- a/scripts/sweep.ts
+++ b/scripts/sweep.ts
@@ -115,6 +115,7 @@ async function closeExpired(owner: string, repo: string) {
 
       for (const issue of issues) {
         if (issue.pull_request) continue;
+        if (issue.locked) continue;
         const base = `/repos/${owner}/${repo}/issues/${issue.number}`;
 
         const events = await githubRequest<any[]>(`${base}/events?per_page=100`);
@@ -144,20 +145,14 @@ async function closeExpired(owner: string, repo: string) {
 
 // --
 
-async function main() {
-  const owner = process.env.GITHUB_REPOSITORY_OWNER;
-  const repo = process.env.GITHUB_REPOSITORY_NAME;
-  if (!owner || !repo)
-    throw new Error("GITHUB_REPOSITORY_OWNER and GITHUB_REPOSITORY_NAME required");
+const owner = process.env.GITHUB_REPOSITORY_OWNER;
+const repo = process.env.GITHUB_REPOSITORY_NAME;
+if (!owner || !repo)
+  throw new Error("GITHUB_REPOSITORY_OWNER and GITHUB_REPOSITORY_NAME required");
 
-  if (DRY_RUN) console.log("DRY RUN — no changes will be made\n");
+if (DRY_RUN) console.log("DRY RUN — no changes will be made\n");
 
-  const labeled = await markStale(owner, repo);
-  const closed = await closeExpired(owner, repo);
+const labeled = await markStale(owner, repo);
+const closed = await closeExpired(owner, repo);
 
-  console.log(`\nDone: ${labeled} ${DRY_RUN ? "would be labeled" : "labeled"} stale, ${closed} ${DRY_RUN ? "would be closed" : "closed"}`);
-}
-
-main().catch(console.error);
-
-export {};
+console.log(`\nDone: ${labeled} ${DRY_RUN ? "would be labeled" : "labeled"} stale, ${closed} ${DRY_RUN ? "would be closed" : "closed"}`);


### PR DESCRIPTION
The sweep job ([run](https://github.com/anthropics/claude-code/actions/runs/21983111029/job/63510453226)) was silently failing when `closeExpired` tried to comment on a locked issue, causing a 403 from the GitHub API.

Two fixes:

1. **Skip locked issues in `closeExpired`** — `markStale` already had an `if (issue.locked) continue` guard but `closeExpired` did not. Commenting on a locked issue returns a 403 which crashed the script.

2. **Remove `main()` wrapper, use top-level `await`** — The script used `main().catch(console.error)` which swallowed errors and exited 0, so CI reported success despite the crash. Since this is a top-level `bun` script, top-level `await` works directly and unhandled errors will properly produce a non-zero exit code.