### PR TITLE
Post a comment when lifecycle labels are applied to issues

### DIFF
--- a/.github/workflows/issue-lifecycle-comment.yml
+++ b/.github/workflows/issue-lifecycle-comment.yml
@@ -1,0 +1,27 @@
+name: "Issue Lifecycle Comment"
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Post lifecycle comment
+        run: bun run scripts/lifecycle-comment.ts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LABEL: ${{ github.event.label.name }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/scripts/issue-lifecycle.ts
+++ b/scripts/issue-lifecycle.ts
@@ -1,0 +1,38 @@
+// Single source of truth for issue lifecycle labels, timeouts, and messages.
+
+export const lifecycle = [
+  {
+    label: "invalid",
+    days: 3,
+    reason: "this doesn't appear to be about Claude Code",
+    nudge: "This doesn't appear to be about [Claude Code](https://github.com/anthropics/claude-code). For general Anthropic support, visit [support.anthropic.com](https://support.anthropic.com).",
+  },
+  {
+    label: "needs-repro",
+    days: 7,
+    reason: "we still need reproduction steps to investigate",
+    nudge: "We weren't able to reproduce this. Could you provide steps to trigger the issue — what you ran, what happened, and what you expected?",
+  },
+  {
+    label: "needs-info",
+    days: 7,
+    reason: "we still need a bit more information to move forward",
+    nudge: "We need more information to continue investigating. Can you make sure to include your Claude Code version (`claude --version`), OS, and any error messages or logs?",
+  },
+  {
+    label: "stale",
+    days: 14,
+    reason: "inactive for too long",
+    nudge: "This issue has been automatically marked as stale due to inactivity.",
+  },
+  {
+    label: "autoclose",
+    days: 14,
+    reason: "inactive for too long",
+    nudge: "This issue has been marked for automatic closure.",
+  },
+] as const;
+
+export type LifecycleLabel = (typeof lifecycle)[number]["label"];
+
+export const STALE_UPVOTE_THRESHOLD = 10;

--- a/scripts/lifecycle-comment.ts
+++ b/scripts/lifecycle-comment.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env bun
+
+// Posts a comment when a lifecycle label is applied to an issue,
+// giving the author a heads-up and a chance to respond before auto-close.
+
+import { lifecycle } from "./issue-lifecycle.ts";
+
+const DRY_RUN = process.argv.includes("--dry-run");
+const token = process.env.GITHUB_TOKEN;
+const repo = process.env.GITHUB_REPOSITORY; // owner/repo
+const label = process.env.LABEL;
+const issueNumber = process.env.ISSUE_NUMBER;
+
+if (!DRY_RUN && !token) throw new Error("GITHUB_TOKEN required");
+if (!repo) throw new Error("GITHUB_REPOSITORY required");
+if (!label) throw new Error("LABEL required");
+if (!issueNumber) throw new Error("ISSUE_NUMBER required");
+
+const entry = lifecycle.find((l) => l.label === label);
+if (!entry) {
+  console.log(`No lifecycle entry for label "${label}", skipping`);
+  process.exit(0);
+}
+
+const body = `${entry.nudge} This issue will be closed automatically if there's no activity within ${entry.days} days.`;
+
+// --
+
+if (DRY_RUN) {
+  console.log(`Would comment on #${issueNumber} for label "${label}":\n\n${body}`);
+  process.exit(0);
+}
+
+const response = await fetch(
+  `https://api.github.com/repos/${repo}/issues/${issueNumber}/comments`,
+  {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github.v3+json",
+      "Content-Type": "application/json",
+      "User-Agent": "lifecycle-comment",
+    },
+    body: JSON.stringify({ body }),
+  }
+);
+
+if (!response.ok) {
+  const text = await response.text();
+  throw new Error(`GitHub API ${response.status}: ${text}`);
+}
+
+console.log(`Commented on #${issueNumber} for label "${label}"`);


### PR DESCRIPTION
When lifecycle labels (needs-info, needs-repro, invalid, stale, autoclose) are applied to an issue, the author currently only sees a label change with no explanation. They then get a closing comment days later without ever being nudged to respond.

Add a GitHub Actions workflow that triggers on `issues.labeled` and runs a new `lifecycle-comment.ts` script to post a comment explaining what's needed and how long before auto-close.

Extract lifecycle config (labels, timeouts, close reasons, nudge messages) into a shared `issue-lifecycle.ts` so the sweep script and comment script stay in sync. Previously the timeouts were duplicated between the sweep script and the comment messages.

- **needs-info**: asks for version, OS, error messages
- **needs-repro**: asks for steps to trigger the issue
- **invalid**: links to the Claude Code repo and Anthropic support
- **stale/autoclose**: explains inactivity auto-close

The script no-ops for non-lifecycle labels, so the workflow fires on every label event and lets the script decide — single source of truth.

## Test plan

Dry-run all labels locally:
```
GITHUB_REPOSITORY=anthropics/claude-code LABEL=needs-info ISSUE_NUMBER=12345 bun run scripts/lifecycle-comment.ts --dry-run
GITHUB_REPOSITORY=anthropics/claude-code LABEL=needs-repro ISSUE_NUMBER=12345 bun run scripts/lifecycle-comment.ts --dry-run
GITHUB_REPOSITORY=anthropics/claude-code LABEL=invalid ISSUE_NUMBER=12345 bun run scripts/lifecycle-comment.ts --dry-run
GITHUB_REPOSITORY=anthropics/claude-code LABEL=stale ISSUE_NUMBER=12345 bun run scripts/lifecycle-comment.ts --dry-run
GITHUB_REPOSITORY=anthropics/claude-code LABEL=autoclose ISSUE_NUMBER=12345 bun run scripts/lifecycle-comment.ts --dry-run
```