### PR TITLE
fix: preserve existing labels when auto-closing duplicate issues

### DIFF
--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -77,6 +77,14 @@ async function closeIssueAsDuplicate(
     {
       state: 'closed',
       state_reason: 'duplicate',
+    }
+  );
+
+  await githubRequest(
+    `/repos/${owner}/${repo}/issues/${issueNumber}/labels`,
+    token,
+    'POST',
+    {
       labels: ['duplicate']
     }
   );


### PR DESCRIPTION
The `closeIssueAsDuplicate` function in `scripts/auto-close-duplicates.ts` was passing `labels: ['duplicate']` inside the PATCH request body when closing an issue. The GitHub Issues API treats the `labels` field in PATCH as a full replacement, so all existing labels on the issue (like `bug`, `enhancement`, `has repro`, `platform:*`, `area:*`, etc.) were being wiped out and replaced with just `duplicate`.

This splits the close operation into two separate API calls:

1. `PATCH /issues/{number}` with only `state` and `state_reason` to close the issue
2. `POST /issues/{number}/labels` to add the `duplicate` label without touching existing ones

This way the issue keeps its original triage labels, which is useful for searching closed issues by category later.