### PR TITLE
fix(ralph-wiggum): isolate ralph-loop state per session

### DIFF
--- a/plugins/ralph-wiggum/commands/cancel-ralph.md
+++ b/plugins/ralph-wiggum/commands/cancel-ralph.md
@@ -1,6 +1,6 @@
 ---
 description: "Cancel active Ralph Wiggum loop"
-allowed-tools: ["Bash(test -f .claude/ralph-loop.local.md:*)", "Bash(rm .claude/ralph-loop.local.md)", "Read(.claude/ralph-loop.local.md)"]
+allowed-tools: ["Bash(ls .claude/ralph-loop.*.local.md:*)", "Bash(rm .claude/ralph-loop.*.local.md)", "Bash(rm .claude/ralph-loop.local.md)", "Read(.claude/*)"]
 hide-from-slash-command-tool: "true"
 ---
 
@@ -8,11 +8,12 @@ hide-from-slash-command-tool: "true"
 
 To cancel the Ralph loop:
 
-1. Check if `.claude/ralph-loop.local.md` exists using Bash: `test -f .claude/ralph-loop.local.md && echo "EXISTS" || echo "NOT_FOUND"`
+1. Check for active ralph-loop state files using Bash: `ls .claude/ralph-loop.*.local.md 2>/dev/null || echo "NOT_FOUND"`
 
-2. **If NOT_FOUND**: Say "No active Ralph loop found."
+2. **If NOT_FOUND**: Also check for legacy file: `ls .claude/ralph-loop.local.md 2>/dev/null || echo "NOT_FOUND"`. If both not found, say "No active Ralph loop found."
 
-3. **If EXISTS**:
-   - Read `.claude/ralph-loop.local.md` to get the current iteration number from the `iteration:` field
-   - Remove the file using Bash: `rm .claude/ralph-loop.local.md`
+3. **If files found**:
+   - Read each state file to get the current iteration number from the `iteration:` field
+   - If `$CLAUDE_SESSION_ID` is set, prefer removing only the file matching this session: `.claude/ralph-loop.${CLAUDE_SESSION_ID}.local.md`
+   - Otherwise, remove all found state files
    - Report: "Cancelled Ralph loop (was at iteration N)" where N is the iteration value

--- a/plugins/ralph-wiggum/hooks/hooks.json
+++ b/plugins/ralph-wiggum/hooks/hooks.json
@@ -1,6 +1,16 @@
 {
-  "description": "Ralph Wiggum plugin stop hook for self-referential loops",
+  "description": "Ralph Wiggum plugin hooks for self-referential loops",
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start-hook.sh"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/plugins/ralph-wiggum/hooks/session-start-hook.sh
+++ b/plugins/ralph-wiggum/hooks/session-start-hook.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Ralph Wiggum Session Start Hook
+# Captures session_id and exports it for use by setup-ralph-loop.sh
+
+set -euo pipefail
+
+HOOK_INPUT=$(cat)
+SESSION_ID=$(echo "$HOOK_INPUT" | jq -r '.session_id // empty')
+
+if [[ -n "$SESSION_ID" ]] && [[ -n "${CLAUDE_ENV_FILE:-}" ]]; then
+  echo "export CLAUDE_SESSION_ID='$SESSION_ID'" >> "$CLAUDE_ENV_FILE"
+fi
+
+exit 0

--- a/plugins/ralph-wiggum/hooks/stop-hook.sh
+++ b/plugins/ralph-wiggum/hooks/stop-hook.sh
@@ -9,11 +9,19 @@ set -euo pipefail
 # Read hook input from stdin (advanced stop hook API)
 HOOK_INPUT=$(cat)
 
-# Check if ralph-loop is active
-RALPH_STATE_FILE=".claude/ralph-loop.local.md"
+# Extract session_id from hook input for session-specific state file
+SESSION_ID=$(echo "$HOOK_INPUT" | jq -r '.session_id // empty')
+
+if [[ -z "$SESSION_ID" ]]; then
+  # No session_id available - can't identify our state file, allow exit
+  exit 0
+fi
+
+# Check if ralph-loop is active FOR THIS SESSION
+RALPH_STATE_FILE=".claude/ralph-loop.${SESSION_ID}.local.md"
 
 if [[ ! -f "$RALPH_STATE_FILE" ]]; then
-  # No active loop - allow exit
+  # No active loop for this session - allow exit
   exit 0
 fi
 

--- a/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
+++ b/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
@@ -50,11 +50,11 @@ STOPPING:
   No manual stop - Ralph runs infinitely by default!
 
 MONITORING:
-  # View current iteration:
-  grep '^iteration:' .claude/ralph-loop.local.md
+  # View current iteration (for current session):
+  grep '^iteration:' .claude/ralph-loop.*.local.md
 
   # View full state:
-  head -10 .claude/ralph-loop.local.md
+  head -10 .claude/ralph-loop.*.local.md
 HELP_EOF
       exit 0
       ;;
@@ -127,8 +127,20 @@ if [[ -z "$PROMPT" ]]; then
   exit 1
 fi
 
+# Determine session ID for session-specific state file
+if [[ -n "${CLAUDE_SESSION_ID:-}" ]]; then
+  SESSION_ID="$CLAUDE_SESSION_ID"
+else
+  # Fallback: generate a random ID (SessionStart hook may not have fired)
+  SESSION_ID=$(date +%s%N | md5sum | cut -c1-12)
+  echo "⚠️  CLAUDE_SESSION_ID not available, using generated ID: $SESSION_ID" >&2
+fi
+
 # Create state file for stop hook (markdown with YAML frontmatter)
 mkdir -p .claude
+
+# Clean up any existing ralph-loop state files for THIS session
+rm -f .claude/ralph-loop."$SESSION_ID".local.md
 
 # Quote completion promise for YAML if it contains special chars or is not null
 if [[ -n "$COMPLETION_PROMISE" ]] && [[ "$COMPLETION_PROMISE" != "null" ]]; then
@@ -137,7 +149,8 @@ else
   COMPLETION_PROMISE_YAML="null"
 fi
 
-cat > .claude/ralph-loop.local.md <<EOF
+RALPH_STATE_FILE=".claude/ralph-loop.${SESSION_ID}.local.md"
+cat > "$RALPH_STATE_FILE" <<EOF
 ---
 active: true
 iteration: 1
@@ -157,11 +170,13 @@ Iteration: 1
 Max iterations: $(if [[ $MAX_ITERATIONS -gt 0 ]]; then echo $MAX_ITERATIONS; else echo "unlimited"; fi)
 Completion promise: $(if [[ "$COMPLETION_PROMISE" != "null" ]]; then echo "${COMPLETION_PROMISE//\"/} (ONLY output when TRUE - do not lie!)"; else echo "none (runs forever)"; fi)
 
+Session ID: $SESSION_ID
+
 The stop hook is now active. When you try to exit, the SAME PROMPT will be
 fed back to you. You'll see your previous work in files, creating a
 self-referential loop where you iteratively improve on the same task.
 
-To monitor: head -10 .claude/ralph-loop.local.md
+To monitor: head -10 $RALPH_STATE_FILE
 
 ⚠️  WARNING: This loop cannot be stopped manually! It will run infinitely
     unless you set --max-iterations or --completion-promise.


### PR DESCRIPTION
## Summary

- Fixes cross-session interference when running ralph-loop in one Claude Code session while another session is open in the same project
- The stop hook was using a shared state file (`.claude/ralph-loop.local.md`) that caused unrelated sessions to get hijacked into the loop when they tried to exit

## Changes

- **New `SessionStart` hook** (`session-start-hook.sh`): Captures `session_id` from hook input and exports it as `CLAUDE_SESSION_ID` via `CLAUDE_ENV_FILE`, making it available to bash commands
- **Session-specific state files**: Setup script now creates `.claude/ralph-loop.{SESSION_ID}.local.md` instead of the shared filename
- **Stop hook session awareness**: Extracts `session_id` from its JSON input and only looks for the matching state file — other sessions' loops are invisible
- **Updated cancel-ralph**: Handles both session-specific and legacy state filenames

## How it works

| Before | After |
|--------|-------|
| Session A starts loop → creates shared `.claude/ralph-loop.local.md` | Session A starts loop → creates `.claude/ralph-loop.abc123.local.md` |
| Session B finishes task → stop hook sees shared file → **hijacked** | Session B finishes task → stop hook looks for `.claude/ralph-loop.xyz789.local.md` → not found → **exits normally** |

## Test plan

- [ ] Start a ralph-loop in Session A (`/ralph-loop "test task" --max-iterations 5`)
- [ ] Open Session B in the same project, do some work, verify it exits cleanly without entering the loop
- [ ] Verify Session A's loop continues to iterate correctly
- [ ] Verify `/cancel-ralph` works in the session that started the loop
- [ ] Verify fallback random ID when `CLAUDE_SESSION_ID` is unavailable (new session before restart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)