### PR TITLE
fix: preserve existing labels when auto-closing duplicate issues

### DIFF
--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -77,6 +77,14 @@ async function closeIssueAsDuplicate(
     {
       state: 'closed',
       state_reason: 'duplicate',
+    }
+  );
+
+  await githubRequest(
+    `/repos/${owner}/${repo}/issues/${issueNumber}/labels`,
+    token,
+    'POST',
+    {
       labels: ['duplicate']
     }
   );


### PR DESCRIPTION
When the auto-close-duplicates script closes an issue as duplicate, it should preserve existing labels rather than replacing them all.

Previously, the PATCH request included `labels: ['duplicate']` in the same request as `state: 'closed'`, which would overwrite all existing labels on the issue. This meant that if an issue had labels like 'bug' or 'feature', those would be lost when it was closed as duplicate.

This change separates the operations:
1. PATCH /issues/{number} - closes the issue with state_reason, no label changes
2. POST /issues/{number}/labels - adds the 'duplicate' label without touching existing ones

The GitHub API behavior is:
- PATCH with labels array: replaces all labels
- POST to /labels endpoint: adds new labels while keeping existing ones

This ensures duplicate issues retain their original classification labels, making it easier to track patterns and categories even after closure.