### PR TITLE
Fix issues being auto-closed despite human activity

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -45,7 +45,7 @@ jobs:
             ALLOWED LABELS — you may ONLY use labels from this list. Never invent new labels.
 
             Type: bug, enhancement, question, documentation, duplicate, invalid
-            Lifecycle: needs-repro, needs-info
+            Lifecycle: needs-repro, needs-info, stale, autoclose
             Platform: platform:linux, platform:macos, platform:windows, platform:wsl, platform:ios, platform:android, platform:vscode, platform:intellij, platform:web, platform:aws-bedrock
             API: api:bedrock, api:vertex
 
@@ -85,10 +85,12 @@ jobs:
             **If EVENT is "issue_comment" (comment on existing issue):**
 
             3. Evaluate lifecycle labels based on the full conversation:
+               - If the issue has `stale` or `autoclose`, remove the label — a new human comment means the issue is still active:
+                 `gh issue edit ${{ github.event.issue.number }} --remove-label "stale" --remove-label "autoclose"`
                - If the issue has `needs-repro` or `needs-info` and the missing information has now been provided, remove the label:
                  `gh issue edit ${{ github.event.issue.number }} --remove-label "needs-repro"`
                - If the issue doesn't have lifecycle labels but clearly needs them (e.g., a maintainer asked for repro steps or more details), add the appropriate label.
-               - Comments like "+1", "me too", "same here", or emoji reactions are NOT the missing information. Only remove labels when substantive details are actually provided.
+               - Comments like "+1", "me too", "same here", or emoji reactions are NOT the missing information. Only remove `needs-repro` or `needs-info` when substantive details are actually provided.
                - Do NOT add or remove category labels (bug, enhancement, etc.) on comment events.
 
             GUIDELINES:


### PR DESCRIPTION
Fixes #16497

## Problem

Issues were being auto-closed despite active human participation:

1. **Triage bot didn't know about `stale`/`autoclose` labels** — when a human commented on a stale issue, the triage workflow ran but had no instructions to remove these labels.

2. **`closeExpired()` in sweep.ts ignored human activity** — it only checked when the lifecycle label was applied and whether enough time had passed. Human comments after the label were irrelevant.

3. **Upvote protection only applied to enhancements** — popular bug reports with 10+ upvotes could still be auto-closed.

Example: [#11792](https://github.com/anthropics/claude-code/issues/11792) had three human comments after the stale warning but was still auto-closed.

## Changes

**`claude-issue-triage.yml`**: Teach the triage bot about `stale` and `autoclose` labels. On any human comment, it now removes these labels since human activity means the issue is still active.

**`sweep.ts`**:
- Add a safety net in `closeExpired()` — before closing, check for non-bot comments posted after the lifecycle label was applied. If any exist, skip closing. This catches race conditions where the sweep runs before the triage bot processes a comment.
- Extend the 10-upvote protection to all issue types, not just enhancements, in both `markStale()` and `closeExpired()`.

## Test plan

Traced through scenarios manually:
- Issue with `stale` label + human comment after → triage removes label; sweep skips even if triage hasn't run yet (safety net)
- Issue with `stale` label + no human comment → closes as before
- Issue with 10+ upvotes of any type → never marked stale or closed
- Race condition: human comments right before sweep runs → `closeExpired()` finds the comment and skips