### PR TITLE
Add Bedrock example settings, warn against MAX_OUTPUT_TOKENS=4096

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -10,17 +10,19 @@ These may be applied at any level of the [settings hierarchy](https://code.claud
 > [!WARNING]
 > These examples are community-maintained snippets which may be unsupported or incorrect. You are responsible for the correctness of your own settings configuration.
 
-| Setting | [`settings-lax.json`](./settings-lax.json) | [`settings-strict.json`](./settings-strict.json) | [`settings-bash-sandbox.json`](./settings-bash-sandbox.json) |
-|---------|:---:|:---:|:---:|
-| Disable `--dangerously-skip-permissions` | ✅ | ✅ | |
-| Block plugin marketplaces | ✅ | ✅ | |
-| Block user and project-defined permission `allow` / `ask` / `deny` | | ✅ | ✅ |
-| Block user and project-defined hooks | | ✅ | |
-| Deny web fetch and search tools | | ✅ | |
-| Bash tool requires approval | | ✅ | |
-| Bash tool must run inside of sandbox | | | ✅ |
+| Setting | [`settings-lax.json`](./settings-lax.json) | [`settings-strict.json`](./settings-strict.json) | [`settings-bash-sandbox.json`](./settings-bash-sandbox.json) | [`settings-bedrock.json`](./settings-bedrock.json) |
+|---------|:---:|:---:|:---:|:---:|
+| Disable `--dangerously-skip-permissions` | ✅ | ✅ | | |
+| Block plugin marketplaces | ✅ | ✅ | | |
+| Block user and project-defined permission `allow` / `ask` / `deny` | | ✅ | ✅ | |
+| Block user and project-defined hooks | | ✅ | | |
+| Deny web fetch and search tools | | ✅ | | |
+| Bash tool requires approval | | ✅ | | |
+| Bash tool must run inside of sandbox | | | ✅ | |
+| Enable Amazon Bedrock | | | | ✅ |
 
 ## Tips
+- **Amazon Bedrock users:** Do not set `CLAUDE_CODE_MAX_OUTPUT_TOKENS` to `4096`. This was previously recommended in the Bedrock documentation but causes file edit operations to fail with "exceeded the 4096 output token maximum" errors. The default of `32,000` works correctly with Bedrock. See [#18963](https://github.com/anthropics/claude-code/issues/18963) for details.
 - Consider merging snippets of the above examples to reach your desired configuration
 - Settings files must be valid JSON
 - Before deploying configuration files to your organization, test them locally by applying to `managed-settings.json`, `settings.json` or `settings.local.json`

--- a/examples/settings/settings-bedrock.json
+++ b/examples/settings/settings-bedrock.json
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "CLAUDE_CODE_USE_BEDROCK": "1",
+    "AWS_REGION": "us-east-1"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `settings-bedrock.json` with the minimal required Bedrock env vars
- Adds a tip in the examples README warning users not to set `CLAUDE_CODE_MAX_OUTPUT_TOKENS` to `4096` (previously recommended, causes edit failures)

## Context
Refs #18963 — the Bedrock docs previously recommended `CLAUDE_CODE_MAX_OUTPUT_TOKENS=4096` to avoid throttling, but this value is too low for file edit operations and causes persistent "exceeded the 4096 output token maximum" errors. The recommendation has since been removed from the docs, but no replacement guidance was added. This example and warning serve as a community-maintained reference until the docs are updated.

## Test plan
- [ ] Verify `settings-bedrock.json` is valid JSON
- [ ] Verify README table renders correctly