### PR TITLE
Fix hook validator to support plugin wrapper format and optional matchers

### DIFF
--- a/plugins/plugin-dev/skills/hook-development/SKILL.md
+++ b/plugins/plugin-dev/skills/hook-development/SKILL.md
@@ -339,46 +339,50 @@ Available in all command hooks:
 
 ## Plugin Hook Configuration
 
-In plugins, define hooks in `hooks/hooks.json`:
+In plugins, define hooks in `hooks/hooks.json` using the **wrapper format**:
 
 ```json
 {
-  "PreToolUse": [
-    {
-      "matcher": "Write|Edit",
-      "hooks": [
-        {
-          "type": "prompt",
-          "prompt": "Validate file write safety"
-        }
-      ]
-    }
-  ],
-  "Stop": [
-    {
-      "matcher": "*",
-      "hooks": [
-        {
-          "type": "prompt",
-          "prompt": "Verify task completion"
-        }
-      ]
-    }
-  ],
-  "SessionStart": [
-    {
-      "matcher": "*",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/load-context.sh",
-          "timeout": 10
-        }
-      ]
-    }
-  ]
+  "description": "Plugin hooks for validation and context loading",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Validate file write safety"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Verify task completion"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/load-context.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
 }
 ```
+
+**Important:** Plugin hooks.json must use the wrapper format (`{"hooks": {...}}`), not the direct format used in settings files. The `matcher` field is optional for SessionStart, SessionEnd, PreCompact, and Notification events.
 
 Plugin hooks merge with user's hooks and run in parallel.
 

--- a/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
@@ -35,12 +35,24 @@ if ! jq empty "$HOOKS_FILE" 2>/dev/null; then
 fi
 echo "✅ Valid JSON"
 
+# Detect format: plugin wrapper format {"hooks": {...}} vs direct format
+# Plugin hooks.json uses: {"description": "...", "hooks": {"SessionStart": [...]}}
+# Settings format uses: {"SessionStart": [...]}
+JQ_PREFIX=""
+if jq -e '.hooks' "$HOOKS_FILE" >/dev/null 2>&1 && jq -e '.hooks | type == "object"' "$HOOKS_FILE" >/dev/null 2>&1; then
+  echo "Detected plugin wrapper format"
+  JQ_PREFIX=".hooks"
+else
+  echo "Detected direct format"
+  JQ_PREFIX="."
+fi
+
 # Check 2: Root structure
 echo ""
 echo "Checking root structure..."
 VALID_EVENTS=("PreToolUse" "PostToolUse" "UserPromptSubmit" "Stop" "SubagentStop" "SessionStart" "SessionEnd" "PreCompact" "Notification")
 
-for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
+for event in $(jq -r "$JQ_PREFIX | keys[]" "$HOOKS_FILE"); do
   found=false
   for valid_event in "${VALID_EVENTS[@]}"; do
     if [ "$event" = "$valid_event" ]; then
@@ -62,20 +74,26 @@ echo "Validating individual hooks..."
 error_count=0
 warning_count=0
 
-for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
-  hook_count=$(jq -r ".\"$event\" | length" "$HOOKS_FILE")
+for event in $(jq -r "$JQ_PREFIX | keys[]" "$HOOKS_FILE"); do
+  hook_count=$(jq -r "$JQ_PREFIX.\"$event\" | length" "$HOOKS_FILE")
 
   for ((i=0; i<hook_count; i++)); do
-    # Check matcher exists
-    matcher=$(jq -r ".\"$event\"[$i].matcher // empty" "$HOOKS_FILE")
+    # Check matcher (optional for all events; defaults to matching everything)
+    # For tool-specific events, warn if missing since it likely should be explicit
+    matcher=$(jq -r "$JQ_PREFIX.\"$event\"[$i].matcher // empty" "$HOOKS_FILE")
     if [ -z "$matcher" ]; then
-      echo "❌ $event[$i]: Missing 'matcher' field"
-      ((error_count++))
-      continue
+      is_tool_event=false
+      if [ "$event" = "PreToolUse" ] || [ "$event" = "PostToolUse" ]; then
+        is_tool_event=true
+      fi
+      if [ "$is_tool_event" = true ]; then
+        echo "⚠️  $event[$i]: No 'matcher' field — hook will match all tools"
+        ((warning_count++))
+      fi
     fi
 
     # Check hooks array exists
-    hooks=$(jq -r ".\"$event\"[$i].hooks // empty" "$HOOKS_FILE")
+    hooks=$(jq -r "$JQ_PREFIX.\"$event\"[$i].hooks // empty" "$HOOKS_FILE")
     if [ -z "$hooks" ] || [ "$hooks" = "null" ]; then
       echo "❌ $event[$i]: Missing 'hooks' array"
       ((error_count++))
@@ -83,10 +101,10 @@ for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
     fi
 
     # Validate each hook in the array
-    hook_array_count=$(jq -r ".\"$event\"[$i].hooks | length" "$HOOKS_FILE")
+    hook_array_count=$(jq -r "$JQ_PREFIX.\"$event\"[$i].hooks | length" "$HOOKS_FILE")
 
     for ((j=0; j<hook_array_count; j++)); do
-      hook_type=$(jq -r ".\"$event\"[$i].hooks[$j].type // empty" "$HOOKS_FILE")
+      hook_type=$(jq -r "$JQ_PREFIX.\"$event\"[$i].hooks[$j].type // empty" "$HOOKS_FILE")
 
       if [ -z "$hook_type" ]; then
         echo "❌ $event[$i].hooks[$j]: Missing 'type' field"
@@ -102,7 +120,7 @@ for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
 
       # Check type-specific fields
       if [ "$hook_type" = "command" ]; then
-        command=$(jq -r ".\"$event\"[$i].hooks[$j].command // empty" "$HOOKS_FILE")
+        command=$(jq -r "$JQ_PREFIX.\"$event\"[$i].hooks[$j].command // empty" "$HOOKS_FILE")
         if [ -z "$command" ]; then
           echo "❌ $event[$i].hooks[$j]: Command hooks must have 'command' field"
           ((error_count++))
@@ -114,7 +132,7 @@ for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
           fi
         fi
       elif [ "$hook_type" = "prompt" ]; then
-        prompt=$(jq -r ".\"$event\"[$i].hooks[$j].prompt // empty" "$HOOKS_FILE")
+        prompt=$(jq -r "$JQ_PREFIX.\"$event\"[$i].hooks[$j].prompt // empty" "$HOOKS_FILE")
         if [ -z "$prompt" ]; then
           echo "❌ $event[$i].hooks[$j]: Prompt hooks must have 'prompt' field"
           ((error_count++))
@@ -128,7 +146,7 @@ for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
       fi
 
       # Check timeout
-      timeout=$(jq -r ".\"$event\"[$i].hooks[$j].timeout // empty" "$HOOKS_FILE")
+      timeout=$(jq -r "$JQ_PREFIX.\"$event\"[$i].hooks[$j].timeout // empty" "$HOOKS_FILE")
       if [ -n "$timeout" ] && [ "$timeout" != "null" ]; then
         if ! [[ "$timeout" =~ ^[0-9]+$ ]]; then
           echo "❌ $event[$i].hooks[$j]: Timeout must be a number"

--- a/plugins/plugin-dev/skills/plugin-structure/references/component-patterns.md
+++ b/plugins/plugin-dev/skills/plugin-structure/references/component-patterns.md
@@ -303,13 +303,16 @@ hooks/
     └── load-context.sh
 ```
 
-**hooks.json**:
+**hooks.json** (plugin wrapper format):
 ```json
 {
-  "PreToolUse": [...],
-  "PostToolUse": [...],
-  "Stop": [...],
-  "SessionStart": [...]
+  "description": "Plugin hooks",
+  "hooks": {
+    "PreToolUse": [...],
+    "PostToolUse": [...],
+    "Stop": [...],
+    "SessionStart": [...]
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary

- **Fix `validate-hook-schema.sh`**: Auto-detect plugin wrapper format (`{"hooks": {...}}`) vs direct settings format, so the validator correctly processes all existing plugin `hooks.json` files instead of failing to find events at the root level
- **Fix `validate-hook-schema.sh`**: Make `matcher` field optional for all events (it defaults to matching everything when omitted). Previously the validator required it, but all real plugins (hookify, ralph-wiggum, learning-output-style, etc.) omit it. A warning is now shown only for PreToolUse/PostToolUse where an explicit matcher is typically desirable.
- **Fix SKILL.md docs**: The "Plugin Hook Configuration" section incorrectly showed the direct format instead of the wrapper format that all plugins actually use
- **Fix component-patterns.md docs**: The hooks.json example incorrectly showed the direct format

Relates to #24529, #27145

## Test plan

- [x] Ran `validate-hook-schema.sh` against all 5 plugin hooks.json files — all pass
- [ ] Verify the validator still catches actual errors (missing `hooks` array, invalid types, etc.)
- [ ] Review documentation changes match actual plugin conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)