### PR TITLE
fix(devcontainer): fix claude login hanging + replace npm with install script

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -59,7 +59,7 @@ USER node
 
 # Install global packages
 ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
-ENV PATH=$PATH:/usr/local/share/npm-global/bin
+ENV PATH=$PATH:/usr/local/share/npm-global/bin:/home/node/.local/bin
 
 # Set the default shell to zsh rather than sh
 ENV SHELL=/bin/zsh
@@ -78,8 +78,9 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
   -a "export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
   -x
 
-# Install Claude
-RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
+# Install Claude Code. The npm package (@anthropic-ai/claude-code) is no longer
+# the supported install method; use the official install script instead.
+RUN curl -fsSL https://claude.ai/install.sh | bash
 
 
 # Copy and set up firewall script

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -2,6 +2,26 @@
 set -euo pipefail  # Exit on error, undefined vars, and pipeline failures
 IFS=$'\n\t'       # Stricter word splitting
 
+# Fix localhost resolving to ::1 (IPv6) instead of 127.0.0.1 (IPv4).
+#
+# Claude Code's OAuth callback server calls getaddrinfo("localhost") and binds
+# to whichever address is returned first. Ubuntu containers list ::1 before
+# 127.0.0.1 in /etc/hosts, so the server ends up on [::1]:PORT. VS Code port
+# forwarding connects via IPv4 and never reaches it, causing `claude login` to
+# hang indefinitely after the user clicks Authorize in the browser.
+#
+# Setting NODE_OPTIONS=--dns-result-order=ipv4first has no effect because
+# Claude Code ships a self-contained binary with a bundled Node.js runtime that
+# ignores environment-level Node.js flags.
+#
+# Removing the ::1 entries from /etc/hosts fixes this at the C library
+# (getaddrinfo) level, which all Node.js runtimes call regardless of bundling.
+# Note: sed -i cannot be used here because Docker mounts /etc/hosts as a bind
+# mount, which does not support the atomic rename that sed -i relies on.
+#
+# See: https://github.com/anthropics/claude-code/issues/9376
+grep -v '^::1' /etc/hosts > /tmp/hosts.tmp && cat /tmp/hosts.tmp > /etc/hosts && rm /tmp/hosts.tmp
+
 # 1. Extract Docker DNS info BEFORE any flushing
 DOCKER_DNS_RULES=$(iptables-save -t nat | grep "127\.0\.0\.11" || true)
 
@@ -60,13 +80,15 @@ while read -r cidr; do
         exit 1
     fi
     echo "Adding GitHub range $cidr"
-    ipset add allowed-domains "$cidr"
+    ipset add -exist allowed-domains "$cidr"
 done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
 
 # Resolve and add other allowed domains
 for domain in \
     "registry.npmjs.org" \
     "api.anthropic.com" \
+    "claude.ai" \
+    "platform.claude.com" \
     "sentry.io" \
     "statsig.anthropic.com" \
     "statsig.com" \
@@ -86,7 +108,7 @@ for domain in \
             exit 1
         fi
         echo "Adding $ip for $domain"
-        ipset add allowed-domains "$ip"
+        ipset add -exist allowed-domains "$ip"
     done < <(echo "$ips")
 done
 


### PR DESCRIPTION
## Problem

Two issues make the reference devcontainer broken out of the box:

**1. `claude login` hangs indefinitely after clicking Authorize**

Claude Code's OAuth callback server calls `getaddrinfo("localhost")` and binds to whichever address is returned first. Ubuntu containers list `::1` before `127.0.0.1` in `/etc/hosts`, so the server ends up on `[::1]:PORT`. VS Code port forwarding connects via IPv4 (`127.0.0.1`) and never reaches it — the browser shows "Waiting for localhost…" forever.

Setting `NODE_OPTIONS=--dns-result-order=ipv4first` does not fix this because Claude Code ships a self-contained binary with a bundled Node.js runtime that ignores environment-level Node.js flags.

The fix is to remove `::1` entries from `/etc/hosts` at container startup, which forces `getaddrinfo` to return only `127.0.0.1` for `localhost`. This works at the C library level, which all Node.js runtimes call regardless of how they are bundled.

Note: `sed -i` cannot be used here because Docker mounts `/etc/hosts` as a bind mount that does not support the atomic rename `sed -i` relies on; `grep + cat` is used instead.

Additionally, `claude.ai` and `platform.claude.com` must be in the firewall allowlist. After receiving the OAuth callback, Claude Code makes outbound requests to these domains to complete the token exchange. Without them the browser hangs waiting for a response from the local callback server even after the `/etc/hosts` fix.

Finally, `ipset add` is changed to `ipset add -exist` throughout. `claude.ai` resolves to IPs already covered by the GitHub CIDR ranges added earlier, causing the script to crash with "Element cannot be added to the set: it's already added" and exit before the firewall is fully configured.

Fixes #9376

**2. Claude Code installation via npm no longer works**

The npm package (`@anthropic-ai/claude-code`) is no longer the supported install method. The Dockerfile is updated to use the official install script (`curl -fsSL https://claude.ai/install.sh | bash`), and `/home/node/.local/bin` is added to `PATH` since that is where the script installs the binary for non-root users.

## Changes

- `.devcontainer/init-firewall.sh`: remove `::1` from `/etc/hosts` at startup; add `claude.ai` and `platform.claude.com` to allowlist; use `ipset add -exist` to handle duplicate IPs
- `.devcontainer/Dockerfile`: replace `npm install -g @anthropic-ai/claude-code` with `curl -fsSL https://claude.ai/install.sh | bash`; add `/home/node/.local/bin` to `PATH`