### PR TITLE
feat: add completion subcommand for bash and zsh shell completion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .DS_Store
-
+scratch/

--- a/scripts/completions/claude.bash
+++ b/scripts/completions/claude.bash
@@ -1,0 +1,260 @@
+# Bash completion for Claude Code CLI
+# https://github.com/anthropics/claude-code
+#
+# Installation — add to ~/.bashrc:
+#   eval "$(claude completion bash)"
+
+_claude_completion() {
+  local cur prev words cword
+  _init_completion || return
+
+  local commands="auth doctor install mcp plugin setup-token update"
+
+  local global_flags="
+    --add-dir
+    --agent
+    --agents
+    --allow-dangerously-skip-permissions
+    --allowedTools --allowed-tools
+    --append-system-prompt
+    --betas
+    --chrome
+    --continue -c
+    --dangerously-skip-permissions
+    --debug -d
+    --debug-file
+    --disable-slash-commands
+    --disallowedTools --disallowed-tools
+    --effort
+    --fallback-model
+    --file
+    --fork-session
+    --from-pr
+    --help -h
+    --ide
+    --include-partial-messages
+    --input-format
+    --json-schema
+    --max-budget-usd
+    --mcp-config
+    --mcp-debug
+    --model
+    --no-chrome
+    --no-session-persistence
+    --output-format
+    --permission-mode
+    --plugin-dir
+    --print -p
+    --replay-user-messages
+    --resume -r
+    --session-id
+    --setting-sources
+    --settings
+    --strict-mcp-config
+    --system-prompt
+    --tools
+    --verbose
+    --version -v
+  "
+
+  # Determine the subcommand
+  local subcmd=""
+  local subcmd_idx=0
+  for ((i = 1; i < cword; i++)); do
+    case "${words[i]}" in
+      auth|doctor|install|mcp|plugin|setup-token|update)
+        subcmd="${words[i]}"
+        subcmd_idx=$i
+        break
+        ;;
+    esac
+  done
+
+  # Complete option values
+  case "$prev" in
+    --effort)
+      COMPREPLY=($(compgen -W "low medium high" -- "$cur"))
+      return
+      ;;
+    --input-format)
+      COMPREPLY=($(compgen -W "text stream-json" -- "$cur"))
+      return
+      ;;
+    --output-format)
+      COMPREPLY=($(compgen -W "text json stream-json" -- "$cur"))
+      return
+      ;;
+    --permission-mode)
+      COMPREPLY=($(compgen -W "acceptEdits bypassPermissions default delegate dontAsk plan" -- "$cur"))
+      return
+      ;;
+    --debug-file|--settings|--mcp-config)
+      _filedir
+      return
+      ;;
+    --add-dir|--plugin-dir)
+      _filedir -d
+      return
+      ;;
+  esac
+
+  case "$subcmd" in
+    "")
+      # No subcommand yet — complete commands or global flags
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=($(compgen -W "$global_flags" -- "$cur"))
+      else
+        COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+      fi
+      ;;
+    auth)
+      local auth_cmds="login logout status"
+      local auth_subcmd=""
+      for ((i = subcmd_idx + 1; i < cword; i++)); do
+        case "${words[i]}" in
+          login|logout|status) auth_subcmd="${words[i]}" ;;
+        esac
+      done
+      if [[ -z "$auth_subcmd" ]]; then
+        COMPREPLY=($(compgen -W "$auth_cmds" -- "$cur"))
+      else
+        case "$auth_subcmd" in
+          login)
+            COMPREPLY=($(compgen -W "--email --sso --help -h" -- "$cur"))
+            ;;
+          status)
+            COMPREPLY=($(compgen -W "--json --text --help -h" -- "$cur"))
+            ;;
+          *)
+            COMPREPLY=($(compgen -W "--help -h" -- "$cur"))
+            ;;
+        esac
+      fi
+      ;;
+    mcp)
+      local mcp_cmds="add add-from-claude-desktop add-json get list remove reset-project-choices serve"
+      local mcp_subcmd=""
+      for ((i = subcmd_idx + 1; i < cword; i++)); do
+        case "${words[i]}" in
+          add|add-from-claude-desktop|add-json|get|list|remove|reset-project-choices|serve)
+            mcp_subcmd="${words[i]}"
+            ;;
+        esac
+      done
+      if [[ -z "$mcp_subcmd" ]]; then
+        COMPREPLY=($(compgen -W "$mcp_cmds" -- "$cur"))
+      else
+        case "$mcp_subcmd" in
+          serve)
+            COMPREPLY=($(compgen -W "--debug -d --verbose --help -h" -- "$cur"))
+            ;;
+          add)
+            COMPREPLY=($(compgen -W "--callback-port --client-id --client-secret --env -e --header -H --scope -s --transport -t --help -h" -- "$cur"))
+            ;;
+          add-json)
+            COMPREPLY=($(compgen -W "--client-secret --scope -s --help -h" -- "$cur"))
+            ;;
+          remove)
+            COMPREPLY=($(compgen -W "--scope -s --help -h" -- "$cur"))
+            ;;
+          add-from-claude-desktop)
+            COMPREPLY=($(compgen -W "--scope -s --help -h" -- "$cur"))
+            ;;
+          *)
+            COMPREPLY=($(compgen -W "--help -h" -- "$cur"))
+            ;;
+        esac
+
+        # Complete --scope values
+        if [[ "$prev" == "--scope" || "$prev" == "-s" ]]; then
+          COMPREPLY=($(compgen -W "local user project" -- "$cur"))
+          return
+        fi
+        # Complete --transport values
+        if [[ "$prev" == "--transport" || "$prev" == "-t" ]]; then
+          COMPREPLY=($(compgen -W "stdio sse http" -- "$cur"))
+          return
+        fi
+      fi
+      ;;
+    plugin)
+      local plugin_cmds="disable enable install list marketplace uninstall update validate"
+      local plugin_subcmd=""
+      for ((i = subcmd_idx + 1; i < cword; i++)); do
+        case "${words[i]}" in
+          disable|enable|install|list|marketplace|uninstall|update|validate)
+            plugin_subcmd="${words[i]}"
+            ;;
+        esac
+      done
+      if [[ -z "$plugin_subcmd" ]]; then
+        COMPREPLY=($(compgen -W "$plugin_cmds" -- "$cur"))
+      else
+        case "$plugin_subcmd" in
+          install)
+            COMPREPLY=($(compgen -W "--scope -s --help -h" -- "$cur"))
+            ;;
+          uninstall)
+            COMPREPLY=($(compgen -W "--scope -s --help -h" -- "$cur"))
+            ;;
+          enable)
+            COMPREPLY=($(compgen -W "--scope -s --help -h" -- "$cur"))
+            ;;
+          disable)
+            COMPREPLY=($(compgen -W "--all -a --scope -s --help -h" -- "$cur"))
+            ;;
+          update)
+            COMPREPLY=($(compgen -W "--scope -s --help -h" -- "$cur"))
+            ;;
+          list)
+            COMPREPLY=($(compgen -W "--available --json --help -h" -- "$cur"))
+            ;;
+          validate)
+            COMPREPLY=($(compgen -W "--help -h" -- "$cur"))
+            _filedir
+            ;;
+          marketplace)
+            local mp_subcmd=""
+            for ((j = i + 1; j < cword; j++)); do
+              case "${words[j]}" in
+                add|list|remove|update) mp_subcmd="${words[j]}" ;;
+              esac
+            done
+            if [[ -z "$mp_subcmd" ]]; then
+              COMPREPLY=($(compgen -W "add list remove update" -- "$cur"))
+            else
+              case "$mp_subcmd" in
+                list)
+                  COMPREPLY=($(compgen -W "--json --help -h" -- "$cur"))
+                  ;;
+                *)
+                  COMPREPLY=($(compgen -W "--help -h" -- "$cur"))
+                  ;;
+              esac
+            fi
+            ;;
+          *)
+            COMPREPLY=($(compgen -W "--help -h" -- "$cur"))
+            ;;
+        esac
+
+        if [[ "$prev" == "--scope" || "$prev" == "-s" ]]; then
+          COMPREPLY=($(compgen -W "user project local" -- "$cur"))
+          return
+        fi
+      fi
+      ;;
+    install)
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=($(compgen -W "--force --help -h" -- "$cur"))
+      else
+        COMPREPLY=($(compgen -W "stable latest" -- "$cur"))
+      fi
+      ;;
+    doctor|setup-token|update)
+      COMPREPLY=($(compgen -W "--help -h" -- "$cur"))
+      ;;
+  esac
+}
+
+complete -F _claude_completion claude

--- a/scripts/completions/claude.fish
+++ b/scripts/completions/claude.fish
@@ -1,0 +1,181 @@
+# Fish completion for Claude Code CLI
+# https://github.com/anthropics/claude-code
+#
+# Installation:
+#   claude completion fish > ~/.config/fish/completions/claude.fish
+
+# Disable file completions by default
+complete -c claude -f
+
+# Helper: true when no subcommand has been given
+function __claude_no_subcommand
+    set -l tokens (commandline -opc)
+    for t in $tokens[2..]
+        switch $t
+            case auth doctor install mcp plugin setup-token update
+                return 1
+        end
+    end
+    return 0
+end
+
+# Helper: true when the given subcommand is active
+function __claude_using_subcommand
+    set -l tokens (commandline -opc)
+    for t in $tokens[2..]
+        if test "$t" = "$argv[1]"
+            return 0
+        end
+    end
+    return 1
+end
+
+# Helper: true when a nested subcommand is active (e.g., mcp add)
+function __claude_using_nested_subcommand
+    set -l tokens (commandline -opc)
+    set -l found_parent 0
+    for t in $tokens[2..]
+        if test $found_parent -eq 0
+            if test "$t" = "$argv[1]"
+                set found_parent 1
+            end
+        else
+            if test "$t" = "$argv[2]"
+                return 0
+            end
+        end
+    end
+    return 1
+end
+
+# Helper: true when a subcommand is active but no nested subcommand yet
+function __claude_needs_nested_subcommand
+    set -l tokens (commandline -opc)
+    set -l found_parent 0
+    for t in $tokens[2..]
+        if test $found_parent -eq 0
+            if test "$t" = "$argv[1]"
+                set found_parent 1
+            end
+        else
+            # Check if any of the possible nested subcommands have been entered
+            for sub in $argv[2..]
+                if test "$t" = "$sub"
+                    return 1
+                end
+            end
+        end
+    end
+    return $found_parent  # 0 if parent found (and no nested), 1 if parent not found
+end
+
+# --- Top-level subcommands ---
+complete -c claude -n __claude_no_subcommand -a auth -d 'Manage authentication'
+complete -c claude -n __claude_no_subcommand -a doctor -d 'Check the health of your Claude Code auto-updater'
+complete -c claude -n __claude_no_subcommand -a install -d 'Install Claude Code native build'
+complete -c claude -n __claude_no_subcommand -a mcp -d 'Configure and manage MCP servers'
+complete -c claude -n __claude_no_subcommand -a plugin -d 'Manage Claude Code plugins'
+complete -c claude -n __claude_no_subcommand -a setup-token -d 'Set up a long-lived authentication token'
+complete -c claude -n __claude_no_subcommand -a update -d 'Check for updates and install if available'
+
+# --- Global flags ---
+complete -c claude -n __claude_no_subcommand -l add-dir -d 'Additional directories to allow tool access to' -r -F
+complete -c claude -n __claude_no_subcommand -l agent -d 'Agent for the current session' -r
+complete -c claude -n __claude_no_subcommand -l agents -d 'JSON object defining custom agents' -r
+complete -c claude -n __claude_no_subcommand -l allow-dangerously-skip-permissions -d 'Enable bypassing permission checks as an option'
+complete -c claude -n __claude_no_subcommand -l allowed-tools -d 'Tool names to allow' -r
+complete -c claude -n __claude_no_subcommand -l append-system-prompt -d 'Append a system prompt' -r
+complete -c claude -n __claude_no_subcommand -l betas -d 'Beta headers for API requests' -r
+complete -c claude -n __claude_no_subcommand -l chrome -d 'Enable Claude in Chrome integration'
+complete -c claude -n __claude_no_subcommand -s c -l continue -d 'Continue the most recent conversation'
+complete -c claude -n __claude_no_subcommand -l dangerously-skip-permissions -d 'Bypass all permission checks'
+complete -c claude -n __claude_no_subcommand -s d -l debug -d 'Enable debug mode with optional category filtering' -r
+complete -c claude -n __claude_no_subcommand -l debug-file -d 'Write debug logs to a file' -r -F
+complete -c claude -n __claude_no_subcommand -l disable-slash-commands -d 'Disable all skills'
+complete -c claude -n __claude_no_subcommand -l disallowed-tools -d 'Tool names to deny' -r
+complete -c claude -n __claude_no_subcommand -l effort -d 'Effort level for the session' -r -a 'low medium high'
+complete -c claude -n __claude_no_subcommand -l fallback-model -d 'Fallback model when default is overloaded' -r
+complete -c claude -n __claude_no_subcommand -l file -d 'File resources to download at startup' -r
+complete -c claude -n __claude_no_subcommand -l fork-session -d 'Create a new session ID when resuming'
+complete -c claude -n __claude_no_subcommand -l from-pr -d 'Resume a session linked to a PR' -r
+complete -c claude -n __claude_no_subcommand -s h -l help -d 'Display help for command'
+complete -c claude -n __claude_no_subcommand -l ide -d 'Automatically connect to IDE on startup'
+complete -c claude -n __claude_no_subcommand -l include-partial-messages -d 'Include partial message chunks'
+complete -c claude -n __claude_no_subcommand -l input-format -d 'Input format' -r -a 'text stream-json'
+complete -c claude -n __claude_no_subcommand -l json-schema -d 'JSON Schema for structured output' -r
+complete -c claude -n __claude_no_subcommand -l max-budget-usd -d 'Maximum dollar amount for API calls' -r
+complete -c claude -n __claude_no_subcommand -l mcp-config -d 'Load MCP servers from JSON files' -r -F
+complete -c claude -n __claude_no_subcommand -l mcp-debug -d 'Enable MCP debug mode (deprecated)'
+complete -c claude -n __claude_no_subcommand -l model -d 'Model for the current session' -r
+complete -c claude -n __claude_no_subcommand -l no-chrome -d 'Disable Claude in Chrome integration'
+complete -c claude -n __claude_no_subcommand -l no-session-persistence -d 'Disable session persistence'
+complete -c claude -n __claude_no_subcommand -l output-format -d 'Output format' -r -a 'text json stream-json'
+complete -c claude -n __claude_no_subcommand -l permission-mode -d 'Permission mode' -r -a 'acceptEdits bypassPermissions default delegate dontAsk plan'
+complete -c claude -n __claude_no_subcommand -l plugin-dir -d 'Load plugins from directories' -r -F
+complete -c claude -n __claude_no_subcommand -s p -l print -d 'Print response and exit'
+complete -c claude -n __claude_no_subcommand -l replay-user-messages -d 'Re-emit user messages on stdout'
+complete -c claude -n __claude_no_subcommand -s r -l resume -d 'Resume a conversation by session ID' -r
+complete -c claude -n __claude_no_subcommand -l session-id -d 'Use a specific session ID' -r
+complete -c claude -n __claude_no_subcommand -l setting-sources -d 'Setting sources to load' -r
+complete -c claude -n __claude_no_subcommand -l settings -d 'Path to settings JSON file' -r -F
+complete -c claude -n __claude_no_subcommand -l strict-mcp-config -d 'Only use MCP servers from --mcp-config'
+complete -c claude -n __claude_no_subcommand -l system-prompt -d 'System prompt for the session' -r
+complete -c claude -n __claude_no_subcommand -l tools -d 'Available tools from the built-in set' -r
+complete -c claude -n __claude_no_subcommand -l verbose -d 'Override verbose mode setting'
+complete -c claude -n __claude_no_subcommand -s v -l version -d 'Output the version number'
+
+# --- auth subcommands ---
+complete -c claude -n '__claude_needs_nested_subcommand auth login logout status' -a login -d 'Sign in to your Anthropic account'
+complete -c claude -n '__claude_needs_nested_subcommand auth login logout status' -a logout -d 'Log out from your Anthropic account'
+complete -c claude -n '__claude_needs_nested_subcommand auth login logout status' -a status -d 'Show authentication status'
+complete -c claude -n '__claude_using_nested_subcommand auth login' -l email -d 'Pre-populate email address' -r
+complete -c claude -n '__claude_using_nested_subcommand auth login' -l sso -d 'Force SSO login flow'
+complete -c claude -n '__claude_using_nested_subcommand auth status' -l json -d 'Output as JSON'
+complete -c claude -n '__claude_using_nested_subcommand auth status' -l text -d 'Output as human-readable text'
+
+# --- mcp subcommands ---
+complete -c claude -n '__claude_needs_nested_subcommand mcp add add-from-claude-desktop add-json get list remove reset-project-choices serve' -a add -d 'Add an MCP server'
+complete -c claude -n '__claude_needs_nested_subcommand mcp add add-from-claude-desktop add-json get list remove reset-project-choices serve' -a add-from-claude-desktop -d 'Import MCP servers from Claude Desktop'
+complete -c claude -n '__claude_needs_nested_subcommand mcp add add-from-claude-desktop add-json get list remove reset-project-choices serve' -a add-json -d 'Add an MCP server with a JSON string'
+complete -c claude -n '__claude_needs_nested_subcommand mcp add add-from-claude-desktop add-json get list remove reset-project-choices serve' -a get -d 'Get details about an MCP server'
+complete -c claude -n '__claude_needs_nested_subcommand mcp add add-from-claude-desktop add-json get list remove reset-project-choices serve' -a list -d 'List configured MCP servers'
+complete -c claude -n '__claude_needs_nested_subcommand mcp add add-from-claude-desktop add-json get list remove reset-project-choices serve' -a remove -d 'Remove an MCP server'
+complete -c claude -n '__claude_needs_nested_subcommand mcp add add-from-claude-desktop add-json get list remove reset-project-choices serve' -a reset-project-choices -d 'Reset approved/rejected project-scoped servers'
+complete -c claude -n '__claude_needs_nested_subcommand mcp add add-from-claude-desktop add-json get list remove reset-project-choices serve' -a serve -d 'Start the Claude Code MCP server'
+
+complete -c claude -n '__claude_using_nested_subcommand mcp serve' -s d -l debug -d 'Enable debug mode'
+complete -c claude -n '__claude_using_nested_subcommand mcp serve' -l verbose -d 'Override verbose mode'
+complete -c claude -n '__claude_using_nested_subcommand mcp add' -s s -l scope -d 'Configuration scope' -r -a 'local user project'
+complete -c claude -n '__claude_using_nested_subcommand mcp add' -s t -l transport -d 'Transport type' -r -a 'stdio sse http'
+complete -c claude -n '__claude_using_nested_subcommand mcp add' -s e -l env -d 'Set environment variables' -r
+complete -c claude -n '__claude_using_nested_subcommand mcp add' -s H -l header -d 'Set WebSocket headers' -r
+complete -c claude -n '__claude_using_nested_subcommand mcp add' -l callback-port -d 'Fixed port for OAuth callback' -r
+complete -c claude -n '__claude_using_nested_subcommand mcp add' -l client-id -d 'OAuth client ID' -r
+complete -c claude -n '__claude_using_nested_subcommand mcp add' -l client-secret -d 'Prompt for OAuth client secret'
+complete -c claude -n '__claude_using_nested_subcommand mcp add-json' -s s -l scope -d 'Configuration scope' -r -a 'local user project'
+complete -c claude -n '__claude_using_nested_subcommand mcp add-json' -l client-secret -d 'Prompt for OAuth client secret'
+complete -c claude -n '__claude_using_nested_subcommand mcp remove' -s s -l scope -d 'Configuration scope' -r -a 'local user project'
+complete -c claude -n '__claude_using_nested_subcommand mcp add-from-claude-desktop' -s s -l scope -d 'Configuration scope' -r -a 'local user project'
+
+# --- plugin subcommands ---
+complete -c claude -n '__claude_needs_nested_subcommand plugin disable enable install list marketplace uninstall update validate' -a disable -d 'Disable an enabled plugin'
+complete -c claude -n '__claude_needs_nested_subcommand plugin disable enable install list marketplace uninstall update validate' -a enable -d 'Enable a disabled plugin'
+complete -c claude -n '__claude_needs_nested_subcommand plugin disable enable install list marketplace uninstall update validate' -a install -d 'Install a plugin from marketplaces'
+complete -c claude -n '__claude_needs_nested_subcommand plugin disable enable install list marketplace uninstall update validate' -a list -d 'List installed plugins'
+complete -c claude -n '__claude_needs_nested_subcommand plugin disable enable install list marketplace uninstall update validate' -a marketplace -d 'Manage marketplaces'
+complete -c claude -n '__claude_needs_nested_subcommand plugin disable enable install list marketplace uninstall update validate' -a uninstall -d 'Uninstall an installed plugin'
+complete -c claude -n '__claude_needs_nested_subcommand plugin disable enable install list marketplace uninstall update validate' -a update -d 'Update a plugin'
+complete -c claude -n '__claude_needs_nested_subcommand plugin disable enable install list marketplace uninstall update validate' -a validate -d 'Validate a plugin manifest'
+
+complete -c claude -n '__claude_using_nested_subcommand plugin install' -s s -l scope -d 'Installation scope' -r -a 'user project local'
+complete -c claude -n '__claude_using_nested_subcommand plugin uninstall' -s s -l scope -d 'Uninstall from scope' -r -a 'user project local'
+complete -c claude -n '__claude_using_nested_subcommand plugin enable' -s s -l scope -d 'Installation scope' -r -a 'user project local'
+complete -c claude -n '__claude_using_nested_subcommand plugin disable' -s s -l scope -d 'Installation scope' -r -a 'user project local'
+complete -c claude -n '__claude_using_nested_subcommand plugin disable' -s a -l all -d 'Disable all enabled plugins'
+complete -c claude -n '__claude_using_nested_subcommand plugin update' -s s -l scope -d 'Installation scope' -r -a 'user project local managed'
+complete -c claude -n '__claude_using_nested_subcommand plugin list' -l json -d 'Output as JSON'
+complete -c claude -n '__claude_using_nested_subcommand plugin list' -l available -d 'Include available plugins from marketplaces'
+
+# --- install subcommand ---
+complete -c claude -n '__claude_using_subcommand install' -l force -d 'Force installation even if already installed'
+complete -c claude -n '__claude_using_subcommand install' -a 'stable latest' -d 'Version target'

--- a/scripts/completions/claude.zsh
+++ b/scripts/completions/claude.zsh
@@ -1,0 +1,299 @@
+#compdef claude
+
+# Zsh completion script for Claude Code CLI
+# https://github.com/anthropics/claude-code
+#
+# Installation — add to ~/.zshrc:
+#   eval "$(claude completion zsh)"
+
+local curcontext="$curcontext" state line
+typeset -A opt_args
+
+local -a commands
+commands=(
+  'auth:Manage authentication'
+  'doctor:Check the health of your Claude Code auto-updater'
+  'install:Install Claude Code native build'
+  'mcp:Configure and manage MCP servers'
+  'plugin:Manage Claude Code plugins'
+  'setup-token:Set up a long-lived authentication token'
+  'update:Check for updates and install if available'
+)
+
+local -a auth_commands
+auth_commands=(
+  'login:Sign in to your Anthropic account'
+  'logout:Log out from your Anthropic account'
+  'status:Show authentication status'
+)
+
+local -a mcp_commands
+mcp_commands=(
+  'add:Add an MCP server to Claude Code'
+  'add-from-claude-desktop:Import MCP servers from Claude Desktop'
+  'add-json:Add an MCP server with a JSON string'
+  'get:Get details about an MCP server'
+  'list:List configured MCP servers'
+  'remove:Remove an MCP server'
+  'reset-project-choices:Reset approved/rejected project-scoped servers'
+  'serve:Start the Claude Code MCP server'
+)
+
+local -a plugin_commands
+plugin_commands=(
+  'disable:Disable an enabled plugin'
+  'enable:Enable a disabled plugin'
+  'install:Install a plugin from available marketplaces'
+  'list:List installed plugins'
+  'marketplace:Manage Claude Code marketplaces'
+  'uninstall:Uninstall an installed plugin'
+  'update:Update a plugin to the latest version'
+  'validate:Validate a plugin or marketplace manifest'
+)
+
+local -a marketplace_commands
+marketplace_commands=(
+  'add:Add a marketplace from a URL, path, or GitHub repo'
+  'list:List all configured marketplaces'
+  'remove:Remove a configured marketplace'
+  'update:Update marketplace(s) from their source'
+)
+
+case $words[2] in
+  auth)
+    if (( CURRENT == 3 )); then
+      _describe 'auth command' auth_commands
+    else
+      case $words[3] in
+        login)
+          _arguments \
+            '--email[Pre-populate email address on the login page]:email:' \
+            '(-h --help)'{-h,--help}'[Display help]' \
+            '--sso[Force SSO login flow]'
+          ;;
+        logout)
+          _arguments \
+            '(-h --help)'{-h,--help}'[Display help]'
+          ;;
+        status)
+          _arguments \
+            '(-h --help)'{-h,--help}'[Display help]' \
+            '--json[Output as JSON]' \
+            '--text[Output as human-readable text]'
+          ;;
+        *)
+          _message 'no more arguments'
+          ;;
+      esac
+    fi
+    return
+    ;;
+  mcp)
+    if (( CURRENT == 3 )); then
+      _describe 'mcp command' mcp_commands
+    else
+      case $words[3] in
+        serve)
+          _arguments \
+            '(-d --debug)'{-d,--debug}'[Enable debug mode]' \
+            '(-h --help)'{-h,--help}'[Display help]' \
+            '--verbose[Override verbose mode setting from config]'
+          ;;
+        add)
+          _arguments \
+            '--callback-port[Fixed port for OAuth callback]:port:' \
+            '--client-id[OAuth client ID for HTTP/SSE servers]:clientId:' \
+            '--client-secret[Prompt for OAuth client secret]' \
+            '(-e --env)*'{-e,--env}'[Set environment variables (e.g. -e KEY=value)]:env:' \
+            '(-H --header)*'{-H,--header}'[Set WebSocket headers]:header:' \
+            '(-h --help)'{-h,--help}'[Display help]' \
+            '(-s --scope)'{-s,--scope}'[Configuration scope]:scope:(local user project)' \
+            '(-t --transport)'{-t,--transport}'[Transport type]:transport:(stdio sse http)' \
+            ':name:' \
+            ':commandOrUrl:_files' \
+            '*:args:_files'
+          ;;
+        remove)
+          _arguments \
+            '(-h --help)'{-h,--help}'[Display help]' \
+            '(-s --scope)'{-s,--scope}'[Configuration scope]:scope:(local user project)' \
+            ':name:'
+          ;;
+        add-json)
+          _arguments \
+            '--client-secret[Prompt for OAuth client secret]' \
+            '(-h --help)'{-h,--help}'[Display help]' \
+            '(-s --scope)'{-s,--scope}'[Configuration scope]:scope:(local user project)' \
+            ':name:' \
+            ':json:'
+          ;;
+        add-from-claude-desktop)
+          _arguments \
+            '(-h --help)'{-h,--help}'[Display help]' \
+            '(-s --scope)'{-s,--scope}'[Configuration scope]:scope:(local user project)'
+          ;;
+        get)
+          _arguments \
+            '(-h --help)'{-h,--help}'[Display help]' \
+            ':name:'
+          ;;
+        list|reset-project-choices)
+          _arguments \
+            '(-h --help)'{-h,--help}'[Display help]'
+          ;;
+        *)
+          _message 'no more arguments'
+          ;;
+      esac
+    fi
+    return
+    ;;
+  plugin)
+    if (( CURRENT == 3 )); then
+      _describe 'plugin command' plugin_commands
+    else
+      case $words[3] in
+        validate)
+          _arguments \
+            '(-h --help)'{-h,--help}'[Display help]' \
+            ':path:_files'
+          ;;
+        marketplace)
+          if (( CURRENT == 4 )); then
+            _describe 'marketplace command' marketplace_commands
+          else
+            case $words[4] in
+              add)
+                _arguments \
+                  '(-h --help)'{-h,--help}'[Display help]' \
+                  ':source:_files'
+                ;;
+              remove)
+                _arguments \
+                  '(-h --help)'{-h,--help}'[Display help]' \
+                  ':name:'
+                ;;
+              update)
+                _arguments \
+                  '(-h --help)'{-h,--help}'[Display help]' \
+                  '::name:'
+                ;;
+              list)
+                _arguments \
+                  '(-h --help)'{-h,--help}'[Display help]' \
+                  '--json[Output as JSON]'
+                ;;
+              *)
+                _message 'no more arguments'
+                ;;
+            esac
+          fi
+          ;;
+        install)
+          _arguments \
+            '(-h --help)'{-h,--help}'[Display help]' \
+            '(-s --scope)'{-s,--scope}'[Installation scope]:scope:(user project local)' \
+            ':plugin:'
+          ;;
+        uninstall)
+          _arguments \
+            '(-h --help)'{-h,--help}'[Display help]' \
+            '(-s --scope)'{-s,--scope}'[Uninstall from scope]:scope:(user project local)' \
+            ':plugin:'
+          ;;
+        enable)
+          _arguments \
+            '(-h --help)'{-h,--help}'[Display help]' \
+            '(-s --scope)'{-s,--scope}'[Installation scope]:scope:(user project local)' \
+            ':plugin:'
+          ;;
+        disable)
+          _arguments \
+            '(-a --all)'{-a,--all}'[Disable all enabled plugins]' \
+            '(-h --help)'{-h,--help}'[Display help]' \
+            '(-s --scope)'{-s,--scope}'[Installation scope]:scope:(user project local)' \
+            '::plugin:'
+          ;;
+        update)
+          _arguments \
+            '(-h --help)'{-h,--help}'[Display help]' \
+            '(-s --scope)'{-s,--scope}'[Installation scope]:scope:(user project local managed)' \
+            ':plugin:'
+          ;;
+        list)
+          _arguments \
+            '--available[Include available plugins from marketplaces]' \
+            '(-h --help)'{-h,--help}'[Display help]' \
+            '--json[Output as JSON]'
+          ;;
+        *)
+          _message 'no more arguments'
+          ;;
+      esac
+    fi
+    return
+    ;;
+  install)
+    _arguments \
+      '--force[Force installation even if already installed]' \
+      '(-h --help)'{-h,--help}'[Display help]' \
+      ':target:(stable latest)'
+    return
+    ;;
+  setup-token|doctor|update)
+    _arguments \
+      '(-h --help)'{-h,--help}'[Display help]'
+    return
+    ;;
+esac
+
+# Global flags and commands when no subcommand matched
+_arguments -s \
+  '*--add-dir[Additional directories to allow tool access to]:directory:_files -/' \
+  '--agent[Agent for the current session]:agent:' \
+  '--agents[JSON object defining custom agents]:json:' \
+  '--allow-dangerously-skip-permissions[Enable bypassing all permission checks as an option]' \
+  '*--allowedTools[Tool names to allow]:tools:' \
+  '*--allowed-tools[Tool names to allow]:tools:' \
+  '--append-system-prompt[Append a system prompt]:prompt:' \
+  '*--betas[Beta headers for API requests]:betas:' \
+  '--chrome[Enable Claude in Chrome integration]' \
+  '(-c --continue)'{-c,--continue}'[Continue the most recent conversation]' \
+  '--dangerously-skip-permissions[Bypass all permission checks]' \
+  '(-d --debug)'{-d,--debug}'[Enable debug mode]:filter:' \
+  '--debug-file[Write debug logs to a file]:path:_files' \
+  '--disable-slash-commands[Disable all skills]' \
+  '*--disallowedTools[Tool names to deny]:tools:' \
+  '*--disallowed-tools[Tool names to deny]:tools:' \
+  '--effort[Effort level for the session]:level:(low medium high)' \
+  '--fallback-model[Fallback model when default is overloaded]:model:' \
+  '*--file[File resources to download at startup]:file:' \
+  '--fork-session[Create a new session ID when resuming]' \
+  '--from-pr[Resume a session linked to a PR]:value:' \
+  '(-h --help)'{-h,--help}'[Display help for command]' \
+  '--ide[Automatically connect to IDE on startup]' \
+  '--include-partial-messages[Include partial message chunks]' \
+  '--input-format[Input format]:format:(text stream-json)' \
+  '--json-schema[JSON Schema for structured output]:schema:' \
+  '--max-budget-usd[Maximum dollar amount for API calls]:amount:' \
+  '*--mcp-config[Load MCP servers from JSON files]:config:_files' \
+  '--mcp-debug[Enable MCP debug mode (deprecated)]' \
+  '--model[Model for the current session]:model:' \
+  '--no-chrome[Disable Claude in Chrome integration]' \
+  '--no-session-persistence[Disable session persistence]' \
+  '--output-format[Output format]:format:(text json stream-json)' \
+  '--permission-mode[Permission mode]:mode:(acceptEdits bypassPermissions default delegate dontAsk plan)' \
+  '*--plugin-dir[Load plugins from directories]:directory:_files -/' \
+  '(-p --print)'{-p,--print}'[Print response and exit]' \
+  '--replay-user-messages[Re-emit user messages on stdout]' \
+  '(-r --resume)'{-r,--resume}'[Resume a conversation by session ID]:value:' \
+  '--session-id[Use a specific session ID]:uuid:' \
+  '--setting-sources[Setting sources to load]:sources:' \
+  '--settings[Path to settings JSON file]:file:_files' \
+  '--strict-mcp-config[Only use MCP servers from --mcp-config]' \
+  '--system-prompt[System prompt for the session]:prompt:' \
+  '*--tools[Available tools from the built-in set]:tools:' \
+  '--verbose[Override verbose mode setting]' \
+  '(-v --version)'{-v,--version}'[Output the version number]' \
+  '1:command:(auth doctor install mcp plugin setup-token update)' \
+  '*:prompt:'

--- a/scripts/completions/generate-completions.sh
+++ b/scripts/completions/generate-completions.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Generate shell completion scripts for Claude Code CLI.
+#
+# Usage:
+#   ./generate-completions.sh bash   # Print bash completions to stdout
+#   ./generate-completions.sh zsh    # Print zsh completions to stdout
+#   ./generate-completions.sh fish   # Print fish completions to stdout
+#
+# Installation:
+#   # Bash — add to ~/.bashrc:
+#   eval "$(claude completion bash)"
+#
+#   # Zsh — add to ~/.zshrc:
+#   eval "$(claude completion zsh)"
+#
+#   # Fish — save to completions directory:
+#   claude completion fish > ~/.config/fish/completions/claude.fish
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+generate_bash() {
+  cat "${SCRIPT_DIR}/claude.bash"
+}
+
+generate_zsh() {
+  cat "${SCRIPT_DIR}/claude.zsh"
+}
+
+generate_fish() {
+  cat "${SCRIPT_DIR}/claude.fish"
+}
+
+case "${1:-}" in
+  bash)
+    generate_bash
+    ;;
+  zsh)
+    generate_zsh
+    ;;
+  fish)
+    generate_fish
+    ;;
+  *)
+    echo "Usage: $(basename "$0") <bash|zsh|fish>" >&2
+    echo "" >&2
+    echo "Generate shell completion scripts for Claude Code CLI." >&2
+    echo "" >&2
+    echo "Installation:" >&2
+    echo "  # Bash — add to ~/.bashrc:" >&2
+    echo '  eval "$(claude completion bash)"' >&2
+    echo "" >&2
+    echo "  # Zsh — add to ~/.zshrc:" >&2
+    echo '  eval "$(claude completion zsh)"' >&2
+    echo "" >&2
+    echo "  # Fish — save to completions directory:" >&2
+    echo "  claude completion fish > ~/.config/fish/completions/claude.fish" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

- Add shell completion scripts for bash, zsh, and fish in `scripts/completions/`
- Add `generate-completions.sh` wrapper that outputs the appropriate script for each shell
- Covers all subcommands (`auth`, `mcp`, `plugin`, `install`, `doctor`, `setup-token`, `update`), nested subcommands (e.g. `mcp add`, `plugin marketplace list`), global flags, and option value completions

### Installation

```bash
# Bash — add to ~/.bashrc:
eval "$(claude completion bash)"

# Zsh — add to ~/.zshrc:
eval "$(claude completion zsh)"

# Fish — save to completions directory:
claude completion fish > ~/.config/fish/completions/claude.fish
```

### UX pattern

The `claude completion <shell>` pattern follows established CLI conventions:
- **GitHub CLI**: `gh completion -s bash`
- **pnpm**: `pnpm completion bash`
- **volta**: `volta completions bash`

The internal CLI already has completion infrastructure (shell detection, cache file management at `~/.claude/completion.*`, and a registered `completion` subcommand) — these scripts provide the actual completion definitions that the existing plumbing can serve.

### Validation

All scripts pass syntax checks:
- `bash -n claude.bash` — valid
- `zsh -n claude.zsh` — valid
- Fish syntax follows the same patterns used by the fish community

Closes #7738