### PR TITLE
fix: correct worktree handling bugs in clean_gone command

### DIFF
--- a/plugins/commit-commands/commands/clean_gone.md
+++ b/plugins/commit-commands/commands/clean_gone.md
@@ -25,12 +25,12 @@ You need to execute the following bash commands to clean up stale local branches
 3. **Finally, remove worktrees and delete [gone] branches (handles both regular and worktree branches)**
    Execute this command:
    ```bash
-   # Process all [gone] branches, removing '+' prefix if present
-   git branch -v | grep '\[gone\]' | sed 's/^[+* ]//' | awk '{print $1}' | while read branch; do
+   # Process all [gone] branches, removing the 2-character prefix (+/*/space + space)
+   git branch -v | grep '\[gone\]' | sed 's/^.\{2\}//' | awk '{print $1}' | while read branch; do
      echo "Processing branch: $branch"
-     # Find and remove worktree if it exists
-     worktree=$(git worktree list | grep "\\[$branch\\]" | awk '{print $1}')
-     if [ ! -z "$worktree" ] && [ "$worktree" != "$(git rev-parse --show-toplevel)" ]; then
+     # Find and remove worktree if it exists (use -F for literal string matching)
+     worktree=$(git worktree list | grep -F "[$branch]" | awk '{print $1}')
+     if [ -n "$worktree" ] && [ "$worktree" != "$(git rev-parse --show-toplevel)" ]; then
        echo "  Removing worktree: $worktree"
        git worktree remove --force "$worktree"
      fi


### PR DESCRIPTION
## Summary

- **sed prefix stripping**: `sed 's/^[+* ]//'` only removed 1 character of the 2-character `git branch -v` prefix (`+ `, `* `, or `  `), leaving a stray leading space. Fixed to `sed 's/^.\{2\}//'` which correctly strips both characters.
- **grep regex injection**: `grep "\\[$branch\\]"` treated the branch name as a regex pattern — branch names containing `.`, `*`, `[`, `]`, etc. would silently match wrong entries or error out. Fixed to `grep -F "[$branch]"` for literal fixed-string matching.
- **Deprecated empty-check**: Replaced `[ ! -z "$worktree" ]` with idiomatic `[ -n "$worktree" ]`.

## Changes

| Line | Bug | Fix |
|------|-----|-----|
| 29 | `sed 's/^[+* ]//'` removed only 1 char of the 2-char `git branch -v` prefix | `sed 's/^.\{2\}//'` removes exactly 2 characters |
| 32 | `grep "\\[$branch\\]"` treated branch name as regex — names with `.`, `*`, `[` etc. would break or match incorrectly | `grep -F "[$branch]"` does literal fixed-string matching |
| 33 | `[ ! -z "$worktree" ]` — negated deprecated test | `[ -n "$worktree" ]` — idiomatic non-empty check |

## Impact

The most critical bug was **grep regex injection** (line 32). If a branch name contained regex metacharacters, the worktree lookup would silently match the wrong entry or error out, potentially removing the wrong worktree or skipping cleanup entirely. The sed bug (line 29) was masked by `awk` skipping leading whitespace downstream, but made the pipeline fragile and incorrect.

## Test plan

- [ ] Run `/clean_gone` on a repo with branches marked `[gone]` that have associated worktrees
- [ ] Verify branches with special characters in names (e.g. `fix/v1.0`, `feature[test]`) are handled correctly
- [ ] Confirm worktrees are correctly identified and removed before branch deletion