### PR TITLE
DOCS: Create `CONTRIBUTING.md` with contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing
+
+Thanks for your interest in contributing. This repository primarily contains documentation and helper scripts for Claude Code.
+
+To set expectations clearly: **we do not accept code changes from external contributors**, and **only staff members’ pull requests are eligible for review and merge**.
+
+## Questions, corrections, and requests
+
+If you have a question, spot an error, or want to suggest an improvement, please **open an** [**issue**](https://github.com/anthropics/claude-code/issues) instead.
+
+## Security / sensitive information
+
+Please do not file public issues or pull requests for security-sensitive reports or confidential information. Visit our [Security](https://github.com/anthropics/claude-code/security) page for more information.


### PR DESCRIPTION
It's considered best practice to include contributing guidelines for a repository that accepts pull requests, and failure to do so can impact your repository's [Community health score](https://github.com/anthropics/claude-code/community).

Looking at the closed PRs tab, one notices that almost all PRs that have been merged in recent months have been from Anthropic staff.

There are perfectly valid reasons to not accept external contributions. But it's important to make one's policy clear.

I found a statement from @rboyce-ant  from last year, which says:

> This repo is primarily intended for bug reports via issues. We'll review PRs to the small amount of code in .devcontainer but its primary purpose is to serve as an example for other users setting up devcontainers, not to be a general purpose solution. So we don't expect external contributor pull requests to this repo to be common.

The amount of code in this repository has grown somewhat since that statement was made, but I don't think the implicit policy has changed much. It's obvious by looking up that external contributor pull requests are not entirely UNcommon.  You would be doing a great kindness to other developers by simply making this policy explicit in a public document, such as I'm sure you all know is considered a matter of basic repository hygiene.

I hope you will give this matter some thought.
