### PR TITLE
fix: batch actionable community PR fixes

### DIFF
--- a/plugins/commit-commands/commands/clean_gone.md
+++ b/plugins/commit-commands/commands/clean_gone.md
@@ -25,12 +25,12 @@ You need to execute the following bash commands to clean up stale local branches
 3. **Finally, remove worktrees and delete [gone] branches (handles both regular and worktree branches)**
    Execute this command:
    ```bash
-   # Process all [gone] branches, removing '+' prefix if present
-   git branch -v | grep '\[gone\]' | sed 's/^[+* ]//' | awk '{print $1}' | while read branch; do
+   # Process all [gone] branches, removing the two-character branch marker prefix
+   git branch -v | grep '\[gone\]' | sed 's/^.\{2\}//' | awk '{print $1}' | while read -r branch; do
      echo "Processing branch: $branch"
      # Find and remove worktree if it exists
-     worktree=$(git worktree list | grep "\\[$branch\\]" | awk '{print $1}')
-     if [ ! -z "$worktree" ] && [ "$worktree" != "$(git rev-parse --show-toplevel)" ]; then
+     worktree=$(git worktree list | grep -F "[$branch]" | awk '{print $1}')
+     if [ -n "$worktree" ] && [ "$worktree" != "$(git rev-parse --show-toplevel)" ]; then
        echo "  Removing worktree: $worktree"
        git worktree remove --force "$worktree"
      fi
@@ -50,4 +50,3 @@ After executing these commands, you will:
 - Provide feedback on which worktrees and branches were removed
 
 If no branches are marked as [gone], report that no cleanup was needed.
-

--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -6,8 +6,8 @@ import sys
 from functools import lru_cache
 from typing import List, Dict, Any, Optional
 
-# Import from local module
-from hookify.core.config_loader import Rule, Condition
+# Import from sibling module to support versioned plugin cache layouts
+from core.config_loader import Rule, Condition
 
 
 # Cache compiled regexes (max 128 patterns)
@@ -275,7 +275,7 @@ class RuleEngine:
 
 # For testing
 if __name__ == '__main__':
-    from hookify.core.config_loader import Condition, Rule
+    from core.config_loader import Condition, Rule
 
     # Test rule evaluation
     rule = Rule(

--- a/plugins/hookify/hooks/posttooluse.py
+++ b/plugins/hookify/hooks/posttooluse.py
@@ -19,8 +19,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)

--- a/plugins/hookify/hooks/pretooluse.py
+++ b/plugins/hookify/hooks/pretooluse.py
@@ -23,8 +23,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     # If imports fail, allow operation and log error
     error_msg = {"systemMessage": f"Hookify import error: {e}"}

--- a/plugins/hookify/hooks/stop.py
+++ b/plugins/hookify/hooks/stop.py
@@ -19,8 +19,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)

--- a/plugins/hookify/hooks/userpromptsubmit.py
+++ b/plugins/hookify/hooks/userpromptsubmit.py
@@ -19,8 +19,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)

--- a/plugins/plugin-dev/skills/command-development/references/frontmatter-reference.md
+++ b/plugins/plugin-dev/skills/command-development/references/frontmatter-reference.md
@@ -267,6 +267,77 @@ argument-hint: [test-pattern] [options]
 Run tests matching $1 with options: $2
 ```
 
+### name
+
+**Type:** String
+**Required:** No
+**Default:** Derived from the filename (without `.md` extension) or folder name
+
+**Purpose:** Override the command or skill name displayed in menus.
+
+**Examples:**
+```yaml
+name: deploy
+```
+```yaml
+name: review-pr
+```
+
+### user-invocable
+
+**Type:** Boolean
+**Required:** No
+**Default:** `true` for skills in `/skills/` directories
+
+**Purpose:** Control whether the skill appears in the slash command menu. Set to `false` to hide from the menu while keeping the skill available for programmatic use.
+
+**Examples:**
+```yaml
+user-invocable: false  # Hide from slash command menu
+```
+
+### context
+
+**Type:** String
+**Required:** No
+**Default:** Runs in the current conversation context
+
+**Purpose:** Control the execution context. Use `fork` to run in a forked sub-agent context, isolating it from the main conversation.
+
+**Examples:**
+```yaml
+context: fork
+```
+
+### agent
+
+**Type:** String
+**Required:** No
+
+**Purpose:** Specify that this command should run as a named agent.
+
+**Examples:**
+```yaml
+agent: code-reviewer
+```
+
+### hooks
+
+**Type:** Object
+**Required:** No
+
+**Purpose:** Define lifecycle hooks (PreToolUse, PostToolUse, Stop) scoped to this command or skill.
+
+**Examples:**
+```yaml
+hooks:
+  PreToolUse:
+    - matcher: Edit
+      hooks:
+        - type: command
+          command: "echo 'About to edit a file'"
+```
+
 ### disable-model-invocation
 
 **Type:** Boolean


### PR DESCRIPTION
## Summary

This PR batches three high-confidence fixes from currently open community submissions and applies them together:

1. **Hookify import-path fix** (from #27796)
   - Switches `hookify.core.*` imports to `core.*` in hook scripts and rule engine
   - Fixes `No module named 'hookify'` when plugin is loaded from versioned cache paths

2. **`/clean_gone` worktree handling fix** (from #27605)
   - Removes the full two-character branch marker prefix from `git branch -v`
   - Uses `grep -F` for literal worktree branch matching
   - Uses `-n` idiomatic non-empty check and `read -r` in loop

3. **Missing frontmatter field docs** (from #27717)
   - Adds `name`, `user-invocable`, `context`, `agent`, and `hooks` to command frontmatter reference

## Validation

- `python -m py_compile` on all modified hookify Python files
- Local hookify smoke test in both layouts:
  - versioned cache layout (`.../hookify/0.1.0/...`)
  - workspace layout (`plugins/hookify/...`)
- All hook entry points return `{}` for benign payloads in both layouts

## Notes

This intentionally consolidates three small fixes into one mergeable patch to reduce review overhead and move open PR backlog items forward.
