### PR TITLE
[IV-280847d8] Fix incorrect Python import paths in hookify plugin hook scripts

### DIFF
--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -7,7 +7,7 @@ from functools import lru_cache
 from typing import List, Dict, Any, Optional
 
 # Import from local module
-from hookify.core.config_loader import Rule, Condition
+from core.config_loader import Rule, Condition
 
 
 # Cache compiled regexes (max 128 patterns)
@@ -275,7 +275,7 @@ class RuleEngine:
 
 # For testing
 if __name__ == '__main__':
-    from hookify.core.config_loader import Condition, Rule
+    from core.config_loader import Condition, Rule
 
     # Test rule evaluation
     rule = Rule(

--- a/plugins/hookify/hooks/posttooluse.py
+++ b/plugins/hookify/hooks/posttooluse.py
@@ -19,8 +19,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)

--- a/plugins/hookify/hooks/pretooluse.py
+++ b/plugins/hookify/hooks/pretooluse.py
@@ -23,8 +23,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     # If imports fail, allow operation and log error
     error_msg = {"systemMessage": f"Hookify import error: {e}"}

--- a/plugins/hookify/hooks/stop.py
+++ b/plugins/hookify/hooks/stop.py
@@ -19,8 +19,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)

--- a/plugins/hookify/hooks/userpromptsubmit.py
+++ b/plugins/hookify/hooks/userpromptsubmit.py
@@ -19,8 +19,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)


### PR DESCRIPTION
## Summary

The hookify plugin fails with `No module named 'hookify'` on every hook invocation. The hook scripts and `core/rule_engine.py` use absolute package imports (`from hookify.core.config_loader import ...`) that assume a `hookify` subdirectory exists. However, when Claude Code sets `CLAUDE_PLUGIN_ROOT` to the plugin root directory (e.g., `.../hookify/0.1.0/`), the plugin root IS the hookify directory — there is no nested `hookify/` package inside it. Adding the parent dir to sys.path doesn't help because the parent is the plugins cache, not a Python package root containing a `hookify` module.

The fix is to change all imports from `from hookify.core.X import Y` to `from core.X import Y` in all affected files. The hook scripts already add `PLUGIN_ROOT` to `sys.path`, so `from core.config_loader import ...` will resolve correctly.

**Files to fix:**
- `plugins/hookify/hooks/userpromptsubmit.py` — 2 imports
- `plugins/hookify/hooks/pretooluse.py` — 2 imports
- `plugins/hookify/hooks/posttooluse.py` — 2 imports
- `plugins/hookify/hooks/stop.py` — 2 imports
- `plugins/hookify/core/rule_engine.py` — 2 imports (top-level + `__main__` block)

## Commits

- 4a0b732 fix: correct Python import paths in hookify plugin hook scripts

---

:robot: Generated by Intern Village