### PR TITLE
fix: Add PermissionRequest hook workaround for piped command permissions (#11775)

### DIFF
--- a/examples/hooks/piped_command_permission_fix.py
+++ b/examples/hooks/piped_command_permission_fix.py
@@ -13,6 +13,12 @@ This PermissionRequest hook intercepts Bash permission prompts, checks if the
 command is a simple pipeline where each segment's base command is in an allowed
 list, and auto-approves if all segments match.
 
+Allowed commands are automatically read from Bash() permission rules in:
+  ~/.claude/settings.json
+  ~/.claude/settings.local.json
+  .claude/settings.json
+  .claude/settings.local.json
+
 Installation
 ------------
 Add to your .claude/settings.json or .claude/settings.local.json:
@@ -32,77 +38,45 @@ Add to your .claude/settings.json or .claude/settings.local.json:
     ]
   }
 }
-
-Configuration
--------------
-Edit ALLOWED_PREFIXES below to match the command prefixes you have whitelisted
-in your permissions.allow rules. For example, if your settings include:
-
-  "permissions": { "allow": ["Bash(ls:*)", "Bash(awk:*)"] }
-
-Then set: ALLOWED_PREFIXES = {"ls", "awk"}
 """
 
 import json
-import shlex
+import re
 import sys
-
-# ============================================================================
-# CONFIGURE THIS: Set of command prefixes that are individually whitelisted
-# in your permissions.allow rules. Add any commands you have allowed via
-# Bash(<command>:*) rules.
-# ============================================================================
-ALLOWED_PREFIXES: set[str] = {
-    "ls",
-    "awk",
-    "grep",
-    "egrep",
-    "fgrep",
-    "cat",
-    "head",
-    "tail",
-    "sort",
-    "wc",
-    "cut",
-    "tr",
-    "sed",
-    "find",
-    "xargs",
-    "echo",
-    "printf",
-    "tee",
-    "uniq",
-    "diff",
-    "comm",
-    "paste",
-    "column",
-    "basename",
-    "dirname",
-    "realpath",
-    "stat",
-    "file",
-    "du",
-    "df",
-    "date",
-    "env",
-    "which",
-    "whoami",
-    "id",
-    "uname",
-    "strings",
-    "od",
-    "hexdump",
-    "xxd",
-    "jq",
-    "yq",
-    "rg",
-    "ag",
-    "tree",
-}
+from pathlib import Path
 
 # Characters/patterns that indicate the command is more complex than a
 # simple pipeline and should go through normal security review.
 DANGEROUS_PATTERNS = ["&&", "||", "$(", "`", ";", "<<"]
+
+# Regex to extract the command name from Bash() permission rules.
+# Matches patterns like: Bash(cmd:*), Bash(cmd:args), Bash(cmd)
+_BASH_RULE_RE = re.compile(r"^Bash\(([^:)]+)")
+
+
+def load_allowed_prefixes() -> set[str]:
+    """Load allowed command prefixes from Claude settings files."""
+    prefixes: set[str] = set()
+
+    settings_paths = [
+        Path.home() / ".claude" / "settings.json",
+        Path.home() / ".claude" / "settings.local.json",
+        Path(".claude") / "settings.json",
+        Path(".claude") / "settings.local.json",
+    ]
+
+    for path in settings_paths:
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+
+        for rule in data.get("permissions", {}).get("allow", []):
+            m = _BASH_RULE_RE.match(rule)
+            if m:
+                prefixes.add(m.group(1))
+
+    return prefixes
 
 
 def is_simple_pipeline(command: str) -> bool:
@@ -129,7 +103,7 @@ def extract_base_command(segment: str) -> str | None:
     return None
 
 
-def all_segments_allowed(command: str) -> bool:
+def all_segments_allowed(command: str, allowed: set[str]) -> bool:
     """Check if all pipe segments have allowed base commands."""
     segments = command.split("|")
 
@@ -137,7 +111,7 @@ def all_segments_allowed(command: str) -> bool:
         base_cmd = extract_base_command(segment)
         if base_cmd is None:
             return False
-        if base_cmd not in ALLOWED_PREFIXES:
+        if base_cmd not in allowed:
             return False
 
     return True
@@ -165,8 +139,12 @@ def main():
     if not is_simple_pipeline(command):
         sys.exit(0)
 
+    allowed = load_allowed_prefixes()
+    if not allowed:
+        sys.exit(0)
+
     # Check if all pipe segments have allowed base commands
-    if all_segments_allowed(command):
+    if all_segments_allowed(command, allowed):
         # All segments are individually allowed - auto-approve
         result = {
             "hookSpecificOutput": {

--- a/examples/hooks/piped_command_permission_fix.py
+++ b/examples/hooks/piped_command_permission_fix.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+Claude Code Hook: Piped Command Permission Fix
+================================================
+Workaround for https://github.com/anthropics/claude-code/issues/11775
+
+When both commands in a piped command (e.g., `ls | awk`) are individually
+whitelisted in settings.json under permissions.allow, the Plan agent still
+prompts for permission. This is a regression where a security check on the
+full compound command overrides per-segment validation.
+
+This PermissionRequest hook intercepts Bash permission prompts, checks if the
+command is a simple pipeline where each segment's base command is in an allowed
+list, and auto-approves if all segments match.
+
+Installation
+------------
+Add to your .claude/settings.json or .claude/settings.local.json:
+
+{
+  "hooks": {
+    "PermissionRequest": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /path/to/piped_command_permission_fix.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+
+Configuration
+-------------
+Edit ALLOWED_PREFIXES below to match the command prefixes you have whitelisted
+in your permissions.allow rules. For example, if your settings include:
+
+  "permissions": { "allow": ["Bash(ls:*)", "Bash(awk:*)"] }
+
+Then set: ALLOWED_PREFIXES = {"ls", "awk"}
+"""
+
+import json
+import shlex
+import sys
+
+# ============================================================================
+# CONFIGURE THIS: Set of command prefixes that are individually whitelisted
+# in your permissions.allow rules. Add any commands you have allowed via
+# Bash(<command>:*) rules.
+# ============================================================================
+ALLOWED_PREFIXES: set[str] = {
+    "ls",
+    "awk",
+    "grep",
+    "egrep",
+    "fgrep",
+    "cat",
+    "head",
+    "tail",
+    "sort",
+    "wc",
+    "cut",
+    "tr",
+    "sed",
+    "find",
+    "xargs",
+    "echo",
+    "printf",
+    "tee",
+    "uniq",
+    "diff",
+    "comm",
+    "paste",
+    "column",
+    "basename",
+    "dirname",
+    "realpath",
+    "stat",
+    "file",
+    "du",
+    "df",
+    "date",
+    "env",
+    "which",
+    "whoami",
+    "id",
+    "uname",
+    "strings",
+    "od",
+    "hexdump",
+    "xxd",
+    "jq",
+    "yq",
+    "rg",
+    "ag",
+    "tree",
+}
+
+# Characters/patterns that indicate the command is more complex than a
+# simple pipeline and should go through normal security review.
+DANGEROUS_PATTERNS = ["&&", "||", "$(", "`", ";", "<<"]
+
+
+def is_simple_pipeline(command: str) -> bool:
+    """Check if a command is a simple pipeline (only pipes, no other operators)."""
+    for pattern in DANGEROUS_PATTERNS:
+        if pattern in command:
+            return False
+    return "|" in command
+
+
+def extract_base_command(segment: str) -> str | None:
+    """Extract the base command from a pipe segment."""
+    segment = segment.strip()
+    if not segment:
+        return None
+
+    # Handle env var prefixes like FOO=bar cmd
+    parts = segment.split()
+    for part in parts:
+        if "=" in part and not part.startswith("-"):
+            continue
+        return part
+
+    return None
+
+
+def all_segments_allowed(command: str) -> bool:
+    """Check if all pipe segments have allowed base commands."""
+    segments = command.split("|")
+
+    for segment in segments:
+        base_cmd = extract_base_command(segment)
+        if base_cmd is None:
+            return False
+        if base_cmd not in ALLOWED_PREFIXES:
+            return False
+
+    return True
+
+
+def main():
+    try:
+        input_data = json.load(sys.stdin)
+    except json.JSONDecodeError as e:
+        print(f"Error: Invalid JSON input: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Bash":
+        # Not a Bash command, let normal flow handle it
+        sys.exit(0)
+
+    tool_input = input_data.get("tool_input", {})
+    command = tool_input.get("command", "")
+
+    if not command:
+        sys.exit(0)
+
+    # Only handle simple pipelines
+    if not is_simple_pipeline(command):
+        sys.exit(0)
+
+    # Check if all pipe segments have allowed base commands
+    if all_segments_allowed(command):
+        # All segments are individually allowed - auto-approve
+        result = {
+            "hookSpecificOutput": {
+                "hookEventName": "PermissionRequest",
+                "decision": {
+                    "behavior": "allow",
+                    "updatedInput": tool_input,
+                },
+            }
+        }
+        json.dump(result, sys.stdout)
+        sys.exit(0)
+
+    # Not all segments are allowed, let normal permission flow handle it
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds a `PermissionRequest` hook example (`examples/hooks/piped_command_permission_fix.py`) that works around the regression where the Plan agent prompts for permission on piped commands even when both individual commands are whitelisted in `settings.json`
- The hook intercepts Bash permission requests, checks if the command is a simple pipeline where each segment's base command is in a configurable allowed list, and auto-approves if all segments match
- Includes safety checks to reject commands with dangerous patterns (`&&`, `||`, `$(`, backticks, `;`, `<<`)

## Root Cause Analysis
The regression was introduced in v2.1.7's security fix ("Fixed security vulnerability where wildcard permission rules could match compound commands containing shell operators"). In the permission checking flow:

1. `FXq` (pipe handler) correctly splits the piped command, validates each segment individually, and returns `"allow"`
2. After `FXq` returns, `jF` (bash security checker) runs on the **original compound command** and flags the pipe operator
3. This overrides the `"allow"` result back to `"ask"`, causing the permission prompt

The proper source-level fix would be to skip the `jF` security check when `FXq` has already validated all pipe segments individually (i.e., when `decisionReason.type === "subcommandResults"`), since the security of each segment has already been verified.

## Test plan
- [ ] Install the hook in `.claude/settings.json` per the docstring instructions
- [ ] Configure `ALLOWED_PREFIXES` to match your `permissions.allow` rules
- [ ] Run a piped command like `ls -lh *.webp | awk '{print $5, $9}'` with both `ls` and `awk` whitelisted
- [ ] Verify the Plan agent no longer prompts for permission on the piped command
- [ ] Verify that piped commands with non-whitelisted commands still prompt for permission
- [ ] Verify that commands with dangerous patterns (`&&`, `||`, etc.) are not auto-approved

Fixes #11775