### PR TITLE
feat: add automated issue triage and weekly digest via Claude API

### DIFF
--- a/.github/claude-triage/README.md
+++ b/.github/claude-triage/README.md
@@ -1,0 +1,82 @@
+# claude-code-triage
+
+Automated issue triage and weekly digest for `anthropics/claude-code`, powered by Claude.
+
+## What it does
+
+**Issue triage** (`issues.opened` trigger):
+- Applies labels from Anthropic's taxonomy (area, type, platform, API, priority)
+- Posts a structured triage comment with summary and reasoning
+- Detects potential duplicate issues
+- Flags issues that need more information
+
+**Weekly digest** (Monday 9am UTC + `workflow_dispatch`):
+- Summarizes the past 7 days of issues and PRs
+- Highlights P0/P1 issues needing attention
+- Creates a new digest issue and closes the previous one
+
+## Cost
+
+| Operation | Model | Est. cost |
+|-----------|-------|-----------|
+| Per issue triage | Haiku 4.5 | ~$0.001 |
+| Weekly digest | Sonnet 4.6 | ~$0.05 |
+| **Monthly total** (50 issues/wk) | | **~$0.25** |
+
+## Setup
+
+1. Add `ANTHROPIC_API_KEY` to your repository secrets
+2. Copy this directory to `.github/claude-triage/` in your repo
+3. Copy the workflow files to `.github/workflows/`
+
+The workflows use `secrets.GITHUB_TOKEN` (auto-provided by Actions) for GitHub operations — no additional GitHub token required.
+
+## Configuration
+
+Override defaults via environment variables in the workflow:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TRIAGE_MODEL` | `claude-haiku-4-5-20251001` | Model for per-issue triage |
+| `DIGEST_MODEL` | `claude-sonnet-4-6` | Model for weekly digest |
+| `ANTHROPIC_BASE_URL` | _(Anthropic default)_ | Override for compatible endpoints |
+| `DIGEST_DAYS` | `7` | Days to include in digest |
+
+## Design principles
+
+- **Labels are suggestions only** — maintainers retain full control, bot adds labels additively
+- **No destructive permissions** — `issues: write` only (label, comment, create/close issues)
+- **Bot-skip guard** — `if: github.actor != 'github-actions[bot]'` prevents infinite loops
+- **Endpoint-agnostic** — `ANTHROPIC_BASE_URL` swap enables alternative providers
+- **Zero build step** — `tsx` runs TypeScript directly in CI, no compiled artifacts
+
+## Local development
+
+```bash
+pnpm install
+
+# Triage a specific issue (read-only token will fail on write ops but validates fetch + LLM)
+ISSUE_NUMBER=27790 GITHUB_TOKEN=<token> ANTHROPIC_API_KEY=<key> pnpm triage
+
+# Generate digest
+GITHUB_TOKEN=<token> ANTHROPIC_API_KEY=<key> pnpm digest
+
+# Typecheck
+pnpm typecheck
+
+# Test Kimi endpoint compatibility
+ANTHROPIC_BASE_URL=https://api.kimi.com/coding/ ANTHROPIC_API_KEY=<kimi-key> ISSUE_NUMBER=27790 GITHUB_TOKEN=<token> pnpm triage
+```
+
+## Architecture
+
+```
+src/
+├── github.ts    # Octokit helpers: fetch, label, comment, search
+├── llm.ts       # Anthropic SDK wrapper with base URL override
+├── prompts.ts   # Label taxonomy, prompt builders, TriageResult type
+├── triage.ts    # Entry point: ISSUE_NUMBER → labels + comment
+└── digest.ts    # Entry point: past N days → weekly digest issue
+```
+
+Inspired by [`duanyytop/agents-radar`](https://github.com/duanyytop/agents-radar), which independently triage'd claude-code issue #27790 as P1 — more precisely than the affected users themselves.

--- a/.github/claude-triage/package.json
+++ b/.github/claude-triage/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "claude-code-triage",
+  "type": "module",
+  "scripts": {
+    "triage": "tsx src/triage.ts",
+    "digest": "tsx src/digest.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.39.0",
+    "@octokit/rest": "^21.0.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.0",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/.github/claude-triage/src/digest.ts
+++ b/.github/claude-triage/src/digest.ts
@@ -1,0 +1,94 @@
+/**
+ * digest.ts — Entry point for weekly digest generation
+ *
+ * Env vars:
+ *   GITHUB_TOKEN        — GitHub token with issues:write
+ *   ANTHROPIC_API_KEY   — Anthropic API key
+ *   GITHUB_REPOSITORY   — "owner/repo" (set automatically in Actions)
+ *   ANTHROPIC_BASE_URL  — Optional: override Anthropic base URL (e.g. Kimi)
+ *   DIGEST_MODEL        — Optional: override digest model
+ *   DIGEST_DAYS         — Optional: number of days to look back (default: 7)
+ */
+
+import { createClient, fetchRecentItems } from "./github.js";
+import { generateDigest } from "./llm.js";
+import { DIGEST_SYSTEM_PROMPT, buildDigestUserPrompt } from "./prompts.js";
+import { Octokit } from "@octokit/rest";
+
+const REPO = process.env.GITHUB_REPOSITORY ?? "anthropics/claude-code";
+const [OWNER, REPO_NAME] = REPO.split("/");
+const DAYS = parseInt(process.env.DIGEST_DAYS ?? "7", 10);
+const DIGEST_LABEL = "weekly-digest";
+
+async function closePreviousDigests(
+  client: Octokit,
+  owner: string,
+  repo: string,
+  currentNumber: number
+): Promise<void> {
+  const { data: openIssues } = await client.issues.listForRepo({
+    owner,
+    repo,
+    state: "open",
+    labels: DIGEST_LABEL,
+    per_page: 20,
+  });
+
+  for (const issue of openIssues) {
+    if (issue.number !== currentNumber) {
+      await client.issues.update({
+        owner,
+        repo,
+        issue_number: issue.number,
+        state: "closed",
+      });
+      console.log(`Closed previous digest #${issue.number}`);
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const client = createClient();
+
+  // Step 1: Fetch recent activity
+  const dateRange = `${new Date(Date.now() - DAYS * 24 * 60 * 60 * 1000).toISOString().split("T")[0]} – ${new Date().toISOString().split("T")[0]}`;
+  console.log(`Fetching activity for ${OWNER}/${REPO_NAME} over past ${DAYS} days (${dateRange})...`);
+
+  const { issues, pullRequests } = await fetchRecentItems(
+    client,
+    OWNER,
+    REPO_NAME,
+    DAYS
+  );
+
+  console.log(`Found ${issues.length} issues and ${pullRequests.length} PRs`);
+
+  // Step 2: Generate digest via LLM
+  console.log("Generating digest...");
+  const userPrompt = buildDigestUserPrompt(issues, pullRequests, DAYS);
+  const digestBody = await generateDigest(DIGEST_SYSTEM_PROMPT, userPrompt);
+
+  // Step 3: Create digest issue
+  const title = `Weekly Claude Code Community Digest — ${dateRange}`;
+  console.log(`Creating digest issue: "${title}"`);
+
+  const { data: newIssue } = await client.issues.create({
+    owner: OWNER,
+    repo: REPO_NAME,
+    title,
+    body: digestBody,
+    labels: [DIGEST_LABEL],
+  });
+
+  console.log(`Created digest issue #${newIssue.number}: ${newIssue.html_url}`);
+
+  // Step 4: Close previous digest issues (keep only latest)
+  await closePreviousDigests(client, OWNER, REPO_NAME, newIssue.number);
+
+  console.log("Digest complete.");
+}
+
+main().catch((err) => {
+  console.error("Digest failed:", err);
+  process.exit(1);
+});

--- a/.github/claude-triage/src/github.ts
+++ b/.github/claude-triage/src/github.ts
@@ -1,0 +1,174 @@
+import { Octokit } from "@octokit/rest";
+
+export interface GitHubIssue {
+  number: number;
+  title: string;
+  body: string | null;
+  state: string;
+  labels: string[];
+  created_at: string;
+  html_url: string;
+  user: string | null;
+}
+
+export interface GitHubPR {
+  number: number;
+  title: string;
+  body: string | null;
+  state: string;
+  merged_at: string | null;
+  created_at: string;
+  html_url: string;
+  user: string | null;
+}
+
+export interface RecentItems {
+  issues: GitHubIssue[];
+  pullRequests: GitHubPR[];
+}
+
+export interface DuplicateCandidate {
+  number: number;
+  title: string;
+  html_url: string;
+  state: string;
+  created_at: string;
+}
+
+export function createClient(): Octokit {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) throw new Error("GITHUB_TOKEN environment variable is required");
+  return new Octokit({ auth: token });
+}
+
+export async function fetchIssue(
+  client: Octokit,
+  owner: string,
+  repo: string,
+  number: number
+): Promise<GitHubIssue> {
+  const { data } = await client.issues.get({ owner, repo, issue_number: number });
+  return {
+    number: data.number,
+    title: data.title,
+    body: data.body ?? null,
+    state: data.state,
+    labels: (data.labels ?? []).map((l) =>
+      typeof l === "string" ? l : (l.name ?? "")
+    ),
+    created_at: data.created_at,
+    html_url: data.html_url,
+    user: data.user?.login ?? null,
+  };
+}
+
+export async function fetchRecentItems(
+  client: Octokit,
+  owner: string,
+  repo: string,
+  days: number
+): Promise<RecentItems> {
+  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+
+  // Fetch issues (excluding PRs)
+  const issuePages = await client.paginate(client.issues.listForRepo, {
+    owner,
+    repo,
+    state: "all",
+    since,
+    per_page: 100,
+  });
+
+  const issues: GitHubIssue[] = issuePages
+    .filter((item) => !item.pull_request)
+    .map((item) => ({
+      number: item.number,
+      title: item.title,
+      body: item.body ?? null,
+      state: item.state,
+      labels: (item.labels ?? []).map((l) =>
+        typeof l === "string" ? l : (l.name ?? "")
+      ),
+      created_at: item.created_at,
+      html_url: item.html_url,
+      user: item.user?.login ?? null,
+    }));
+
+  // Fetch PRs
+  const prPages = await client.paginate(client.pulls.list, {
+    owner,
+    repo,
+    state: "all",
+    per_page: 100,
+  });
+
+  const cutoff = new Date(since);
+  const pullRequests: GitHubPR[] = prPages
+    .filter((pr) => new Date(pr.created_at) >= cutoff)
+    .map((pr) => ({
+      number: pr.number,
+      title: pr.title,
+      body: pr.body ?? null,
+      state: pr.state,
+      merged_at: pr.merged_at ?? null,
+      created_at: pr.created_at,
+      html_url: pr.html_url,
+      user: pr.user?.login ?? null,
+    }));
+
+  return { issues, pullRequests };
+}
+
+export async function searchDuplicates(
+  client: Octokit,
+  owner: string,
+  repo: string,
+  title: string,
+  body: string | null
+): Promise<DuplicateCandidate[]> {
+  // Build search query from title keywords (strip special chars for GH search)
+  const keywords = title
+    .replace(/[^\w\s]/g, " ")
+    .split(/\s+/)
+    .filter((w) => w.length > 3)
+    .slice(0, 6)
+    .join(" ");
+
+  const query = `repo:${owner}/${repo} is:issue ${keywords}`;
+
+  const { data } = await client.search.issuesAndPullRequests({
+    q: query,
+    per_page: 5,
+  });
+
+  return data.items
+    .filter((item) => !("pull_request" in item))
+    .map((item) => ({
+      number: item.number,
+      title: item.title,
+      html_url: item.html_url,
+      state: item.state,
+      created_at: item.created_at,
+    }));
+}
+
+export async function addLabels(
+  client: Octokit,
+  owner: string,
+  repo: string,
+  number: number,
+  labels: string[]
+): Promise<void> {
+  if (labels.length === 0) return;
+  await client.issues.addLabels({ owner, repo, issue_number: number, labels });
+}
+
+export async function postComment(
+  client: Octokit,
+  owner: string,
+  repo: string,
+  number: number,
+  body: string
+): Promise<void> {
+  await client.issues.createComment({ owner, repo, issue_number: number, body });
+}

--- a/.github/claude-triage/src/llm.ts
+++ b/.github/claude-triage/src/llm.ts
@@ -1,0 +1,51 @@
+import Anthropic from "@anthropic-ai/sdk";
+
+// Cost-optimized model selection:
+// Haiku for per-issue triage (~$0.001/issue at volume)
+// Sonnet for weekly digest synthesis (~$0.05/week)
+const TRIAGE_MODEL =
+  process.env.TRIAGE_MODEL ?? "claude-haiku-4-5-20251001";
+const DIGEST_MODEL =
+  process.env.DIGEST_MODEL ?? "claude-sonnet-4-6";
+
+// ANTHROPIC_BASE_URL handled natively by SDK — Kimi swap = 1 env var
+function createClient(): Anthropic {
+  return new Anthropic({
+    apiKey: process.env.ANTHROPIC_API_KEY,
+    ...(process.env.ANTHROPIC_BASE_URL
+      ? { baseURL: process.env.ANTHROPIC_BASE_URL }
+      : {}),
+  });
+}
+
+export async function triageIssue(
+  systemPrompt: string,
+  userContent: string
+): Promise<string> {
+  const client = createClient();
+  const message = await client.messages.create({
+    model: TRIAGE_MODEL,
+    max_tokens: 1024,
+    system: systemPrompt,
+    messages: [{ role: "user", content: userContent }],
+  });
+  const block = message.content[0];
+  if (block.type !== "text") throw new Error("Unexpected non-text response");
+  return block.text;
+}
+
+export async function generateDigest(
+  systemPrompt: string,
+  userContent: string
+): Promise<string> {
+  const client = createClient();
+  const message = await client.messages.create({
+    model: DIGEST_MODEL,
+    max_tokens: 4096,
+    system: systemPrompt,
+    messages: [{ role: "user", content: userContent }],
+  });
+  const block = message.content[0];
+  if (block.type !== "text") throw new Error("Unexpected non-text response");
+  return block.text;
+}

--- a/.github/claude-triage/src/prompts.ts
+++ b/.github/claude-triage/src/prompts.ts
@@ -1,0 +1,266 @@
+import type { DuplicateCandidate } from "./github.js";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface TriageResult {
+  labels: string[];
+  priority: "P0" | "P1" | "P2";
+  summary: string;
+  category: string;
+  area: string;
+  platform: string;
+  api_provider: string;
+  has_repro: boolean;
+  needs_info: boolean;
+  reasoning: string;
+}
+
+export interface DuplicateMatch {
+  number: number;
+  title: string;
+  url: string;
+  confidence: "high" | "medium" | "low";
+  reasoning: string;
+}
+
+// ── Label taxonomy (mirrors anthropics/claude-code) ───────────────────────
+
+export const AREA_LABELS = [
+  "area:agent-sdk",
+  "area:mcp",
+  "area:tools",
+  "area:hooks",
+  "area:ide-integrations",
+  "area:context-window",
+  "area:memory",
+  "area:performance",
+  "area:permissions",
+  "area:plugins",
+  "area:terminal",
+  "area:network",
+  "area:claude-desktop",
+  "area:bedrock",
+  "area:vertex",
+] as const;
+
+export const TYPE_LABELS = ["bug", "enhancement", "question", "needs-info"] as const;
+export const PLATFORM_LABELS = ["platform:linux", "platform:macos", "platform:windows"] as const;
+export const API_LABELS = ["api:anthropic", "api:bedrock", "api:vertex"] as const;
+export const PRIORITY_LABELS = ["P0", "P1", "P2"] as const;
+
+// ── System prompts ─────────────────────────────────────────────────────────
+
+export const TRIAGE_SYSTEM_PROMPT = `You are an expert issue triager for the anthropics/claude-code repository.
+Your job is to analyze GitHub issues and return a structured triage result as JSON.
+
+## Label taxonomy
+
+**Area labels** (pick the most relevant one or two):
+${AREA_LABELS.join(", ")}
+
+**Type labels** (pick exactly one):
+${TYPE_LABELS.join(", ")}
+
+**Platform labels** (include if mentioned or inferable):
+${PLATFORM_LABELS.join(", ")}
+
+**API labels** (include if the issue involves a specific API backend):
+${API_LABELS.join(", ")}
+
+**Priority** (pick exactly one):
+- P0: crash, security vulnerability, data loss, or complete feature breakage with no workaround
+- P1: significant functionality broken, no reasonable workaround, affects many users
+- P2: minor bug, cosmetic issue, enhancement request, or has a workaround
+
+## Output format
+
+Respond with ONLY valid JSON (no markdown fences, no explanation):
+{
+  "labels": ["bug", "area:performance", "platform:macos"],
+  "priority": "P1",
+  "summary": "One sentence describing the issue",
+  "category": "Human-readable category (e.g. 'Fast Action Bug', 'MCP Connection Error')",
+  "area": "primary area label value (e.g. 'area:performance')",
+  "platform": "platform label if applicable, else empty string",
+  "api_provider": "api label if applicable, else empty string",
+  "has_repro": true,
+  "needs_info": false,
+  "reasoning": "2-3 sentences explaining priority and label choices"
+}
+
+## Triage guidelines
+
+- Mark \`needs_info: true\` when the issue lacks version, OS, repro steps, or error output
+- \`has_repro: true\` when issue includes concrete repro steps or error output
+- P0 only for crashes, security issues, or complete data loss
+- P1 for things that break a core workflow without workaround
+- Default to P2 for enhancements and minor issues
+- Always include the type label (bug/enhancement/question/needs-info)`;
+
+export const DUPLICATE_CHECK_SYSTEM_PROMPT = `You are evaluating whether GitHub issues are duplicates.
+Given a new issue and a list of candidate existing issues, determine which (if any) are likely duplicates.
+Respond with ONLY valid JSON (no markdown fences):
+{
+  "duplicates": [
+    {
+      "number": 123,
+      "title": "exact title from candidates",
+      "url": "https://github.com/...",
+      "confidence": "high",
+      "reasoning": "Both describe the same fast-action edit-without-read problem"
+    }
+  ]
+}
+Only include candidates with medium or high confidence. Return empty array if no duplicates found.`;
+
+export const DIGEST_SYSTEM_PROMPT = `You are a technical writer generating a weekly digest for the anthropics/claude-code repository.
+Your audience is Anthropic engineers and maintainers. Write in clear, professional English.
+
+Structure your digest as a GitHub issue body using this exact format:
+
+# Weekly Claude Code Community Digest — {date range}
+
+## Highlights
+- [2-4 bullet points: most important things that happened]
+
+## Needs Attention
+Issues that are P0 or P1 and still open (or recently reported):
+| Issue | Priority | Summary | Reported |
+|-------|----------|---------|----------|
+| #N [title](url) | P0/P1 | brief desc | date |
+
+## Bug Reports ({count} new)
+| Issue | Area | Platform | Has Repro | Summary |
+|-------|------|----------|-----------|---------|
+| #N [title](url) | area | platform | ✅/❌ | summary |
+
+## Enhancement Requests ({count} new)
+| Issue | Area | Summary |
+|-------|------|---------|
+| #N [title](url) | area | summary |
+
+## Merged PRs ({count})
+| PR | Summary | Author |
+|----|---------|--------|
+| #N [title](url) | summary | @user |
+
+## Trends & Patterns
+[2-4 sentences about patterns you notice: recurring issues, hot areas, user pain points]
+
+## Stats
+| Metric | Count |
+|--------|-------|
+| New issues | N |
+| Closed issues | N |
+| Open P0/P1 | N |
+| Merged PRs | N |
+| Contributors | N |
+
+---
+*Generated by claude-code-triage · Model: {model} · [Source](https://github.com/anthropics/claude-code/tree/main/.github/claude-triage)*`;
+
+// ── Prompt builders ────────────────────────────────────────────────────────
+
+export function buildTriageUserPrompt(
+  number: number,
+  title: string,
+  body: string | null
+): string {
+  return `Issue #${number}: ${title}
+
+${body ?? "(no body provided)"}`;
+}
+
+export function buildDuplicateCheckUserPrompt(
+  newTitle: string,
+  newBody: string | null,
+  candidates: DuplicateCandidate[]
+): string {
+  return `New issue: "${newTitle}"
+Body: ${newBody?.slice(0, 500) ?? "(no body)"}
+
+Candidate existing issues:
+${candidates
+  .map(
+    (c) =>
+      `- #${c.number} [${c.state}] "${c.title}" (${c.html_url}) opened ${c.created_at}`
+  )
+  .join("\n")}`;
+}
+
+export function buildDigestUserPrompt(
+  issues: Array<{ number: number; title: string; body: string | null; state: string; labels: string[]; created_at: string; html_url: string; user: string | null }>,
+  pullRequests: Array<{ number: number; title: string; body: string | null; state: string; merged_at: string | null; created_at: string; html_url: string; user: string | null }>,
+  days: number
+): string {
+  const issueLines = issues
+    .map(
+      (i) =>
+        `#${i.number} [${i.state}] "${i.title}" labels=[${i.labels.join(",")}] opened=${i.created_at} url=${i.html_url} author=${i.user ?? "unknown"}`
+    )
+    .join("\n");
+
+  const prLines = pullRequests
+    .map(
+      (pr) =>
+        `#${pr.number} [${pr.state}${pr.merged_at ? " merged" : ""}] "${pr.title}" opened=${pr.created_at} url=${pr.html_url} author=${pr.user ?? "unknown"}`
+    )
+    .join("\n");
+
+  return `Generate a weekly digest for the past ${days} days.
+
+ISSUES (${issues.length} total):
+${issueLines || "(none)"}
+
+PULL REQUESTS (${pullRequests.length} total):
+${prLines || "(none)"}`;
+}
+
+// ── Comment formatters ─────────────────────────────────────────────────────
+
+export function formatTriageComment(
+  result: TriageResult,
+  duplicates: DuplicateMatch[]
+): string {
+  const rows = [
+    ["Priority", `**${result.priority}**`],
+    ["Category", result.category],
+    ["Area", result.area || "—"],
+    ["Platform", result.platform || "—"],
+    ["API Provider", result.api_provider || "—"],
+    ["Has Repro", result.has_repro ? "✅ Yes" : "❌ No"],
+    ["Needs Info", result.needs_info ? "⚠️ Yes" : "No"],
+  ];
+
+  const table = [
+    "| Field | Value |",
+    "|-------|-------|",
+    ...rows.map(([k, v]) => `| ${k} | ${v} |`),
+  ].join("\n");
+
+  let comment = `### Automated Triage
+
+${table}
+
+**Summary:** ${result.summary}
+
+**Reasoning:** ${result.reasoning}`;
+
+  if (result.needs_info) {
+    comment += `\n\n> [!NOTE]\n> This issue appears to be missing information needed to reproduce or investigate. Could you please provide: version (\`claude --version\`), OS/platform, minimal repro steps, and any error output?`;
+  }
+
+  if (duplicates.length > 0) {
+    const dupLines = duplicates
+      .map(
+        (d) =>
+          `- [#${d.number} ${d.title}](${d.url}) — ${d.confidence} confidence: ${d.reasoning}`
+      )
+      .join("\n");
+    comment += `\n\n**Possible duplicates:**\n${dupLines}`;
+  }
+
+  comment += `\n\n---\n*Automated triage by [claude-code-triage](https://github.com/anthropics/claude-code/tree/main/.github/claude-triage) · Labels are suggestions only — maintainers have final say.*`;
+
+  return comment;
+}

--- a/.github/claude-triage/src/triage.ts
+++ b/.github/claude-triage/src/triage.ts
@@ -1,0 +1,115 @@
+/**
+ * triage.ts — Entry point for single-issue triage
+ *
+ * Env vars:
+ *   GITHUB_TOKEN        — GitHub token with issues:write
+ *   ANTHROPIC_API_KEY   — Anthropic API key
+ *   ISSUE_NUMBER        — Issue number to triage
+ *   GITHUB_REPOSITORY   — "owner/repo" (set automatically in Actions)
+ *   ANTHROPIC_BASE_URL  — Optional: override Anthropic base URL (e.g. Kimi)
+ *   TRIAGE_MODEL        — Optional: override triage model
+ */
+
+import {
+  createClient,
+  fetchIssue,
+  searchDuplicates,
+  addLabels,
+  postComment,
+} from "./github.js";
+import { triageIssue } from "./llm.js";
+import {
+  TRIAGE_SYSTEM_PROMPT,
+  DUPLICATE_CHECK_SYSTEM_PROMPT,
+  buildTriageUserPrompt,
+  buildDuplicateCheckUserPrompt,
+  formatTriageComment,
+  type TriageResult,
+  type DuplicateMatch,
+} from "./prompts.js";
+
+const REPO = process.env.GITHUB_REPOSITORY ?? "anthropics/claude-code";
+const [OWNER, REPO_NAME] = REPO.split("/");
+
+async function main(): Promise<void> {
+  const issueNumberStr = process.env.ISSUE_NUMBER;
+  if (!issueNumberStr) throw new Error("ISSUE_NUMBER environment variable is required");
+  const issueNumber = parseInt(issueNumberStr, 10);
+  if (isNaN(issueNumber)) throw new Error(`Invalid ISSUE_NUMBER: ${issueNumberStr}`);
+
+  const client = createClient();
+
+  // Step 1: Fetch the issue
+  console.log(`Fetching issue #${issueNumber} from ${OWNER}/${REPO_NAME}...`);
+  const issue = await fetchIssue(client, OWNER, REPO_NAME, issueNumber);
+  console.log(`Issue: "${issue.title}"`);
+
+  // Step 2: LLM triage
+  console.log("Running LLM triage...");
+  const userPrompt = buildTriageUserPrompt(issue.number, issue.title, issue.body);
+  const rawResult = await triageIssue(TRIAGE_SYSTEM_PROMPT, userPrompt);
+
+  let triageResult: TriageResult;
+  try {
+    triageResult = JSON.parse(rawResult) as TriageResult;
+  } catch {
+    throw new Error(`LLM returned invalid JSON:\n${rawResult}`);
+  }
+
+  console.log(
+    `Triage result: ${triageResult.priority} | ${triageResult.category} | labels: ${triageResult.labels.join(", ")}`
+  );
+
+  // Step 3: Duplicate detection
+  console.log("Searching for duplicates...");
+  const candidates = await searchDuplicates(
+    client,
+    OWNER,
+    REPO_NAME,
+    issue.title,
+    issue.body
+  );
+
+  let duplicates: DuplicateMatch[] = [];
+  if (candidates.length > 0) {
+    const dupUserPrompt = buildDuplicateCheckUserPrompt(
+      issue.title,
+      issue.body,
+      candidates
+    );
+    const rawDupResult = await triageIssue(DUPLICATE_CHECK_SYSTEM_PROMPT, dupUserPrompt);
+    try {
+      const parsed = JSON.parse(rawDupResult) as { duplicates: DuplicateMatch[] };
+      duplicates = parsed.duplicates ?? [];
+    } catch {
+      console.warn("Duplicate check returned invalid JSON, skipping");
+    }
+  }
+
+  if (duplicates.length > 0) {
+    console.log(`Found ${duplicates.length} potential duplicate(s)`);
+  }
+
+  // Step 4: Apply labels
+  const labelsToApply = [
+    ...triageResult.labels,
+    triageResult.priority,
+    ...(triageResult.has_repro ? ["has repro"] : []),
+    ...(triageResult.needs_info ? ["needs-info"] : []),
+  ];
+
+  console.log(`Applying labels: ${labelsToApply.join(", ")}`);
+  await addLabels(client, OWNER, REPO_NAME, issueNumber, labelsToApply);
+
+  // Step 5: Post triage comment
+  const comment = formatTriageComment(triageResult, duplicates);
+  console.log("Posting triage comment...");
+  await postComment(client, OWNER, REPO_NAME, issueNumber, comment);
+
+  console.log(`Done. Issue #${issueNumber} triaged as ${triageResult.priority}.`);
+}
+
+main().catch((err) => {
+  console.error("Triage failed:", err);
+  process.exit(1);
+});

--- a/.github/claude-triage/tsconfig.json
+++ b/.github/claude-triage/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,41 @@
+name: Issue Triage
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  triage:
+    name: Triage issue with Claude
+    runs-on: ubuntu-latest
+    # Skip bot-created issues to avoid infinite loops
+    if: github.actor != 'github-actions[bot]'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install dependencies
+        working-directory: .github/claude-triage
+        run: pnpm install --frozen-lockfile
+
+      - name: Run triage
+        working-directory: .github/claude-triage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: pnpm triage

--- a/.github/workflows/weekly-digest.yml
+++ b/.github/workflows/weekly-digest.yml
@@ -1,0 +1,46 @@
+name: Weekly Digest
+
+on:
+  schedule:
+    # Every Monday at 9am UTC
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "Number of days to look back (default: 7)"
+        required: false
+        default: "7"
+
+permissions:
+  issues: write
+
+jobs:
+  digest:
+    name: Generate weekly digest with Claude
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install dependencies
+        working-directory: .github/claude-triage
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate digest
+        working-directory: .github/claude-triage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          DIGEST_DAYS: ${{ github.event.inputs.days || '7' }}
+        run: pnpm digest


### PR DESCRIPTION
## Summary

- Haiku 4.5 for per-issue triage (~\$0.001/issue), Sonnet 4.6 for weekly digest (~\$0.05/week) — ~\$0.25/month total at typical volume
- Labels are additive suggestions only — maintainers retain full control
- `ANTHROPIC_BASE_URL` override support built in (endpoint-agnostic via SDK constructor)

## What it does

**Issue triage** (triggers on `issues.opened`):
- Applies labels from Anthropic's full taxonomy (area, type, platform, API, priority P0/P1/P2)
- Posts a structured triage comment with summary, reasoning, and needs-info callout
- Detects potential duplicate issues via GitHub search + LLM confirmation

**Weekly digest** (Monday 9am UTC + `workflow_dispatch`):
- Summarizes past 7 days of issues and PRs
- Highlights P0/P1 issues needing attention
- Creates a new digest issue, closes the previous one

## Design

- **No build step** — `tsx` runs TypeScript directly in CI
- **Bot-skip guard** — `if: github.actor != 'github-actions[bot]'` prevents loops
- **Single secret** — only `ANTHROPIC_API_KEY` required (`GITHUB_TOKEN` is auto-provided)
- **No destructive permissions** — `issues: write` only

## Inspiration

Inspired by [duanyytop/agents-radar](https://github.com/duanyytop/agents-radar), which independently triage'd our own claude-code issue (reported as #27790) as P1 — more precisely than the affected users, ourselves included. We are grateful for the elegance of their simple solution, and honored to offer it back to the broader Anthropic community.

The architecture is theirs: TypeScript + `tsx` + `@anthropic-ai/sdk` with `ANTHROPIC_BASE_URL` override. We adapted it into English, extended the label taxonomy, and added the weekly digest. The core insight — that Claude can triage Claude's own community feedback — belongs to them.

## Test plan

- [ ] Typecheck passes: `pnpm typecheck`
- [ ] Dry-run triage against a real issue with read-only token (validates fetch + LLM, fails gracefully on write)
- [ ] Workflow dispatch on weekly digest
- [ ] Confirm labels are additive (no existing labels removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)