### PR TITLE
docs: clarify Windows install command requires PowerShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ For more installation options, uninstall steps, and troubleshooting, see the [se
     ```
 
     **Windows (Recommended):**
+    > Run in **PowerShell**
     ```powershell
     irm https://claude.ai/install.ps1 | iex
     ```
@@ -43,7 +44,7 @@ For more installation options, uninstall steps, and troubleshooting, see the [se
     npm install -g @anthropic-ai/claude-code
     ```
 
-2. Navigate to your project directory and run `claude`.
+3. Navigate to your project directory and run `claude`.
 
 ## Plugins
 


### PR DESCRIPTION
Adds a visible note under the Windows (Recommended) install section indicating the command must be run in PowerShell, not Command Prompt.

The ```powershell code fence language tag is not visible when rendered on GitHub, so users running the command in cmd.exe receive a "'irm' is not recognized" error with no obvious explanation.