### PR TITLE
fix(hookify): use typing.Tuple for Python 3.8 compatibility

### DIFF
--- a/plugins/hookify/core/config_loader.py
+++ b/plugins/hookify/core/config_loader.py
@@ -8,7 +8,7 @@ import os
 import sys
 import glob
 import re
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Tuple
 from dataclasses import dataclass, field
 
 
@@ -84,7 +84,7 @@ class Rule:
         )
 
 
-def extract_frontmatter(content: str) -> tuple[Dict[str, Any], str]:
+def extract_frontmatter(content: str) -> Tuple[Dict[str, Any], str]:
     """Extract YAML frontmatter and message body from markdown.
 
     Returns (frontmatter_dict, message_body).


### PR DESCRIPTION
## Summary

- Lowercase `tuple[Dict[str, Any], str]` type hint in `config_loader.py` requires Python 3.9+ (PEP 585)
- On Python 3.8, importing the hookify plugin raises `TypeError: 'type' object is not subscriptable`
- Changed to `Tuple` from `typing` module, consistent with existing imports in the file (`List`, `Dict`, `Optional`)

## Changes

- `plugins/hookify/core/config_loader.py` line 11: added `Tuple` to typing imports
- `plugins/hookify/core/config_loader.py` line 87: `tuple[...]` → `Tuple[...]`

## Test plan

- [ ] `python3.8 -c "from hookify.core.config_loader import extract_frontmatter"` — no TypeError
- [ ] Run existing `if __name__ == '__main__'` self-test in config_loader.py
- [ ] Verify no behavior change on Python 3.9+

Fixes #14588