### PR TITLE
fix(security-guidance): normalize backslashes in path checks for Windows

### DIFF
--- a/plugins/security-guidance/hooks/security_reminder_hook.py
+++ b/plugins/security-guidance/hooks/security_reminder_hook.py
@@ -182,8 +182,9 @@ def save_state(session_id, shown_warnings):
 
 def check_patterns(file_path, content):
     """Check if file path or content matches any security patterns."""
-    # Normalize path by removing leading slashes
-    normalized_path = file_path.lstrip("/")
+    # Normalize path: remove leading slashes and convert backslashes to forward slashes
+    # (Windows paths use backslashes, but path_check lambdas use forward slashes)
+    normalized_path = file_path.lstrip("/").replace("\\", "/")
 
     for pattern in SECURITY_PATTERNS:
         # Check path-based patterns


### PR DESCRIPTION
## Summary

- On Windows, file paths use backslashes (`.github\workflows\ci.yml`)
- The `path_check` lambda checks for `.github/workflows/` with forward slashes
- Result: security reminder for GitHub Actions workflow editing was **silently skipped for all Windows users**
- Fix: normalize `\` → `/` in `check_patterns()` alongside existing leading-slash normalization

## Changes

- `plugins/security-guidance/hooks/security_reminder_hook.py` line 186: added `.replace("\\", "/")` to path normalization

The `replace()` is a no-op on Linux/macOS where paths already use forward slashes.

## Test plan

- [ ] Feed hook JSON with `file_path: ".github\workflows\ci.yml"` — should trigger GitHub Actions security warning
- [ ] Feed hook JSON with `file_path: ".github/workflows/ci.yml"` — should still trigger (no regression)
- [ ] Feed hook JSON with `file_path: "C:\project\.github\workflows\deploy.yaml"` — should trigger
- [ ] Feed hook JSON with `file_path: "src/main.py"` — should NOT trigger path-based rule

Fixes #18508