### PR TITLE
fix(hookify): search both project and home directories for rule files

### DIFF
--- a/plugins/hookify/core/config_loader.py
+++ b/plugins/hookify/core/config_loader.py
@@ -207,8 +207,20 @@ def load_rules(event: Optional[str] = None) -> List[Rule]:
     rules = []
 
     # Find all hookify.*.local.md files
-    pattern = os.path.join('.claude', 'hookify.*.local.md')
-    files = glob.glob(pattern)
+    # Search project-level rules (current working directory)
+    project_pattern = os.path.join('.claude', 'hookify.*.local.md')
+    files = glob.glob(project_pattern)
+
+    # Search home-level rules (~/.claude/)
+    home_dir = os.path.expanduser('~')
+    home_pattern = os.path.join(home_dir, '.claude', 'hookify.*.local.md')
+    home_files = glob.glob(home_pattern)
+
+    # Add home rules, dedup by absolute path (handles cwd == home)
+    seen = set(os.path.abspath(f) for f in files)
+    for f in home_files:
+        if os.path.abspath(f) not in seen:
+            files.append(f)
 
     for file_path in files:
         try:


### PR DESCRIPTION
## Summary

- `load_rules()` uses `glob.glob('.claude/hookify.*.local.md')` — a relative path from cwd
- When Claude Code runs in a project directory (which is always), global rules in `~/.claude/` are silently ignored
- Users creating rules in `~/.claude/hookify.*.local.md` see them never loaded

## Changes

- `plugins/hookify/core/config_loader.py` lines 209-211: search both project-level (`.claude/`) and home-level (`~/.claude/`) directories
- Deduplicate by `os.path.abspath()` to handle the edge case where cwd is the home directory

## Test plan

- [ ] Create `~/.claude/hookify.test-global.local.md` with a valid rule
- [ ] Run hookify from a project directory (cwd != home)
- [ ] Verify the global rule is loaded and evaluated
- [ ] Create same-named file in both `~/.claude/` and `<project>/.claude/` — verify loaded only once
- [ ] Run from home directory — verify no duplicate loading

Fixes #20749