### PR TITLE
fix(security-guidance): output structured JSON so model receives security warnings

### DIFF
--- a/plugins/security-guidance/hooks/security_reminder_hook.py
+++ b/plugins/security-guidance/hooks/security_reminder_hook.py
@@ -268,9 +268,16 @@ def main():
             shown_warnings.add(warning_key)
             save_state(session_id, shown_warnings)
 
-            # Output the warning to stderr and block execution
-            print(reminder, file=sys.stderr)
-            sys.exit(2)  # Block tool execution (exit code 2 for PreToolUse hooks)
+            # Output structured JSON to stdout so the model receives the warning
+            output = {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny"
+                },
+                "systemMessage": reminder
+            }
+            print(json.dumps(output))
+            sys.exit(0)
 
     # Allow tool to proceed
     sys.exit(0)


### PR DESCRIPTION
## Summary

- The security reminder hook wrote plain text warnings to **stderr** with `exit(2)`
- The model (Claude) never received the security warning in its context — it was only visible in the terminal
- The hookify plugin demonstrates the correct pattern: output JSON to **stdout** with `hookSpecificOutput.permissionDecision` and `systemMessage` fields

## Changes

- `plugins/security-guidance/hooks/security_reminder_hook.py` lines 271-273: replaced `print(reminder, file=sys.stderr)` + `sys.exit(2)` with structured JSON output to stdout + `sys.exit(0)`
- The JSON format matches the hookify plugin's established pattern (`rule_engine.py` lines 72-79)

## Before

```python
print(reminder, file=sys.stderr)   # model never sees this
sys.exit(2)
```

## After

```python
output = {
    "hookSpecificOutput": {
        "hookEventName": "PreToolUse",
        "permissionDecision": "deny"
    },
    "systemMessage": reminder        # model receives this
}
print(json.dumps(output))
sys.exit(0)
```

## Test plan

- [ ] Edit a `.github/workflows/*.yml` file — Claude should see the security warning in its context and deny the operation
- [ ] Edit a file containing `eval(` — same behavior
- [ ] Edit the same file again in the same session — warning should NOT repeat (dedup still works)
- [ ] Edit a normal file — should proceed without any output

Fixes #18509