### PR TITLE
docs: clarify excludedCommands requires :* suffix

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -25,6 +25,7 @@ These may be applied at any level of the [settings hierarchy](https://code.claud
 - Settings files must be valid JSON
 - Before deploying configuration files to your organization, test them locally by applying to `managed-settings.json`, `settings.json` or `settings.local.json`
 - The `sandbox` property only applies to the `Bash` tool; it does not apply to other tools (like Read, Write, WebSearch, WebFetch, MCPs), hooks, or internal commands
+- `excludedCommands` entries use the same pattern syntax as permission rules: append `:*` to match a command with any arguments (e.g. `"docker:*"`). Without `:*`, only the bare command with no arguments is matched
 
 ## Full Documentation
 

--- a/examples/settings/settings-bash-sandbox.json
+++ b/examples/settings/settings-bash-sandbox.json
@@ -4,7 +4,7 @@
     "enabled": true,
     "autoAllowBashIfSandboxed": false,
     "allowUnsandboxedCommands": false,
-    "excludedCommands": [],
+    "excludedCommands": ["docker:*"],
     "network": {
       "allowUnixSockets": [],
       "allowAllUnixSockets": false,


### PR DESCRIPTION
## Summary

- Update `excludedCommands` example in `settings-bash-sandbox.json` to use `"docker:*"` instead of empty array
- Add tip to `examples/settings/README.md` explaining that `:*` is required to match commands with arguments

Without `:*`, an entry like `"docker"` only matches the bare command with no arguments — `docker build`, `git push`, etc. are still sandboxed. This is the same pattern syntax used by permission rules but isn't documented for `excludedCommands`.

Workaround identified in https://github.com/anthropics/claude-code/issues/10524#issuecomment-3572948230.

Note: the [official settings docs](https://code.claude.com/docs/en/settings) show `["git", "docker"]` as the example for `excludedCommands`, which has the same problem. That likely needs a separate update on the docs site.

Fixes #17821, fixes #10524. Related: #11481, #29274.