### PR TITLE
Fix commit-commands allowed-tools mismatch

### DIFF
--- a/plugins/commit-commands/commands/commit-push-pr.md
+++ b/plugins/commit-commands/commands/commit-push-pr.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*)
+allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(git diff:*), Bash(git branch:*), Bash(gh pr create:*)
 description: Commit, push, and open a PR
 ---
 

--- a/plugins/commit-commands/commands/commit.md
+++ b/plugins/commit-commands/commands/commit.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*), Bash(git diff:*), Bash(git branch:*), Bash(git log:*)
 description: Create a git commit
 ---
 


### PR DESCRIPTION
## Why
`/commit` in the official `commit-commands` plugin can fail with permission errors because its dynamic context injection runs git commands that are not included in `allowed-tools`.

This is reported in #21642.

## What changed
Updated command frontmatter so each command's `allowed-tools` fully covers the git commands it invokes in inline context blocks.

### `plugins/commit-commands/commands/commit.md`
Added:
- `Bash(git diff:*)`
- `Bash(git branch:*)`
- `Bash(git log:*)`

### `plugins/commit-commands/commands/commit-push-pr.md`
Added:
- `Bash(git diff:*)`
- `Bash(git branch:*)`

## Impact
- Fixes `/commit` permission mismatch.
- Prevents the same class of mismatch in `/commit-push-pr`.

## Related
- Fixes #21642
