### PR TITLE
Constrain dedupe candidates to canonical open issues

### DIFF
--- a/.claude/commands/dedupe.md
+++ b/.claude/commands/dedupe.md
@@ -23,5 +23,14 @@ Notes (be sure to tell this to your agents, too):
   - `./scripts/gh.sh issue view 123 --comments` — view with comments
   - `./scripts/gh.sh issue list --state open --limit 20` — list issues
   - `./scripts/gh.sh search issues "query" --limit 10` — search for issues
+- Hard candidate constraints (required):
+  - Candidate issue must be `open`.
+  - Candidate issue must be older than the base issue.
+  - Candidate issue must NOT be labeled `duplicate`.
+  - Candidate issue must NOT be the base issue itself.
+  - If no candidates satisfy all constraints, do not post a duplicate comment.
+- Prefer canonical candidates:
+  - Prefer issues without lifecycle labels that indicate pending closure (`stale`, `autoclose`).
+  - Prefer issues with clearer reproduction detail and stable discussion context.
 - Do not use other tools, beyond `./scripts/gh.sh` and the comment script (eg. don't use other MCP servers, file edit, etc.)
 - Make a todo list first


### PR DESCRIPTION
## Why
Duplicate-bot suggestions can create noisy/circular duplicate webs and can point to poor canonical targets.

This is described in:
- #19267
- #20282

## What changed
Updated `.claude/commands/dedupe.md` with explicit required candidate constraints before posting duplicate suggestions:

- candidate must be open
- candidate must be older than base issue
- candidate must not be labeled `duplicate`
- candidate must not be the base issue itself
- if no candidates satisfy constraints, do not post duplicate comment

Also added canonical preference guidance to avoid unstable targets (e.g. `stale`/`autoclose`).

## Impact
- Reduces duplicate-of-duplicate chains.
- Prevents suggesting non-canonical or low-signal targets.
- Improves reliability of duplicate comments used by downstream auto-close flow.

## Related
- Addresses #19267
- Addresses #20282
