### PR TITLE
fix: Fix three bugs making hookify plugin non-functional

### DIFF
--- a/plugins/hookify/core/config_loader.py
+++ b/plugins/hookify/core/config_loader.py
@@ -207,7 +207,8 @@ def load_rules(event: Optional[str] = None) -> List[Rule]:
     rules = []
 
     # Find all hookify.*.local.md files
-    pattern = os.path.join('.claude', 'hookify.*.local.md')
+    claude_dir = os.path.join(os.path.expanduser('~'), '.claude')
+    pattern = os.path.join(claude_dir, 'hookify.*.local.md')
     files = glob.glob(pattern)
 
     for file_path in files:

--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -7,7 +7,7 @@ from functools import lru_cache
 from typing import List, Dict, Any, Optional
 
 # Import from local module
-from hookify.core.config_loader import Rule, Condition
+from core.config_loader import Rule, Condition
 
 
 # Cache compiled regexes (max 128 patterns)
@@ -86,8 +86,14 @@ class RuleEngine:
         # If only warnings, show them but allow operation
         if warning_rules:
             messages = [f"**[{r.name}]**\n{r.message}" for r in warning_rules]
+            combined_message = "\n\n".join(messages)
             return {
-                "systemMessage": "\n\n".join(messages)
+                "systemMessage": combined_message,
+                "hookSpecificOutput": {
+                    "hookEventName": hook_event or "PreToolUse",
+                    "permissionDecision": "allow",
+                    "additionalContext": combined_message
+                }
             }
 
         # No matches - allow operation
@@ -275,7 +281,7 @@ class RuleEngine:
 
 # For testing
 if __name__ == '__main__':
-    from hookify.core.config_loader import Condition, Rule
+    from core.config_loader import Condition, Rule
 
     # Test rule evaluation
     rule = Rule(

--- a/plugins/hookify/hooks/posttooluse.py
+++ b/plugins/hookify/hooks/posttooluse.py
@@ -19,8 +19,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)

--- a/plugins/hookify/hooks/pretooluse.py
+++ b/plugins/hookify/hooks/pretooluse.py
@@ -23,8 +23,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     # If imports fail, allow operation and log error
     error_msg = {"systemMessage": f"Hookify import error: {e}"}

--- a/plugins/hookify/hooks/stop.py
+++ b/plugins/hookify/hooks/stop.py
@@ -19,8 +19,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)

--- a/plugins/hookify/hooks/userpromptsubmit.py
+++ b/plugins/hookify/hooks/userpromptsubmit.py
@@ -19,8 +19,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)


### PR DESCRIPTION
## Summary

- **Fix broken Python imports (#28299):** Change `from hookify.core.X` to `from core.X` in all hook scripts and `rule_engine.py`, since `CLAUDE_PLUGIN_ROOT` points directly to the `hookify/` directory and `core/` is a direct child
- **Fix relative path for rule discovery (#20749):** Use `os.path.expanduser('~')` for an absolute path to `~/.claude/` so rules load regardless of CWD
- **Fix warnings not reaching the model (#20747):** Add `hookSpecificOutput` with `additionalContext` to warning responses so the model receives warning messages, not just the UI

Fixes #28299, #20749, #20747

## Test plan

- [x] All 6 modified Python files pass syntax validation (`ast.parse`)
- [x] `from core.config_loader import load_rules, extract_frontmatter, Rule` succeeds from plugin root
- [x] `from core.rule_engine import RuleEngine` succeeds from plugin root
- [ ] Install hookify as a plugin and verify hooks no longer print `Hookify import error: No module named 'hookify'`
- [ ] Create a rule file in `~/.claude/` and verify it loads from a non-`$HOME` working directory
- [ ] Trigger a warning rule and verify the model sees and responds to the warning via `additionalContext`

🤖 Generated with [Claude Code](https://claude.com/claude-code)