### PR TITLE
Fix GitHub Actions shell injection vulnerability

### DIFF
--- a/.github/workflows/claude-dedupe-issues.yml
+++ b/.github/workflows/claude-dedupe-issues.yml
@@ -37,10 +37,11 @@ jobs:
         if: always()
         env:
           STATSIG_API_KEY: ${{ secrets.STATSIG_API_KEY }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+          REPO: ${{ github.repository }}
+          TRIGGERED_BY: ${{ github.event_name }}
+          RUN_ID: ${{ github.run_id }}
         run: |
-          ISSUE_NUMBER=${{ github.event.issue.number || inputs.issue_number }}
-          REPO=${{ github.repository }}
-          
           if [ -z "$STATSIG_API_KEY" ]; then
             echo "STATSIG_API_KEY not found, skipping Statsig logging"
             exit 0
@@ -50,7 +51,7 @@ jobs:
           EVENT_PAYLOAD=$(jq -n \
             --arg issue_number "$ISSUE_NUMBER" \
             --arg repo "$REPO" \
-            --arg triggered_by "${{ github.event_name }}" \
+            --arg triggered_by "$TRIGGERED_BY" \
             '{
               events: [{
                 eventName: "github_duplicate_comment_added",
@@ -59,7 +60,7 @@ jobs:
                   repository: $repo,
                   issue_number: ($issue_number | tonumber),
                   triggered_by: $triggered_by,
-                  workflow_run_id: "${{ github.run_id }}"
+                  workflow_run_id: "'"$RUN_ID"'"
                 },
                 time: (now | floor | tostring)
               }]


### PR DESCRIPTION
- Move all GitHub context variables to env: section
- Use environment variables instead of direct interpolation in shell commands
- Prevents code injection via workflow_dispatch inputs
- Fixes Semgrep ERROR: yaml.github-actions.security.run-shell-injection

This change ensures that user-controlled inputs (like issue_number) and GitHub context variables (repository, event_name, run_id) are safely passed as environment variables rather than being directly interpolated into shell commands, preventing potential command injection attacks.