### PR TITLE
fix: handle unbound PROMPT_PARTS array in ralph-wiggum setup

### DIFF
--- a/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
+++ b/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
@@ -109,8 +109,8 @@ HELP_EOF
   esac
 done
 
-# Join all prompt parts with spaces
-PROMPT="${PROMPT_PARTS[*]}"
+# Join all prompt parts with spaces (use ${PROMPT_PARTS[*]+${PROMPT_PARTS[*]}} to handle empty array under set -u)
+PROMPT="${PROMPT_PARTS[*]+${PROMPT_PARTS[*]}}"
 
 # Validate prompt is non-empty
 if [[ -z "$PROMPT" ]]; then


### PR DESCRIPTION
## Summary
- Fixes `unbound variable` crash in `setup-ralph-loop.sh` when invoking `/ralph-loop`
- The script uses `set -u` (nounset), which causes `${PROMPT_PARTS[*]}` to error when the array is empty
- Uses `${PROMPT_PARTS[*]+${PROMPT_PARTS[*]}}` syntax for safe expansion under `set -u`

## Test plan
- [x] Run `/ralph-loop "test prompt" --max-iterations 2 --completion-promise "DONE"` — activates successfully
- [x] Run `/cancel-ralph` — cancels cleanly
- [x] Previously crashed with: `PROMPT_PARTS[*]: unbound variable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)