### PR TITLE
docs: use lowercase hyphenated format for skill name examples

### DIFF
--- a/plugins/plugin-dev/skills/plugin-structure/SKILL.md
+++ b/plugins/plugin-dev/skills/plugin-structure/SKILL.md
@@ -185,7 +185,7 @@ skills/
 **SKILL.md format**:
 ```markdown
 ---
-name: Skill Name
+name: skill-name
 description: When to use this skill
 version: 1.0.0
 ---

--- a/plugins/plugin-dev/skills/plugin-structure/SKILL.md
+++ b/plugins/plugin-dev/skills/plugin-structure/SKILL.md
@@ -193,6 +193,8 @@ version: 1.0.0
 Skill instructions and guidance...
 ```
 
+> **Note:** The `name` field is used as the slash command trigger (e.g., `name: skill-name` triggers via `/skill-name`). Always use lowercase hyphenated format, not title case with spaces.
+
 **Supporting files**: Skills can include scripts, references, examples, or assets in subdirectories
 
 **Usage**: Claude Code autonomously activates skills based on task context matching the description

--- a/plugins/plugin-dev/skills/skill-development/SKILL.md
+++ b/plugins/plugin-dev/skills/skill-development/SKILL.md
@@ -163,11 +163,13 @@ Also, delete any example files and directories not needed for the skill. Create 
 
 ```yaml
 ---
-name: Skill Name
+name: skill-name
 description: This skill should be used when the user asks to "specific phrase 1", "specific phrase 2", "specific phrase 3". Include exact phrases users would say that should trigger this skill. Be concrete and specific.
 version: 0.1.0
 ---
 ```
+
+> **Note:** The `name` field is used as the slash command trigger (e.g., `name: skill-name` triggers via `/skill-name`). Always use lowercase hyphenated format, not title case with spaces.
 
 **Good description examples:**
 ```yaml
@@ -418,7 +420,7 @@ Before finalizing a skill:
 
 **Structure:**
 - [ ] SKILL.md file exists with valid YAML frontmatter
-- [ ] Frontmatter has `name` and `description` fields
+- [ ] Frontmatter has `name` (lowercase hyphenated) and `description` fields
 - [ ] Markdown body is present and substantial
 - [ ] Referenced files actually exist
 


### PR DESCRIPTION
## Summary

- Fix skill `name` field examples in `plugin-dev` to use lowercase hyphenated format (`skill-name`) instead of title case with spaces (`Skill Name`)
- Add a note explaining that the `name` field is used as the slash command trigger, so it must be lowercase hyphenated
- Update the validation checklist to mention the naming requirement

## Context

Fixes #24556

The `skill-development` and `plugin-structure` skills in the `plugin-dev` plugin showed examples with space-separated title case names in YAML frontmatter (e.g., `name: Skill Name`), but slash command triggering requires lowercase hyphenated format (e.g., `name: skill-name`). Using `name: Skill Name` causes `/skill-name` to fail with "Unknown skill" because only the first word matches.

## Changes

### `plugins/plugin-dev/skills/skill-development/SKILL.md`
- Change frontmatter example from `name: Skill Name` to `name: skill-name`
- Add a note explaining that the `name` field is used as the slash command trigger and must use lowercase hyphenated format
- Update validation checklist to mention the naming requirement: `name` (lowercase hyphenated)

### `plugins/plugin-dev/skills/plugin-structure/SKILL.md`
- Change frontmatter example from `name: Skill Name` to `name: skill-name`

## Test plan

- [ ] Verify the updated examples match the expected naming format
- [ ] Confirm the note is clear about the naming requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)