### PR TITLE
feat: Add push-guardrails plugin to prevent accidental code exposure

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -136,6 +136,17 @@
       "category": "development"
     },
     {
+      "name": "push-guardrails",
+      "description": "Guardrails to prevent accidental exposure of private code to public repositories. Checks repo visibility before push, detects sensitive files before commit, and warns about fork visibility.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Yohei Demachi",
+        "email": "yohei.demachi@example.com"
+      },
+      "source": "./plugins/push-guardrails",
+      "category": "security"
+    },
+    {
       "name": "security-guidance",
       "description": "Security reminder hook that warns about potential security issues when editing files, including command injection, XSS, and unsafe code patterns",
       "version": "1.0.0",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -140,8 +140,7 @@
       "description": "Guardrails to prevent accidental exposure of private code to public repositories. Checks repo visibility before push, detects sensitive files before commit, and warns about fork visibility.",
       "version": "1.0.0",
       "author": {
-        "name": "Yohei Demachi",
-        "email": "yohei.demachi@example.com"
+        "name": "Yohei Demachi"
       },
       "source": "./plugins/push-guardrails",
       "category": "security"

--- a/plugins/push-guardrails/.claude-plugin/plugin.json
+++ b/plugins/push-guardrails/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "push-guardrails",
+  "version": "1.0.0",
+  "description": "Guardrails to prevent accidental exposure of private code to public repositories. Checks repo visibility before push, detects sensitive files before commit, and warns about fork visibility.",
+  "author": {
+    "name": "Yohei Demachi",
+    "email": "yohei.demachi@example.com"
+  }
+}

--- a/plugins/push-guardrails/.claude-plugin/plugin.json
+++ b/plugins/push-guardrails/.claude-plugin/plugin.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "description": "Guardrails to prevent accidental exposure of private code to public repositories. Checks repo visibility before push, detects sensitive files before commit, and warns about fork visibility.",
   "author": {
-    "name": "Yohei Demachi",
-    "email": "yohei.demachi@example.com"
+    "name": "Yohei Demachi"
   }
 }

--- a/plugins/push-guardrails/README.md
+++ b/plugins/push-guardrails/README.md
@@ -1,0 +1,84 @@
+# push-guardrails
+
+Guardrails to prevent accidental exposure of private code to public repositories.
+
+## Problem
+
+Claude Code can unintentionally push proprietary or private files to public repositories. In a [real-world incident](https://github.com/anthropics/claude-code/issues/29225), a user's proprietary trading algorithms were exposed on a public GitHub PR because Claude pushed code without checking repository visibility.
+
+This plugin adds pre-push and pre-commit safety checks to catch these situations before they happen.
+
+## What it does
+
+### 1. Pre-push visibility check
+
+Before `git push` or `gh pr create`, the plugin checks repository visibility via the GitHub API. If the repository is **public**, it:
+
+- Warns that the repo is public and code will be visible to everyone
+- Lists the files that will be pushed
+- Flags any sensitive files in the push
+- Blocks the command until acknowledged
+
+### 2. Fork visibility warning
+
+If the repository is a **fork of a public repo**, the plugin warns that forks of public repos are always public on GitHub. This is a common blind spot — users may think their fork is private.
+
+### 3. Sensitive file detection
+
+Before `git commit` or broad `git add` (e.g., `git add .`, `git add -A`), the plugin checks for sensitive file patterns:
+
+**Credentials & keys:**
+`.env`, `.pem`, `.key`, `.p12`, `.pfx`, `.jks`, `id_rsa`, `id_ed25519`, `id_ecdsa`, `.keystore`, `credentials.*`, `secrets.*`
+
+**API & auth tokens:**
+`api_key`, `token.*`, `auth_token`, `.npmrc`, `.pypirc`, `.netrc`, `.htpasswd`
+
+**Cloud provider configs:**
+`.aws/`, `gcloud*.json`, `kubeconfig`, `terraform.tfvars`
+
+**Application configs:**
+`database.yml`, `wp-config.php`
+
+## Installation
+
+Install via Claude Code:
+
+```
+/install-plugin plugins/push-guardrails
+```
+
+## Commands intercepted
+
+| Command | Check performed |
+|:---|:---|
+| `git push` (all variants) | Repository visibility + sensitive file scan |
+| `gh pr create` | Repository visibility + sensitive file scan |
+| `git commit` | Sensitive file scan on staged files |
+| `git add .` / `git add -A` | Sensitive file scan on files to be staged |
+
+## Behavior
+
+- **First warning per session**: Blocks the command (exit code 2) and shows a detailed warning
+- **Subsequent runs for same repo**: Allows silently (session-based dedup)
+- **Private repos**: No action, immediate pass-through
+- **`gh` CLI not available**: Warns but does not block
+
+## Configuration
+
+### Disable the plugin
+
+Set the environment variable:
+
+```bash
+export PUSH_GUARDRAILS_DISABLED=1
+```
+
+### Debug logging
+
+Debug logs are written to `/tmp/push-guardrails-log.txt`.
+
+## Requirements
+
+- Python 3.6+
+- `gh` CLI (for repository visibility checks) — optional but recommended
+- `git` CLI

--- a/plugins/push-guardrails/README.md
+++ b/plugins/push-guardrails/README.md
@@ -75,7 +75,7 @@ export PUSH_GUARDRAILS_DISABLED=1
 
 ### Debug logging
 
-Debug logs are written to `/tmp/push-guardrails-log.txt`.
+Debug logs are written to `~/.claude/push-guardrails-debug.log`.
 
 ## Requirements
 

--- a/plugins/push-guardrails/hooks/hooks.json
+++ b/plugins/push-guardrails/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "Pre-push and pre-commit guardrails to prevent accidental exposure of private code to public repos",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/push_guardrails.py",
+            "timeout": 15
+          }
+        ],
+        "matcher": "Bash"
+      }
+    ]
+  }
+}

--- a/plugins/push-guardrails/hooks/push_guardrails.py
+++ b/plugins/push-guardrails/hooks/push_guardrails.py
@@ -1,0 +1,543 @@
+#!/usr/bin/env python3
+"""
+Push Guardrails Hook for Claude Code
+
+Prevents accidental exposure of private code to public repositories by:
+1. Checking repository visibility before git push / gh pr create
+2. Detecting sensitive files (credentials, keys, etc.) before git commit
+3. Warning about fork visibility (forks of public repos are always public)
+
+Addresses: https://github.com/anthropics/claude-code/issues/29225
+"""
+
+import json
+import os
+import random
+import re
+import subprocess
+import sys
+from datetime import datetime
+
+# Debug log file
+DEBUG_LOG_FILE = "/tmp/push-guardrails-log.txt"
+
+
+def debug_log(message):
+    """Append debug message to log file with timestamp."""
+    try:
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+        with open(DEBUG_LOG_FILE, "a") as f:
+            f.write(f"[{timestamp}] {message}\n")
+    except Exception:
+        pass
+
+
+# --- Command detection patterns ---
+
+# Commands that push code to remote (need repo visibility check)
+PUSH_PATTERNS = [
+    re.compile(r"\bgit\s+push\b"),
+    re.compile(r"\bgh\s+pr\s+create\b"),
+]
+
+# Commands that stage/commit code (need sensitive file check)
+COMMIT_PATTERNS = [
+    re.compile(r"\bgit\s+commit\b"),
+]
+
+# Broad git add patterns (git add . / git add -A / git add --all)
+ADD_BROAD_PATTERNS = [
+    re.compile(r"\bgit\s+add\s+(-A|--all|\.)\s*$"),
+    re.compile(r"\bgit\s+add\s+(-A|--all|\.)\s*(&|;|\|)"),
+]
+
+# Quick skip: commands that are definitely not git-related
+SKIP_PATTERN = re.compile(
+    r"^\s*(ls|pwd|echo|cat|head|tail|grep|rg|find|mkdir|cd|npm|npx|pip|python|"
+    r"python3|node|cargo|make|curl|wget|which|type|touch|cp|mv|rm|chmod|chown|"
+    r"date|whoami|hostname|uname|df|du|ps|kill|top|htop|brew|apt|yum|dnf)\b"
+)
+
+# --- Sensitive file patterns ---
+
+SENSITIVE_FILE_PATTERNS = [
+    # Credentials and secrets
+    re.compile(r"\.env$"),
+    re.compile(r"\.env\.[a-zA-Z]+$"),
+    re.compile(r"credentials", re.IGNORECASE),
+    re.compile(r"secrets?\.", re.IGNORECASE),
+    re.compile(r"\.pem$"),
+    re.compile(r"\.key$"),
+    re.compile(r"\.p12$"),
+    re.compile(r"\.pfx$"),
+    re.compile(r"\.jks$"),
+    re.compile(r"id_rsa"),
+    re.compile(r"id_ed25519"),
+    re.compile(r"id_ecdsa"),
+    re.compile(r"\.keystore$"),
+    # API and token files
+    re.compile(r"api[_-]?key", re.IGNORECASE),
+    re.compile(r"token\.(json|txt|ya?ml|cfg|ini|xml)$", re.IGNORECASE),
+    re.compile(r"auth[_-]?token", re.IGNORECASE),
+    re.compile(r"\.npmrc$"),
+    re.compile(r"\.pypirc$"),
+    re.compile(r"\.netrc$"),
+    re.compile(r"\.htpasswd$"),
+    # Cloud provider configs
+    re.compile(r"\.aws/"),
+    re.compile(r"gcloud.*\.json$"),
+    re.compile(r"kubeconfig"),
+    re.compile(r"terraform\.tfvars$"),
+    # Database and application config
+    re.compile(r"database\.yml$"),
+    re.compile(r"wp-config\.php$"),
+]
+
+
+# --- Session state management ---
+
+
+def get_state_file(session_id):
+    """Get session-specific state file path."""
+    return os.path.expanduser(
+        f"~/.claude/push_guardrails_state_{session_id}.json"
+    )
+
+
+def cleanup_old_state_files():
+    """Remove state files older than 7 days."""
+    try:
+        state_dir = os.path.expanduser("~/.claude")
+        if not os.path.exists(state_dir):
+            return
+        current_time = datetime.now().timestamp()
+        seven_days_ago = current_time - (7 * 24 * 60 * 60)
+        for filename in os.listdir(state_dir):
+            if filename.startswith("push_guardrails_state_") and filename.endswith(
+                ".json"
+            ):
+                file_path = os.path.join(state_dir, filename)
+                try:
+                    if os.path.getmtime(file_path) < seven_days_ago:
+                        os.remove(file_path)
+                except (OSError, IOError):
+                    pass
+    except Exception:
+        pass
+
+
+def load_state(session_id):
+    """Load the set of already-shown warnings for this session."""
+    state_file = get_state_file(session_id)
+    if os.path.exists(state_file):
+        try:
+            with open(state_file, "r") as f:
+                return set(json.load(f))
+        except (json.JSONDecodeError, IOError):
+            return set()
+    return set()
+
+
+def save_state(session_id, shown_warnings):
+    """Save the set of shown warnings."""
+    state_file = get_state_file(session_id)
+    try:
+        os.makedirs(os.path.dirname(state_file), exist_ok=True)
+        with open(state_file, "w") as f:
+            json.dump(list(shown_warnings), f)
+    except IOError as e:
+        debug_log(f"Failed to save state file: {e}")
+
+
+# --- Helper functions ---
+
+
+def get_repo_info():
+    """Get repository visibility info via gh API.
+
+    Returns:
+        Tuple of (repo_full_name, visibility, is_fork, parent_visibility)
+        or None on failure.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "api",
+                "repos/{owner}/{repo}",
+                "--jq",
+                "[.full_name, .visibility, .fork, .parent.visibility] | @tsv",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            debug_log(f"gh api failed: {result.stderr}")
+            return None
+
+        parts = result.stdout.strip().split("\t")
+        if len(parts) < 3:
+            debug_log(f"Unexpected gh api output: {result.stdout}")
+            return None
+
+        repo_name = parts[0]
+        visibility = parts[1]  # "public" or "private"
+        is_fork = parts[2].lower() == "true"
+        parent_visibility = (
+            parts[3] if len(parts) > 3 and parts[3] not in ("", "null") else None
+        )
+
+        return (repo_name, visibility, is_fork, parent_visibility)
+    except FileNotFoundError:
+        debug_log("gh CLI not found")
+        return None
+    except subprocess.TimeoutExpired:
+        debug_log("gh api timed out")
+        return None
+    except Exception as e:
+        debug_log(f"get_repo_info error: {e}")
+        return None
+
+
+def get_unpushed_files():
+    """Get list of files in unpushed commits.
+
+    Returns:
+        List of file paths, or empty list on failure.
+    """
+    try:
+        # Try upstream tracking branch first
+        result = subprocess.run(
+            [
+                "git",
+                "log",
+                "--name-only",
+                "--pretty=format:",
+                "@{upstream}..HEAD",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            # Try common default branches
+            for default_branch in ["origin/main", "origin/master"]:
+                result = subprocess.run(
+                    [
+                        "git",
+                        "log",
+                        "--name-only",
+                        "--pretty=format:",
+                        f"{default_branch}..HEAD",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                if result.returncode == 0:
+                    break
+            else:
+                return []
+
+        files = [f for f in result.stdout.strip().split("\n") if f.strip()]
+        return list(set(files))
+    except Exception as e:
+        debug_log(f"get_unpushed_files error: {e}")
+        return []
+
+
+def get_staged_files():
+    """Get list of currently staged files.
+
+    Returns:
+        List of staged file paths.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--cached", "--name-only"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            return []
+        return [f for f in result.stdout.strip().split("\n") if f.strip()]
+    except Exception as e:
+        debug_log(f"get_staged_files error: {e}")
+        return []
+
+
+def detect_sensitive_files(file_list):
+    """Check a list of file paths against sensitive patterns.
+
+    Returns:
+        List of file paths that match sensitive patterns.
+    """
+    sensitive = []
+    for filepath in file_list:
+        for pattern in SENSITIVE_FILE_PATTERNS:
+            if pattern.search(filepath):
+                sensitive.append(filepath)
+                break
+    return sensitive
+
+
+# --- Command handlers ---
+
+
+def handle_push_command(command, session_id):
+    """Handle git push / gh pr create commands.
+
+    Checks repository visibility and warns if pushing to a public repo.
+    """
+    repo_info = get_repo_info()
+    if repo_info is None:
+        # Could not determine repo info -- warn but allow
+        print(
+            "[push-guardrails] Could not verify repository visibility. "
+            "Ensure `gh` CLI is installed and authenticated (`gh auth login`).",
+            file=sys.stderr,
+        )
+        sys.exit(0)
+
+    repo_name, visibility, is_fork, parent_visibility = repo_info
+
+    # Private non-fork repos need no checks
+    if visibility != "public" and not is_fork:
+        sys.exit(0)
+
+    # Session-based dedup
+    warning_key = f"push-{repo_name}"
+    shown_warnings = load_state(session_id)
+    if warning_key in shown_warnings:
+        sys.exit(0)
+
+    warnings = []
+
+    # Check 1: Public repo
+    if visibility == "public":
+        warnings.append(
+            "PUBLIC REPOSITORY DETECTED\n"
+            f"  Repository '{repo_name}' is PUBLIC.\n"
+            "  Any code pushed will be visible to everyone on the internet.\n"
+            "  Please verify that no proprietary code, trade secrets, API keys,\n"
+            "  or credentials are included."
+        )
+
+    # Check 2: Fork of a public repo
+    if is_fork and parent_visibility == "public":
+        warnings.append(
+            "PUBLIC FORK DETECTED\n"
+            f"  This repository is a fork of a PUBLIC repository.\n"
+            "  Forks of public repos are always public on GitHub.\n"
+            "  Any code pushed here will be publicly visible."
+        )
+    elif is_fork and visibility == "public":
+        warnings.append(
+            "FORK VISIBILITY WARNING\n"
+            "  This is a fork and it is public.\n"
+            "  Ensure you intend to expose this code publicly."
+        )
+
+    # Check 3: List files that will be exposed
+    if warnings:
+        files_to_push = get_unpushed_files()
+        if files_to_push:
+            sensitive_files = detect_sensitive_files(files_to_push)
+
+            file_summary = "\n".join(f"    - {f}" for f in files_to_push[:20])
+            if len(files_to_push) > 20:
+                file_summary += f"\n    ... and {len(files_to_push) - 20} more files"
+
+            warnings.append(
+                f"FILES TO BE PUSHED ({len(files_to_push)} files):\n{file_summary}"
+            )
+
+            if sensitive_files:
+                sensitive_summary = "\n".join(
+                    f"    - {f}" for f in sensitive_files
+                )
+                warnings.append(
+                    "SENSITIVE FILES DETECTED in push:\n" + sensitive_summary
+                )
+
+    if warnings:
+        shown_warnings.add(warning_key)
+        save_state(session_id, shown_warnings)
+
+        header = "push-guardrails: Push to public repository detected"
+        separator = "=" * len(header)
+        message = f"\n{separator}\n{header}\n{separator}\n\n"
+        message += "\n\n".join(f"WARNING: {w}" for w in warnings)
+        message += (
+            "\n\n"
+            "To proceed, acknowledge the warnings and re-run the push command.\n"
+            "To disable this check, set PUSH_GUARDRAILS_DISABLED=1."
+        )
+
+        print(message, file=sys.stderr)
+        sys.exit(2)  # Block
+
+    sys.exit(0)
+
+
+def handle_commit_command(command, session_id):
+    """Handle git commit commands.
+
+    Checks staged files for sensitive patterns.
+    """
+    staged_files = get_staged_files()
+    if not staged_files:
+        sys.exit(0)
+
+    sensitive_files = detect_sensitive_files(staged_files)
+    if not sensitive_files:
+        sys.exit(0)
+
+    # Session dedup by sensitive file set
+    warning_key = "commit-" + ",".join(sorted(sensitive_files))
+    shown_warnings = load_state(session_id)
+    if warning_key in shown_warnings:
+        sys.exit(0)
+
+    shown_warnings.add(warning_key)
+    save_state(session_id, shown_warnings)
+
+    sensitive_summary = "\n".join(f"  - {f}" for f in sensitive_files)
+    message = (
+        "\n"
+        "======================================================\n"
+        "push-guardrails: Sensitive files detected in staged changes\n"
+        "======================================================\n"
+        "\n"
+        f"WARNING: The following staged files may contain credentials,\n"
+        f"API keys, or proprietary code:\n\n"
+        f"{sensitive_summary}\n\n"
+        "Please verify these files should be committed.\n"
+        "Consider adding them to .gitignore if they contain secrets.\n"
+        "To disable this check, set PUSH_GUARDRAILS_DISABLED=1."
+    )
+
+    print(message, file=sys.stderr)
+    sys.exit(2)  # Block
+
+
+def handle_add_broad_command(command, session_id):
+    """Handle broad git add commands (git add . / git add -A).
+
+    Warns about staging all files which may include sensitive files.
+    """
+    # Check what would be staged
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            sys.exit(0)
+
+        # Parse untracked and modified files
+        files = []
+        for line in result.stdout.strip().split("\n"):
+            if line.strip():
+                # Status is first 2 chars, filename starts at position 3
+                filepath = line[3:].strip()
+                # Handle renames: "old -> new"
+                if " -> " in filepath:
+                    filepath = filepath.split(" -> ")[-1]
+                files.append(filepath)
+
+        sensitive_files = detect_sensitive_files(files)
+        if not sensitive_files:
+            sys.exit(0)
+
+        warning_key = "add-broad-" + ",".join(sorted(sensitive_files))
+        shown_warnings = load_state(session_id)
+        if warning_key in shown_warnings:
+            sys.exit(0)
+
+        shown_warnings.add(warning_key)
+        save_state(session_id, shown_warnings)
+
+        sensitive_summary = "\n".join(f"  - {f}" for f in sensitive_files)
+        message = (
+            "\n"
+            "======================================================\n"
+            "push-guardrails: Sensitive files would be staged\n"
+            "======================================================\n"
+            "\n"
+            f"WARNING: Broad `git add` detected. The following files may\n"
+            f"contain credentials or sensitive data:\n\n"
+            f"{sensitive_summary}\n\n"
+            "Consider staging files individually instead.\n"
+            "To disable this check, set PUSH_GUARDRAILS_DISABLED=1."
+        )
+
+        print(message, file=sys.stderr)
+        sys.exit(2)
+
+    except Exception as e:
+        debug_log(f"handle_add_broad error: {e}")
+        sys.exit(0)
+
+
+# --- Main ---
+
+
+def main():
+    """Main hook function."""
+    # Check if guardrails are disabled
+    if os.environ.get("PUSH_GUARDRAILS_DISABLED", "0") == "1":
+        sys.exit(0)
+
+    # Periodically clean up old state files (10% chance per run)
+    if random.random() < 0.1:
+        cleanup_old_state_files()
+
+    # Read input from stdin
+    try:
+        raw_input = sys.stdin.read()
+        input_data = json.loads(raw_input)
+    except json.JSONDecodeError as e:
+        debug_log(f"JSON decode error: {e}")
+        sys.exit(0)
+
+    # Quick exit if not a Bash tool
+    if input_data.get("tool_name") != "Bash":
+        sys.exit(0)
+
+    command = input_data.get("tool_input", {}).get("command", "")
+    if not command:
+        sys.exit(0)
+
+    # Fast-path skip for non-git commands
+    if SKIP_PATTERN.match(command):
+        sys.exit(0)
+
+    session_id = input_data.get("session_id", "default")
+
+    # Route to appropriate handler (push takes priority)
+    for pattern in PUSH_PATTERNS:
+        if pattern.search(command):
+            handle_push_command(command, session_id)
+            return
+
+    for pattern in ADD_BROAD_PATTERNS:
+        if pattern.search(command):
+            handle_add_broad_command(command, session_id)
+            return
+
+    for pattern in COMMIT_PATTERNS:
+        if pattern.search(command):
+            handle_commit_command(command, session_id)
+            return
+
+    # Not a relevant command
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/push-guardrails/hooks/push_guardrails.py
+++ b/plugins/push-guardrails/hooks/push_guardrails.py
@@ -10,16 +10,19 @@ Prevents accidental exposure of private code to public repositories by:
 Addresses: https://github.com/anthropics/claude-code/issues/29225
 """
 
+import fcntl
+import hashlib
 import json
 import os
-import random
 import re
 import subprocess
 import sys
 from datetime import datetime
 
-# Debug log file
-DEBUG_LOG_FILE = "/tmp/push-guardrails-log.txt"
+# Debug log file (user-specific to avoid conflicts in multi-user environments)
+DEBUG_LOG_FILE = os.path.join(
+    os.path.expanduser("~"), ".claude", "push-guardrails-debug.log"
+)
 
 
 def debug_log(message):
@@ -34,26 +37,32 @@ def debug_log(message):
 
 # --- Command detection patterns ---
 
+# Optional prefix: env vars (FOO=bar), `env`, `command`, `builtin`
+_CMD_PREFIX = r"(?:(?:\w+=\S*\s+)*(?:env\s+|command\s+|builtin\s+)*)"
+# Optional git global options like -C /path, -c key=val, --git-dir=...
+_GIT_OPTS = r"(?:\s+(?:-[Cc]\s+\S+|--git-dir[=\s]\S+|--work-tree[=\s]\S+))*"
+
 # Commands that push code to remote (need repo visibility check)
 PUSH_PATTERNS = [
-    re.compile(r"\bgit\s+push\b"),
-    re.compile(r"\bgh\s+pr\s+create\b"),
+    re.compile(_CMD_PREFIX + r"\bgit" + _GIT_OPTS + r"\s+push\b"),
+    re.compile(_CMD_PREFIX + r"\bgh\s+pr\s+create\b"),
 ]
 
 # Commands that stage/commit code (need sensitive file check)
 COMMIT_PATTERNS = [
-    re.compile(r"\bgit\s+commit\b"),
+    re.compile(_CMD_PREFIX + r"\bgit" + _GIT_OPTS + r"\s+commit\b"),
 ]
 
 # Broad git add patterns (git add . / git add -A / git add --all)
 ADD_BROAD_PATTERNS = [
-    re.compile(r"\bgit\s+add\s+(-A|--all|\.)\s*$"),
-    re.compile(r"\bgit\s+add\s+(-A|--all|\.)\s*(&|;|\|)"),
+    re.compile(_CMD_PREFIX + r"\bgit" + _GIT_OPTS + r"\s+add\s+(-A|--all|\.)(\s|$|&|;|\|)"),
 ]
 
 # Quick skip: commands that are definitely not git-related
+# Only matches when the very first token is a known non-git command
 SKIP_PATTERN = re.compile(
-    r"^\s*(ls|pwd|echo|cat|head|tail|grep|rg|find|mkdir|cd|npm|npx|pip|python|"
+    r"^\s*(?:\w+=\S*\s+)*"
+    r"(ls|pwd|echo|cat|head|tail|grep|rg|find|mkdir|cd|npm|npx|pip|python|"
     r"python3|node|cargo|make|curl|wget|which|type|touch|cp|mv|rm|chmod|chown|"
     r"date|whoami|hostname|uname|df|du|ps|kill|top|htop|brew|apt|yum|dnf)\b"
 )
@@ -105,11 +114,19 @@ def get_state_file(session_id):
 
 
 def cleanup_old_state_files():
-    """Remove state files older than 7 days."""
+    """Remove state files older than 7 days. Runs at most once per day."""
     try:
         state_dir = os.path.expanduser("~/.claude")
         if not os.path.exists(state_dir):
             return
+
+        # Check if cleanup ran recently (within the last 24 hours)
+        marker = os.path.join(state_dir, ".push_guardrails_last_cleanup")
+        if os.path.exists(marker):
+            last_cleanup = os.path.getmtime(marker)
+            if datetime.now().timestamp() - last_cleanup < 86400:
+                return
+
         current_time = datetime.now().timestamp()
         seven_days_ago = current_time - (7 * 24 * 60 * 60)
         for filename in os.listdir(state_dir):
@@ -122,6 +139,10 @@ def cleanup_old_state_files():
                         os.remove(file_path)
                 except (OSError, IOError):
                     pass
+
+        # Update marker
+        with open(marker, "w") as f:
+            f.write("")
     except Exception:
         pass
 
@@ -132,7 +153,11 @@ def load_state(session_id):
     if os.path.exists(state_file):
         try:
             with open(state_file, "r") as f:
-                return set(json.load(f))
+                fcntl.flock(f, fcntl.LOCK_SH)
+                try:
+                    return set(json.load(f))
+                finally:
+                    fcntl.flock(f, fcntl.LOCK_UN)
         except (json.JSONDecodeError, IOError):
             return set()
     return set()
@@ -144,7 +169,11 @@ def save_state(session_id, shown_warnings):
     try:
         os.makedirs(os.path.dirname(state_file), exist_ok=True)
         with open(state_file, "w") as f:
-            json.dump(list(shown_warnings), f)
+            fcntl.flock(f, fcntl.LOCK_EX)
+            try:
+                json.dump(list(shown_warnings), f)
+            finally:
+                fcntl.flock(f, fcntl.LOCK_UN)
     except IOError as e:
         debug_log(f"Failed to save state file: {e}")
 
@@ -307,8 +336,14 @@ def handle_push_command(command, session_id):
     if visibility != "public" and not is_fork:
         sys.exit(0)
 
-    # Session-based dedup
-    warning_key = f"push-{repo_name}"
+    # Get files early so we can include them in the dedup key
+    files_to_push = get_unpushed_files()
+    files_hash = hashlib.sha256(
+        ",".join(sorted(files_to_push)).encode()
+    ).hexdigest()[:12]
+
+    # Session-based dedup (includes file hash so new files trigger re-warning)
+    warning_key = f"push-{repo_name}-{files_hash}"
     shown_warnings = load_state(session_id)
     if warning_key in shown_warnings:
         sys.exit(0)
@@ -341,26 +376,24 @@ def handle_push_command(command, session_id):
         )
 
     # Check 3: List files that will be exposed
-    if warnings:
-        files_to_push = get_unpushed_files()
-        if files_to_push:
-            sensitive_files = detect_sensitive_files(files_to_push)
+    if warnings and files_to_push:
+        sensitive_files = detect_sensitive_files(files_to_push)
 
-            file_summary = "\n".join(f"    - {f}" for f in files_to_push[:20])
-            if len(files_to_push) > 20:
-                file_summary += f"\n    ... and {len(files_to_push) - 20} more files"
+        file_summary = "\n".join(f"    - {f}" for f in files_to_push[:20])
+        if len(files_to_push) > 20:
+            file_summary += f"\n    ... and {len(files_to_push) - 20} more files"
 
-            warnings.append(
-                f"FILES TO BE PUSHED ({len(files_to_push)} files):\n{file_summary}"
+        warnings.append(
+            f"FILES TO BE PUSHED ({len(files_to_push)} files):\n{file_summary}"
+        )
+
+        if sensitive_files:
+            sensitive_summary = "\n".join(
+                f"    - {f}" for f in sensitive_files
             )
-
-            if sensitive_files:
-                sensitive_summary = "\n".join(
-                    f"    - {f}" for f in sensitive_files
-                )
-                warnings.append(
-                    "SENSITIVE FILES DETECTED in push:\n" + sensitive_summary
-                )
+            warnings.append(
+                "SENSITIVE FILES DETECTED in push:\n" + sensitive_summary
+            )
 
     if warnings:
         shown_warnings.add(warning_key)
@@ -493,9 +526,8 @@ def main():
     if os.environ.get("PUSH_GUARDRAILS_DISABLED", "0") == "1":
         sys.exit(0)
 
-    # Periodically clean up old state files (10% chance per run)
-    if random.random() < 0.1:
-        cleanup_old_state_files()
+    # Clean up old state files (runs at most once per day)
+    cleanup_old_state_files()
 
     # Read input from stdin
     try:


### PR DESCRIPTION
## Summary

Adds a new `push-guardrails` plugin that prevents accidental exposure of private code to public repositories. This directly addresses #29225, where a user's proprietary trading algorithms were exposed on a public GitHub PR because Claude pushed without checking repository visibility.

**What it does:**
- Intercepts `git push` / `gh pr create` and checks repo visibility via `gh api` — blocks with a warning if the repo is public
- Detects forks of public repos (which are always public on GitHub) and warns accordingly
- Scans staged files on `git commit` / `git add .` for sensitive patterns (~25 patterns: `.env`, `.pem`, SSH keys, API keys, cloud configs, etc.)
- Lists files that would be publicly exposed before allowing the push
- Session-based dedup to avoid repeated warnings
- Graceful degradation when `gh` CLI is unavailable (warns but doesn't block)

**Architecture:** Follows the same minimal hook plugin pattern as `plugins/security-guidance/` — a single Python `PreToolUse` hook script with session-scoped state management.

## Files

- `plugins/push-guardrails/.claude-plugin/plugin.json` — Plugin metadata
- `plugins/push-guardrails/hooks/hooks.json` — PreToolUse hook config (Bash matcher, 15s timeout)
- `plugins/push-guardrails/hooks/push_guardrails.py` — Main hook script (~330 lines)
- `plugins/push-guardrails/README.md` — Documentation
- `.claude-plugin/marketplace.json` — Added plugin registration

## Test plan

- [x] Non-git commands (`ls`, `npm install`, etc.) — immediate exit 0 via fast-path
- [x] Non-Bash tools (Write, Edit) — immediate exit 0
- [x] `git status`, `git log`, etc. — not intercepted, exit 0
- [x] `git push` on a public repo — exit 2 with visibility warning + file list
- [x] `git push` second time same session — exit 0 (session dedup)
- [x] `gh pr create` on a public repo — exit 2 with warning
- [x] `PUSH_GUARDRAILS_DISABLED=1` — exit 0, fully bypassed
- [x] Sensitive file pattern detection — correctly flags `.env`, `credentials.json`, `id_rsa`, `terraform.tfvars`, `token.json`
- [x] Safe files (`main.py`, `package.json`, `README.md`) — not flagged
- [x] Broad `git add .` — detected; `git add src/file.py` — not flagged
- [x] `gh` CLI not installed — warns but allows (graceful degradation)

🤖 Generated with [Claude Code](https://claude.ai/code)