### PR TITLE
feat: add verified-code-answers plugin to fix unverified assertions (fixes #29753)

### DIFF
--- a/plugins/verified-code-answers/.claude-plugin/plugin.json
+++ b/plugins/verified-code-answers/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "verified-code-answers",
+  "version": "1.0.0",
+  "description": "Ensures Claude reads source files before answering factual questions about code behavior, and explicitly caveats any unverified assertions. Addresses issue #29753.",
+  "author": {
+    "name": "HarshalJain-cs",
+    "email": ""
+  }
+}

--- a/plugins/verified-code-answers/README.md
+++ b/plugins/verified-code-answers/README.md
@@ -1,0 +1,37 @@
+# Verified Code Answers Plugin
+
+This plugin ensures Claude reads actual source files before answering factual questions about code behavior, and explicitly caveats any unverified assertions.
+
+## Problem Solved
+
+Addresses [issue #29753](https://github.com/anthropics/claude-code/issues/29753): Claude Code was presenting unverified assertions about code behavior with the same confidence as verified ones. Users had no way to distinguish between answers grounded in actual source code vs. answers pattern-matched from training data.
+
+## What This Plugin Does
+
+This plugin injects a `SessionStart` hook that adds the following behavioral rules to every Claude Code session:
+
+### Rule 1: Read Before You Assert
+When a user asks a factual question about how code behaves, Claude **must** use its file reading tools (`Read`, `Glob`, `Grep`) to inspect the actual source code **before** giving an answer.
+
+### Rule 2: Caveat Unverified Answers
+If Claude cannot read the relevant source file, it **must** explicitly caveat its answer using phrases like:
+- "I haven't read the source file, but based on common patterns..."
+- "Without checking the actual code, I believe..."
+- "This is an unverified assumption - please check [filename] to confirm."
+
+### Rule 3: Never Present Unverified Information as Verified
+Claude must never answer a code-behavior question with the same confidence as a verified answer unless it has actually read the relevant code.
+
+## Installation
+
+Copy this plugin directory to your Claude Code plugins folder and enable it:
+
+```bash
+cp -r plugins/verified-code-answers ~/.claude/plugins/
+```
+
+## Files
+
+- `.claude-plugin/plugin.json` - Plugin metadata
+- `hooks/hooks.json` - Hook configuration (SessionStart)
+- `hooks-handlers/session-start.sh` - The hook script that injects behavioral instructions

--- a/plugins/verified-code-answers/hooks-handlers/session-start.sh
+++ b/plugins/verified-code-answers/hooks-handlers/session-start.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Verified Code Answers plugin - SessionStart hook
+# Addresses: https://github.com/anthropics/claude-code/issues/29753
+#
+# This hook injects instructions that require Claude to verify code behavior
+# by reading actual source files before making factual assertions.
+
+cat << 'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "## Verified Code Answers Policy\n\nWhen answering any factual question about how code behaves, you MUST follow this policy:\n\n### Rule 1: Read Before You Assert\nIf a user asks a question about what a specific piece of code does, how a function behaves, what a variable contains, or whether a code path executes - you MUST use your file reading tools (Read, Glob, Grep) to inspect the actual source code BEFORE giving your answer. Do NOT rely on training data or pattern-matching to answer code-behavior questions.\n\n### Rule 2: Caveat Unverified Answers\nIf you are unable to read the relevant source file (e.g., the file doesn't exist, you lack access, or the scope is too broad), you MUST explicitly caveat your answer. Use language like:\n- 'I haven't read the source file, but based on common patterns...'\n- 'Without checking the actual code, I believe...'\n- 'This is an unverified assumption - please check [filename] to confirm.'\n\n### Rule 3: Never Present Unverified Information as Verified\nNever answer a code-behavior question with the same confidence as a verified answer unless you have actually read the code. The existing instruction 'Do not say things you haven't verified' applies especially to code behavior questions.\n\n### Example of Correct Behavior\nUser: 'Will spells with empty roleAffinity ever get assigned to actors?'\nCorrect: Read the selector/filter code first, then answer based on what the code actually does.\nIncorrect: Answer based on what 'usually' happens in game systems without checking.\n\nThis policy exists to prevent users from acting on incorrect information about their own codebase."
+  }
+}
+EOF
+
+exit 0

--- a/plugins/verified-code-answers/hooks/hooks.json
+++ b/plugins/verified-code-answers/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "description": "Verified code answers hook - requires reading source before answering code behavior questions",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks-handlers/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #29753 — Claude Code presents unverified assertions with the same confidence as verified ones.

## Problem

When Claude Code answers a question about code behavior, there is no discernible difference in tone, confidence, or presentation between:
1. An answer that was **verified** by reading the actual source code with tools
2. An answer that was **pattern-matched** from training data without checking

The existing system prompt instruction "Do not say things you haven't verified" is insufficient on its own, as Claude still generates confident unverified answers.

## Solution

This PR adds a new plugin `verified-code-answers` that injects a `SessionStart` hook with three explicit behavioral rules:

### Rule 1: Read Before You Assert
Claude **must** use file reading tools (`Read`, `Glob`, `Grep`) to inspect actual source code **before** answering any factual question about code behavior.

### Rule 2: Caveat Unverified Answers
If Claude cannot read the relevant source file, it **must** explicitly caveat its answer (e.g., "I haven't read the source file, but based on common patterns...").

### Rule 3: Never Present Unverified Information as Verified
Code-behavior questions must never be answered with the same confidence as verified answers unless the code was actually read.

## Files Added

```
plugins/verified-code-answers/
  .claude-plugin/plugin.json       # Plugin metadata
  hooks/hooks.json                  # SessionStart hook configuration
  hooks-handlers/session-start.sh  # Core instruction injection script
  README.md                         # Documentation
```

## Testing

This plugin works identically to the existing `explanatory-output-style` plugin in structure and hook mechanism. Install by copying to your Claude Code plugins directory.