### PR TITLE
fix: RTL text rendering regression in VSCode webview since v2.1.63 (fixes #29754)

### DIFF
--- a/plugins/rtl-text-support/.claude-plugin/plugin.json
+++ b/plugins/rtl-text-support/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "rtl-text-support",
+  "version": "1.0.0",
+  "description": "Fixes RTL (right-to-left) text rendering broken in VSCode chat panel since v2.1.63. The webview CSS unicode-bidi:bidi-override incorrectly forces all text LTR, breaking Persian/Arabic/Hebrew. Addresses issues #29545, #29658, #29662, #29754.",
+  "author": {
+    "name": "HarshalJain-cs",
+    "email": ""
+  }
+}

--- a/plugins/rtl-text-support/README.md
+++ b/plugins/rtl-text-support/README.md
@@ -1,0 +1,79 @@
+# RTL Text Support Plugin
+
+Fixes right-to-left (RTL) text rendering broken in the Claude Code VSCode extension webview since **v2.1.63**.
+
+## Problem
+
+Version v2.1.63 introduced a global CSS regression in the extension webview (`webview/index.css`):
+
+```css
+* { direction: ltr; unicode-bidi: bidi-override; }
+```
+
+The `unicode-bidi: bidi-override` property **forces all text to render left-to-right**, completely breaking RTL languages:
+- Persian / Farsi
+- Arabic
+- Hebrew
+
+Individual characters within words are reversed, making the text unreadable.
+
+**Related issues:** #29754, #29658, #29662, #29545
+
+## The Fix
+
+Change `unicode-bidi` from `bidi-override` to `normal`:
+
+```css
+* { direction: ltr; unicode-bidi: normal; }
+```
+
+This allows the browser's native **Unicode Bidirectional Algorithm (BIDI)** to handle RTL text correctly, while keeping the overall layout direction left-to-right. Mixed RTL/LTR content (e.g., Hebrew + English) works correctly with this change.
+
+## Installation (Plugin Method — Auto-patches on every session start)
+
+```bash
+cp -r plugins/rtl-text-support ~/.claude/plugins/
+```
+
+The plugin's `SessionStart` hook automatically detects and patches the installed extension's CSS on every Claude Code session start. It covers:
+- `~/.vscode/extensions/anthropic.claude-code-*/webview/index.css`
+- `~/.vscode-server/extensions/...` (remote SSH)
+- `~/.cursor/extensions/...` (Cursor IDE)
+- macOS paths under `~/Library/Application Support/`
+
+> **Note:** The fix must be re-applied after each extension update. The plugin handles this automatically.
+
+## Quick Fix (Standalone Script Method)
+
+If you prefer a one-time manual fix:
+
+```bash
+chmod +x scripts/fix-rtl-css.sh
+./scripts/fix-rtl-css.sh
+```
+
+Then reload VSCode: `Ctrl+Shift+P` → `Developer: Reload Window`
+
+## Manual Fix
+
+Locate and edit the file directly:
+
+```bash
+# Find the file
+find ~/.vscode/extensions -name 'index.css' -path '*/anthropic.claude-code-*/webview/*'
+
+# Apply the fix (Linux)
+sed -i 's/unicode-bidi: bidi-override/unicode-bidi: normal/g' <path-to-index.css>
+
+# Apply the fix (macOS)
+sed -i '' 's/unicode-bidi: bidi-override/unicode-bidi: normal/g' <path-to-index.css>
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `.claude-plugin/plugin.json` | Plugin metadata |
+| `hooks/hooks.json` | SessionStart hook configuration |
+| `hooks-handlers/session-start.sh` | Auto-patches extension CSS at session start |
+| `../../scripts/fix-rtl-css.sh` | Standalone one-time patch script |

--- a/plugins/rtl-text-support/hooks-handlers/session-start.sh
+++ b/plugins/rtl-text-support/hooks-handlers/session-start.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# RTL Text Support plugin - SessionStart hook
+# Fixes: https://github.com/anthropics/claude-code/issues/29754
+# Related: #29545, #29658, #29662
+#
+# Root cause: The VSCode extension webview/index.css introduced a global CSS rule
+# in v2.1.63 that forces unicode-bidi: bidi-override on all elements, which
+# reverses RTL text (Arabic, Hebrew, Persian/Farsi) making it unreadable.
+#
+# Fix: Patch the installed extension's index.css to change
+#   * { direction: ltr; unicode-bidi: bidi-override; }
+# to:
+#   * { direction: ltr; unicode-bidi: normal; }
+#
+# This allows the browser's native Unicode Bidirectional Algorithm (BIDI)
+# to handle RTL text correctly while keeping overall layout LTR.
+
+set -euo pipefail
+
+FIX_APPLIED=false
+FIX_MESSAGE=""
+
+# Locate all installed Claude Code extension webview CSS files
+# Works on Linux/macOS for both VSCode and Cursor
+for SEARCH_DIR in \
+  "$HOME/.vscode/extensions" \
+  "$HOME/.vscode-server/extensions" \
+  "$HOME/.cursor/extensions" \
+  "$HOME/Library/Application Support/Code/extensions" \
+  "$HOME/Library/Application Support/Cursor/extensions"
+do
+  if [ ! -d "$SEARCH_DIR" ]; then
+    continue
+  fi
+
+  # Find all matching index.css files in anthropic.claude-code-* extension dirs
+  while IFS= read -r CSS_FILE; do
+    if grep -q 'unicode-bidi: bidi-override' "$CSS_FILE" 2>/dev/null; then
+      # Create backup before patching
+      cp "$CSS_FILE" "${CSS_FILE}.rtl-backup" 2>/dev/null || true
+      # Apply the fix: replace bidi-override with normal
+      sed -i 's/unicode-bidi: bidi-override/unicode-bidi: normal/g' "$CSS_FILE"
+      FIX_APPLIED=true
+      FIX_MESSAGE="RTL CSS fix applied to: $CSS_FILE (backup saved as ${CSS_FILE}.rtl-backup)"
+    fi
+  done < <(find "$SEARCH_DIR" -path '*/anthropic.claude-code-*/webview/index.css' 2>/dev/null)
+done
+
+# Output JSON for Claude Code hook system
+if [ "$FIX_APPLIED" = true ]; then
+  STATUS="RTL text rendering fix was applied automatically. Persian/Arabic/Hebrew text should now display correctly in the chat panel. The webview CSS unicode-bidi property has been changed from bidi-override to normal. A backup of the original CSS was saved. Note: This fix will need to be re-applied after extension updates."
+else
+  STATUS="RTL text support plugin is active. No patching was needed (either already fixed or extension CSS not found at expected paths). If you are experiencing RTL text rendering issues, see the README for manual fix instructions."
+fi
+
+cat << EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "$STATUS"
+  }
+}
+EOF
+
+exit 0

--- a/plugins/rtl-text-support/hooks/hooks.json
+++ b/plugins/rtl-text-support/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "description": "RTL text support hook - runs CSS patch on session start to fix unicode-bidi regression in v2.1.63+",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks-handlers/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/fix-rtl-css.sh
+++ b/scripts/fix-rtl-css.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# fix-rtl-css.sh
+#
+# Standalone script to fix RTL (right-to-left) text rendering in the
+# Claude Code VSCode extension webview.
+#
+# Root cause: v2.1.63 introduced a global CSS rule:
+#   * { direction: ltr; unicode-bidi: bidi-override; }
+# The unicode-bidi: bidi-override property forces all text LTR,
+# breaking Persian/Arabic/Hebrew text rendering.
+#
+# This script replaces bidi-override with normal in the installed
+# extension's webview/index.css file.
+#
+# Related issues:
+#   https://github.com/anthropics/claude-code/issues/29754
+#   https://github.com/anthropics/claude-code/issues/29658
+#   https://github.com/anthropics/claude-code/issues/29545
+#   https://github.com/anthropics/claude-code/issues/29662
+#
+# Usage:
+#   chmod +x scripts/fix-rtl-css.sh
+#   ./scripts/fix-rtl-css.sh
+#
+# Note: Re-run after every Claude Code extension update.
+
+set -euo pipefail
+
+echo "RTL CSS Fix for Claude Code VSCode Extension"
+echo "=============================================="
+echo ""
+
+FIX_COUNT=0
+NOT_FOUND=true
+
+# Search paths for the extension on Linux/macOS (VSCode, VSCode-Server, Cursor)
+SEARCH_DIRS=(
+  "$HOME/.vscode/extensions"
+  "$HOME/.vscode-server/extensions"
+  "$HOME/.cursor/extensions"
+  "$HOME/Library/Application Support/Code/extensions"
+  "$HOME/Library/Application Support/Cursor/extensions"
+)
+
+for SEARCH_DIR in "${SEARCH_DIRS[@]}"; do
+  if [ ! -d "$SEARCH_DIR" ]; then
+    continue
+  fi
+
+  while IFS= read -r CSS_FILE; do
+    NOT_FOUND=false
+    echo "Found: $CSS_FILE"
+
+    if grep -q 'unicode-bidi: bidi-override' "$CSS_FILE"; then
+      echo "  Status: BROKEN (unicode-bidi: bidi-override found)"
+      # Back up original
+      cp "$CSS_FILE" "${CSS_FILE}.rtl-backup"
+      echo "  Backup: ${CSS_FILE}.rtl-backup"
+      # Apply fix
+      if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' 's/unicode-bidi: bidi-override/unicode-bidi: normal/g' "$CSS_FILE"
+      else
+        sed -i 's/unicode-bidi: bidi-override/unicode-bidi: normal/g' "$CSS_FILE"
+      fi
+      echo "  Fixed:  unicode-bidi changed to normal"
+      FIX_COUNT=$((FIX_COUNT + 1))
+    else
+      echo "  Status: OK (no bidi-override found, may already be fixed)"
+    fi
+    echo ""
+  done < <(find "$SEARCH_DIR" -path '*/anthropic.claude-code-*/webview/index.css' 2>/dev/null)
+done
+
+if [ "$NOT_FOUND" = true ]; then
+  echo "No Claude Code extension CSS files found."
+  echo "Make sure the Claude Code VSCode extension is installed."
+  echo "Expected path: ~/.vscode/extensions/anthropic.claude-code-*/webview/index.css"
+  exit 1
+fi
+
+if [ "$FIX_COUNT" -gt 0 ]; then
+  echo "SUCCESS: Fixed $FIX_COUNT file(s)."
+  echo "Please reload the VSCode window (Ctrl+Shift+P -> 'Developer: Reload Window')"
+  echo "RTL text (Persian/Arabic/Hebrew) should now render correctly."
+else
+  echo "No fixes needed. RTL rendering may already be working correctly."
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Fixes #29754 (and related: #29658, #29662, #29545, #29958) — RTL text rendering is broken in the Claude Code VSCode chat panel since v2.1.63.

**Affected languages:** Persian/Farsi, Arabic, Hebrew, and all RTL scripts
**Affected platforms:** Linux, macOS, Windows
**Confirmed on:** Debian Linux, macOS (Apple Silicon), Windows 11 Pro, VSCode 1.109.5, extension v2.1.63+

## Root Cause

Version v2.1.63 introduced a global CSS rule in the extension webview (`webview/index.css`):

```css
* {
  direction: ltr;
  unicode-bidi: bidi-override;
}
```

The `unicode-bidi: bidi-override` property **forces all text LTR**, completely reversing RTL characters within words. This breaks Persian/Farsi, Arabic, and Hebrew text, making it completely unreadable.

## The Fix

Change `bidi-override` → `normal`:

```css
* {
  direction: ltr;
  unicode-bidi: normal;
}
```

This allows the browser's native Unicode Bidirectional Algorithm (BIDI) to handle RTL text correctly while keeping overall layout LTR. Mixed RTL+LTR content works perfectly with this change. The Claude Desktop app already handles this correctly.

> The ideal fix is to update `webview/index.css` in the extension source. Until that's released, this PR provides an automated workaround via a plugin and a standalone script.

## Changes

### New Plugin: `plugins/rtl-text-support/`

A `SessionStart` hook plugin that **automatically patches the installed extension's CSS** at each session start:

- Detects `~/.vscode/extensions/anthropic.claude-code-*/webview/index.css`
- Also covers VSCode-Server (remote SSH), Cursor IDE, and macOS paths
- Creates a `.rtl-backup` before patching
- Re-patches automatically after extension updates

### New Script: `scripts/fix-rtl-css.sh`

A standalone one-time script for users who prefer manual fixing. Supports both Linux (`sed -i`) and macOS (`sed -i ''`) syntax.

## Testing

1. Install the plugin to `~/.claude/plugins/rtl-text-support/`
2. Start a Claude Code session — the hook runs and patches the CSS
3. Reload VSCode window (`Ctrl+Shift+P` → `Developer: Reload Window`)
4. Type Persian/Arabic/Hebrew text in the chat — it should render RTL correctly

## Affected Users

Any user of Claude Code extension v2.1.63+ who writes in: **Persian/Farsi, Arabic, Hebrew** or any other RTL language.

Related issues tracking this across platforms:
- #29754 — Persian, Linux (original)
- #29658 — Hebrew, macOS
- #29662 — Persian/Arabic/Hebrew, macOS + Cursor
- #29545 — earlier report
- #29958 — Arabic, Windows 11 (newest)