### PR TITLE
feat: Add agents-md plugin for AGENTS.md fallback support

### DIFF
--- a/plugins/agents-md/.claude-plugin/plugin.json
+++ b/plugins/agents-md/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "agents-md",
+  "version": "1.0.0",
+  "description": "Adds AGENTS.md support to Claude Code. Reads AGENTS.md files as a fallback when no CLAUDE.md is present, enabling cross-tool compatibility with Codex, Cursor, Amp, and other AI coding tools.",
+  "author": {
+    "name": "baktybekb",
+    "url": "https://github.com/baktybekb"
+  },
+  "license": "MIT",
+  "keywords": ["agents-md", "interoperability", "context", "instructions"]
+}

--- a/plugins/agents-md/README.md
+++ b/plugins/agents-md/README.md
@@ -1,0 +1,62 @@
+# agents-md plugin for Claude Code
+
+Adds [AGENTS.md](https://github.com/anthropics/claude-code/issues/6235) support to Claude Code, enabling cross-tool compatibility with Codex, Cursor, Amp, and other AI coding tools that use the `AGENTS.md` standard.
+
+## Problem
+
+Over 20,000 open-source repositories use `AGENTS.md` to provide instructions to AI coding assistants. Claude Code only reads `CLAUDE.md` files, which means it ignores project-level AI instructions when working on these repositories.
+
+See: [anthropics/claude-code#6235](https://github.com/anthropics/claude-code/issues/6235) (2,900+ upvotes)
+
+## How it works
+
+This plugin uses a `SessionStart` hook to detect and load `AGENTS.md` files as a fallback:
+
+1. On session start, the hook walks from the project root up to the filesystem root
+2. At each directory level, it checks for `CLAUDE.md` (or `.claude/CLAUDE.md`)
+3. If `CLAUDE.md` exists at that level, `AGENTS.md` is **skipped** (CLAUDE.md takes priority)
+4. If only `AGENTS.md` exists, its content is loaded into Claude's context via `additionalContext`
+
+This mirrors Claude Code's native CLAUDE.md loading order (root-first) and respects the priority hierarchy: if a project has both files, `CLAUDE.md` wins.
+
+### Lookup locations
+
+For each directory from root to CWD:
+- `<dir>/AGENTS.md`
+- `<dir>/.claude/AGENTS.md`
+
+### Behavior matrix
+
+| CLAUDE.md exists | AGENTS.md exists | Result |
+|:---:|:---:|---|
+| Yes | Yes | Only CLAUDE.md is used (native behavior) |
+| Yes | No | Only CLAUDE.md is used (native behavior) |
+| No | Yes | **AGENTS.md is loaded by this plugin** |
+| No | No | Nothing loaded |
+
+## Installation
+
+Copy or symlink this plugin directory into your Claude Code plugins location:
+
+```bash
+# Option 1: Clone into your project's .claude/plugins/
+cp -r agents-md-plugin /path/to/project/.claude/plugins/agents-md
+
+# Option 2: Symlink for global use
+ln -s /path/to/agents-md-plugin ~/.claude/plugins/agents-md
+```
+
+## Requirements
+
+- Claude Code v2.1+
+- `bash` and `python3` available in PATH
+
+## Limitations
+
+- Content is injected via `additionalContext`, not through the native CLAUDE.md pipeline. This means it won't appear in `/memory` views or support `@include` syntax.
+- The `AGENTS.md` content does not support Claude Code's frontmatter `paths:` conditional rules.
+- Maximum content size is capped at 40,000 characters (matching CLAUDE.md's warning threshold).
+
+## License
+
+MIT

--- a/plugins/agents-md/hooks-handlers/session-start.sh
+++ b/plugins/agents-md/hooks-handlers/session-start.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# AGENTS.md SessionStart Hook
+#
+# Reads AGENTS.md files and injects them into Claude Code's context
+# when no CLAUDE.md is present at the same directory level.
+#
+# Behavior:
+#   - Walks from project root up to filesystem root (mirrors CLAUDE.md loading)
+#   - At each directory, if CLAUDE.md (or .claude/CLAUDE.md) exists, skip AGENTS.md
+#   - If only AGENTS.md exists, read and collect it
+#   - Concatenates all found AGENTS.md files (root-first order)
+#   - Returns content via SessionStart additionalContext
+#
+# Supports: AGENTS.md at project root, parent directories, and .claude/AGENTS.md
+#
+
+set -euo pipefail
+
+# Read hook input from stdin
+INPUT=$(cat)
+
+# Extract current working directory from hook input
+CWD=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('cwd',''))" 2>/dev/null)
+
+# Fallback to environment or pwd
+if [ -z "$CWD" ]; then
+  CWD="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+fi
+
+# Collect directories from CWD up to root
+dirs=()
+dir="$CWD"
+while [ "$dir" != "/" ]; do
+  dirs+=("$dir")
+  dir=$(dirname "$dir")
+done
+
+# Reverse to get root-first order (matches CLAUDE.md loading behavior)
+reversed=()
+for (( i=${#dirs[@]}-1; i>=0; i-- )); do
+  reversed+=("${dirs[$i]}")
+done
+
+collected=""
+
+for dir in "${reversed[@]}"; do
+  # Check if CLAUDE.md exists at this level (any variant)
+  has_claude_md=false
+  if [ -f "$dir/CLAUDE.md" ] || [ -f "$dir/.claude/CLAUDE.md" ]; then
+    has_claude_md=true
+  fi
+
+  # If CLAUDE.md exists here, skip AGENTS.md at this level
+  if [ "$has_claude_md" = true ]; then
+    continue
+  fi
+
+  # Look for AGENTS.md variants
+  for agents_path in "$dir/AGENTS.md" "$dir/.claude/AGENTS.md"; do
+    if [ -f "$agents_path" ]; then
+      content=$(cat "$agents_path" 2>/dev/null || true)
+      if [ -n "$content" ]; then
+        if [ -n "$collected" ]; then
+          collected="${collected}
+
+"
+        fi
+        collected="${collected}Contents of ${agents_path} (project instructions from AGENTS.md, loaded by agents-md plugin):
+
+${content}"
+      fi
+    fi
+  done
+done
+
+# If nothing found, exit silently (no context to add)
+if [ -z "$collected" ]; then
+  exit 0
+fi
+
+# Truncate if excessively large (40k chars, matching CLAUDE.md warning threshold)
+max_chars=40000
+if [ "${#collected}" -gt "$max_chars" ]; then
+  collected="${collected:0:$max_chars}
+
+... [AGENTS.md content truncated at ${max_chars} characters]"
+fi
+
+# Output as JSON for SessionStart hook
+# Use python3 for safe JSON encoding (handles special chars, newlines, quotes)
+python3 -c "
+import json, sys
+
+content = sys.stdin.read()
+output = {
+    'hookSpecificOutput': {
+        'hookEventName': 'SessionStart',
+        'additionalContext': content
+    }
+}
+print(json.dumps(output))
+" <<< "$collected"
+
+exit 0

--- a/plugins/agents-md/hooks/hooks.json
+++ b/plugins/agents-md/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Loads AGENTS.md files as fallback context when no CLAUDE.md is present",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks-handlers/session-start.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new plugin (`plugins/agents-md`) that provides AGENTS.md support for Claude Code, addressing the most upvoted issue in this repository.

- **SessionStart hook** detects and loads `AGENTS.md` files when no `CLAUDE.md` is present at the same directory level
- Mirrors native CLAUDE.md loading order (root-first ancestor walk)
- Supports both `<dir>/AGENTS.md` and `<dir>/.claude/AGENTS.md` locations
- Respects priority hierarchy: if `CLAUDE.md` exists, `AGENTS.md` is skipped
- Handles edge cases: special characters, unicode, large files (40k char cap)

This enables cross-tool compatibility with **20,000+ repositories** using the [AGENTS.md standard](https://github.com/anthropics/claude-code/issues/6235) (Codex, Cursor, Amp, and other AI coding tools).

Resolves #6235

## Behavior matrix

| CLAUDE.md exists | AGENTS.md exists | Result |
|:---:|:---:|---|
| Yes | Yes | Only CLAUDE.md is used (native behavior) |
| Yes | No | Only CLAUDE.md is used (native behavior) |
| No | Yes | **AGENTS.md is loaded by this plugin** |
| No | No | Nothing loaded |

## Plugin structure

```
plugins/agents-md/
├── .claude-plugin/plugin.json      # Plugin manifest
├── hooks/hooks.json                # SessionStart hook config
├── hooks-handlers/session-start.sh # Detection & loading logic
└── README.md                       # Documentation
```

## Test plan

- [x] AGENTS.md only present — loads content correctly
- [x] Both CLAUDE.md and AGENTS.md present — skips AGENTS.md
- [x] Neither file present — silent, no output
- [x] `.claude/AGENTS.md` nested location — loads correctly
- [x] Mixed hierarchy (parent AGENTS.md + child CLAUDE.md) — correct per-level behavior
- [x] Special characters, unicode, quotes, JSON-like content — safe JSON encoding