### PR TITLE
Fix ralph-loop crash when invoked without arguments

### DIFF
--- a/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
+++ b/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
@@ -110,7 +110,7 @@ HELP_EOF
 done
 
 # Join all prompt parts with spaces
-PROMPT="${PROMPT_PARTS[*]}"
+PROMPT="${PROMPT_PARTS[*]:-}"
 
 # Validate prompt is non-empty
 if [[ -z "$PROMPT" ]]; then


### PR DESCRIPTION
## Summary

Fixes the `PROMPT_PARTS[*]: unbound variable` crash in the ralph-loop plugin when invoked without arguments (`/ralph-loop`).

Closes #18496

## Changes

- **`plugins/ralph-wiggum/scripts/setup-ralph-loop.sh`**: Changed `${PROMPT_PARTS[*]}` to `${PROMPT_PARTS[*]:-}` on line 113 to provide a default empty string when the array is empty

## Root Cause

The script uses `set -euo pipefail` (line 6), which enables `set -u` (treat unset variables as errors). When `/ralph-loop` is called with no arguments, `PROMPT_PARTS` remains an empty array. On bash 3.2 (macOS default), referencing `${PROMPT_PARTS[*]}` on an empty array triggers an "unbound variable" error, crashing the script before it can reach the "No prompt provided" validation message on line 116.

## Testing

Verified both cases with bash under `set -euo pipefail`:

```bash
# Empty array (the bug case) — now returns empty string instead of crashing
$ bash -c 'set -euo pipefail; A=(); echo "${A[*]:-}"'
# (empty output, exit 0)

# Non-empty array — still joins correctly
$ bash -c 'set -euo pipefail; A=("hello" "world"); echo "${A[*]:-}"'
hello world
```

🤖 Generated with [Claude Code](https://claude.ai/code)