### PR TITLE
fix(ralph-wiggum): prevent stop hook stdin block when no loop active

### DIFF
--- a/plugins/ralph-wiggum/hooks/hooks.json
+++ b/plugins/ralph-wiggum/hooks/hooks.json
@@ -6,7 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.sh",
+            "timeout": 10
           }
         ]
       }

--- a/plugins/ralph-wiggum/hooks/stop-hook.sh
+++ b/plugins/ralph-wiggum/hooks/stop-hook.sh
@@ -6,16 +6,19 @@
 
 set -euo pipefail
 
-# Read hook input from stdin (advanced stop hook API)
-HOOK_INPUT=$(cat)
-
-# Check if ralph-loop is active
+# Check if ralph-loop is active BEFORE reading stdin.
+# Reading stdin first (cat) blocks when no data is piped, causing the hook
+# to hang/timeout with a non-zero exit on every session end — even when
+# no loop is active (the 99.9% case).
 RALPH_STATE_FILE=".claude/ralph-loop.local.md"
 
 if [[ ! -f "$RALPH_STATE_FILE" ]]; then
-  # No active loop - allow exit
+  # No active loop - allow exit immediately (no stdin read needed)
   exit 0
 fi
+
+# Read hook input from stdin (advanced stop hook API — only when loop is active)
+HOOK_INPUT=$(timeout 5 cat 2>/dev/null || echo "{}")
 
 # Parse markdown frontmatter (YAML between ---) and extract values
 FRONTMATTER=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$RALPH_STATE_FILE")


### PR DESCRIPTION
## Summary

- Stop hook reads stdin (`cat`) **before** checking if a ralph-loop state file exists
- When no loop is active (99.9% of session ends), `cat` blocks waiting for EOF, causing the hook to timeout with a non-zero exit code
- Every session end shows: `Stop hook error: Failed with non-blocking status code`

## Fix

1. **Reorder**: Move state file existence check before stdin read — hook exits immediately when no loop is active
2. **Timeout guard**: Add `timeout 5 cat` with fallback for the active-loop path
3. **hooks.json**: Add missing `"timeout": 10"` field

## Before

```
cat (blocks) → check state file → exit 0
```

## After

```
check state file → exit 0 (no stdin read needed)
check state file → exists → timeout 5 cat → continue loop
```

## Test plan

- [ ] Session end with no `.claude/ralph-loop.local.md` — hook exits instantly, no error
- [ ] Active ralph-loop — hook reads stdin and continues loop as before
- [ ] stdin timeout during active loop — graceful fallback to empty JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)