### PR TITLE
feat: add open-hive plugin for multi-agent collision detection

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -145,6 +145,16 @@
       },
       "source": "./plugins/security-guidance",
       "category": "security"
+    },
+    {
+      "name": "open-hive",
+      "description": "Developer collision detection for AI-assisted teams — alerts before merge conflicts happen when multiple developers or Agent Teams work on the same codebase",
+      "version": "0.2.0",
+      "author": {
+        "name": "Chase Skibeness"
+      },
+      "source": "./plugins/open-hive",
+      "category": "productivity"
     }
   ]
 }

--- a/plugins/open-hive/.claude-plugin/plugin.json
+++ b/plugins/open-hive/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "open-hive",
+  "version": "0.2.0",
+  "description": "Developer collision detection — know what your team is working on before you collide",
+  "author": {
+    "name": "Chase Skibeness"
+  },
+  "repository": "https://github.com/look-itsaxiom/open-hive",
+  "license": "MIT"
+}

--- a/plugins/open-hive/README.md
+++ b/plugins/open-hive/README.md
@@ -1,0 +1,110 @@
+# Open Hive
+
+**Developer collision detection for AI-assisted teams.**
+
+When multiple developers (or Claude Code Agent Teams teammates) work on the same codebase, Open Hive passively detects overlapping work and alerts before conflicts escalate. No workflow changes — hooks fire silently in the background.
+
+## How It Works
+
+Three levels of collision detection run automatically:
+
+| Level | Severity | Detection |
+|-------|----------|-----------|
+| **L1** | Critical | Two sessions editing the same file |
+| **L2** | Warning | Two sessions editing files in the same directory |
+| **L3a** | Info | Semantic keyword overlap between developer intents |
+
+When a collision is detected, you see an inline alert like:
+
+> **Heads up** — Alice is also editing `src/auth/login.ts` right now. You might want to sync before continuing.
+
+## Hooks
+
+The plugin registers six hooks that run automatically:
+
+| Hook | Trigger | What It Does |
+|------|---------|--------------|
+| **SessionStart** | Session opens | Registers you with the backend |
+| **UserPromptSubmit** | Every prompt | Captures intent, checks for semantic overlap |
+| **PreToolUse** | Before Write/Edit | Checks if someone else is modifying the same file |
+| **PostToolUse** | After Write/Edit | Records which files you touched |
+| **SessionEnd** | Session closes | Deregisters your session |
+| **PreCompact** | Context compaction | Preserves collision awareness across compaction |
+
+All hooks have 3–5 second timeouts and fail silently. If the backend is down, your dev experience is unchanged.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/hive setup` | Configure backend URL and developer identity |
+| `/hive status` | Show your active session and any collisions |
+| `/hive who` | List all active developers and what they're working on |
+| `/hive history` | View recent activity signals for the current repo |
+
+## Setup
+
+### 1. Start the Backend
+
+Open Hive requires a self-hosted backend (Fastify + SQLite, ~30MB Docker image):
+
+```bash
+git clone https://github.com/look-itsaxiom/open-hive.git
+cd open-hive
+docker compose up -d
+```
+
+The backend starts on `http://localhost:3000`.
+
+### 2. Configure the Plugin
+
+Run `/hive setup` in any Claude Code session. This saves your config to `~/.open-hive.yaml`:
+
+```yaml
+backend_url: http://localhost:3000
+identity:
+  email: you@company.com
+  display_name: Your Name
+team: engineering
+```
+
+That's it. The plugin works automatically from here.
+
+## Skills Library
+
+The [Open Hive repository](https://github.com/look-itsaxiom/open-hive) includes 12 integration skills that extend the backend:
+
+- **Notifications:** Slack, Microsoft Teams, Discord
+- **Auth:** GitHub OAuth, GitLab OAuth, Azure DevOps OAuth
+- **Storage:** PostgreSQL (swap SQLite)
+- **UI:** Embedded web dashboard
+- **Plugin:** MCP Server (6 `hive_*` tools)
+- **Detection:** L3b embedding similarity, L3c LLM comparison
+
+Each skill is a self-contained `SKILL.md` that teaches Claude how to add the integration. See [skills/README.md](https://github.com/look-itsaxiom/open-hive/tree/main/skills) for details.
+
+## Architecture
+
+```
+┌─────────────────────┐     ┌─────────────────────┐
+│  Developer A        │     │  Developer B        │
+│  Claude Code        │     │  Claude Code        │
+│  + Open Hive Plugin │     │  + Open Hive Plugin │
+└────────┬────────────┘     └────────┬────────────┘
+         │  hooks fire passively      │
+         ▼                            ▼
+┌─────────────────────────────────────────────────┐
+│              Open Hive Backend                  │
+│         Fastify + SQLite (Docker)               │
+│  ┌───────────┐  ┌──────────┐  ┌──────────────┐ │
+│  │ Sessions  │  │ Signals  │  │  Collision   │ │
+│  │ Registry  │  │  Store   │  │   Engine     │ │
+│  └───────────┘  └──────────┘  └──────────────┘ │
+└─────────────────────────────────────────────────┘
+```
+
+## Links
+
+- **Full repository:** [github.com/look-itsaxiom/open-hive](https://github.com/look-itsaxiom/open-hive)
+- **Skills library:** [12 integration skills](https://github.com/look-itsaxiom/open-hive/tree/main/skills)
+- **License:** MIT

--- a/plugins/open-hive/commands/history.md
+++ b/plugins/open-hive/commands/history.md
@@ -1,0 +1,17 @@
+---
+name: history
+description: Show recent Open Hive activity for a file, directory, or repo
+allowed-tools: ["Bash"]
+---
+
+Query Open Hive for recent activity history.
+
+If the user specifies a file or directory, filter to that path.
+Otherwise, show recent activity for the current repo.
+
+1. Read `~/.open-hive.yaml` to get the backend URL
+2. Call `GET <backend_url>/api/history?limit=20`
+3. Present recent signals grouped by developer:
+   - What they worked on
+   - Which files they modified
+   - When (relative time)

--- a/plugins/open-hive/commands/setup.md
+++ b/plugins/open-hive/commands/setup.md
@@ -1,0 +1,27 @@
+---
+name: setup
+description: Configure Open Hive for this developer — set backend URL, identity, and team
+allowed-tools: ["Write", "Bash", "AskUserQuestion"]
+---
+
+Set up Open Hive for the current developer.
+
+1. Ask the user for the Open Hive backend URL (e.g., https://hive.internal.company.com)
+2. Auto-detect git email via `git config user.email`
+3. Ask for display name (default to git name via `git config user.name`)
+4. Optionally ask for team name
+5. Write the config to `~/.open-hive.yaml`:
+
+```yaml
+backend_url: <url>
+identity:
+  email: <git-email>
+  display_name: <name>
+team: <team-or-empty>
+notifications:
+  inline: true
+  webhook_url:
+```
+
+6. Test the connection by calling `<backend_url>/api/health`
+7. Confirm setup is complete

--- a/plugins/open-hive/commands/status.md
+++ b/plugins/open-hive/commands/status.md
@@ -1,0 +1,14 @@
+---
+name: status
+description: Show Open Hive status — active sessions, collisions, your current activity
+allowed-tools: ["Bash"]
+---
+
+Show the current Open Hive status by querying the backend.
+
+1. Read `~/.open-hive.yaml` to get the backend URL
+2. Call `GET <backend_url>/api/sessions/active` to get all active sessions
+3. Present a summary:
+   - How many developers are active
+   - What each is working on (intent + areas)
+   - Any active collisions with severity

--- a/plugins/open-hive/commands/who.md
+++ b/plugins/open-hive/commands/who.md
@@ -1,0 +1,17 @@
+---
+name: who
+description: Show who is working on what right now across the organization
+allowed-tools: ["Bash"]
+---
+
+Query Open Hive to show who is actively working and what they're doing.
+
+1. Read `~/.open-hive.yaml` to get the backend URL
+2. Call `GET <backend_url>/api/sessions/active` to get all active sessions
+3. Present each active session:
+   - Developer name
+   - Repository
+   - Intent (what they said they're working on)
+   - Areas (directories they've touched)
+   - Duration (time since session started)
+4. Highlight any collisions between active sessions

--- a/plugins/open-hive/dist/client/hive-client.js
+++ b/plugins/open-hive/dist/client/hive-client.js
@@ -1,0 +1,61 @@
+export class HiveClient {
+    baseUrl;
+    constructor(baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+    async registerSession(req) {
+        return this.post('/api/sessions/register', req);
+    }
+    async endSession(req) {
+        await this.post('/api/sessions/end', req);
+    }
+    async sendIntent(req) {
+        return this.post('/api/signals/intent', req);
+    }
+    async sendActivity(req) {
+        return this.post('/api/signals/activity', req);
+    }
+    async checkConflicts(session_id, file_path, repo) {
+        const params = new URLSearchParams({ session_id, file_path });
+        if (repo)
+            params.set('repo', repo);
+        return this.get(`/api/conflicts/check?${params}`);
+    }
+    async listActive(repo) {
+        const params = repo ? `?repo=${encodeURIComponent(repo)}` : '';
+        return this.get(`/api/sessions/active${params}`);
+    }
+    async heartbeat(session_id) {
+        await this.post('/api/sessions/heartbeat', { session_id });
+    }
+    async post(path, body) {
+        try {
+            const res = await fetch(`${this.baseUrl}${path}`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+                signal: AbortSignal.timeout(3000),
+            });
+            if (!res.ok)
+                return null;
+            return res.json();
+        }
+        catch {
+            return null; // Backend unreachable — never block the developer
+        }
+    }
+    async get(path) {
+        try {
+            const res = await fetch(`${this.baseUrl}${path}`, {
+                signal: AbortSignal.timeout(3000),
+            });
+            if (!res.ok)
+                return null;
+            return res.json();
+        }
+        catch {
+            return null;
+        }
+    }
+}
+//# sourceMappingURL=hive-client.js.map

--- a/plugins/open-hive/dist/config/config.js
+++ b/plugins/open-hive/dist/config/config.js
@@ -1,0 +1,48 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+export function loadClientConfig() {
+    const home = process.env.HOME ?? process.env.USERPROFILE ?? '';
+    const configPath = join(home, '.open-hive.yaml');
+    if (!existsSync(configPath))
+        return null;
+    const raw = readFileSync(configPath, 'utf-8');
+    const lines = raw.split('\n');
+    const config = {};
+    let currentSection = '';
+    for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed.startsWith('#') || !trimmed)
+            continue;
+        if (!line.startsWith(' ') && trimmed.endsWith(':')) {
+            currentSection = trimmed.slice(0, -1);
+            continue;
+        }
+        const match = trimmed.match(/^(\w+):\s*(.+)$/);
+        if (match) {
+            const key = currentSection ? `${currentSection}.${match[1]}` : match[1];
+            config[key] = match[2].replace(/^["']|["']$/g, '');
+        }
+    }
+    return {
+        backend_url: config['backend_url'] ?? '',
+        identity: {
+            email: config['identity.email'] ?? getGitEmail(),
+            display_name: config['identity.display_name'] ?? config['identity.email'] ?? 'Unknown',
+        },
+        team: config['team'],
+        notifications: {
+            inline: config['notifications.inline'] !== 'false',
+            webhook_url: config['notifications.webhook_url'] || undefined,
+        },
+    };
+}
+function getGitEmail() {
+    try {
+        return execSync('git config user.email', { encoding: 'utf-8' }).trim();
+    }
+    catch {
+        return 'unknown@localhost';
+    }
+}
+//# sourceMappingURL=config.js.map

--- a/plugins/open-hive/dist/hooks/handler.js
+++ b/plugins/open-hive/dist/hooks/handler.js
@@ -1,0 +1,160 @@
+import { HiveClient } from '../client/hive-client.js';
+import { loadClientConfig } from '../config/config.js';
+import { basename } from 'node:path';
+const config = loadClientConfig();
+const client = config?.backend_url ? new HiveClient(config.backend_url) : null;
+function getSessionId(input) {
+    return input.session_id ?? 'unknown';
+}
+function getRepo(input) {
+    return basename(input.cwd ?? process.cwd());
+}
+function formatCollisions(collisions) {
+    if (collisions.length === 0)
+        return '';
+    return collisions.map(c => {
+        const icon = c.severity === 'critical' ? '!!!' : c.severity === 'warning' ? '!!' : '!';
+        return `[Open Hive ${icon}] ${c.details}`;
+    }).join('\n');
+}
+async function handleSessionStart(input) {
+    if (!client || !config)
+        return {};
+    const session_id = getSessionId(input);
+    const repo = getRepo(input);
+    const result = await client.registerSession({
+        session_id,
+        developer_email: config.identity.email,
+        developer_name: config.identity.display_name,
+        repo,
+        project_path: input.cwd ?? process.cwd(),
+    });
+    if (!result)
+        return {};
+    const messages = [];
+    if (result.active_sessions_in_repo.length > 0) {
+        messages.push('Open Hive: Active sessions in this repo:');
+        for (const s of result.active_sessions_in_repo) {
+            messages.push(`  - ${s.developer_name}: ${s.intent ?? 'no intent declared'} (areas: ${s.areas.join(', ') || 'none yet'})`);
+        }
+    }
+    if (result.active_collisions.length > 0) {
+        messages.push(formatCollisions(result.active_collisions));
+    }
+    return messages.length > 0 ? { systemMessage: messages.join('\n') } : {};
+}
+async function handleUserPromptSubmit(input) {
+    if (!client)
+        return {};
+    const session_id = getSessionId(input);
+    const prompt = input.prompt ?? input.user_prompt ?? '';
+    if (!prompt)
+        return {};
+    const result = await client.sendIntent({
+        session_id,
+        content: prompt,
+        type: 'prompt',
+    });
+    if (!result || result.collisions.length === 0)
+        return {};
+    return { systemMessage: formatCollisions(result.collisions) };
+}
+async function handlePreToolUse(input) {
+    if (!client)
+        return {};
+    const toolName = input.tool_name ?? '';
+    if (!['Write', 'Edit'].includes(toolName))
+        return {};
+    const filePath = input.tool_input?.file_path;
+    if (!filePath)
+        return {};
+    const session_id = getSessionId(input);
+    const repo = getRepo(input);
+    const result = await client.checkConflicts(session_id, filePath, repo);
+    if (!result || !result.has_conflicts)
+        return {};
+    return { systemMessage: formatCollisions(result.collisions) };
+}
+async function handlePostToolUse(input) {
+    if (!client)
+        return {};
+    const toolName = input.tool_name ?? '';
+    if (!['Write', 'Edit'].includes(toolName))
+        return {};
+    const filePath = input.tool_input?.file_path;
+    if (!filePath)
+        return {};
+    const session_id = getSessionId(input);
+    await client.sendActivity({
+        session_id,
+        file_path: filePath,
+        type: 'file_modify',
+    });
+    return {};
+}
+async function handleSessionEnd(input) {
+    if (!client)
+        return {};
+    await client.endSession({ session_id: getSessionId(input) });
+    return {};
+}
+async function handlePreCompact(input) {
+    if (!client)
+        return {};
+    const repo = getRepo(input);
+    const result = await client.listActive(repo);
+    if (!result || result.sessions.length === 0)
+        return {};
+    const session_id = getSessionId(input);
+    const others = result.sessions.filter(s => s.session_id !== session_id);
+    if (others.length === 0)
+        return {};
+    const lines = others.map(s => `- ${s.developer_name}: ${s.intent ?? 'no intent'} (areas: ${s.areas?.join(', ') || 'none'})`);
+    return {
+        systemMessage: `Open Hive: Active sessions in this repo (preserve across compaction):\n${lines.join('\n')}`,
+    };
+}
+// Main: read stdin, route to handler, write stdout
+async function main() {
+    const chunks = [];
+    for await (const chunk of process.stdin) {
+        chunks.push(chunk);
+    }
+    const raw = Buffer.concat(chunks).toString('utf-8');
+    let input;
+    try {
+        input = JSON.parse(raw);
+    }
+    catch {
+        return;
+    }
+    const event = input.hook_event_name ?? '';
+    let result = {};
+    switch (event) {
+        case 'SessionStart':
+            result = await handleSessionStart(input);
+            break;
+        case 'UserPromptSubmit':
+            result = await handleUserPromptSubmit(input);
+            break;
+        case 'PreToolUse':
+            result = await handlePreToolUse(input);
+            break;
+        case 'PostToolUse':
+            result = await handlePostToolUse(input);
+            break;
+        case 'SessionEnd':
+            result = await handleSessionEnd(input);
+            break;
+        case 'PreCompact':
+            result = await handlePreCompact(input);
+            break;
+        default:
+            break;
+    }
+    if (Object.keys(result).length > 0) {
+        process.stdout.write(JSON.stringify(result));
+    }
+}
+main().catch(() => process.exit(0));
+//# sourceMappingURL=handler.js.map

--- a/plugins/open-hive/dist/hooks/handler.js
+++ b/plugins/open-hive/dist/hooks/handler.js
@@ -9,6 +9,16 @@ function getSessionId(input) {
 function getRepo(input) {
     return basename(input.cwd ?? process.cwd());
 }
+function timeSince(isoTimestamp) {
+    const diff = Date.now() - new Date(isoTimestamp).getTime();
+    const hours = Math.floor(diff / (1000 * 60 * 60));
+    if (hours < 1)
+        return '<1h';
+    if (hours < 24)
+        return `${hours}h`;
+    const days = Math.floor(hours / 24);
+    return `${days}d`;
+}
 function formatCollisions(collisions) {
     if (collisions.length === 0)
         return '';
@@ -36,6 +46,13 @@ async function handleSessionStart(input) {
         messages.push('Open Hive: Active sessions in this repo:');
         for (const s of result.active_sessions_in_repo) {
             messages.push(`  - ${s.developer_name}: ${s.intent ?? 'no intent declared'} (areas: ${s.areas.join(', ') || 'none yet'})`);
+        }
+    }
+    if (result.recent_historical_intents?.length > 0) {
+        messages.push('Open Hive: Recent work in this repo (last 48h):');
+        for (const hi of result.recent_historical_intents) {
+            const ago = timeSince(hi.timestamp);
+            messages.push(`  - ${hi.developer_name} (${ago} ago): ${hi.intent}`);
         }
     }
     if (result.active_collisions.length > 0) {

--- a/plugins/open-hive/hooks/hooks.json
+++ b/plugins/open-hive/hooks/hooks.json
@@ -1,0 +1,77 @@
+{
+  "description": "Open Hive — developer collision detection hooks",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/dist/hooks/handler.js",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/dist/hooks/handler.js",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/dist/hooks/handler.js",
+            "timeout": 3
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/dist/hooks/handler.js",
+            "timeout": 3
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/dist/hooks/handler.js",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/dist/hooks/handler.js",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/open-hive/skills/collision-awareness/SKILL.md
+++ b/plugins/open-hive/skills/collision-awareness/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: collision-awareness
+description: >
+  Use when Open Hive injects collision warnings via systemMessage,
+  when you detect that another developer may be working in the same area,
+  or when the user asks about team activity or potential conflicts.
+---
+
+# Collision Awareness
+
+You have Open Hive collision detection data available. Here's how to use it:
+
+## Interpreting Severity
+
+- **[Open Hive !!!]** — CRITICAL: Same file being edited by another developer. Mention this immediately and prominently. Suggest the user coordinate before continuing.
+- **[Open Hive !!]** — WARNING: Same directory/area being worked in. Mention it naturally but don't alarm. Suggest awareness.
+- **[Open Hive !]** — INFO: Semantic overlap detected. Mention briefly — "FYI, Sarah is working on something similar in another repo."
+
+## When to Proactively Check
+
+Before making significant changes (editing multiple files, refactoring, creating new modules), use the `/hive status` command to check if anyone else is working in the same area.
+
+## How to Present Collisions
+
+Be natural and helpful, not alarming:
+- CRITICAL: "Heads up — [name] is also editing this file right now. You might want to sync with them before continuing."
+- WARNING: "I see [name] is also working in the auth/ directory. Their intent: '[intent]'. Worth being aware of."
+- INFO: "Interesting — [name] in [repo] is working on something related: '[intent]'."
+
+## Resolving Collisions
+
+If the user says they've talked to the other developer and it's fine, you can resolve the alert by calling the backend API directly via Bash:
+```
+curl -X POST <backend_url>/api/conflicts/resolve -H 'Content-Type: application/json' -d '{"collision_id":"<id>","resolved_by":"<email>"}'
+```
+Read `~/.open-hive.yaml` to get the backend URL and identity.
+
+## If Backend Is Unavailable
+
+If Open Hive hooks return no data or errors, don't mention it. The system is designed to be silent when the backend is down.


### PR DESCRIPTION
## Summary

Open Hive is a developer collision detection plugin for Claude Code. When multiple developers (or Agent Teams teammates) work on the same codebase, it passively detects overlapping work and alerts before effort is wasted.

- **6 hooks** fire silently in the background — no workflow changes required
- **3-level detection:** L1 file overlap (critical), L2 directory overlap (warning), L3a semantic keyword similarity (info)
- **4 commands:** `/hive setup`, `/hive status`, `/hive who`, `/hive history`
- **1 skill:** collision-awareness (teaches Claude how to interpret and present collision alerts)
- **Self-hosted backend** via Docker (Fastify + SQLite, zero external deps, ~30MB image)

### The Problem

In any organization with multiple developers or AI agents, people independently start working on overlapping problems without knowing about each other. The work is similar enough to be wasteful duplication, but different enough that merging the two efforts later causes real headaches.

For example: Employee X begins work on feature XZ on Monday. Two days later, Employee Y starts building feature YZ — a different approach to a similar problem. Without Open Hive, nobody notices until days of effort have been sunk into both. With Open Hive, Employee Y gets an alert on their first session: "Employee X has been working on something similar — reach out to coordinate." The collision is caught in minutes, not days.

This problem gets worse with AI coding agents. Agent Teams teammates work fast and autonomously — two agents can silently duplicate effort across an organization before anyone notices. Open Hive makes that invisible overlap visible.

### How It Works

```
Employee X (Monday):    "Building feature XZ — new auth flow"
Employee Y (Wednesday): "Starting feature YZ — refactoring login"
                    |
              Open Hive detects
           semantic overlap (L3a)
                    |
         Employee Y sees on session start:
   "Employee X is working on something similar —
    reach out to coordinate before continuing."
```

Hooks fire on every prompt, file edit, and session lifecycle event. All calls have 3–5 second timeouts and fail silently — if the backend is down, the developer experience is unchanged.

### Architecture

```
┌─────────────────────┐     ┌─────────────────────┐
│  Developer A        │     │  Developer B        │
│  Claude Code        │     │  Claude Code        │
│  + Open Hive Plugin │     │  + Open Hive Plugin │
└────────┬────────────┘     └────────┬────────────┘
         │  hooks fire passively      │
         ▼                            ▼
┌─────────────────────────────────────────────────┐
│              Open Hive Backend                  │
│         Fastify + SQLite (Docker)               │
│  ┌───────────┐  ┌──────────┐  ┌──────────────┐ │
│  │ Sessions  │  │ Signals  │  │  Collision   │ │
│  │ Registry  │  │  Store   │  │   Engine     │ │
│  └───────────┘  └──────────┘  └──────────────┘ │
└─────────────────────────────────────────────────┘
```

### Skills Library

The [full repository](https://github.com/look-itsaxiom/open-hive) includes 12 integration skills (12,180 lines of SKILL.md files) that extend the backend — Slack, Teams, Discord notifications; GitHub/GitLab/Azure DevOps OAuth; PostgreSQL; web dashboard; MCP server; embedding similarity; LLM comparison. Each skill is a self-contained guide that teaches Claude how to add the integration.

### Plugin Contents

| Component | Files | Description |
|-----------|-------|-------------|
| `.claude-plugin/plugin.json` | 1 | Plugin metadata |
| `hooks/hooks.json` | 1 | 6 hook registrations |
| `commands/` | 4 | setup, status, who, history |
| `skills/collision-awareness/` | 1 | Severity interpretation + resolution |
| `dist/` | 3 | Pre-compiled JS handler (no runtime deps beyond Node) |

## Test plan

- [ ] Plugin installs via marketplace
- [ ] `/hive setup` prompts for backend URL and identity
- [ ] Hooks fire silently when backend is unreachable (graceful degradation)
- [ ] With backend running, collision detection works across two sessions
- [ ] Commands `/hive status`, `/hive who`, `/hive history` return formatted output

🤖 Generated with [Claude Code](https://claude.com/claude-code)