### PR TITLE
Update 25+ stale documentation URLs to new canonical domains

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,11 +4,11 @@ contact_links:
     url: https://anthropic.com/discord
     about: Get help, ask questions, and chat with other Claude Code users
   - name: 📖 Documentation
-    url: https://docs.claude.com/en/docs/claude-code
+    url: https://code.claude.com/docs/en
     about: Read the official documentation and guides
   - name: 🎓 Getting Started Guide
-    url: https://docs.claude.com/en/docs/claude-code/quickstart
+    url: https://code.claude.com/docs/en/quickstart
     about: New to Claude Code? Start here
   - name: 🔧 Troubleshooting Guide
-    url: https://docs.claude.com/en/docs/claude-code/troubleshooting
+    url: https://code.claude.com/docs/en/troubleshooting
     about: Common issues and how to fix them

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -32,7 +32,7 @@ body:
     attributes:
       label: Documentation Location
       description: Where did you encounter this issue? Provide a URL if possible
-      placeholder: "e.g., https://docs.anthropic.com/en/docs/claude-code/getting-started"
+      placeholder: "e.g., https://code.claude.com/docs/en/getting-started"
     validations:
       required: false
       

--- a/examples/hooks/bash_command_validator_example.py
+++ b/examples/hooks/bash_command_validator_example.py
@@ -6,7 +6,7 @@ This hook runs as a PreToolUse hook for the Bash tool.
 It validates bash commands against a set of rules before execution.
 In this case it changes grep calls to using rg.
 
-Read more about hooks here: https://docs.anthropic.com/en/docs/claude-code/hooks
+Read more about hooks here: https://code.claude.com/docs/en/hooks
 
 Make sure to change your path to your actual script.
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -6,7 +6,7 @@ This directory contains some official Claude Code plugins that extend functional
 
 Claude Code plugins are extensions that enhance Claude Code with custom slash commands, specialized agents, hooks, and MCP servers. Plugins can be shared across projects and teams, providing consistent tooling and workflows.
 
-Learn more in the [official plugins documentation](https://docs.claude.com/en/docs/claude-code/plugins).
+Learn more in the [official plugins documentation](https://code.claude.com/docs/en/plugins).
 
 ## Plugins in This Directory
 
@@ -30,9 +30,9 @@ Learn more in the [official plugins documentation](https://docs.claude.com/en/do
 
 These plugins are included in the Claude Code repository. To use them in your own projects:
 
-1. Install Claude Code globally:
+1. Install Claude Code:
 ```bash
-npm install -g @anthropic-ai/claude-code
+curl -fsSL https://claude.ai/install.sh | bash
 ```
 
 2. Navigate to your project and run Claude Code:
@@ -42,7 +42,7 @@ claude
 
 3. Use the `/plugin` command to install plugins from marketplaces, or configure them in your project's `.claude/settings.json`.
 
-For detailed plugin installation and configuration, see the [official documentation](https://docs.claude.com/en/docs/claude-code/plugins).
+For detailed plugin installation and configuration, see the [official documentation](https://code.claude.com/docs/en/plugins).
 
 ## Plugin Structure
 
@@ -72,6 +72,6 @@ When adding new plugins to this directory:
 
 ## Learn More
 
-- [Claude Code Documentation](https://docs.claude.com/en/docs/claude-code/overview)
-- [Plugin System Documentation](https://docs.claude.com/en/docs/claude-code/plugins)
-- [Agent SDK Documentation](https://docs.claude.com/en/api/agent-sdk/overview)
+- [Claude Code Documentation](https://code.claude.com/docs/en/overview)
+- [Plugin System Documentation](https://code.claude.com/docs/en/plugins)
+- [Agent SDK Documentation](https://platform.claude.com/docs/en/agent-sdk/overview)

--- a/plugins/agent-sdk-dev/README.md
+++ b/plugins/agent-sdk-dev/README.md
@@ -165,10 +165,10 @@ This plugin is included in the Claude Code repository. To use it:
 
 ## Resources
 
-- [Agent SDK Overview](https://docs.claude.com/en/api/agent-sdk/overview)
-- [TypeScript SDK Reference](https://docs.claude.com/en/api/agent-sdk/typescript)
-- [Python SDK Reference](https://docs.claude.com/en/api/agent-sdk/python)
-- [Agent SDK Examples](https://docs.claude.com/en/api/agent-sdk/examples)
+- [Agent SDK Overview](https://platform.claude.com/docs/en/agent-sdk/overview)
+- [TypeScript SDK Reference](https://platform.claude.com/docs/en/agent-sdk/typescript)
+- [Python SDK Reference](https://platform.claude.com/docs/en/agent-sdk/python)
+- [Agent SDK Examples](https://platform.claude.com/docs/en/agent-sdk/examples)
 
 ## Troubleshooting
 

--- a/plugins/agent-sdk-dev/agents/agent-sdk-verifier-py.md
+++ b/plugins/agent-sdk-dev/agents/agent-sdk-verifier-py.md
@@ -88,7 +88,7 @@ Your verification should prioritize SDK functionality and best practices over ge
 
 2. **Check SDK Documentation Adherence**:
 
-   - Use WebFetch to reference the official Python SDK docs: https://docs.claude.com/en/api/agent-sdk/python
+   - Use WebFetch to reference the official Python SDK docs: https://platform.claude.com/docs/en/agent-sdk/python
    - Compare the implementation against official patterns and recommendations
    - Note any deviations from documented best practices
 

--- a/plugins/agent-sdk-dev/agents/agent-sdk-verifier-ts.md
+++ b/plugins/agent-sdk-dev/agents/agent-sdk-verifier-ts.md
@@ -94,7 +94,7 @@ Your verification should prioritize SDK functionality and best practices over ge
 
 2. **Check SDK Documentation Adherence**:
 
-   - Use WebFetch to reference the official TypeScript SDK docs: https://docs.claude.com/en/api/agent-sdk/typescript
+   - Use WebFetch to reference the official TypeScript SDK docs: https://platform.claude.com/docs/en/agent-sdk/typescript
    - Compare the implementation against official patterns and recommendations
    - Note any deviations from documented best practices
 

--- a/plugins/agent-sdk-dev/commands/new-sdk-app.md
+++ b/plugins/agent-sdk-dev/commands/new-sdk-app.md
@@ -9,10 +9,10 @@ You are tasked with helping the user create a new Claude Agent SDK application. 
 
 Before starting, review the official documentation to ensure you provide accurate and up-to-date guidance. Use WebFetch to read these pages:
 
-1. **Start with the overview**: https://docs.claude.com/en/api/agent-sdk/overview
+1. **Start with the overview**: https://platform.claude.com/docs/en/agent-sdk/overview
 2. **Based on the user's language choice, read the appropriate SDK reference**:
-   - TypeScript: https://docs.claude.com/en/api/agent-sdk/typescript
-   - Python: https://docs.claude.com/en/api/agent-sdk/python
+   - TypeScript: https://platform.claude.com/docs/en/agent-sdk/typescript
+   - Python: https://platform.claude.com/docs/en/agent-sdk/python
 3. **Read relevant guides mentioned in the overview** such as:
    - Streaming vs Single Mode
    - Permissions
@@ -147,8 +147,8 @@ Once setup is complete and verified, provide the user with:
 
 2. **Useful resources**:
 
-   - Link to TypeScript SDK reference: https://docs.claude.com/en/api/agent-sdk/typescript
-   - Link to Python SDK reference: https://docs.claude.com/en/api/agent-sdk/python
+   - Link to TypeScript SDK reference: https://platform.claude.com/docs/en/agent-sdk/typescript
+   - Link to Python SDK reference: https://platform.claude.com/docs/en/agent-sdk/python
    - Explain key concepts: system prompts, permissions, tools, MCP servers
 
 3. **Common next steps**:

--- a/plugins/explanatory-output-style/README.md
+++ b/plugins/explanatory-output-style/README.md
@@ -57,7 +57,7 @@ CLAUDE.md, but it is more flexible and allows for distribution through plugins.
 
 Note: Output styles that involve tasks besides software development, are better
 expressed as
-[subagents](https://docs.claude.com/en/docs/claude-code/sub-agents), not as
+[subagents](https://code.claude.com/docs/en/sub-agents), not as
 SessionStart hooks. Subagents change the system prompt while SessionStart hooks
 add to the default system prompt.
 
@@ -68,5 +68,5 @@ add to the default system prompt.
 - Update the plugin - create a local copy of this plugin to personalize this
   plugin
   - Hint: Ask Claude to read
-    https://docs.claude.com/en/docs/claude-code/plugins.md and set it up for
+    https://code.claude.com/docs/en/plugins and set it up for
     you!

--- a/plugins/learning-output-style/README.md
+++ b/plugins/learning-output-style/README.md
@@ -86,7 +86,7 @@ This SessionStart hook pattern is roughly equivalent to CLAUDE.md, but it is mor
 - Disable the plugin - keep the code installed on your device
 - Uninstall the plugin - remove the code from your device
 - Update the plugin - create a local copy of this plugin to personalize it
-  - Hint: Ask Claude to read https://docs.claude.com/en/docs/claude-code/plugins.md and set it up for you!
+  - Hint: Ask Claude to read https://code.claude.com/docs/en/plugins and set it up for you!
 
 ## Philosophy
 

--- a/plugins/plugin-dev/skills/hook-development/SKILL.md
+++ b/plugins/plugin-dev/skills/hook-development/SKILL.md
@@ -690,7 +690,7 @@ Development tools in `scripts/`:
 
 ### External Resources
 
-- **Official Docs**: https://docs.claude.com/en/docs/claude-code/hooks
+- **Official Docs**: https://code.claude.com/docs/en/hooks
 - **Examples**: See security-guidance plugin in marketplace
 - **Testing**: Use `claude --debug` for detailed logs
 - **Validation**: Use `jq` to validate hook JSON output

--- a/plugins/plugin-dev/skills/mcp-integration/SKILL.md
+++ b/plugins/plugin-dev/skills/mcp-integration/SKILL.md
@@ -533,7 +533,7 @@ Working examples in `examples/`:
 ### External Resources
 
 - **Official MCP Docs**: https://modelcontextprotocol.io/
-- **Claude Code MCP Docs**: https://docs.claude.com/en/docs/claude-code/mcp
+- **Claude Code MCP Docs**: https://code.claude.com/docs/en/mcp
 - **MCP SDK**: @modelcontextprotocol/sdk
 - **Testing**: Use `claude --debug` and `/mcp` command
 


### PR DESCRIPTION
## Summary
  - Replace all `docs.anthropic.com/en/docs/claude-code/*` → `code.claude.com/docs/en/*` (2 files)
  - Replace all `docs.claude.com/en/docs/claude-code/*` → `code.claude.com/docs/en/*` (8 files)
  - Replace all `docs.claude.com/en/api/agent-sdk/*` → `platform.claude.com/docs/en/agent-sdk/*` (5 files)
  - Update `plugins/README.md` install instructions from deprecated `npm install -g` to native `curl` method

  ## Motivation
  All Claude Code documentation has migrated to `code.claude.com/docs` and Agent SDK docs to `platform.claude.com/docs`. The old URLs currently return 301 redirects, but
  canonical URLs should be used for:
  - Faster page loads (no redirect hops)
  - Future-proofing (redirects may be removed)
  - Consistency with the rest of the codebase (e.g., `README.md` already uses `code.claude.com`)

  ## Changed files (12)
  | File | Change |
  |------|--------|
  | `examples/hooks/bash_command_validator_example.py` | `docs.anthropic.com` → `code.claude.com` |
  | `.github/ISSUE_TEMPLATE/documentation.yml` | `docs.anthropic.com` → `code.claude.com` |
  | `.github/ISSUE_TEMPLATE/config.yml` | `docs.claude.com` → `code.claude.com` |
  | `plugins/README.md` | URLs + npm install → curl |
  | `plugins/explanatory-output-style/README.md` | `docs.claude.com` → `code.claude.com` |
  | `plugins/learning-output-style/README.md` | `docs.claude.com` → `code.claude.com` |
  | `plugins/plugin-dev/skills/hook-development/SKILL.md` | `docs.claude.com` → `code.claude.com` |
  | `plugins/plugin-dev/skills/mcp-integration/SKILL.md` | `docs.claude.com` → `code.claude.com` |
  | `plugins/agent-sdk-dev/README.md` | `docs.claude.com` → `platform.claude.com` |
  | `plugins/agent-sdk-dev/commands/new-sdk-app.md` | `docs.claude.com` → `platform.claude.com` |
  | `plugins/agent-sdk-dev/agents/agent-sdk-verifier-py.md` | `docs.claude.com` → `platform.claude.com` |
  | `plugins/agent-sdk-dev/agents/agent-sdk-verifier-ts.md` | `docs.claude.com` → `platform.claude.com` |

  ## Note
  `CHANGELOG.md` contains one `docs.anthropic.com` reference in a past release entry — intentionally left unchanged to preserve historical accuracy.

  ## Test plan
  - [x] Verified no `docs.claude.com` references remain (except CHANGELOG)
  - [x] Verify each replacement URL resolves correctly (no 404s)

 
Closes #30628