### PR TITLE
feat: add container isolation example with guard hook

### DIFF
--- a/examples/container/Dockerfile
+++ b/examples/container/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y \
+    git \
+    openssh-client \
+    curl \
+    less \
+    jq \
+    ca-certificates \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Remove the default ubuntu user (UID 1000) so --passwd-entry can set the
+# correct home directory for the host user. Without this, SSH resolves ~ from
+# /home/ubuntu instead of $HOME, breaking ~/.ssh/config.
+RUN userdel ubuntu && rm -rf /home/ubuntu
+
+# Host tools (claude, gh) are mounted read-only at runtime.
+# No default entrypoint — the wrapper script specifies the command.

--- a/examples/container/README.md
+++ b/examples/container/README.md
@@ -118,7 +118,7 @@ You can — and the guard hook works without a container for exactly this. But p
 
 **What about outgoing network access?**
 
-The container does NOT restrict outgoing network access. Claude has full outbound connectivity — needed for git push, API calls, package installs, etc. This is a deliberate trade-off: restricting the network would break too many common workflows. If you need network isolation, add `--network=none` via `CLAUDE_DOCKER_EXTRA`, but expect git and API operations to fail.
+The container does NOT restrict outgoing network access. Claude has full outbound connectivity — needed for git push, API calls, package installs, etc. The risk: a compromised model could exfiltrate secrets injected into the container (your Claude API key, GitHub token, SSH agent access). For most users this is an acceptable trade-off — these credentials are already exposed to any process on your host. If you need stricter isolation, add `--network=none` via `CLAUDE_DOCKER_EXTRA`, but expect git and API operations to fail. A middle ground (allowlist proxy or DNS filtering) is possible but not included here.
 
 **Why not Docker?**
 

--- a/examples/container/README.md
+++ b/examples/container/README.md
@@ -1,6 +1,6 @@
 # Running Claude Code in a Container
 
-Run Claude Code inside a Podman or Docker container for isolation instead of the built-in sandbox.
+Run Claude Code inside a Podman container for isolation instead of the built-in sandbox.
 
 ## Why a container?
 
@@ -48,7 +48,7 @@ The guard hook intercepts destructive git commands (force push, hard reset, bran
 
 ### Prerequisites
 
-- Podman (recommended) or Docker
+- Podman (required — the wrapper uses `--userns=keep-id` and `--passwd-entry` which are Podman-specific)
 - `claude` CLI installed on the host
 - `gh` CLI (optional, for GitHub integration)
 
@@ -132,6 +132,6 @@ Then mount the toolchain directories read-only (e.g. `~/.local/share/mise/instal
 
 ### Docker (non-Podman) notes
 
-The wrapper defaults to Podman. For Docker:
+The wrapper requires Podman. To adapt for Docker manually:
 - Replace `--userns=keep-id` with `--user "$(id -u):$(id -g)"`
-- The `--passwd-entry` flag is Podman-specific — use a bind-mounted `/etc/passwd` entry instead, or remove it if home directory resolution isn't needed
+- Remove `--passwd-entry` (Podman-specific) — use a bind-mounted `/etc/passwd` entry instead if home directory resolution is needed

--- a/examples/container/README.md
+++ b/examples/container/README.md
@@ -1,0 +1,137 @@
+# Running Claude Code in a Container
+
+Run Claude Code inside a Podman or Docker container for isolation instead of the built-in sandbox.
+
+## Why a container?
+
+Claude Code's built-in sandbox restricts which commands can run. A container flips this model: Claude gets broad permissions *inside* the container, while the container limits access to the host. This gives Claude freedom to work productively while keeping your system safe.
+
+The guard hook works standalone (no container needed) and catches destructive git commands even with `--dangerously-skip-permissions`.
+
+## Quick start — guard hook only
+
+The guard hook intercepts destructive git commands (force push, hard reset, branch -D, rm -rf) and prompts for confirmation. It works with or without a container.
+
+1. Copy [`guard-destructive-git`](./guard-destructive-git) to `~/.claude/bin/` and make it executable:
+   ```bash
+   mkdir -p ~/.claude/bin
+   cp guard-destructive-git ~/.claude/bin/
+   chmod +x ~/.claude/bin/guard-destructive-git
+   ```
+
+2. Add the hook to your `~/.claude/settings.json` (or `settings.local.json`):
+   ```json
+   {
+     "hooks": {
+       "PreToolUse": [
+         {
+           "matcher": "Bash",
+           "hooks": [
+             {
+               "type": "command",
+               "command": "$HOME/.claude/bin/guard-destructive-git"
+             }
+           ]
+         }
+       ]
+     }
+   }
+   ```
+
+3. Verify it works:
+   ```bash
+   echo '{"tool_input":{"command":"git push --force origin main"}}' | ~/.claude/bin/guard-destructive-git
+   # Expected: JSON with "permissionDecision": "ask"
+   ```
+
+## Full container setup
+
+### Prerequisites
+
+- Podman (recommended) or Docker
+- `claude` CLI installed on the host
+- `gh` CLI (optional, for GitHub integration)
+
+### Steps
+
+1. Copy and customize the files from this directory:
+   ```bash
+   mkdir -p ~/.claude/docker
+   cp Dockerfile              ~/.claude/docker/
+   cp settings.container.json ~/.claude/docker/
+   cp container-rules.md      ~/.claude/docker/
+   cp claude-wrapper.sh       ~/.claude/bin/claude
+   chmod +x ~/.claude/bin/claude
+   ```
+
+2. Add `~/.claude/bin` to the front of your PATH (in `.bashrc`/`.zshrc`):
+   ```bash
+   export PATH="$HOME/.claude/bin:$PATH"
+   ```
+
+3. Set up secrets — the wrapper reads from a file (default: `/tmp/claude-secrets.env`):
+   ```bash
+   cat > /tmp/claude-secrets.env << 'EOF'
+   ANTHROPIC_API_KEY=sk-ant-...
+   GITHUB_TOKEN=ghp_...
+   EOF
+   ```
+   Or set `CLAUDE_SECRETS_FILE` to point elsewhere.
+
+4. Build and run:
+   ```bash
+   CLAUDE_DOCKER_REBUILD=1 claude  # first run builds the image
+   claude                          # subsequent runs reuse it
+   ```
+
+## Security model
+
+The container replaces Claude Code's built-in sandbox. Podman rootless provides the isolation boundary.
+
+### What the container prevents
+
+| Threat | How |
+|--------|-----|
+| **Settings escalation** | `settings.json` overlaid read-only from `settings.container.json`. `settings.local.json` blocked via `/dev/null:ro` — Claude cannot grant itself additional permissions. |
+| **Host binary tampering** | Claude, gh, git config, and SSH keys are mounted read-only. |
+| **Privilege escalation** | `--cap-drop=ALL`, `--security-opt=no-new-privileges`, Podman rootless user namespace. |
+| **Destructive git commands** | Guard hook intercepts force push, hard reset, branch -D, rm -rf, and PR merges — prompts for confirmation. |
+
+### What the container does NOT prevent
+
+| Risk | Mitigation |
+|------|------------|
+| **Network access** | Full outbound (needed for git push, API calls). Restrict with `CLAUDE_DOCKER_EXTRA="--network=none"`. |
+| **SSH agent access** | Socket mounted for git auth. Scoped by your SSH agent's own approval mechanism. |
+| **Repo writes** | Claude can modify files in mounted directories — that's the point. Guard hook catches destructive git ops. |
+| **Secrets in env vars** | API keys are visible inside the container. Use short-lived tokens where possible. |
+
+## Customization
+
+| Env var | Purpose |
+|---------|---------|
+| `CLAUDE_DOCKER_IMAGE` | Image name (default: `claude-code`) |
+| `CLAUDE_DOCKER_EXTRA` | Extra podman/docker args (e.g. `-v /extra:/extra:ro`) |
+| `CLAUDE_DOCKER_REBUILD` | Set to `1` to force image rebuild |
+| `CLAUDE_SECRETS_FILE` | Path to secrets env file (default: `/tmp/claude-secrets.env`) |
+
+### Tool manager integration
+
+If you use mise, asdf, nix, or another tool manager, you can inject host toolchains into the container instead of installing them in the image. Run your tool manager's env export on the host and pass the results as `-e` flags:
+
+```bash
+# Example for mise — add to the wrapper script before the `exec` line:
+while IFS= read -r line; do
+  line="${line#export }"
+  key="${line%%=*}"; value="${line#*=}"; value="${value#\'}"; value="${value%\'}"
+  EXTRA_ENV+=(-e "$key=$value")
+done < <(mise env 2>/dev/null | grep "^export " || true)
+```
+
+Then mount the toolchain directories read-only (e.g. `~/.local/share/mise/installs`).
+
+### Docker (non-Podman) notes
+
+The wrapper defaults to Podman. For Docker:
+- Replace `--userns=keep-id` with `--user "$(id -u):$(id -g)"`
+- The `--passwd-entry` flag is Podman-specific — use a bind-mounted `/etc/passwd` entry instead, or remove it if home directory resolution isn't needed

--- a/examples/container/README.md
+++ b/examples/container/README.md
@@ -106,6 +106,24 @@ The container replaces Claude Code's built-in sandbox. Podman rootless provides 
 | **Repo writes** | Claude can modify files in mounted directories — that's the point. Guard hook catches destructive git ops. |
 | **Secrets in env vars** | API keys are visible inside the container. Use short-lived tokens where possible. |
 
+## FAQ
+
+**Why not just use the built-in sandbox?**
+
+The sandbox restricts *which commands* Claude can run. This means you either approve commands one by one (slow, breaks flow) or pre-allow patterns that may be too broad. A container flips the model: Claude runs `--dangerously-skip-permissions` and can do anything *inside* the container, but the container itself limits what reaches the host. You get full autonomy for Claude with less risk, not more.
+
+**Why not just configure permissions carefully?**
+
+You can — and the guard hook works without a container for exactly this. But permissions are allow-lists: you're always one missed pattern away from an unexpected action. The container is a deny-by-default boundary. Even if Claude finds a creative way to combine allowed tools, it can't escape the container. The two approaches complement each other — the container handles the "unknown unknowns."
+
+**Why not Docker?**
+
+The wrapper uses Podman-specific flags (`--userns=keep-id`, `--passwd-entry`) for rootless UID mapping. Docker doesn't support these. You can adapt the setup for Docker (see [Docker notes](#docker-non-podman-notes) below), but Podman's rootless mode is a better security fit — no daemon running as root.
+
+**Does this replace the permission system entirely?**
+
+No. The container settings overlay (`settings.container.json`) still controls what Claude *thinks* it's allowed to do. The guard hook still catches destructive git commands. The container adds a third layer: even if both the permission system and the hook miss something, the container limits blast radius.
+
 ## Customization
 
 | Env var | Purpose |

--- a/examples/container/README.md
+++ b/examples/container/README.md
@@ -110,11 +110,15 @@ The container replaces Claude Code's built-in sandbox. Podman rootless provides 
 
 **Why not just use the built-in sandbox?**
 
-The sandbox restricts *which commands* Claude can run. This means you either approve commands one by one (slow, breaks flow) or pre-allow patterns that may be too broad. A container flips the model: Claude runs `--dangerously-skip-permissions` and can do anything *inside* the container, but the container itself limits what reaches the host. You get full autonomy for Claude with less risk, not more.
+In practice, the sandbox doesn't stay out of the way. Shell expansion, pipes, and compound commands trigger permission prompts even when the underlying operation is safe. You end up approving things constantly, which defeats the purpose of autonomous operation. A container flips the model: Claude runs `--dangerously-skip-permissions` and can do anything *inside* the container, but the container itself limits what reaches the host. No prompts, no flow interruption.
 
 **Why not just configure permissions carefully?**
 
-You can — and the guard hook works without a container for exactly this. But permissions are allow-lists: you're always one missed pattern away from an unexpected action. The container is a deny-by-default boundary. Even if Claude finds a creative way to combine allowed tools, it can't escape the container. The two approaches complement each other — the container handles the "unknown unknowns."
+You can — and the guard hook works without a container for exactly this. But permissions are allow-lists: you're always one missed pattern away from an unexpected prompt. The container is a deny-by-default boundary. Even if Claude finds a creative way to combine allowed tools, it can't escape the container. The two approaches complement each other — the container handles the "unknown unknowns."
+
+**What about outgoing network access?**
+
+The container does NOT restrict outgoing network access. Claude has full outbound connectivity — needed for git push, API calls, package installs, etc. This is a deliberate trade-off: restricting the network would break too many common workflows. If you need network isolation, add `--network=none` via `CLAUDE_DOCKER_EXTRA`, but expect git and API operations to fail.
 
 **Why not Docker?**
 

--- a/examples/container/claude-wrapper.sh
+++ b/examples/container/claude-wrapper.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Launch Claude Code inside a Podman container.
+# Place at ~/.claude/bin/claude and add ~/.claude/bin to PATH.
+#
+# Environment variables:
+#   CLAUDE_DOCKER_IMAGE   - image name (default: claude-code)
+#   CLAUDE_DOCKER_EXTRA   - extra podman args (space-separated)
+#   CLAUDE_DOCKER_REBUILD - set to 1 to force image rebuild
+#   CLAUDE_SECRETS_FILE   - path to env file with API keys (default: /tmp/claude-secrets.env)
+
+set -euo pipefail
+
+IMAGE="${CLAUDE_DOCKER_IMAGE:-claude-code}"
+CLAUDE_HOME="$HOME/.claude"
+DOCKER_DIR="${CLAUDE_HOME}/docker"
+PODMAN="$(command -v podman || command -v docker)"
+
+# --- Build image if needed ---
+if [[ "${CLAUDE_DOCKER_REBUILD:-}" == "1" ]] || ! "$PODMAN" image inspect "$IMAGE" &>/dev/null; then
+  echo "Building $IMAGE image..."
+  "$PODMAN" build -t "$IMAGE" "$DOCKER_DIR"
+fi
+
+# --- Working directory ---
+WORK_DIR="$(pwd)"
+if git rev-parse --show-toplevel &>/dev/null; then
+  WORK_DIR="$(git rev-parse --show-toplevel)"
+fi
+
+# --- Container settings overlay ---
+CONTAINER_SETTINGS="$DOCKER_DIR/settings.container.json"
+SETTINGS_TARGET="$(readlink -f "$CLAUDE_HOME/settings.json" 2>/dev/null || echo "$CLAUDE_HOME/settings.json")"
+
+# --- Secrets ---
+ENV_ARGS=()
+SECRETS_FILE="${CLAUDE_SECRETS_FILE:-/tmp/claude-secrets.env}"
+if [[ -f "$SECRETS_FILE" ]]; then
+  while IFS='=' read -r key value; do
+    key="${key#export }"
+    value="${value#\"}"
+    value="${value%\"}"
+    [[ -z "$key" || "$key" =~ ^# ]] && continue
+    ENV_ARGS+=(-e "$key=$value")
+  done < "$SECRETS_FILE"
+fi
+
+# --- SSH ---
+SSH_ARGS=()
+if [[ -n "${SSH_AUTH_SOCK:-}" ]]; then
+  SSH_ARGS+=(-v "$SSH_AUTH_SOCK:/tmp/ssh-agent.sock" -e "SSH_AUTH_SOCK=/tmp/ssh-agent.sock")
+fi
+# 1Password agent
+OP_AGENT="$HOME/.1password/agent.sock"
+if [[ -S "$OP_AGENT" ]]; then
+  SSH_ARGS+=(-v "$OP_AGENT:$OP_AGENT")
+fi
+
+# --- Find real claude binary (skip this wrapper) ---
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+CLAUDE_BIN=""
+IFS=: read -ra PATH_DIRS <<< "$PATH"
+for dir in "${PATH_DIRS[@]}"; do
+  [[ "$(cd "$dir" 2>/dev/null && pwd)" == "$SELF_DIR" ]] && continue
+  if [[ -x "$dir/claude" ]]; then
+    CLAUDE_BIN="$(readlink -f "$dir/claude")"
+    break
+  fi
+done
+if [[ -z "$CLAUDE_BIN" ]]; then
+  echo "Error: could not find the real claude binary on PATH" >&2
+  exit 1
+fi
+CLAUDE_VERSIONS_DIR="$(dirname "$CLAUDE_BIN")"
+
+# --- Host binaries ---
+BINARY_MOUNTS=(
+  -v "$CLAUDE_VERSIONS_DIR:$CLAUDE_VERSIONS_DIR:ro"
+  -v "$CLAUDE_BIN:/usr/local/bin/claude:ro"
+)
+GH_BIN="$(command -v gh 2>/dev/null || true)"
+if [[ -n "$GH_BIN" ]]; then
+  BINARY_MOUNTS+=(-v "$GH_BIN:/usr/local/bin/gh:ro")
+fi
+
+# --- Run ---
+mkdir -p "$CLAUDE_HOME/rules"
+
+exec "$PODMAN" run --rm -it --userns=keep-id \
+  --cap-drop=ALL --security-opt=no-new-privileges \
+  --passwd-entry "$(whoami):*:$(id -u):$(id -g)::$HOME:/bin/bash" \
+  -v "$CLAUDE_HOME:$HOME/.claude" \
+  -v "$CONTAINER_SETTINGS:$SETTINGS_TARGET:ro" \
+  -v /dev/null:$HOME/.claude/settings.local.json:ro \
+  -v "$DOCKER_DIR/container-rules.md:$HOME/.claude/rules/container.md:ro" \
+  -v "$WORK_DIR:$WORK_DIR" \
+  -w "$WORK_DIR" \
+  -v "$HOME/.claude.json:$HOME/.claude.json" \
+  -v "$HOME/.ssh:$HOME/.ssh:ro" \
+  -v "$HOME/.gitconfig:$HOME/.gitconfig:ro" \
+  -e "HOME=$HOME" \
+  -e "TERM=$TERM" \
+  -e "COLORTERM=${COLORTERM:-}" \
+  --hostname "container" \
+  "${BINARY_MOUNTS[@]}" \
+  ${SSH_ARGS[@]+"${SSH_ARGS[@]}"} \
+  ${ENV_ARGS[@]+"${ENV_ARGS[@]}"} \
+  ${CLAUDE_DOCKER_EXTRA:-} \
+  "$IMAGE" sh -c 'exec claude --dangerously-skip-permissions "$@"' -- "$@"

--- a/examples/container/claude-wrapper.sh
+++ b/examples/container/claude-wrapper.sh
@@ -88,6 +88,75 @@ if [[ -n "$GH_BIN" ]]; then
   BINARY_MOUNTS+=(-v "$GH_BIN:/usr/local/bin/gh:ro")
 fi
 
+# --- Host toolchains ---
+# Auto-detect common language toolchains and mount them into the container.
+# This is best-effort — missing tools are silently skipped.
+TOOLCHAIN_MOUNTS=()
+TOOLCHAIN_ENV=()
+
+# Go
+if command -v go &>/dev/null; then
+  GO_BIN="$(command -v go)"
+  TOOLCHAIN_MOUNTS+=(-v "$GO_BIN:/usr/local/bin/go:ro")
+  GOROOT="$(go env GOROOT 2>/dev/null || true)"
+  if [[ -n "$GOROOT" && -d "$GOROOT" ]]; then
+    TOOLCHAIN_MOUNTS+=(-v "$GOROOT:$GOROOT:ro")
+    TOOLCHAIN_ENV+=(-e "GOROOT=$GOROOT")
+  fi
+  GOPATH="${GOPATH:-$HOME/go}"
+  if [[ -d "$GOPATH" ]]; then
+    TOOLCHAIN_MOUNTS+=(-v "$GOPATH:$GOPATH")
+    TOOLCHAIN_ENV+=(-e "GOPATH=$GOPATH")
+  fi
+fi
+
+# Node.js
+if command -v node &>/dev/null; then
+  NODE_BIN="$(command -v node)"
+  NODE_DIR="$(dirname "$NODE_BIN")"
+  TOOLCHAIN_MOUNTS+=(-v "$NODE_DIR:$NODE_DIR:ro")
+  [[ -d "$HOME/.npm" ]] && TOOLCHAIN_MOUNTS+=(-v "$HOME/.npm:$HOME/.npm")
+fi
+
+# Python
+if command -v python3 &>/dev/null; then
+  PYTHON_BIN="$(command -v python3)"
+  PYTHON_DIR="$(dirname "$PYTHON_BIN")"
+  TOOLCHAIN_MOUNTS+=(-v "$PYTHON_DIR:$PYTHON_DIR:ro")
+fi
+
+# Java
+if command -v java &>/dev/null; then
+  JAVA_BIN="$(command -v java)"
+  TOOLCHAIN_MOUNTS+=(-v "$JAVA_BIN:/usr/local/bin/java:ro")
+  if command -v javac &>/dev/null; then
+    JAVAC_BIN="$(command -v javac)"
+    TOOLCHAIN_MOUNTS+=(-v "$JAVAC_BIN:/usr/local/bin/javac:ro")
+  fi
+  JAVA_REAL="$(readlink -f "$JAVA_BIN")"
+  JAVA_HOME_DETECTED="$(dirname "$(dirname "$JAVA_REAL")")"
+  if [[ -d "$JAVA_HOME_DETECTED/lib" ]]; then
+    TOOLCHAIN_MOUNTS+=(-v "$JAVA_HOME_DETECTED:$JAVA_HOME_DETECTED:ro")
+    TOOLCHAIN_ENV+=(-e "JAVA_HOME=$JAVA_HOME_DETECTED")
+  fi
+fi
+
+# Rust
+if command -v rustc &>/dev/null; then
+  RUSTC_BIN="$(command -v rustc)"
+  TOOLCHAIN_MOUNTS+=(-v "$RUSTC_BIN:/usr/local/bin/rustc:ro")
+  command -v cargo &>/dev/null && TOOLCHAIN_MOUNTS+=(-v "$(command -v cargo):/usr/local/bin/cargo:ro")
+  [[ -d "$HOME/.cargo" ]] && TOOLCHAIN_MOUNTS+=(-v "$HOME/.cargo:$HOME/.cargo")
+  [[ -d "$HOME/.rustup" ]] && TOOLCHAIN_MOUNTS+=(-v "$HOME/.rustup:$HOME/.rustup:ro")
+fi
+
+# Build tools
+for tool in make cmake; do
+  if command -v "$tool" &>/dev/null; then
+    TOOLCHAIN_MOUNTS+=(-v "$(command -v "$tool"):/usr/local/bin/$tool:ro")
+  fi
+done
+
 # --- Run ---
 mkdir -p "$CLAUDE_HOME/rules"
 
@@ -108,6 +177,8 @@ exec "$PODMAN" run --rm -it --userns=keep-id \
   -e "COLORTERM=${COLORTERM:-}" \
   --hostname "container" \
   "${BINARY_MOUNTS[@]}" \
+  ${TOOLCHAIN_MOUNTS[@]+"${TOOLCHAIN_MOUNTS[@]}"} \
+  ${TOOLCHAIN_ENV[@]+"${TOOLCHAIN_ENV[@]}"} \
   ${SSH_ARGS[@]+"${SSH_ARGS[@]}"} \
   ${ENV_ARGS[@]+"${ENV_ARGS[@]}"} \
   ${CLAUDE_DOCKER_EXTRA:-} \

--- a/examples/container/claude-wrapper.sh
+++ b/examples/container/claude-wrapper.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Launch Claude Code inside a Podman container.
+# Launch Claude Code inside a Podman container (Podman only — uses --userns=keep-id
+# and --passwd-entry which have no Docker equivalent).
 # Place at ~/.claude/bin/claude and add ~/.claude/bin to PATH.
 #
 # Environment variables:
@@ -13,7 +14,12 @@ set -euo pipefail
 IMAGE="${CLAUDE_DOCKER_IMAGE:-claude-code}"
 CLAUDE_HOME="$HOME/.claude"
 DOCKER_DIR="${CLAUDE_HOME}/docker"
-PODMAN="$(command -v podman || command -v docker)"
+PODMAN="$(command -v podman || true)"
+if [[ -z "$PODMAN" ]]; then
+  echo "Error: podman is required (Docker is not supported — uses Podman-specific flags)." >&2
+  echo "See README.md 'Docker (non-Podman) notes' for manual adaptation." >&2
+  exit 1
+fi
 
 # --- Build image if needed ---
 if [[ "${CLAUDE_DOCKER_REBUILD:-}" == "1" ]] || ! "$PODMAN" image inspect "$IMAGE" &>/dev/null; then

--- a/examples/container/container-rules.md
+++ b/examples/container/container-rules.md
@@ -1,0 +1,7 @@
+## Container Environment
+
+You are running inside a container.
+
+- **Source directories**: Mounted read-write. You can read and edit files in the working directory.
+- **`settings.json`**: Read-only bind mount overlaid by `settings.container.json`. `settings.local.json` is blocked to prevent permission escalation. To change container settings, edit `~/.claude/docker/settings.container.json` on the host.
+- **Host binaries**: Claude, gh, and other tools are mounted read-only from the host.

--- a/examples/container/guard-destructive-git
+++ b/examples/container/guard-destructive-git
@@ -14,8 +14,37 @@
 #   }
 # }
 
+set -euo pipefail
+
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+# Ensure jq is available; if not, fail closed by asking for confirmation.
+if ! command -v jq >/dev/null 2>&1; then
+  cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "ask",
+    "permissionDecisionReason": "jq is not installed; cannot safely inspect git command."
+  }
+}
+EOF
+  exit 0
+fi
+
+# Safely extract the command; on parse failure, fail closed with an ask decision.
+if ! COMMAND=$(echo "$INPUT" | jq -er '.tool_input.command'); then
+  cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "ask",
+    "permissionDecisionReason": "Failed to parse tool input JSON; cannot safely inspect git command."
+  }
+}
+EOF
+  exit 0
+fi
 
 check() {
   local pattern="$1" reason="$2"

--- a/examples/container/guard-destructive-git
+++ b/examples/container/guard-destructive-git
@@ -1,0 +1,46 @@
+#!/bin/bash
+# PreToolUse hook: prompt for confirmation on destructive git commands.
+# Works even with --dangerously-skip-permissions (hooks always fire).
+# Uses regex matching so compound commands (e.g. "git fetch && git merge")
+# are caught too.
+#
+# Install: copy to ~/.claude/bin/ and add to settings.json:
+# {
+#   "hooks": {
+#     "PreToolUse": [{
+#       "matcher": "Bash",
+#       "hooks": [{"type": "command", "command": "$HOME/.claude/bin/guard-destructive-git"}]
+#     }]
+#   }
+# }
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+check() {
+  local pattern="$1" reason="$2"
+  if [[ "$COMMAND" =~ $pattern ]]; then
+    REASON="$reason"
+    return 0
+  fi
+  return 1
+}
+
+check 'git push (--force|-f)' "Force push will overwrite remote history." ||
+check 'git reset --hard'      "Hard reset discards uncommitted changes." ||
+check 'git branch -D '        "Force-deleting a branch cannot be easily undone." ||
+check 'git checkout (--|\.)'  "This discards uncommitted changes." ||
+check 'git clean -f'          "This permanently deletes untracked files." ||
+check 'rm -rf '               "Recursive force-delete is irreversible." ||
+check 'gh (.+ )?merge '       "Merging a PR cannot be easily undone." ||
+exit 0
+
+cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "ask",
+    "permissionDecisionReason": "$REASON"
+  }
+}
+EOF

--- a/examples/container/settings.container.json
+++ b/examples/container/settings.container.json
@@ -1,0 +1,21 @@
+{
+  "permissions": {
+    "allow": [],
+    "ask": [],
+    "deny": []
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/bin/guard-destructive-git"
+          }
+        ]
+      }
+    ]
+  },
+  "enabled": true
+}


### PR DESCRIPTION
## Summary

Adds `examples/container/` with a complete setup for running Claude Code inside a Podman/Docker container instead of the built-in sandbox.

- **`guard-destructive-git`** — PreToolUse hook that catches force push, hard reset, branch -D, rm -rf, and PR merges. Works standalone without a container — useful on its own as a safety net.
- **`Dockerfile`** — Minimal Ubuntu 24.04 base with git and build tools. Host binaries (claude, gh) mounted at runtime.
- **`claude-wrapper.sh`** — Wrapper script that launches Claude in a rootless Podman container with `--cap-drop=ALL`, `--security-opt=no-new-privileges`, read-only settings overlay, and `settings.local.json` blocked via `/dev/null`.
- **`settings.container.json`** — Template container settings with guard hook pre-wired.
- **`container-rules.md`** — Context rules injected so Claude knows it's in a container.
- **`README.md`** — Quick start (guard-only and full container), security model, customization, tool manager integration tips.

## Test plan

- [ ] Copy files to `~/.claude/docker/` and `~/.claude/bin/`, run `claude` — verify container starts
- [ ] Verify guard hook standalone: `echo '{"tool_input":{"command":"git push --force"}}' | ./guard-destructive-git` returns `"permissionDecision": "ask"`
- [ ] Verify settings overlay: inside container, `settings.json` shows container settings, `settings.local.json` is empty
- [ ] Verify `--cap-drop=ALL` and `--security-opt=no-new-privileges` are applied (inspect with `podman inspect`)