### PR TITLE
fix: remove stale/autoclose labels deterministically on new comment

### DIFF
--- a/.claude/commands/triage-issue.md
+++ b/.claude/commands/triage-issue.md
@@ -53,8 +53,7 @@ TASK:
 **If EVENT is "issue_comment" (comment on existing issue):**
 
 4. Evaluate lifecycle labels based on the full conversation:
-   - If the issue has `stale` or `autoclose`, remove the label — a new human comment means the issue is still active:
-     `./scripts/edit-issue-labels.sh --issue ISSUE_NUMBER --remove-label "stale" --remove-label "autoclose"`
+   - `stale` and `autoclose` labels are already removed automatically by the workflow before this step — no action needed for those.
    - If the issue has `needs-repro` or `needs-info` and the missing information has now been provided, remove the label:
      `./scripts/edit-issue-labels.sh --issue ISSUE_NUMBER --remove-label "needs-repro"`
    - If the issue doesn't have lifecycle labels but clearly needs them (e.g., a maintainer asked for repro steps or more details), add the appropriate label.

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -23,6 +23,26 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Remove stale/autoclose labels on new comment
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const labelsToRemove = ['stale', 'autoclose'];
+            const currentLabels = issue.labels.map(l => l.name);
+            for (const label of labelsToRemove) {
+              if (currentLabels.includes(label)) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  name: label,
+                });
+                console.log(`Removed "${label}" label from #${issue.number}`);
+              }
+            }
+
       - name: Run Claude Code for Issue Triage
         timeout-minutes: 5
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## Summary

- The triage workflow currently delegates stale/autoclose label removal to Claude (via the triage-issue skill), but this is non-deterministic and sometimes fails silently — labels remain even after human comments
- `sweep.ts` `closeExpired()` has a safety net that skips closing when human comments exist, so issues aren't wrongly closed. But the stale label stays, which is confusing for users
- Added a deterministic `github-script` step that mechanically removes `stale`/`autoclose` labels when triggered by a new comment, before the Claude triage step runs
- Updated the triage-issue skill to reflect that stale/autoclose removal is now handled by the workflow

The Claude triage step still handles `needs-repro`/`needs-info` removal, which requires reading the comment content to judge whether the requested information was actually provided.

## Test plan

- [ ] Comment on an issue that has the `stale` label → label should be removed immediately
- [ ] Comment on an issue that has the `autoclose` label → label should be removed immediately
- [ ] Comment on an issue with `needs-repro` → Claude should still evaluate whether to remove it
- [ ] New issue opened → no change in behavior (the new step only runs on `issue_comment`)

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)