### PR TITLE
Fix ``` codeblock syntax in ralph-loop.md

### DIFF
--- a/plugins/ralph-wiggum/commands/ralph-loop.md
+++ b/plugins/ralph-wiggum/commands/ralph-loop.md
@@ -9,9 +9,9 @@ hide-from-slash-command-tool: "true"
 
 Execute the setup script to initialize the Ralph loop:
 
-```!
-"${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh" $ARGUMENTS
-```
+
+    "${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh" $ARGUMENTS
+
 
 Please work on the task. When you try to exit, the Ralph loop will feed the SAME PROMPT back to you for the next iteration. You'll see your previous work in files and git history, allowing you to iterate and improve.
 


### PR DESCRIPTION
the ` ```! ` syntax sometimes confuses the agent to run ` ```! ` as a bash command.

This causes failure when agent runs with tight permissions, such as, when claude code runs in "don't ask" mode, as `Bash(```*)` is unlikely permitted by the user.

Fixing by use the whitespace syntax instead of a ``` block which eliminates the confusion from agent's point of view.

Indent line with 4 whitespace also makes it a code block in markdown so it renders similarly for humans on github.com.