### PR TITLE
feat(plugin): add safe-edit-guard — block Edit/Write on unread files

### DIFF
--- a/plugins/safe-edit-guard/.claude-plugin/plugin.json
+++ b/plugins/safe-edit-guard/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "safe-edit-guard",
+  "version": "1.0.0",
+  "description": "PreToolUse hook that blocks Edit/Write on files Claude hasn't Read first in the current session. Prevents blind edits, hallucinated file paths, and accidental overwrites.",
+  "author": {
+    "name": "OZmasterAI",
+    "url": "https://github.com/OZmasterAI"
+  }
+}

--- a/plugins/safe-edit-guard/README.md
+++ b/plugins/safe-edit-guard/README.md
@@ -1,0 +1,69 @@
+# safe-edit-guard
+
+A PreToolUse hook that blocks Edit and Write on files Claude hasn't Read first in the current session.
+
+## The problem
+
+Claude Code's most common source of regressions: editing files it hasn't read. When Claude edits blind, it guesses at file contents, overwrites working code, breaks imports, and introduces bugs based on wrong assumptions.
+
+This happens because Claude's system prompt says "read files before editing" — but there's no enforcement. This plugin adds mechanical enforcement.
+
+## What it does
+
+- **Tracks** every `Read` call per session (stored in `/tmp`)
+- **Blocks** `Edit`, `Write`, and `MultiEdit` on code files that haven't been read
+- **Allows** writing new files (creating from scratch)
+- **Allows** editing test files if the source file was read (and vice versa)
+- **Ignores** non-code files (markdown, config, JSON, etc.)
+
+## What it doesn't do
+
+- No network calls, no external dependencies, no state beyond `/tmp`
+- Doesn't block destructive shell commands (use [guard-destructive-git](../../../examples/container/guard-destructive-git) for that)
+- Doesn't persist across sessions (each session starts clean)
+
+## Install
+
+```bash
+claude plugin add safe-edit-guard
+```
+
+Or manually: copy the `safe-edit-guard` directory to `~/.claude/plugins/`.
+
+## Guarded file types
+
+`.py` `.js` `.ts` `.jsx` `.tsx` `.rs` `.go` `.java` `.c` `.cpp` `.h` `.hpp` `.rb` `.php` `.sh` `.sql` `.swift` `.kt` `.cs` `.vue` `.svelte`
+
+Non-code files (`.md`, `.json`, `.yaml`, `.toml`, `.txt`, etc.) are not guarded.
+
+## How it works
+
+1. On every `Read` call, the file path is recorded in a session-scoped tracker (`/tmp/safe-edit-guard-{session_id}.json`)
+2. On `Edit`/`Write`/`MultiEdit`, the hook checks if the target file (or a related file) was read
+3. If not read: **exit 2** (blocks the tool call). Claude sees the denial and reads the file first
+4. If read: **exit 0** (allows the tool call)
+
+### Related-file matching
+
+Reading `foo.py` also unlocks editing `test_foo.py` (and vice versa). This covers the common pattern of reading source code then writing its tests.
+
+### Exemptions
+
+- **New files**: `Write` to a path that doesn't exist yet is always allowed
+- **Lock files**: `package-lock.json`, `yarn.lock`, `Cargo.lock`, `__init__.py`
+- **Non-code files**: anything not in the guarded extensions list
+
+## Example
+
+```
+> Edit src/utils/parser.py ...
+
+PreToolUse hook denied: Read src/utils/parser.py before editing it.
+This prevents blind edits that overwrite working code.
+
+> Read src/utils/parser.py
+(file contents shown)
+
+> Edit src/utils/parser.py ...
+(edit proceeds normally)
+```

--- a/plugins/safe-edit-guard/hooks/hooks.json
+++ b/plugins/safe-edit-guard/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Block Edit/Write on files not yet Read in this session. Prevents blind edits and hallucinated file paths.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/safe_edit_guard.py"
+          }
+        ],
+        "matcher": "Read|Edit|Write|MultiEdit"
+      }
+    ]
+  }
+}

--- a/plugins/safe-edit-guard/hooks/safe_edit_guard.py
+++ b/plugins/safe-edit-guard/hooks/safe_edit_guard.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+Safe Edit Guard for Claude Code
+
+Blocks Edit/Write on files that haven't been Read first in the current session.
+Prevents the most common source of Claude Code regressions: blind edits to files
+the model hasn't seen, leading to lost code, broken imports, and wrong assumptions.
+
+Exit codes:
+  0 = allow (file was read, or exempt)
+  2 = block (file not read yet)
+"""
+
+import json
+import os
+import sys
+
+# --- Configuration ---
+
+# File extensions that require read-before-edit.
+# Config files, markdown, etc. are allowed without reading first.
+GUARDED_EXTENSIONS = {
+    ".py", ".js", ".ts", ".jsx", ".tsx", ".rs", ".go", ".java",
+    ".c", ".cpp", ".h", ".hpp", ".rb", ".php", ".sh", ".sql",
+    ".swift", ".kt", ".cs", ".vue", ".svelte",
+}
+
+# Files always allowed without reading (frequently auto-generated or managed).
+EXEMPT_BASENAMES = {
+    "__init__.py",
+    "package-lock.json",
+    "yarn.lock",
+    "Cargo.lock",
+}
+
+
+def get_tracker_path(session_id):
+    """Session-scoped tracker file for read history."""
+    return os.path.join("/tmp", f"safe-edit-guard-{session_id}.json")
+
+
+def load_reads(session_id):
+    """Load set of files Read in this session."""
+    path = get_tracker_path(session_id)
+    try:
+        with open(path) as f:
+            return set(json.load(f))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return set()
+
+
+def save_reads(session_id, reads):
+    """Persist read tracker atomically."""
+    path = get_tracker_path(session_id)
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(sorted(reads), f)
+    os.replace(tmp, path)
+
+
+def normalize(filepath):
+    """Resolve symlinks and normalize path for consistent matching."""
+    return os.path.realpath(os.path.normpath(filepath))
+
+
+def is_related(read_path, edit_path):
+    """Check if a read file is related to the edit target.
+
+    Allows editing test_foo.py if foo.py was read (and vice versa),
+    or editing foo.py in a different directory if the same basename was read.
+    """
+    read_base = os.path.basename(read_path)
+    edit_base = os.path.basename(edit_path)
+
+    # Same file in different directory
+    if read_base == edit_base:
+        return True
+
+    # Strip test prefixes/suffixes and compare stems
+    read_stem = strip_test_affixes(os.path.splitext(read_base)[0])
+    edit_stem = strip_test_affixes(os.path.splitext(edit_base)[0])
+    return read_stem == edit_stem and read_stem != ""
+
+
+def strip_test_affixes(stem):
+    """Remove common test prefixes and suffixes from a filename stem."""
+    s = stem.lower()
+    for prefix in ("test_", "test"):
+        if s.startswith(prefix):
+            s = s[len(prefix):]
+            break
+    for suffix in ("_test", "_spec", ".test", ".spec"):
+        if s.endswith(suffix):
+            s = s[:-len(suffix)]
+            break
+    return s
+
+
+def main():
+    try:
+        data = json.loads(sys.stdin.read())
+    except json.JSONDecodeError:
+        # Can't parse input — fail open to avoid blocking legitimate work
+        sys.exit(0)
+
+    tool_name = data.get("tool_name", "")
+    tool_input = data.get("tool_input", {}) or {}
+    session_id = data.get("session_id", "default")
+
+    # --- Track Read calls ---
+    if tool_name == "Read":
+        file_path = tool_input.get("file_path", "")
+        if file_path:
+            reads = load_reads(session_id)
+            reads.add(normalize(file_path))
+            save_reads(session_id, reads)
+        sys.exit(0)
+
+    # --- Guard Edit/Write/MultiEdit ---
+    if tool_name not in ("Edit", "Write", "MultiEdit"):
+        sys.exit(0)
+
+    file_path = tool_input.get("file_path", "")
+    if not file_path:
+        sys.exit(0)
+
+    file_path_norm = normalize(file_path)
+    _, ext = os.path.splitext(file_path)
+
+    # Only guard code files
+    if ext.lower() not in GUARDED_EXTENSIONS:
+        sys.exit(0)
+
+    # Exempt specific files
+    if os.path.basename(file_path) in EXEMPT_BASENAMES:
+        sys.exit(0)
+
+    # Allow Write to new files (creating from scratch)
+    if tool_name == "Write" and not os.path.exists(file_path):
+        sys.exit(0)
+
+    # Check if file (or a related file) was read this session
+    reads = load_reads(session_id)
+
+    if file_path_norm in reads:
+        sys.exit(0)
+
+    for read_file in reads:
+        if is_related(read_file, file_path_norm):
+            sys.exit(0)
+
+    # Block — file was not read
+    print(
+        f"Read {file_path} before editing it. "
+        f"This prevents blind edits that overwrite working code.",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a `safe-edit-guard` plugin that blocks `Edit`/`Write`/`MultiEdit` on code files Claude hasn't `Read` first in the current session.

This prevents the most common source of Claude Code regressions: blind edits where the model guesses at file contents, overwrites working code, breaks imports, or edits based on wrong assumptions.

- **~140 lines of Python**, zero external dependencies
- **Session-scoped** tracking via `/tmp` — each session starts clean
- **Fail-open** on errors — won't block legitimate work if something goes wrong
- **Related-file matching** — reading `foo.py` unlocks editing `test_foo.py` (and vice versa)
- **Only guards code files** — markdown, JSON, config files are not affected

### How it works

1. On every `Read`, the file path is recorded in a session-scoped tracker
2. On `Edit`/`Write`/`MultiEdit`, the hook checks if the target (or a related file) was read
3. If not → **exit 2** (block). Claude sees the denial and reads the file first
4. If yes → **exit 0** (allow)

### Complements existing plugins

This is complementary to `security-guidance` (which checks *what* is being written) and the `guard-destructive-git` example (which blocks destructive shell commands). This plugin checks *whether Claude has seen the file* before changing it.

## Test plan

- [x] Read then Edit same file → allowed
- [x] Edit unread code file → blocked with message
- [x] Write new file (doesn't exist yet) → allowed
- [x] Edit non-code file (.md, .json) → allowed (not guarded)
- [x] Read `foo.py`, edit `test_foo.py` → allowed (related-file match)
- [x] Malformed JSON input → fail-open (allowed)
- [x] Edit exempt file (`__init__.py`) → allowed

🤖 Generated with [Claude Code](https://claude.ai/code)