### PR TITLE
fix: add missing plugin.json manifest for plugin-dev plugin

### DIFF
--- a/plugins/plugin-dev/.claude-plugin/plugin.json
+++ b/plugins/plugin-dev/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "plugin-dev",
+  "version": "0.1.0",
+  "description": "Comprehensive toolkit for developing Claude Code plugins with 7 expert skills and AI-assisted creation",
+  "author": {
+    "name": "Daisy Hollman",
+    "email": "daisy@anthropic.com"
+  }
+}


### PR DESCRIPTION
## Summary

- The `plugin-dev` plugin was the only plugin missing a `.claude-plugin/plugin.json` manifest file
- This causes validation failures when installed from the marketplace (related to #31495 — Zod schema rejects unrecognized keys, but without a manifest at all the fallback path is even worse)
- Added manifest with metadata matching the existing README (name, version, description, author)

## Test plan

- [ ] Verify plugin loads correctly with the new manifest
- [ ] Confirm manifest fields match the README metadata