### PR TITLE
docs: expand plugin-dev plugin management guidance

### DIFF
--- a/plugins/plugin-dev/README.md
+++ b/plugins/plugin-dev/README.md
@@ -207,6 +207,29 @@ Or for development, use directly:
 cc --plugin-dir /path/to/plugin-dev
 ```
 
+## Plugin Management Quick Reference
+
+When working inside an active Claude Code session, prefer the built-in `/plugin` slash command:
+
+```bash
+/plugin install plugin-name@marketplace-name
+/plugin update plugin-name
+/plugin enable plugin-name
+```
+
+When working outside Claude Code in a normal terminal, use the CLI subcommand in its singular form:
+
+```bash
+claude plugin list
+claude plugin marketplace add owner/repo
+```
+
+Important notes:
+- Use `claude plugin ...`, not `claude plugins ...`
+- For `marketplace add`, pass `owner/repo` directly
+- Do not add a `github:` prefix or paste a full GitHub URL unless a specific marketplace explicitly documents that format
+- If Claude is already running in a session, do not rely on Bash to manage plugins with `claude plugin ...`; prefer `/plugin ...` in-session or ask the user to run the CLI in a separate terminal
+
 ## Quick Start
 
 ### Creating Your First Plugin

--- a/plugins/plugin-dev/commands/create-plugin.md
+++ b/plugins/plugin-dev/commands/create-plugin.md
@@ -281,6 +281,13 @@ Guide the user through creating a complete, high-quality Claude Code plugin from
      cc --plugin-dir /path/to/plugin-name
      ```
    - Or copy to `.claude-plugin/` for project testing
+   - For install, update, and enable flows inside Claude Code, prefer `/plugin ...` commands instead of running `claude plugin ...` through Bash
+   - If the user needs CLI plugin management, tell them to use a separate terminal and the singular subcommand form:
+     ```bash
+     claude plugin list
+     claude plugin marketplace add owner/repo
+     ```
+   - For `marketplace add`, use `owner/repo` directly. Do not prepend `github:` or substitute a full GitHub URL unless the marketplace explicitly requires it.
 
 2. **Verification checklist** for user to perform:
    - [ ] Skills load when triggered (ask questions with trigger phrases)
@@ -320,6 +327,8 @@ Guide the user through creating a complete, high-quality Claude Code plugin from
    - Show user how to add to marketplace.json
    - Help draft marketplace description
    - Suggest category and tags
+   - Remind the user to bump the plugin version whenever published plugin files change
+   - If a marketplace registry also stores the plugin version, keep the registry entry in sync with `.claude-plugin/plugin.json`
 
 3. **Create summary**:
    - Mark all todos complete

--- a/plugins/plugin-dev/skills/plugin-structure/SKILL.md
+++ b/plugins/plugin-dev/skills/plugin-structure/SKILL.md
@@ -83,6 +83,11 @@ The manifest defines plugin metadata and configuration. Located at `.claude-plug
 **Version format**: Follow semantic versioning (MAJOR.MINOR.PATCH)
 **Keywords**: Use for plugin discovery and categorization
 
+**Versioning guidance**:
+- Treat `version` as the update key for distributed plugins
+- If plugin files change, bump the version before asking users to reinstall or update
+- For marketplace-managed plugins, keep any registry version in sync with `.claude-plugin/plugin.json`
+
 ### Component Path Configuration
 
 Specify custom paths for components (supplements default directories):
@@ -353,6 +358,18 @@ Claude Code automatically discovers and loads components:
 - No restart required: Changes take effect on next Claude Code session
 
 **Override behavior**: Custom paths in `plugin.json` supplement (not replace) default directories
+
+## Plugin Management and Updates
+
+When teaching users how to install or update plugins:
+
+- Inside a Claude Code session, prefer `/plugin ...` commands
+- In an external terminal, use `claude plugin ...` with the singular `plugin` subcommand
+- For marketplace registration, use `claude plugin marketplace add owner/repo`
+- Do not use `claude plugins ...`
+- Do not add a `github:` prefix unless the marketplace explicitly documents that syntax
+
+If you are guiding a user from within Claude Code, avoid assuming `claude plugin ...` can be run safely through the Bash tool. Prefer `/plugin ...` in-session, or direct the user to run CLI plugin commands in a separate terminal.
 
 ## Best Practices
 

--- a/plugins/plugin-dev/skills/plugin-structure/references/manifest-reference.md
+++ b/plugins/plugin-dev/skills/plugin-structure/references/manifest-reference.md
@@ -62,6 +62,12 @@ Semantic versioning guidelines:
 - `"1.2.3"` - Patch update to 1.2
 - `"2.0.0"` - Major version with breaking changes
 
+**Operational guidance**:
+- Treat `version` as the update key for distributed plugins
+- If you change plugin files and keep the same version, users may continue seeing cached plugin content
+- Bump the version for every published change that should propagate to installed users
+- If a marketplace registry or manifest also stores the plugin version, update that entry in the same commit so published metadata stays in sync
+
 #### description
 
 **Type**: String
@@ -537,11 +543,17 @@ Full configuration with all features:
 
 ### Maintenance
 
-1. **Bump version on changes**: Follow semantic versioning
+1. **Bump version on changes**: Follow semantic versioning and treat version as part of update propagation
 2. **Update keywords**: Reflect new functionality
 3. **Keep description current**: Match actual capabilities
 4. **Maintain changelog**: Track version history
 5. **Update repository links**: Keep URLs current
+
+**Publishing checklist**:
+1. Update `.claude-plugin/plugin.json`
+2. Bump the plugin version if files changed
+3. Update any marketplace registry entry that also records plugin version
+4. Test install/update from a clean environment before publishing
 
 ### Distribution
 


### PR DESCRIPTION
Fixes #30792

## Summary
- add plugin-dev guidance for using `/plugin` inside Claude Code sessions
- document the singular `claude plugin` CLI syntax and marketplace `owner/repo` format
- explain when to use a separate terminal for CLI plugin management
- add version-bump/update propagation notes for distributed plugins

## Testing
- docs-only change; reviewed the updated plugin-dev guidance against the issue requirements
