### PR TITLE
fix: correct ralph-loop hook schema

### DIFF
--- a/plugins/ralph-wiggum/hooks/hooks.json
+++ b/plugins/ralph-wiggum/hooks/hooks.json
@@ -1,15 +1,13 @@
 {
-  "description": "Ralph Wiggum plugin stop hook for self-referential loops",
-  "hooks": {
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.sh"
-          }
-        ]
-      }
-    ]
-  }
+  "Stop": [
+    {
+      "matcher": "*",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.sh"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Fixes #31278

## Summary
- remove the invalid top-level `description` field from `plugins/ralph-wiggum/hooks/hooks.json`
- flatten the `Stop` hook configuration to the expected root shape
- add the required `matcher` field for the stop hook entry

## Testing
- ran `bash plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh plugins/ralph-wiggum/hooks/hooks.json`
- validator output: `All checks passed!`
