### PR TITLE
fix(code-review): correct README algorithm description and add tests/lint.sh

### DIFF
--- a/plugins/code-review/README.md
+++ b/plugins/code-review/README.md
@@ -1,10 +1,10 @@
 # Code Review Plugin
 
-Automated code review for pull requests using multiple specialized agents with confidence-based scoring to filter false positives.
+Automated code review for pull requests using multiple specialized agents with independent validation to filter false positives.
 
 ## Overview
 
-The Code Review Plugin automates pull request review by launching multiple agents in parallel to independently audit changes from different perspectives. It uses confidence scoring to filter out false positives, ensuring only high-quality, actionable feedback is posted.
+The Code Review Plugin automates pull request review by launching multiple agents in parallel to independently audit changes from different perspectives. Each flagged issue is validated by a separate subagent before surfacing, ensuring only high-confidence, actionable feedback is posted.
 
 ## Commands
 
@@ -18,10 +18,10 @@ Performs automated code review on a pull request using multiple specialized agen
 3. Summarizes the pull request changes
 4. Launches 4 parallel agents to independently review:
    - **Agents #1 & #2**: Audit for CLAUDE.md compliance
-   - **Agent #3**: Scan for obvious bugs in changes
-   - **Agent #4**: Analyze git blame/history for context-based issues
-5. Scores each issue 0-100 for confidence level
-6. Filters out issues below 80 confidence threshold
+   - **Agent #3**: Scan for obvious bugs in the diff
+   - **Agent #4**: Scan for security issues and incorrect logic in introduced code
+5. Validates each issue from agents 3 and 4 with an independent subagent
+6. Filters out issues that were not validated
 7. Outputs review (to terminal by default, or as PR comment with `--comment` flag)
 
 **Usage:**
@@ -42,17 +42,16 @@ Performs automated code review on a pull request using multiple specialized agen
 
 # Claude will:
 # - Launch 4 review agents in parallel
-# - Score each issue for confidence
-# - Output issues ≥80 confidence (to terminal or PR depending on flag)
-# - Skip if no high-confidence issues found
+# - Validate each flagged issue with an independent subagent
+# - Output only validated high-signal issues
+# - Skip if no validated issues found
 ```
 
 **Features:**
 - Multiple independent agents for comprehensive review
-- Confidence-based scoring reduces false positives (threshold: 80)
+- Independent validation subagents reduce false positives
 - CLAUDE.md compliance checking with explicit guideline verification
 - Bug detection focused on changes (not pre-existing issues)
-- Historical context analysis via git blame
 - Automatic skipping of closed, draft, or already-reviewed PRs
 - Links directly to code with full SHA and line ranges
 
@@ -75,13 +74,6 @@ https://github.com/owner/repo/blob/abc123.../src/auth.ts#L88-L95
 https://github.com/owner/repo/blob/abc123.../src/utils.ts#L23-L28
 ```
 
-**Confidence scoring:**
-- **0**: Not confident, false positive
-- **25**: Somewhat confident, might be real
-- **50**: Moderately confident, real but minor
-- **75**: Highly confident, real and important
-- **100**: Absolutely certain, definitely real
-
 **False positives filtered:**
 - Pre-existing issues not introduced in PR
 - Code that looks like a bug but isn't
@@ -98,7 +90,6 @@ This plugin is included in the Claude Code repository. The command is automatica
 
 ### Using `/code-review`
 - Maintain clear CLAUDE.md files for better compliance checking
-- Trust the 80+ confidence threshold - false positives are filtered
 - Run on all non-trivial pull requests
 - Review agent findings as a starting point for human review
 - Update CLAUDE.md based on recurring review patterns
@@ -162,8 +153,8 @@ This plugin is included in the Claude Code repository. The command is automatica
 **Issue**: Review flags issues that aren't real
 
 **Solution**:
-- Default threshold is 80 (already filters most false positives)
-- Make CLAUDE.md more specific about what matters
+- Each issue is validated by an independent subagent before surfacing
+- Make CLAUDE.md more specific about what should be flagged
 - Consider if the flagged issue is actually valid
 
 ### No review comment posted
@@ -176,7 +167,7 @@ Check if:
 - PR is draft (reviews skipped)
 - PR is trivial/automated (reviews skipped)
 - PR already has review (reviews skipped)
-- No issues scored ≥80 (no comment needed)
+- No issues passed validation (no comment needed)
 
 ### Link formatting broken
 
@@ -204,21 +195,10 @@ https://github.com/owner/repo/blob/[full-sha]/path/file.ext#L[start]-L[end]
 
 - **Write specific CLAUDE.md files**: Clear guidelines = better reviews
 - **Include context in PRs**: Helps agents understand intent
-- **Use confidence scores**: Issues ≥80 are usually correct
 - **Iterate on guidelines**: Update CLAUDE.md based on patterns
 - **Review automatically**: Set up as part of PR workflow
-- **Trust the filtering**: Threshold prevents noise
 
 ## Configuration
-
-### Adjusting confidence threshold
-
-The default threshold is 80. To adjust, modify the command file at `commands/code-review.md`:
-```markdown
-Filter out any issues with a score less than 80.
-```
-
-Change `80` to your preferred threshold (0-100).
 
 ### Customizing review focus
 
@@ -232,21 +212,20 @@ Edit `commands/code-review.md` to add or modify agent tasks:
 
 ### Agent architecture
 - **2x CLAUDE.md compliance agents**: Redundancy for guideline checks
-- **1x bug detector**: Focused on obvious bugs in changes only
-- **1x history analyzer**: Context from git blame and history
-- **Nx confidence scorers**: One per issue for independent scoring
+- **1x bug detector**: Focused on obvious bugs in the diff only
+- **1x logic/security agent**: Focused on incorrect logic and security issues in introduced code
+- **Nx validation agents**: One per flagged issue for independent verification
 
-### Scoring system
-- Each issue independently scored 0-100
-- Scoring considers evidence strength and verification
-- Threshold (default 80) filters low-confidence issues
-- For CLAUDE.md issues: verifies guideline explicitly mentions it
+### Validation system
+- Each issue flagged by agents 3 and 4 is independently validated by a subagent
+- Validation confirms the issue is real, scoped to the changed code, and not a false positive
+- Issues that fail validation are filtered before output
+- For CLAUDE.md issues: validates the rule is scoped to the file and is actually violated
 
 ### GitHub integration
 Uses `gh` CLI for:
 - Viewing PR details and diffs
 - Fetching repository data
-- Reading git blame and history
 - Posting review comments
 
 ## Author

--- a/plugins/code-review/tests/lint.sh
+++ b/plugins/code-review/tests/lint.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+PASS=0
+FAIL=0
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+COMMAND="$ROOT/commands/code-review.md"
+
+check() {
+  local description="$1"
+  local result="$2"
+  if [[ "$result" == "pass" ]]; then
+    echo "  PASS  $description"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $description"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "Linting code-review plugin..."
+echo ""
+
+check "command has allowed-tools in frontmatter" \
+  "$(grep -q '^allowed-tools:' "$COMMAND" && echo pass || echo fail)"
+
+check "command has description in frontmatter" \
+  "$(grep -q '^description:' "$COMMAND" && echo pass || echo fail)"
+
+while IFS= read -r ref; do
+  check "referenced file exists: $ref" \
+    "$([[ -f "$ROOT/$ref" ]] && echo pass || echo fail)"
+done < <(grep -oE 'references/[a-zA-Z0-9_-]+\.md' "$COMMAND" || true)
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

The README documented a confidence-scoring algorithm (0–100, threshold 80) that was replaced by a validate/filter subagent approach. It also described Agent 4 as a "git blame/history analyzer" when it actually scans introduced code for security issues and incorrect logic. Anyone reading the README to understand how the plugin works was reading a description of a previous implementation.

## Changes

**`plugins/code-review/README.md`**
- Replace all confidence-scoring language with accurate validate/filter description
- Fix Agent 4 description: "git blame/history analysis" → "security and logic review of introduced code"
- Remove "Confidence scoring" section (0/25/50/75/100 scale that doesn't exist)
- Remove "Adjusting confidence threshold" configuration section (referenced code that doesn't exist)
- Replace "Scoring system" technical details with accurate "Validation system" description

**`plugins/code-review/tests/lint.sh`**
- Checks `allowed-tools` and `description` frontmatter fields are present
- Checks any `references/*.md` files cited in command files exist on disk
- Stateless, fast, exits non-zero on failure

## Test plan
- [ ] Run `bash plugins/code-review/tests/lint.sh` — should pass 2/2
- [ ] Read through README and verify it accurately matches `commands/code-review.md`