### PR TITLE
fix(code-review): include CLAUDE.md agents in step 5 validation

### DIFF
--- a/plugins/code-review/commands/code-review.md
+++ b/plugins/code-review/commands/code-review.md
@@ -52,7 +52,7 @@ Note: Still review Claude generated PR's.
 
    In addition to the above, each subagent should be told the PR title and description. This will help provide context regarding the author's intent.
 
-5. For each issue found in the previous step by agents 3 and 4, launch parallel subagents to validate the issue. These subagents should get the PR title and description along with a description of the issue. The agent's job is to review the issue to validate that the stated issue is truly an issue with high confidence. For example, if an issue such as "variable is not defined" was flagged, the subagent's job would be to validate that is actually true in the code. Another example would be CLAUDE.md issues. The agent should validate that the CLAUDE.md rule that was violated is scoped for this file and is actually violated. Use Opus subagents for bugs and logic issues, and sonnet agents for CLAUDE.md violations.
+5. For each issue found in the previous step, launch parallel subagents to validate the issue. These subagents should get the PR title and description along with a description of the issue. The agent's job is to review the issue to validate that the stated issue is truly an issue with high confidence. For example, if an issue such as "variable is not defined" was flagged, the subagent's job would be to validate that is actually true in the code. Another example would be CLAUDE.md issues. The agent should validate that the CLAUDE.md rule that was violated is scoped for this file and is actually violated. Use Opus subagents for bugs and logic issues, and sonnet agents for CLAUDE.md violations.
 
 6. Filter out any issues that were not validated in step 5. This step will give us our list of high signal issues for our review.
 


### PR DESCRIPTION
## Summary

Step 5 validated issues from agents 3 and 4 only, silently dropping all issues flagged by the CLAUDE.md compliance agents (1 and 2). Since step 6 filters out anything not validated in step 5, CLAUDE.md violations were never surfacing in the output — making the compliance review effectively a no-op.

## Change

**`plugins/code-review/commands/code-review.md`**
- Remove "by agents 3 and 4" scope restriction from step 5 so all four agents' issues go through validation before filtering

## Before / After

**Before:**
> For each issue found in the previous step **by agents 3 and 4**, launch parallel subagents to validate the issue.

**After:**
> For each issue found in the previous step, launch parallel subagents to validate the issue.

## Test plan
- [ ] Run a review on a PR that violates a CLAUDE.md rule — violation should now appear in output
- [ ] Confirm step 5 still uses Opus subagents for bugs and Sonnet subagents for CLAUDE.md violations (unchanged)