### PR TITLE
fix(code-review): strengthen step 1 gating agent reliability

### DIFF
--- a/plugins/code-review/commands/code-review.md
+++ b/plugins/code-review/commands/code-review.md
@@ -11,11 +11,11 @@ Provide a code review for the given pull request.
 
 To do this, follow these steps precisely:
 
-1. Launch a haiku agent to check if any of the following are true:
+1. Launch a sonnet agent to check if any of the following are true:
    - The pull request is closed
    - The pull request is a draft
-   - The pull request does not need code review (e.g. automated PR, trivial change that is obviously correct)
-   - Claude has already commented on this PR (check `gh pr view <PR> --comments` for comments left by claude)
+   - The pull request is trivial and does not need code review. A PR is trivial only if it exclusively contains one or more of the following: auto-generated file changes (lock files, changelogs, generated code), whitespace or formatting changes with no logic modifications, or automated dependency version bumps (e.g. Dependabot, Renovate). If the PR contains any non-trivial changes alongside these, it is not trivial.
+   - Claude has already reviewed this PR (check `gh pr view <PR> --comments` for a comment containing the `## Code review` header)
 
    If any condition is true, stop and do not proceed.
 


### PR DESCRIPTION
## Summary

Step 1 used a Haiku agent with no defined criteria to decide whether to skip a PR as "trivial". A wrong skip silently drops the entire review with no output. Two issues fixed:

1. **Wrong model**: Haiku is the weakest model for a binary decision that gates the entire workflow. Upgraded to Sonnet.
2. **Vague skip criteria**: "trivial change that is obviously correct" is undefined — Haiku would interpret this inconsistently. Replaced with explicit criteria.
3. **Fragile "already reviewed" check**: "comments left by claude" would match any comment mentioning the word "claude". Changed to look for the `## Code review` header that the plugin actually posts.

## Changes

**`plugins/code-review/commands/code-review.md`**
- Step 1: Haiku → Sonnet
- Step 1: Replace vague "trivial" description with explicit skip criteria (lock files, changelogs, generated code, whitespace-only, automated dependency bumps)
- Step 1: Replace "comments left by claude" with check for `## Code review` header

## Before / After

**Before:**
> Launch a **haiku** agent to check if...
> - The pull request does not need code review (e.g. **automated PR, trivial change that is obviously correct**)
> - Claude has already commented on this PR (check for **comments left by claude**)

**After:**
> Launch a **sonnet** agent to check if...
> - The pull request is trivial... **A PR is trivial only if it exclusively contains**: auto-generated file changes, whitespace/formatting with no logic changes, or automated dependency bumps. If the PR contains any non-trivial changes alongside these, it is not trivial.
> - Claude has already reviewed this PR (check for a comment containing the **`## Code review` header**)

## Test plan
- [ ] Run on a Dependabot PR — should be skipped
- [ ] Run on a PR with a Dependabot bump + one logic change — should NOT be skipped
- [ ] Run on a PR already reviewed — should be skipped (check via `## Code review` header, not author name)
- [ ] Run on a substantive PR — should proceed to review