### PR TITLE
feat(code-review): add --model flag to override agent model selection

### DIFF
--- a/plugins/code-review/README.md
+++ b/plugins/code-review/README.md
@@ -26,11 +26,12 @@ Performs automated code review on a pull request using multiple specialized agen
 
 **Usage:**
 ```bash
-/code-review [--comment]
+/code-review [--comment] [--model haiku|sonnet|opus]
 ```
 
 **Options:**
 - `--comment`: Post the review as a comment on the pull request (default: outputs to terminal only)
+- `--model <value>`: Override the model used for all agents. Valid values: `haiku`, `sonnet`, `opus`. Default uses per-step model selection (Haiku for lightweight tasks, Sonnet for compliance, Opus for bug detection).
 
 **Example workflow:**
 ```bash

--- a/plugins/code-review/commands/code-review.md
+++ b/plugins/code-review/commands/code-review.md
@@ -9,6 +9,8 @@ Provide a code review for the given pull request.
 - All tools are functional and will work without error. Do not test tools or make exploratory calls. Make sure this is clear to every subagent that is launched.
 - Only call a tool if it is required to complete the task. Every tool call should have a clear purpose.
 
+If `--model <value>` is provided in the arguments, use that model for all agents in every step below, overriding the per-step defaults. Valid values: `haiku`, `sonnet`, `opus`. If an invalid value is provided, stop and print: "unknown model — valid values are haiku, sonnet, opus". If `--model` is not provided, use the model specified per step.
+
 To do this, follow these steps precisely:
 
 1. Launch a haiku agent to check if any of the following are true:


### PR DESCRIPTION
## Summary

The plugin uses different models per step (Haiku for lightweight tasks, Sonnet for compliance, Opus for bug detection). Users with different cost/quality preferences have no way to override this. This adds a `--model` flag that overrides all agents to use the specified model.

## Usage

```bash
# Use Sonnet for all agents (cost-conscious, still high quality)
/code-review --model sonnet

# Use Opus for all agents (maximum thoroughness)
/code-review --model opus --comment

# Default behavior unchanged (per-step model selection)
/code-review
```

## Changes

**`plugins/code-review/commands/code-review.md`**
- Add `--model` argument handling before step 1: if provided, overrides all per-step model defaults; if invalid, stops with a clear error

**`plugins/code-review/README.md`**
- Document `--model` flag in Options section with valid values and default behavior

## Design decisions

- **All-or-nothing override**: `--model` applies to every agent uniformly. Per-agent overrides (e.g. `--bug-model`) would add complexity with limited benefit.
- **Invalid value → hard stop**: Silently falling back to defaults on a typo would be confusing. Explicit error is better.
- **All three values allowed**: Users choosing `haiku` for everything accept the quality tradeoff. Not our call to block it.

## Test plan
- [ ] `/code-review --model sonnet` — all agents use Sonnet
- [ ] `/code-review --model opus` — all agents use Opus
- [ ] `/code-review --model invalid` — stops with "unknown model — valid values are haiku, sonnet, opus"
- [ ] `/code-review` (no flag) — per-step model selection unchanged