### PR TITLE
Fix hooks.json schema to use direct format across all plugins

### DIFF
--- a/plugins/explanatory-output-style/hooks/hooks.json
+++ b/plugins/explanatory-output-style/hooks/hooks.json
@@ -1,15 +1,13 @@
 {
-  "description": "Explanatory mode hook that adds educational insights instructions",
-  "hooks": {
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks-handlers/session-start.sh"
-          }
-        ]
-      }
-    ]
-  }
+  "SessionStart": [
+    {
+      "matcher": "*",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/hooks-handlers/session-start.sh"
+        }
+      ]
+    }
+  ]
 }

--- a/plugins/hookify/hooks/hooks.json
+++ b/plugins/hookify/hooks/hooks.json
@@ -1,49 +1,50 @@
 {
-  "description": "Hookify plugin - User-configurable hooks from .local.md files",
-  "hooks": {
-    "PreToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse.py",
-            "timeout": 10
-          }
-        ]
-      }
-    ],
-    "PostToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/posttooluse.py",
-            "timeout": 10
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/stop.py",
-            "timeout": 10
-          }
-        ]
-      }
-    ],
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/userpromptsubmit.py",
-            "timeout": 10
-          }
-        ]
-      }
-    ]
-  }
+  "PreToolUse": [
+    {
+      "matcher": "*",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse.py",
+          "timeout": 10
+        }
+      ]
+    }
+  ],
+  "PostToolUse": [
+    {
+      "matcher": "*",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/posttooluse.py",
+          "timeout": 10
+        }
+      ]
+    }
+  ],
+  "Stop": [
+    {
+      "matcher": "*",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/stop.py",
+          "timeout": 10
+        }
+      ]
+    }
+  ],
+  "UserPromptSubmit": [
+    {
+      "matcher": "*",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/userpromptsubmit.py",
+          "timeout": 10
+        }
+      ]
+    }
+  ]
 }

--- a/plugins/learning-output-style/hooks/hooks.json
+++ b/plugins/learning-output-style/hooks/hooks.json
@@ -1,15 +1,13 @@
 {
-  "description": "Learning mode hook that adds interactive learning instructions",
-  "hooks": {
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks-handlers/session-start.sh"
-          }
-        ]
-      }
-    ]
-  }
+  "SessionStart": [
+    {
+      "matcher": "*",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/hooks-handlers/session-start.sh"
+        }
+      ]
+    }
+  ]
 }

--- a/plugins/plugin-dev/skills/hook-development/SKILL.md
+++ b/plugins/plugin-dev/skills/hook-development/SKILL.md
@@ -61,47 +61,7 @@ Execute bash commands for deterministic checks:
 
 ### Plugin hooks.json Format
 
-**For plugin hooks** in `hooks/hooks.json`, use wrapper format:
-
-```json
-{
-  "description": "Brief explanation of hooks (optional)",
-  "hooks": {
-    "PreToolUse": [...],
-    "Stop": [...],
-    "SessionStart": [...]
-  }
-}
-```
-
-**Key points:**
-- `description` field is optional
-- `hooks` field is required wrapper containing actual hook events
-- This is the **plugin-specific format**
-
-**Example:**
-```json
-{
-  "description": "Validation hooks for code quality",
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate.sh"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-### Settings Format (Direct)
-
-**For user settings** in `.claude/settings.json`, use direct format:
+**For plugin hooks** in `hooks/hooks.json` and **user settings** in `.claude/settings.json`, use the direct format:
 
 ```json
 {
@@ -112,11 +72,25 @@ Execute bash commands for deterministic checks:
 ```
 
 **Key points:**
-- No wrapper - events directly at top level
-- No description field
-- This is the **settings format**
+- No wrapper - events are directly at the top level
+- No `description` or `hooks` wrapper fields
 
-**Important:** The examples below show the hook event structure that goes inside either format. For plugin hooks.json, wrap these in `{"hooks": {...}}`.
+**Example:**
+```json
+{
+  "PreToolUse": [
+    {
+      "matcher": "Write",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate.sh"
+        }
+      ]
+    }
+  ]
+}
+```
 
 ## Hook Events
 

--- a/plugins/ralph-wiggum/hooks/hooks.json
+++ b/plugins/ralph-wiggum/hooks/hooks.json
@@ -1,15 +1,13 @@
 {
-  "description": "Ralph Wiggum plugin stop hook for self-referential loops",
-  "hooks": {
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.sh"
-          }
-        ]
-      }
-    ]
-  }
+  "Stop": [
+    {
+      "matcher": "*",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.sh"
+        }
+      ]
+    }
+  ]
 }

--- a/plugins/security-guidance/hooks/hooks.json
+++ b/plugins/security-guidance/hooks/hooks.json
@@ -1,16 +1,13 @@
 {
-  "description": "Security reminder hook that warns about potential security issues when editing files",
-  "hooks": {
-    "PreToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/security_reminder_hook.py"
-          }
-        ],
-        "matcher": "Edit|Write|MultiEdit"
-      }
-    ]
-  }
+  "PreToolUse": [
+    {
+      "matcher": "Edit|Write|MultiEdit",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/security_reminder_hook.py"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Fixes #31278

The `hooks.json` schema validation enforces the direct event format. The previous setup incorrectly nested the events in a `{"hooks": {...}}` wrapper and included an invalid `"description"` field, resulting in errors during Claude Code hook execution (e.g., `Stop hook error: JSON validation failed`). This nested format also triggered `jq` validation errors inside `validate-hook-schema.sh`.

### Changes Made
- Removed the incorrect `{"hooks": {...}}` wrapper and `"description"` field from all `hooks.json` files across all plugins.
- Added the required `"matcher": "*"` fields where they were omitted (e.g., `hookify`, `learning-output-style`, `ralph-wiggum`).
- Fixed `plugin-dev/skills/hook-development/SKILL.md` documentation to instruct developers to use the correct direct format instead of the nested wrapper.
- Verified that all updated `hooks.json` configurations now cleanly pass `validate-hook-schema.sh`.


Made with [Cursor](https://cursor.com)