### PR TITLE
Fix hookify plugin imports missing CLAUDE_PLUGIN_ROOT fallback

### DIFF
--- a/plugins/hookify/hooks/posttooluse.py
+++ b/plugins/hookify/hooks/posttooluse.py
@@ -10,7 +10,7 @@ import sys
 import json
 
 # CRITICAL: Add plugin root to Python path for imports
-PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
+PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT') or os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PLUGIN_ROOT:
     parent_dir = os.path.dirname(PLUGIN_ROOT)
     if parent_dir not in sys.path:

--- a/plugins/hookify/hooks/pretooluse.py
+++ b/plugins/hookify/hooks/pretooluse.py
@@ -11,7 +11,7 @@ import json
 
 # CRITICAL: Add plugin root to Python path for imports
 # We need to add the parent of the plugin directory so Python can find "hookify" package
-PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
+PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT') or os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PLUGIN_ROOT:
     # Add the parent directory of the plugin
     parent_dir = os.path.dirname(PLUGIN_ROOT)

--- a/plugins/hookify/hooks/stop.py
+++ b/plugins/hookify/hooks/stop.py
@@ -10,7 +10,7 @@ import sys
 import json
 
 # CRITICAL: Add plugin root to Python path for imports
-PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
+PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT') or os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PLUGIN_ROOT:
     parent_dir = os.path.dirname(PLUGIN_ROOT)
     if parent_dir not in sys.path:

--- a/plugins/hookify/hooks/userpromptsubmit.py
+++ b/plugins/hookify/hooks/userpromptsubmit.py
@@ -10,7 +10,7 @@ import sys
 import json
 
 # CRITICAL: Add plugin root to Python path for imports
-PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
+PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT') or os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PLUGIN_ROOT:
     parent_dir = os.path.dirname(PLUGIN_ROOT)
     if parent_dir not in sys.path:


### PR DESCRIPTION
Fixes #29842

When executing python hooks for the hookify plugin (`pretooluse.py`, `posttooluse.py`, `stop.py`, `userpromptsubmit.py`), the environment variable `CLAUDE_PLUGIN_ROOT` might not be present because it is only interpolated in the command string but not necessarily exported to the Python environment. This leads to `Hookify import error: No module named 'core'` because `sys.path` does not get updated correctly.

### Changes Made
- Modified the 4 python hook scripts to include a reliable `__file__`-based fallback: `PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT') or os.path.dirname(os.path.dirname(os.path.abspath(__file__)))`.
- This ensures that even if the `CLAUDE_PLUGIN_ROOT` environment variable is null, the script dynamically resolves the correct directory and updates `sys.path`, fixing the import crashes.

Made with [Cursor](https://cursor.com)