### PR TITLE
feat(plugin-dev): add HTTP hook type support to validate-hook-schema.sh

### DIFF
--- a/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
@@ -94,8 +94,8 @@ for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
         continue
       fi
 
-      if [ "$hook_type" != "command" ] && [ "$hook_type" != "prompt" ]; then
-        echo "❌ $event[$i].hooks[$j]: Invalid type '$hook_type' (must be 'command' or 'prompt')"
+      if [ "$hook_type" != "command" ] && [ "$hook_type" != "prompt" ] && [ "$hook_type" != "http" ]; then
+        echo "❌ $event[$i].hooks[$j]: Invalid type '$hook_type' (must be 'command', 'prompt', or 'http')"
         ((error_count++))
         continue
       fi
@@ -124,6 +124,12 @@ for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
         if [ "$event" != "Stop" ] && [ "$event" != "SubagentStop" ] && [ "$event" != "UserPromptSubmit" ] && [ "$event" != "PreToolUse" ]; then
           echo "⚠️  $event[$i].hooks[$j]: Prompt hooks may not be fully supported on $event (best on Stop, SubagentStop, UserPromptSubmit, PreToolUse)"
           ((warning_count++))
+        fi
+      elif [ "$hook_type" = "http" ]; then
+        url=$(jq -r ".\"$event\"[$i].hooks[$j].url // empty" "$HOOKS_FILE")
+        if [ -z "$url" ]; then
+          echo "❌ $event[$i].hooks[$j]: HTTP hooks must have 'url' field"
+          ((error_count++))
         fi
       fi
 


### PR DESCRIPTION
Fixes / Relates to #31653 and #30171

The `validate-hook-schema.sh` script in `plugins/plugin-dev/skills/hook-development/scripts/` explicitly rejected any hook type that was not `"command"` or `"prompt"`. However, as documented in #30171 and requested in #31653, Claude Code supports `"http"` hooks for event routing to remote webhooks or services. 

Because of this omission, plugin developers attempting to follow the `plugin-dev` documentation and running the schema validation tool would receive false-positive `Invalid type 'http'` errors.

### Changes Made
- Added `"http"` as a valid `hook_type` alongside `"command"` and `"prompt"`.
- Added validation to ensure HTTP hooks specify a required `"url"` field in their configuration.


Made with [Cursor](https://cursor.com)