### PR TITLE
docs(plugin-dev): document MCP server deduplication behavior

### DIFF
--- a/plugins/plugin-dev/skills/mcp-integration/SKILL.md
+++ b/plugins/plugin-dev/skills/mcp-integration/SKILL.md
@@ -238,6 +238,9 @@ allowed-tools: ["mcp__plugin_asana_asana__*"]
 **Viewing servers:**
 Use `/mcp` command to see all servers including plugin-provided ones.
 
+**Deduplication:**
+If a plugin provides an MCP server with the same command or URL as a manually-configured server, the plugin's server is automatically skipped. This prevents duplicate connections and redundant tool sets. Suppressed plugin servers are listed in the `/plugin` menu.
+
 ## Authentication Patterns
 
 ### OAuth (SSE/HTTP)


### PR DESCRIPTION
Fixes #31682 by adding documentation about how plugin-provided MCP servers that duplicate manually-configured servers are automatically skipped.

Made with [Cursor](https://cursor.com)