### PR TITLE
feat(feature-dev): add dry-run preview and iterative PR workflow

### DIFF
--- a/plugins/feature-dev/commands/feature-dev.md
+++ b/plugins/feature-dev/commands/feature-dev.md
@@ -90,11 +90,19 @@ If the user says "whatever you think is best", provide your recommendation and g
 
 **Actions**:
 1. Wait for explicit user approval
-2. Read all relevant files identified in previous phases
-3. Implement following chosen architecture
-4. Follow codebase conventions strictly
-5. Write clean, well-documented code
-6. Update todos as you progress
+2. Before making any changes, provide a dry-run preview showing:
+   - List of files to be created vs modified
+   - Estimated scope and lines of code per file
+   - Overall complexity assessment
+3. Ask the user for explicit confirmation of the dry-run before any code changes are made
+4. Read all relevant files identified in previous phases
+5. Break the implementation down into logical chunks that can be reviewed independently
+6. For each chunk:
+   - Implement the code following the chosen architecture and codebase conventions
+   - Write clean, well-documented code
+   - Present the chunk to the user for review
+   - If requested, assist with creating a Pull Request for the increment and wait for approval before proceeding
+7. Update todos as you progress
 
 ---
 

--- a/plugins/plugin-dev/skills/mcp-integration/SKILL.md
+++ b/plugins/plugin-dev/skills/mcp-integration/SKILL.md
@@ -238,6 +238,9 @@ allowed-tools: ["mcp__plugin_asana_asana__*"]
 **Viewing servers:**
 Use `/mcp` command to see all servers including plugin-provided ones.
 
+**Deduplication:**
+If a plugin provides an MCP server with the same command or URL as a manually-configured server, the plugin's server is automatically skipped. This prevents duplicate connections and redundant tool sets. Suppressed plugin servers are listed in the `/plugin` menu.
+
 ## Authentication Patterns
 
 ### OAuth (SSE/HTTP)


### PR DESCRIPTION
## Summary
- Introduces a dry-run preview before implementation begins in the `feature-dev` plugin, showing files to be created/modified, scope, and complexity
- Breaks down implementation into logical chunks that can be independently reviewed via PRs

## Test plan
- Validate that `feature-dev.md` correctly prompts the model to pause for dry-run confirmation and chunk PR reviews.

Fixes #30843
Fixes #30845

Made with [Cursor](https://cursor.com)