### PR TITLE
feat(code-review): add pattern learning to auto-suggest CLAUDE.md rules

### DIFF
--- a/plugins/code-review/commands/code-review.md
+++ b/plugins/code-review/commands/code-review.md
@@ -56,9 +56,49 @@ Note: Still review Claude generated PR's.
 
 6. Filter out any issues that were not validated in step 5. This step will give us our list of high signal issues for our review.
 
+   After filtering, update the pattern store:
+
+   a. Read `.claude/review-patterns.json` from the repo root. If it does not exist, initialize it as `{"version": 1, "patterns": []}`.
+
+   b. For each validated issue, search the store for a semantically similar pattern — same category of problem regardless of specific file names, variable names, or line numbers (e.g. "missing error handling in async functions" matches whether it appears in auth.ts or api.ts). If a match exists, append a new occurrence with: PR number, PR title, files affected, full issue description, and current ISO timestamp. If no match exists, create a new pattern entry with a concise one-line summary.
+
+   c. Write the updated store to `.claude/review-patterns.json`, creating the `.claude/` directory if it does not exist. If `.claude/review-patterns.json` is not listed in the repo root `.gitignore`, append it.
+
+   d. Identify patterns where 3 or more of the last 5 distinct PR numbers in the occurrence list had this pattern. For each such pattern, read the CLAUDE.md files from step 2 and determine:
+      - If an existing rule already addresses this pattern: draft a strengthened or clarified replacement for that rule.
+      - If no rule covers it: draft a new rule.
+      Store these as "pattern suggestions" to be shown in step 7.
+
 7. Output a summary of the review findings to the terminal:
    - If issues were found, list each issue with a brief description.
    - If no issues were found, state: "No issues found. Checked for bugs and CLAUDE.md compliance."
+
+   After the main findings, if any pattern suggestions exist from step 6d, show each one sequentially using this format:
+
+   ```
+   Recurring pattern — seen in {n} of last 5 PRs
+
+     Pattern   {one-line summary}
+     Seen in   PR #{n}, PR #{n}, PR #{n}
+
+     [If existing rule covers it:]
+     Existing rule in {CLAUDE.md path}:
+       "{current rule text}"
+     This rule keeps being violated — suggested update:
+       "{strengthened rule text}"
+
+     Update this rule? [y/n]
+
+     [If no existing rule:]
+     No existing CLAUDE.md rule covers this.
+     Suggested rule: "{drafted rule text}"
+
+     Add to {CLAUDE.md path}? [y/n]
+   ```
+
+   If y: read the target CLAUDE.md file, add the new rule or replace the existing rule at the appropriate location, write the file back, and print:
+     `✓ rule added    {CLAUDE.md path}` or `✓ rule updated  {CLAUDE.md path}`
+   If n: skip and move to the next pattern suggestion.
 
    If `--comment` argument was NOT provided, stop here. Do not post any GitHub comments.
 


### PR DESCRIPTION
## Summary

Every review the plugin runs produces signal that currently disappears. If the same category of issue gets flagged across multiple PRs, that's a gap in the repo's CLAUDE.md — but today nothing surfaces it.

This adds a pattern learning layer that silently tracks validated issues across reviews, detects recurring patterns (3+ occurrences in the last 5 PRs), and proposes targeted CLAUDE.md changes directly in the terminal. The system also checks whether an existing rule already covers the pattern — if so, it suggests strengthening it rather than adding a duplicate.

The result: the plugin gets smarter the more you use it. Each review makes the next one cheaper.

## How it works

**Storage:** `.claude/review-patterns.json` in the repo root (automatically gitignored). Schema:
```json
{
  "version": 1,
  "patterns": [
    {
      "id": "uuid",
      "summary": "missing error handling in async functions",
      "occurrences": [
        {
          "pr_number": 123,
          "pr_title": "feat: add OAuth",
          "files_affected": ["src/auth.ts"],
          "issue_description": "OAuth state not cleaned up in finally block",
          "reviewed_at": "2026-03-07T10:00:00Z"
        }
      ]
    }
  ]
}
```

**Threshold:** 3 or more occurrences across the last 5 distinct PRs reviewed.

**Terminal output when threshold is hit:**
```
Recurring pattern — seen in 3 of last 5 PRs

  Pattern   missing error handling in async functions
  Seen in   PR #118, PR #121, PR #123

  No existing CLAUDE.md rule covers this.
  Suggested rule: "Always wrap async functions in try/catch.
                   Do not let Promise rejections go unhandled."

  Add to .claude/CLAUDE.md? [y/n]
```

If an existing rule already covers the pattern but violations keep occurring, the plugin suggests strengthening it instead of adding a duplicate.

## Changes

**`plugins/code-review/commands/code-review.md`**
- **Step 6** (expanded): after filtering validated issues, update `.claude/review-patterns.json` with new occurrences, detect patterns meeting the threshold, and cross-reference existing CLAUDE.md rules
- **Step 7** (expanded): after main findings, surface pattern suggestions with y/n prompts; if confirmed, write the rule directly to the appropriate CLAUDE.md file

## Design decisions

- **Local file, gitignored**: keeps it zero-setup, no shared infrastructure needed. Team-wide pattern sharing is a natural v2.
- **3 of last 5 PRs threshold**: high enough to filter noise, low enough to surface real patterns quickly. Configurable in a future PR.
- **Modify/remove existing rules**: the plugin doesn't just add rules — if a rule exists but the pattern persists, it suggests strengthening it. This prevents CLAUDE.md bloat.
- **Always terminal-only**: pattern suggestions never appear in GitHub PR comments. They're a coaching tool for the developer running the review, not reviewer feedback.

## Test plan
- [ ] Review 3 PRs with the same category of issue — pattern suggestion should appear on the 3rd
- [ ] Confirm `.claude/review-patterns.json` is created and gitignored automatically
- [ ] Review a PR with an issue covered by an existing CLAUDE.md rule — should suggest strengthening, not adding duplicate
- [ ] Answer `n` to all suggestions — store should still be updated, no CLAUDE.md changes
- [ ] Answer `y` — CLAUDE.md should be updated with the drafted rule