### PR TITLE
Add usage transparency plugin for quota troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ For more installation options, uninstall steps, and troubleshooting, see the [se
 
 This repository includes several Claude Code plugins that extend functionality with custom commands and agents. See the [plugins directory](./plugins/README.md) for detailed documentation on available plugins.
 
+For quota / usage-limit transparency specifically, see the new [usage-transparency plugin](./plugins/usage-transparency/README.md), which adds repository-scoped slash commands for distinguishing rate limits, exhausted allowance, auth conflicts, and org/subscription-related access issues from local signals without inventing backend billing data.
+
 ## Reporting Bugs
 
 We welcome your feedback. Use the `/bug` command to report issues directly within Claude Code, or file a [GitHub issue](https://github.com/anthropics/claude-code/issues).

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -25,6 +25,7 @@ Learn more in the [official plugins documentation](https://docs.claude.com/en/do
 | [pr-review-toolkit](./pr-review-toolkit/) | Comprehensive PR review agents specializing in comments, tests, error handling, type design, code quality, and code simplification | **Command:** `/pr-review-toolkit:review-pr` - Run with optional review aspects (comments, tests, errors, types, code, simplify, all)<br>**Agents:** `comment-analyzer`, `pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer`, `code-reviewer`, `code-simplifier` |
 | [ralph-wiggum](./ralph-wiggum/) | Interactive self-referential AI loops for iterative development. Claude works on the same task repeatedly until completion | **Commands:** `/ralph-loop`, `/cancel-ralph` - Start/stop autonomous iteration loops<br>**Hook:** Stop - Intercepts exit attempts to continue iteration |
 | [security-guidance](./security-guidance/) | Security reminder hook that warns about potential security issues when editing files | **Hook:** PreToolUse - Monitors 9 security patterns including command injection, XSS, eval usage, dangerous HTML, pickle deserialization, and os.system calls |
+| [usage-transparency](./usage-transparency/) | Diagnose quota, rate-limit, auth, and subscription-related access failures without inventing backend billing details | **Commands:** `/usage-status`, `/usage-help` - Classify usage/access failures, separate local signals from platform-side unknowns, and suggest next steps |
 
 ## Installation
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -29,21 +29,18 @@ Learn more in the [official plugins documentation](https://docs.claude.com/en/do
 
 ## Installation
 
-These plugins are included in the Claude Code repository. To use them in your own projects:
+These plugins are included in the Claude Code repository as examples and building blocks. They are not the primary Claude Code installation path.
 
-1. Install Claude Code globally:
-```bash
-npm install -g @anthropic-ai/claude-code
-```
+To use them in your own projects:
 
+1. Install Claude Code using one of the recommended methods from the top-level README or setup docs.
 2. Navigate to your project and run Claude Code:
 ```bash
 claude
 ```
+3. Use the `/plugin` command to install plugins from marketplaces, or copy/configure a plugin in your project's `.claude` plugin settings.
 
-3. Use the `/plugin` command to install plugins from marketplaces, or configure them in your project's `.claude/settings.json`.
-
-For detailed plugin installation and configuration, see the [official documentation](https://docs.claude.com/en/docs/claude-code/plugins).
+For detailed Claude Code setup plus plugin installation and configuration, see the [official documentation](https://docs.claude.com/en/docs/claude-code/plugins).
 
 ## Plugin Structure
 

--- a/plugins/usage-transparency/.claude-plugin/plugin.json
+++ b/plugins/usage-transparency/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "usage-transparency",
   "version": "0.1.0",
-  "description": "Add slash commands for explaining Claude Code usage, quota, rate limits, and auth-related access failures",
+  "description": "Add slash commands for explaining Claude Code rate limits, quota exhaustion, auth conflicts, organization restrictions, and subscription-related access failures",
   "author": {
     "name": "Anthropic",
     "email": "support@anthropic.com"

--- a/plugins/usage-transparency/.claude-plugin/plugin.json
+++ b/plugins/usage-transparency/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "usage-transparency",
+  "version": "0.1.0",
+  "description": "Add slash commands for explaining Claude Code usage, quota, rate limits, and auth-related access failures",
+  "author": {
+    "name": "Anthropic",
+    "email": "support@anthropic.com"
+  }
+}

--- a/plugins/usage-transparency/README.md
+++ b/plugins/usage-transparency/README.md
@@ -28,6 +28,16 @@ This plugin adds slash commands that focus on **classification, visible local si
 
 ## What this plugin does
 
+These plugin commands do not replace Claude Code's built-in `/usage` command or any backend or future quota API. They provide a consistent interpretation layer for troubleshooting when official visible signals are limited or do not clearly distinguish rate limits, quota exhaustion, and access-path issues.
+
+### Command relationship
+
+| Command | Scope | When to use it |
+|---|---|---|
+| `/usage` | Built-in Claude Code usage view | Use when you want the official usage information the CLI currently exposes |
+| `/usage-help` | Plugin interpretation of a pasted error | Use when you already have an error and want it classified without inventing backend details |
+| `/usage-status` | Plugin diagnosis flow for a current symptom | Use when you want step-by-step troubleshooting from local signals |
+
 ### `/usage-status`
 
 Provides a structured diagnosis flow for current usage/access problems.
@@ -100,9 +110,21 @@ It cannot, by itself, guarantee access to:
 
 Those are platform-side capabilities.
 
-## Reproducible classification examples
+## Publicly verifiable acceptance samples
 
-Use these pasted-error examples as a compact manual check that the taxonomy stays stable.
+This section is limited to genuinely public or directly verifiable material. It is not proof of backend billing visibility.
+
+### Public issue evidence
+
+Public issue reports motivating clearer usage differentiation include [#25805](https://github.com/anthropics/claude-code/issues/25805), [#21943](https://github.com/anthropics/claude-code/issues/21943), and [#28999](https://github.com/anthropics/claude-code/issues/28999). Use [#25805](https://github.com/anthropics/claude-code/issues/25805) as the concrete public runtime sample with the verified string `API Error: Rate limit reached`. Treat [#21943](https://github.com/anthropics/claude-code/issues/21943) and [#28999](https://github.com/anthropics/claude-code/issues/28999) as positioning evidence for clearer `/usage` visibility, not as exact runtime error samples.
+
+| Publicly verifiable sample | Expected classification |
+|---|---|
+| `API Error: Rate limit reached` | `rate limit` |
+
+## Synthetic taxonomy examples
+
+The examples below are synthetic prompt-taxonomy fixtures for maintainers. They are intentionally invented to exercise category boundaries and should not be presented as quotations from public issues.
 
 | Pasted error example | Expected classification |
 |---|---|
@@ -116,7 +138,9 @@ Use these pasted-error examples as a compact manual check that the taxonomy stay
 
 Reviewer checklist:
 
-- Feed each example above to `/usage-help`.
+- For public-facing acceptance checks, use the publicly verifiable sample above and keep public-issue references labeled as evidence rather than exact source strings unless the exact string is verified.
+- Use the synthetic taxonomy examples only as invented fixtures for maintainers, not as public evidence.
+- Feed each sample above to `/usage-help`.
 - Confirm the output includes the expected classification.
 - Confirm the output includes `What Claude Code can confirm locally`.
 - Confirm the output includes `What remains unavailable locally`.

--- a/plugins/usage-transparency/README.md
+++ b/plugins/usage-transparency/README.md
@@ -1,0 +1,153 @@
+# Usage Transparency Plugin
+
+Add clearer, repeatable troubleshooting for Claude Code usage failures without pretending the CLI has backend billing visibility.
+
+## Installation and availability
+
+This plugin lives in the Claude Code repository as an example plugin. Its commands are not core built-in commands in this repo by default; they are available only when this plugin is installed or enabled through the normal Claude Code plugin workflow.
+
+To use it in a project, install or copy the plugin following your normal Claude Code plugin workflow.
+
+## Why this plugin exists
+
+A common Claude Code failure mode is not just "being limited" — it is **not knowing what kind of limit or access problem happened**.
+
+Users often need to distinguish between:
+
+- **Rate limit**: temporary throttling or retry window
+- **Quota exhausted**: the current allowance is consumed
+- **Auth conflict**: stale credentials, wrong account, or mismatched auth path
+- **Organization disabled**: org/workspace state blocks access
+- **Subscription mismatch**: signed in, but the active entitlement path does not match expectations
+
+This plugin adds slash commands that focus on **classification, visible local signals, and next-step guidance**.
+
+## What this plugin does
+
+### `/usage-status`
+
+Provides a structured diagnosis flow for current usage/access problems.
+
+It is designed to:
+- classify the failure mode
+- use local diagnostics only when relevant
+- clearly separate **known local facts** from **unknown platform-side billing state**
+- avoid fake quota estimates or invented reset times
+
+When useful, it can inspect:
+- `claude auth status`
+- `claude doctor`
+- the exact error text pasted by the user
+
+Example invocation:
+
+```text
+/usage-status I keep getting "rate limited, try again later" in the terminal
+```
+
+### `/usage-help`
+
+Explains what a reported error *means* and how it differs from similar errors.
+
+Use it when the user already has an error message and mainly needs interpretation.
+
+Example invocation:
+
+```text
+/usage-help You do not have access to this organization
+```
+
+## Design principles
+
+### 1. Do not invent billing data
+
+If Claude Code does not expose exact remaining quota, reset time, or entitlement state in the current environment, say so explicitly.
+
+Good wording:
+
+> Claude Code does not expose exact remaining quota from the currently available local signals.
+
+Avoid:
+- guessed reset timestamps
+- rough percentage estimates
+- vague answers that collapse everything into "usage limit"
+
+### 2. Keep categories distinct
+
+The plugin intentionally separates:
+
+| Category | Meaning | Typical next step |
+|---|---|---|
+| Rate limit | Temporary throttling window | Retry later, reduce burstiness, inspect retry hint |
+| Quota exhausted | Allowance consumed | Check whether any quota/reset info is actually visible; avoid guessing |
+| Auth conflict | Session/account mismatch | Inspect auth status and active account context |
+| Organization disabled | Admin or workspace state issue | Confirm org context and escalate to admin if needed |
+| Subscription mismatch | Signed in, but entitlement path differs from expectation | Check auth path, account context, and entitlement assumptions |
+
+### 3. Separate repository scope from platform scope
+
+This repository can improve **guidance and diagnostics workflows**.
+
+It cannot, by itself, guarantee access to:
+- exact quota remaining
+- quota reset timestamps
+- backend billing breakdowns
+- authoritative subscription entitlement APIs
+
+Those are platform-side capabilities.
+
+## Example outcomes
+
+### Example: rate limit
+
+```markdown
+## Usage status
+- **Classification:** rate limit
+- **What Claude Code can confirm locally:** the error indicates temporary throttling
+- **What remains unavailable locally:** exact backend capacity policy and future reset timing
+
+## Why this is happening
+- The current request pattern hit a temporary throttle window.
+- This differs from an exhausted usage bucket.
+
+## What to do next
+- Retry after the indicated delay if one was shown.
+- Reduce repeated or concurrent requests.
+```
+
+### Example: quota exhausted
+
+```markdown
+## Usage status
+- **Classification:** quota exhausted
+- **What Claude Code can confirm locally:** the current allowance appears consumed
+- **What remains unavailable locally:** exact remaining quota and reset timestamp
+
+## Why this is happening
+- This looks like allowance exhaustion rather than a short-term rate throttle.
+
+## What to do next
+- Check whether the current environment exposes any concrete quota details.
+- If not, say so explicitly instead of estimating.
+```
+
+### Example: auth conflict
+
+```markdown
+## Usage status
+- **Classification:** auth conflict
+- **What Claude Code can confirm locally:** authentication state can be inspected locally
+- **What remains unavailable locally:** backend entitlement decisions unless explicitly exposed
+
+## Why this is happening
+- The session may be using a different auth path or stale credentials.
+
+## What to do next
+- Inspect `claude auth status`.
+- Re-authenticate only if the observed state supports that conclusion.
+```
+
+## Commands summary
+
+- `/usage-status` — diagnose current usage, quota, and auth symptoms
+- `/usage-help` — explain a pasted error and clarify what it does and does not mean

--- a/plugins/usage-transparency/README.md
+++ b/plugins/usage-transparency/README.md
@@ -12,9 +12,11 @@ This repository copy is primarily a reference/example; simply cloning this repo 
 
 ## Why this plugin exists
 
-A common Claude Code failure mode is not just "being limited" — it is **not knowing what kind of limit or access problem happened**.
+A recurring troubleshooting problem in Claude Code is not just "being limited" — it is **not knowing what kind of limit or access problem happened**.
 
-Users often need to distinguish between:
+This also reflects recurring public requests for clearer distinction between throttling vs exhausted allowance and for more visible usage signals, including [#25805](https://github.com/anthropics/claude-code/issues/25805), [#21943](https://github.com/anthropics/claude-code/issues/21943), and [#28999](https://github.com/anthropics/claude-code/issues/28999).
+
+When troubleshooting, users need to distinguish between:
 
 - **Rate limit**: temporary throttling or retry window
 - **Quota exhausted**: the current allowance is consumed
@@ -98,6 +100,28 @@ It cannot, by itself, guarantee access to:
 
 Those are platform-side capabilities.
 
+## Reproducible classification examples
+
+Use these pasted-error examples as a compact manual check that the taxonomy stays stable.
+
+| Pasted error example | Expected classification |
+|---|---|
+| `Rate limited, try again in 2 minutes.` | `rate limit` |
+| `Usage limit reached for your current plan.` | `quota exhausted` |
+| `Your session appears valid, but this workspace was opened under a different account.` | `auth conflict` |
+| `Access denied: your organization has been disabled.` | `organization disabled` |
+| `You are signed in, but your current subscription does not include access to this model in this workspace.` | `subscription mismatch` |
+
+## Acceptance check
+
+Reviewer checklist:
+
+- Feed each example above to `/usage-help`.
+- Confirm the output includes the expected classification.
+- Confirm the output includes `What Claude Code can confirm locally`.
+- Confirm the output includes `What remains unavailable locally`.
+- Confirm the output does not invent quota or reset numbers.
+
 ## Example outcomes
 
 ### Example: rate limit
@@ -135,6 +159,12 @@ Those are platform-side capabilities.
 
 ### Example: auth conflict
 
+Pasted error input:
+
+```text
+Your session appears valid, but this workspace was opened under a different account. Please re-check which account is active.
+```
+
 ```markdown
 ## Usage status
 - **Classification:** auth conflict
@@ -148,6 +178,57 @@ Those are platform-side capabilities.
 - Inspect `claude auth status`.
 - Re-authenticate only if the observed state supports that conclusion.
 ```
+
+### Example: organization disabled
+
+Pasted error input:
+
+```text
+Access denied: your organization has been disabled. Contact your workspace administrator.
+```
+
+```markdown
+## Usage status
+- **Classification:** organization disabled
+- **What Claude Code can confirm locally:** the pasted error points to an organization or workspace access block
+- **What remains unavailable locally:** backend org status details and any admin-side remediation state
+
+## Why this is happening
+- This looks like an org or workspace state issue rather than a normal rate or quota limit.
+
+## What to do next
+- Confirm the active org or workspace context.
+- Escalate to the workspace administrator because local CLI signals usually cannot confirm backend org state directly.
+```
+
+### Example: subscription mismatch
+
+Pasted error input:
+
+```text
+You are signed in, but your current subscription does not include access to this model in this workspace.
+```
+
+```markdown
+## Usage status
+- **Classification:** subscription mismatch
+- **What Claude Code can confirm locally:** the pasted error indicates a signed-in session whose entitlement path does not match the expected access
+- **What remains unavailable locally:** the exact platform-side entitlement rule or billing reason unless explicitly exposed
+
+## Why this is happening
+- The account appears authenticated, but the active entitlement path differs from the expected subscription or workspace access.
+
+## What to do next
+- Check which account and workspace are active.
+- State only the locally observed auth or subscription hints, and avoid guessing the backend billing reason.
+```
+
+## Maintainer notes
+
+- This is a documentation/prompt-guidance-only example plugin in the repository.
+- Keep the default taxonomy at five categories unless Claude Code platform behavior clearly changes.
+- If Claude Code later exposes authoritative quota or entitlement signals, revise the examples and the unknown-boundary wording to use those outputs directly.
+- If a claim cannot be verified from public documentation or local CLI behavior, write it as unknown instead of inferring it.
 
 ## Commands summary
 

--- a/plugins/usage-transparency/README.md
+++ b/plugins/usage-transparency/README.md
@@ -6,7 +6,9 @@ Add clearer, repeatable troubleshooting for Claude Code usage failures without p
 
 This plugin lives in the Claude Code repository as an example plugin. Its commands are not core built-in commands in this repo by default; they are available only when this plugin is installed or enabled through the normal Claude Code plugin workflow.
 
-To use it in a project, install or copy the plugin following your normal Claude Code plugin workflow.
+For a repo-local setup example, copy `plugins/usage-transparency` into your own project's plugin directory (for example, `.claude/plugins/usage-transparency`) and enable it through your normal Claude Code plugin workflow there.
+
+This repository copy is primarily a reference/example; simply cloning this repo does not make `/usage-status` or `/usage-help` available in every Claude Code session.
 
 ## Why this plugin exists
 

--- a/plugins/usage-transparency/commands/usage-help.md
+++ b/plugins/usage-transparency/commands/usage-help.md
@@ -8,7 +8,7 @@ allowed-tools:
 
 # Usage Help
 
-Explain the difference between Claude Code usage-related failures in plain language.
+Explain the difference between Claude Code usage-related failures in plain language. This plugin command complements built-in `/usage` by interpreting pasted errors from local visible signals; it does not replace any official usage view.
 
 ## Goal
 

--- a/plugins/usage-transparency/commands/usage-help.md
+++ b/plugins/usage-transparency/commands/usage-help.md
@@ -1,0 +1,65 @@
+---
+description: Explain quota, rate-limit, auth, and subscription failure modes in Claude Code
+argument-hint: Optional error message to classify
+allowed-tools:
+  - AskUserQuestion
+  - Read
+---
+
+# Usage Help
+
+Explain the difference between Claude Code usage-related failures in plain language.
+
+## Goal
+
+When a user says Claude Code "hit a limit" or "stopped working", help them understand which class of problem they are dealing with and what evidence is actually available.
+
+## Classification guide
+
+Use the user's pasted text, screenshots, or description to map to one of these categories:
+
+1. **Rate limit**
+   - Temporary throttling
+   - Usually recoverable after a wait period
+   - May mention retry delay, too many requests, or a short-term limit
+
+2. **Quota exhausted / usage exhausted**
+   - Allowance is consumed
+   - Not the same as a burst rate limit
+   - Exact remaining amount or reset time may be unavailable in Claude Code
+
+3. **Auth conflict**
+   - Logged into the wrong account
+   - Stale credentials or OAuth state
+   - API key and account context not matching the user’s expectation
+
+4. **Organization disabled / workspace restricted**
+   - Access blocked by org/workspace status or policy
+   - Often needs admin-side follow-up
+
+5. **Subscription mismatch**
+   - Signed in successfully, but the active entitlement path does not match expected plan/model access
+
+## Response format
+
+Always answer with:
+
+```markdown
+## What this error means
+- **Category:** <category>
+- **This usually indicates:** <short explanation>
+
+## What Claude Code can and cannot tell you
+- **Can tell locally:** <facts from the user’s message only>
+- **Cannot tell locally:** <quota remaining, reset time, backend entitlement details if absent>
+
+## Recommended next step
+- <one or two concrete next steps>
+```
+
+## Important wording rules
+
+- Explicitly distinguish `rate limit` from `quota exhausted`.
+- If the user asks for exact quota numbers and you do not have them, say that clearly.
+- If the problem sounds account-related, explain why it is different from quota exhaustion.
+- If evidence is ambiguous, say `unknown` instead of guessing.

--- a/plugins/usage-transparency/commands/usage-help.md
+++ b/plugins/usage-transparency/commands/usage-help.md
@@ -17,6 +17,7 @@ When a user says Claude Code "hit a limit" or "stopped working", help them under
 ## Classification guide
 
 Use the user's pasted text, screenshots, or description to map to one of these categories:
+- If the user provides an image path or screenshot path, inspect it with `Read` before classifying.
 
 1. **Rate limit**
    - Temporary throttling

--- a/plugins/usage-transparency/commands/usage-status.md
+++ b/plugins/usage-transparency/commands/usage-status.md
@@ -9,7 +9,7 @@ allowed-tools:
 
 # Usage Status
 
-Help the user understand *why Claude Code is currently limited* without pretending you have access to billing data that may not exist in the CLI.
+Help the user understand *why Claude Code is currently limited* without pretending you have access to billing data that may not exist in the CLI. This plugin command complements built-in `/usage` by adding a troubleshooting interpretation layer from local visible signals.
 
 ## Core rules
 

--- a/plugins/usage-transparency/commands/usage-status.md
+++ b/plugins/usage-transparency/commands/usage-status.md
@@ -1,0 +1,153 @@
+---
+description: Inspect Claude Code usage, quota, and auth signals without inventing unavailable billing data
+argument-hint: Optional pasted error message or symptom
+allowed-tools:
+  - AskUserQuestion
+  - Bash
+  - Read
+---
+
+# Usage Status
+
+Help the user understand *why Claude Code is currently limited* without pretending you have access to billing data that may not exist in the CLI.
+
+## Core rules
+
+- Do **not** invent remaining quota, reset times, or subscription entitlements.
+- Clearly separate **observed local signals** from **unknown platform-side state**.
+- Prefer concrete classification: `rate limit`, `quota exhausted`, `auth conflict`, `organization disabled`, `subscription mismatch`, or `unknown`.
+- If a signal is unavailable, say so explicitly.
+
+## Inputs
+
+- User-provided argument: `$ARGUMENTS`
+- If the user pasted an error message, treat it as the strongest signal.
+- If no error text is provided, gather context interactively.
+
+## Step 1: Collect the minimum context
+
+If `$ARGUMENTS` is empty, use `AskUserQuestion` to gather the current symptom. Ask up to two short questions:
+
+1. **What are you seeing right now?**
+   - Rate-limited message
+   - Quota / usage exhausted
+   - Login / auth problem
+   - Organization / workspace access issue
+   - Unsure / something else
+
+2. **Where is this happening?**
+   - Terminal Claude Code session
+   - VS Code Claude session
+   - Remote / container / CI
+   - Unsure
+
+If the user already pasted a clear error, skip the questions.
+
+## Step 2: Gather local diagnostics
+
+Use these commands when relevant:
+
+1. `claude auth status`
+   - Use to determine whether the current session appears authenticated and what auth path is active.
+
+2. `claude doctor`
+   - Use to gather CLI environment diagnostics if auth/configuration seems suspicious.
+
+Only run commands that are relevant to the current symptom. Do not run unrelated commands.
+
+## Step 3: Classify the issue
+
+Classify using the strongest evidence available.
+
+### A. Rate limit
+Use this category when the error indicates temporary throttling, request rate saturation, or short-term overage handling.
+
+**Explain:**
+- This usually means requests are being throttled for a window, not that the account is permanently broken.
+- Reset timing may be controlled by the service and may not be visible locally.
+
+**Next steps:**
+- Retry after the indicated delay if one exists.
+- Reduce concurrent or repeated requests.
+- Mention environment-specific follow-up options only if they are explicitly available in the user's setup or pasted error.
+
+### B. Quota exhausted / usage exhausted
+Use this category when the error indicates that the current plan, allowance, or usage bucket has been consumed.
+
+**Explain:**
+- This differs from rate limiting: the issue is allowance exhaustion, not a short burst throttle.
+- Exact remaining quota or reset time may not be available from local CLI signals.
+
+**Next steps:**
+- Tell the user whether the CLI exposed any concrete quota or reset data.
+- If not, explicitly say: "Claude Code does not expose exact remaining quota from the currently available local signals."
+- Mention environment-specific usage or billing follow-up only if it is explicitly relevant to the user’s setup or pasted error.
+
+### C. Auth conflict
+Use this category when signs suggest conflicting auth modes, stale login state, expired credentials, or mismatched account context.
+
+**Explain:**
+- The problem may come from stale OAuth state, mixed auth methods, or a session bound to a different account than expected.
+
+**Next steps:**
+- Use `claude auth status` results if available.
+- Tell the user which auth state was confirmed locally and which parts remain unknown.
+- Recommend re-authentication only if the observed state supports it.
+
+### D. Organization disabled / workspace access issue
+Use this category when the message indicates the organization, workspace, or policy context is preventing access.
+
+**Explain:**
+- This is not a normal rate-limit problem.
+- The failure is likely due to org state, admin policy, or workspace entitlement.
+
+**Next steps:**
+- Say that local CLI tools usually cannot confirm the backend org status directly.
+- Recommend checking the active org/account context and escalating to the workspace admin if needed.
+
+### E. Subscription mismatch
+Use this category when the user appears signed in, but the active session, model access, or entitlement does not match the expected subscription path.
+
+**Explain:**
+- The account may be authenticated, but the active entitlement path may differ from what the user expects.
+- Avoid guessing the exact billing reason unless the evidence is explicit.
+
+**Next steps:**
+- State any locally observed subscription/auth hints.
+- State what remains unknown because it depends on platform-side entitlement logic.
+
+### F. Unknown
+If the evidence is weak or contradictory, say so directly and provide the smallest useful next step.
+
+## Step 4: Produce a structured answer
+
+Respond with this structure:
+
+```markdown
+## Usage status
+- **Classification:** <one category>
+- **What Claude Code can confirm locally:** <facts only>
+- **What remains unavailable locally:** <unknown billing/quota/reset details>
+
+## Why this is happening
+- <1-3 bullets tailored to the category>
+
+## What to do next
+- <targeted next steps>
+```
+
+## Required distinctions
+
+Be explicit about these differences:
+- `rate limit` = temporary throttling window
+- `quota exhausted` = allowance consumed
+- `auth conflict` = credential/account/session mismatch
+- `organization disabled` = admin/org state problem
+- `subscription mismatch` = signed in, but entitlement path does not match expectation
+
+## Never do these things
+
+- Do not make up a reset timestamp.
+- Do not estimate remaining quota.
+- Do not claim backend billing visibility unless the command output explicitly shows it.
+- Do not collapse all failures into a generic "usage limit" answer.


### PR DESCRIPTION
## Problem
- Users often conflate temporary rate limits, quota exhaustion, auth conflicts, and organization/subscription access failures.
- That makes Claude Code failures harder to diagnose, especially when the CLI only exposes local signals and not backend billing state.

## Change
- Add an example plugin, `usage-transparency`, with `/usage-status` and `/usage-help`.
- These commands focus on classifying the failure mode, separating observed local facts from unknown platform-side state, and giving targeted next steps.

## Scope boundary / non-goals
- This PR adds repo-scoped guidance only.
- It does not add backend billing or quota visibility.
- It does not change core Claude Code CLI or TUI runtime behavior.

## Test plan
- [x] Manually reviewed the plugin README and command markdown for accuracy and consistency.
- [x] Checked representative examples to ensure `rate limit` stays distinct from `quota exhausted`.
- [x] Verified the docs explicitly state when quota, reset time, or entitlement details remain unknown locally.
- [x] Confirmed the change is limited to plugin/docs packaging, with no core runtime behavior changes.