### PR TITLE
feat(feature-dev): add iterative PR workflow to implementation phase

### DIFF
--- a/plugins/feature-dev/.claude-plugin/plugin.json
+++ b/plugins/feature-dev/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "feature-dev",
-  "version": "1.0.0",
-  "description": "Comprehensive feature development workflow with specialized agents for codebase exploration, architecture design, and quality review",
+  "version": "1.1.0",
+  "description": "Comprehensive feature development workflow with specialized agents for codebase exploration, architecture design, iterative PR-based implementation, and quality review",
   "author": {
     "name": "Sid Bidasaria",
     "email": "sbidasaria@anthropic.com"

--- a/plugins/feature-dev/README.md
+++ b/plugins/feature-dev/README.md
@@ -4,7 +4,7 @@ A comprehensive, structured workflow for feature development with specialized ag
 
 ## Overview
 
-The Feature Development Plugin provides a systematic 7-phase approach to building new features. Instead of jumping straight into code, it guides you through understanding the codebase, asking clarifying questions, designing architecture, and ensuring quality—resulting in better-designed features that integrate seamlessly with your existing code.
+The Feature Development Plugin provides a systematic 8-phase approach to building new features. Instead of jumping straight into code, it guides you through understanding the codebase, asking clarifying questions, designing architecture, and ensuring quality—resulting in better-designed features that integrate seamlessly with your existing code. Implementation is broken into reviewable increments with PRs created between each, supporting collaborative development workflows.
 
 ## Philosophy
 
@@ -18,7 +18,7 @@ This plugin embeds these practices into a structured workflow that runs automati
 
 ## Command: `/feature-dev`
 
-Launches a guided feature development workflow with 7 distinct phases.
+Launches a guided feature development workflow with 8 distinct phases.
 
 **Usage:**
 ```bash
@@ -32,7 +32,7 @@ Or simply:
 
 The command will guide you through the entire process interactively.
 
-## The 7-Phase Workflow
+## The 8-Phase Workflow
 
 ### Phase 1: Discovery
 
@@ -155,25 +155,61 @@ excessive refactoring, and fits your existing architecture well.
 Which approach would you like to use?
 ```
 
-### Phase 5: Implementation
+### Phase 5: Implementation Planning
 
-**Goal**: Build the feature
+**Goal**: Break the feature into reviewable increments
 
 **What happens:**
-- **Waits for explicit approval** before starting
-- Reads all relevant files identified in previous phases
-- Implements following chosen architecture
-- Follows codebase conventions strictly
-- Writes clean, well-documented code
-- Updates todos as progress is made
+- **Waits for explicit approval** of the architecture before starting
+- Breaks implementation into 2-5 logical increments, each self-contained and non-breaking
+- Presents the increment plan with descriptions and estimated files per increment
+- **Asks you to confirm or adjust the granularity**
+
+**Example output:**
+```
+Implementation plan (3 increments):
+
+1. Data layer: Add OAuthProvider model and migration
+   Files: src/models/OAuthProvider.ts, src/db/migrations/
+2. Auth service: Integrate OAuth flow into AuthService
+   Files: src/auth/AuthService.ts, src/auth/OAuthProvider.ts
+3. API routes + UI: Add OAuth routes and login buttons
+   Files: src/routes/auth.ts, src/components/LoginForm.tsx
+
+Does this breakdown work, or would you prefer different granularity?
+```
+
+### Phase 6: Iterative Implementation
+
+**Goal**: Build each increment and submit it for review
+
+**What happens:**
+- For each increment in the plan:
+  - Implements the changes following the chosen architecture
+  - Creates a commit with a clear message summarizing the increment
+  - Pushes and creates a pull request via `gh pr create`
+  - **Presents the PR link to you**
+  - **Waits for your go-ahead before starting the next increment**
+- If you prefer a single PR for the whole feature, the workflow respects that
 
 **Notes:**
-- Implementation only starts after you approve
-- Follows patterns discovered in Phase 2
-- Uses architecture designed in Phase 4
-- Continuously tracks progress
+- Each increment should pass tests and not break existing functionality
+- Later increments build on earlier ones (stacked changes on the same branch)
+- You can adjust scope or direction between increments
 
-### Phase 6: Quality Review
+**Example interaction:**
+```
+Increment 1 complete: Data layer
+
+PR created: https://github.com/you/repo/pull/42
+  Title: "Add OAuthProvider model and migration"
+  Files changed: 3
+
+Ready to proceed to increment 2 (Auth service), or do you want
+to adjust anything?
+```
+
+### Phase 7: Quality Review
 
 **Goal**: Ensure code is simple, DRY, elegant, and functionally correct
 
@@ -207,7 +243,7 @@ All tests pass. Code follows project conventions.
 What would you like to do?
 ```
 
-### Phase 7: Summary
+### Phase 8: Summary
 
 **Goal**: Document what was accomplished
 
@@ -303,7 +339,7 @@ Suggested next steps:
 - Confidence-based filtering (only reports high-confidence issues ≥80)
 
 **When triggered:**
-- Automatically in Phase 6
+- Automatically in Phase 7
 - Can be invoked manually after writing code
 
 **Output:**
@@ -319,7 +355,7 @@ Suggested next steps:
 /feature-dev Add rate limiting to API endpoints
 ```
 
-Let the workflow guide you through all 7 phases.
+Let the workflow guide you through all 8 phases.
 
 ### Manual agent invocation:
 
@@ -340,11 +376,12 @@ Let the workflow guide you through all 7 phases.
 
 ## Best Practices
 
-1. **Use the full workflow for complex features**: The 7 phases ensure thorough planning
+1. **Use the full workflow for complex features**: The 8 phases ensure thorough planning
 2. **Answer clarifying questions thoughtfully**: Phase 3 prevents future confusion
 3. **Choose architecture deliberately**: Phase 4 gives you options for a reason
-4. **Don't skip code review**: Phase 6 catches issues before they reach production
-5. **Read the suggested files**: Phase 2 identifies key files—read them to understand context
+4. **Review each increment**: Phase 6 creates PRs so you can review changes incrementally
+5. **Don't skip code review**: Phase 7 catches issues before they reach production
+6. **Read the suggested files**: Phase 2 identifies key files—read them to understand context
 
 ## When to Use This Plugin
 
@@ -409,4 +446,4 @@ Sid Bidasaria (sbidasaria@anthropic.com)
 
 ## Version
 
-1.0.0
+1.1.0

--- a/plugins/feature-dev/commands/feature-dev.md
+++ b/plugins/feature-dev/commands/feature-dev.md
@@ -82,23 +82,52 @@ If the user says "whatever you think is best", provide your recommendation and g
 
 ---
 
-## Phase 5: Implementation
+## Phase 5: Implementation Planning
 
-**Goal**: Build the feature
+**Goal**: Break the feature into reviewable increments
 
 **DO NOT START WITHOUT USER APPROVAL**
 
 **Actions**:
-1. Wait for explicit user approval
-2. Read all relevant files identified in previous phases
-3. Implement following chosen architecture
-4. Follow codebase conventions strictly
-5. Write clean, well-documented code
-6. Update todos as you progress
+1. Wait for explicit user approval of the architecture
+2. Break the implementation into logical increments (2-5 chunks), where each increment:
+   - Is a self-contained, working change that doesn't break the build
+   - Represents a logical unit (e.g., data layer, then API, then UI)
+   - Is small enough for a focused code review
+3. Present the increment plan to the user:
+   - List each increment with a brief description and estimated files touched
+   - **Ask user to confirm the plan or adjust the granularity**
 
 ---
 
-## Phase 6: Quality Review
+## Phase 6: Iterative Implementation
+
+**Goal**: Build and submit each increment for review
+
+**For each increment**:
+
+1. Read all relevant files for this increment
+2. Implement following chosen architecture and codebase conventions
+3. Write clean, well-documented code
+4. Update todos as you progress
+5. When the increment is complete:
+   - Create a new branch (if not already on one) using a descriptive name
+   - Stage and commit the changes with a clear commit message summarizing the increment
+   - Push and create a pull request using `gh pr create` with:
+     - A concise title describing the increment
+     - A body summarizing what changed and why
+   - **Present the PR link to the user**
+   - **Ask: "Ready to proceed to the next increment, or do you want to adjust anything?"**
+6. Wait for user confirmation before starting the next increment
+
+**Notes**:
+- If the user prefers a single PR for the whole feature, respect that and skip per-increment PRs
+- Each increment should pass tests and not break existing functionality
+- Later increments can build on earlier ones (stacked changes on the same branch are fine)
+
+---
+
+## Phase 7: Quality Review
 
 **Goal**: Ensure code is simple, DRY, elegant, easy to read, and functionally correct
 
@@ -110,7 +139,7 @@ If the user says "whatever you think is best", provide your recommendation and g
 
 ---
 
-## Phase 7: Summary
+## Phase 8: Summary
 
 **Goal**: Document what was accomplished
 


### PR DESCRIPTION
## Summary

- Splits the monolithic Phase 5 (Implementation) into **Phase 5: Implementation Planning** + **Phase 6: Iterative Implementation**
- Implementation is broken into 2-5 reviewable increments with PR creation between each
- User confirms the increment plan before implementation starts, and approves each increment before the next begins
- Users who prefer a single PR can opt out of per-increment PRs

## Motivation

Addresses #30845 — the feature-dev plugin previously implemented entire features in a single monolithic phase, creating large changesets difficult to code review. Teams need smaller, logical increments that can be reviewed and merged iteratively.

## Changes

- `plugins/feature-dev/commands/feature-dev.md`: Split Phase 5 into Planning + Iterative Implementation, renumber subsequent phases (7→Quality Review, 8→Summary)
- `plugins/feature-dev/README.md`: Updated documentation to reflect 8-phase workflow with new examples for Phases 5-6
- `plugins/feature-dev/.claude-plugin/plugin.json`: Bumped version to 1.1.0, updated description

## Test plan

- [ ] Install the plugin via `claude plugin add ./plugins/feature-dev`
- [ ] Run `/feature-dev` on a multi-file feature and verify Phase 5 presents an increment plan
- [ ] Confirm Phase 6 creates PRs between increments and waits for user approval
- [ ] Verify opting out of per-increment PRs still works as a single-PR flow
- [ ] Confirm Phase 7 (Quality Review) and Phase 8 (Summary) still function correctly