### PR TITLE
Clarify plugin examples versus built-ins

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -2,6 +2,8 @@
 
 This directory contains some official Claude Code plugins that extend functionality through custom commands, agents, and workflows. These are examples of what's possible with the Claude Code plugin system—many more plugins are available through community marketplaces.
 
+These plugins are examples and building blocks, not replacements for Claude Code's built-in features. Start with existing built-in commands and the official documentation, and reach for plugins when you need project-specific workflows, commands, agents, hooks, or MCP integrations.
+
 ## What are Claude Code Plugins?
 
 Claude Code plugins are extensions that enhance Claude Code with custom slash commands, specialized agents, hooks, and MCP servers. Plugins can be shared across projects and teams, providing consistent tooling and workflows.


### PR DESCRIPTION
## Summary
- add a short top-level note in `plugins/README.md` clarifying that repository plugins are examples and building blocks
- explain that plugins complement, rather than replace, Claude Code's built-in features
- point readers toward built-in commands and official docs before project-specific plugin customization

## Test plan
- [x] Read `plugins/README.md` and confirm the new note appears near the top-level overview
- [x] Confirm the wording stays directory-wide and does not change plugin behavior
- [x] Confirm the existing `usage-transparency-plugin` PR branch no longer contains this unrelated README-only commit