### PR TITLE
fix(hookify): map stop/prompt events to correct field names

### DIFF
--- a/plugins/hookify/core/config_loader.py
+++ b/plugins/hookify/core/config_loader.py
@@ -63,6 +63,10 @@ class Rule:
                 field = 'command'
             elif event == 'file':
                 field = 'new_text'
+            elif event == 'stop':
+                field = 'reason'
+            elif event == 'prompt':
+                field = 'user_prompt'
             else:
                 field = 'content'
 


### PR DESCRIPTION
## Summary

Fixes #32153

Hookify rules using the simple `pattern` syntax with `event: stop` or `event: prompt` never fire because `config_loader.py` maps them to `field='content'`, which `rule_engine._extract_field()` cannot resolve for Stop/UserPromptSubmit events (it only handles `content` for Write/Edit tools).

**Fix:** Map `event: stop` to `field='reason'` and `event: prompt` to `field='user_prompt'` in `Rule.from_dict()`. These field names are already correctly handled by `_extract_field()`.

## Changes

- `plugins/hookify/core/config_loader.py`: Added explicit field mappings for `stop` and `prompt` events in the simple pattern conversion logic (4 lines added)

## Test plan

1. Create `.claude/hookify.test-stop.local.md`:
   ```markdown
   ---
   name: test-stop
   enabled: true
   event: stop
   pattern: .*
   action: warn
   ---
   This should trigger on every stop event.
   ```
2. Verify the rule now fires on Stop events
3. Create a similar rule with `event: prompt` and verify it fires on UserPromptSubmit events
4. Verify existing `event: bash` and `event: file` rules still work

This contribution was developed with AI assistance (Claude Code).