### PR TITLE
docs: add PreToolUse auto-approve and PostToolUse hook examples

### DIFF
--- a/examples/hooks/permission_auto_approve_example.py
+++ b/examples/hooks/permission_auto_approve_example.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+Claude Code Hook: Permission Auto-Approve
+==========================================
+This hook runs as a PreToolUse hook to auto-approve known-safe tools
+without prompting the user. Tools not in the allow list fall through
+to the normal permission prompt.
+
+Read more about hooks here: https://code.claude.com/docs/en/hooks
+
+Make sure to change your path to your actual script.
+
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /path/to/claude-code/examples/hooks/permission_auto_approve_example.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+
+"""
+
+import json
+import re
+import sys
+
+# Tools to auto-approve. Each entry is a regex matched against tool_name.
+# Customize this list to fit your workflow.
+_ALLOWED_TOOLS = [
+    r"^Read$",          # Reading files is always safe
+    r"^Glob$",          # File pattern matching is safe
+    r"^Grep$",          # Searching file contents is safe
+    r"^Bash\(git ",     # Git read commands (git status, git log, git diff)
+    r"^Bash\(gh ",      # GitHub CLI commands
+]
+
+# Tools to always deny. Matched before the allow list.
+_DENIED_TOOLS = [
+    r"^Bash\(rm -rf /",   # Never allow recursive delete from root
+]
+
+
+def main():
+    try:
+        input_data = json.load(sys.stdin)
+    except json.JSONDecodeError as e:
+        print(f"Error: Invalid JSON input: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    tool_name = input_data.get("tool_name", "")
+    tool_input = input_data.get("tool_input", {})
+
+    # Build a descriptor for matching (e.g., "Bash(git status)")
+    descriptor = tool_name
+    if tool_name == "Bash" and "command" in tool_input:
+        descriptor = f"Bash({tool_input['command']})"
+
+    # Check deny list first
+    for pattern in _DENIED_TOOLS:
+        if re.search(pattern, descriptor):
+            result = {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                },
+                "systemMessage": f"Blocked by auto-approve hook: {descriptor}",
+            }
+            json.dump(result, sys.stdout)
+            sys.exit(0)
+
+    # Check allow list
+    for pattern in _ALLOWED_TOOLS:
+        if re.search(pattern, descriptor):
+            result = {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "allow",
+                }
+            }
+            json.dump(result, sys.stdout)
+            sys.exit(0)
+
+    # Not in either list - fall through to normal permission prompt
+    json.dump({}, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hooks/post_tool_notify_example.py
+++ b/examples/hooks/post_tool_notify_example.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""
+Claude Code Hook: Post-Tool Notification
+=========================================
+This hook runs as a PostToolUse hook and sends a system message to Claude
+after specific tool operations complete. Useful for adding context, warnings,
+or reminders based on what Claude just did.
+
+Read more about hooks here: https://code.claude.com/docs/en/hooks
+
+Make sure to change your path to your actual script.
+
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /path/to/claude-code/examples/hooks/post_tool_notify_example.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+
+"""
+
+import json
+import os
+import sys
+
+# Patterns to watch for in edited files. Each entry:
+# (file_pattern_substring, message_to_show)
+_WATCH_PATTERNS = [
+    (".env", "Reminder: .env files may contain secrets. Do not commit them."),
+    ("migration", "Reminder: Run migrations locally to verify they work."),
+    ("Dockerfile", "Reminder: Rebuild the Docker image to test this change."),
+    ("package.json", "Reminder: Run `npm install` to update dependencies."),
+    ("Gemfile", "Reminder: Run `bundle install` to update dependencies."),
+]
+
+
+def main():
+    try:
+        input_data = json.load(sys.stdin)
+    except json.JSONDecodeError as e:
+        print(f"Error: Invalid JSON input: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    tool_name = input_data.get("tool_name", "")
+    tool_input = input_data.get("tool_input", {})
+
+    # Only process Edit and Write tools
+    if tool_name not in ("Edit", "Write"):
+        json.dump({}, sys.stdout)
+        sys.exit(0)
+
+    file_path = tool_input.get("file_path", "")
+    if not file_path:
+        json.dump({}, sys.stdout)
+        sys.exit(0)
+
+    # Check file against watch patterns
+    basename = os.path.basename(file_path)
+    messages = []
+    for pattern, message in _WATCH_PATTERNS:
+        if pattern in basename or pattern in file_path:
+            messages.append(message)
+
+    if messages:
+        result = {"systemMessage": "\n".join(messages)}
+        json.dump(result, sys.stdout)
+    else:
+        json.dump({}, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fixes #26703

The `examples/hooks/` directory currently has only one example (`bash_command_validator_example.py`). The hooks docs reference auto-approval scripts, but no working example exists. This PR adds two practical examples covering the most-requested hook patterns.

## New examples

### `permission_auto_approve_example.py` (PreToolUse)
- Auto-approves known-safe tools (Read, Glob, Grep, git/gh commands) without prompting
- Deny list for dangerous operations (`rm -rf /`)
- Falls through to normal permission prompt for unknown tools
- Demonstrates `permissionDecision: "allow"` and `"deny"` responses

### `post_tool_notify_example.py` (PostToolUse)
- Sends contextual reminders after Edit/Write on specific files
- Watches for .env, migration, Dockerfile, package.json, Gemfile edits
- Demonstrates `systemMessage` response pattern
- Non-blocking (warns but doesn't deny)

Both examples follow the exact structure of the existing `bash_command_validator_example.py`: docstring with settings JSON, `#!/usr/bin/env python3` shebang, stdin JSON parsing with error handling.

## Test plan

- [ ] Both scripts parse valid hook JSON from stdin without errors
- [ ] `permission_auto_approve_example.py` returns `permissionDecision: "allow"` for Read tool
- [ ] `permission_auto_approve_example.py` returns `{}` for unknown tools (falls through)
- [ ] `post_tool_notify_example.py` returns `systemMessage` when editing `.env` files
- [ ] `post_tool_notify_example.py` returns `{}` for unmatched files

This contribution was developed with AI assistance (Claude Code).