### PR TITLE
fix: Add missing plugin metadata, docs, and CI/CD permissions guide

### DIFF
--- a/plugins/code-review/README.md
+++ b/plugins/code-review/README.md
@@ -140,6 +140,54 @@ This plugin is included in the Claude Code repository. The command is automatica
 # Skip if review already exists
 ```
 
+### Required Permissions for CI/CD
+
+When running in CI/CD with a restrictive `.claude/settings.json`, the code-review plugin needs the following tool permissions to function correctly. Without these, the plugin will silently complete without posting any review comments.
+
+Add these permissions to your workflow's `settings` input or your project's `.claude/settings.json`:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Read",
+      "Glob",
+      "Grep"
+    ]
+  }
+}
+```
+
+**Example GitHub Actions workflow with permissions:**
+```yaml
+- uses: anthropics/claude-code-action@v1
+  with:
+    claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+    plugins: 'code-review@claude-code-plugins'
+    prompt: '/code-review:code-review --comment'
+    settings: |
+      {
+        "permissions": {
+          "allow": [
+            "Bash(gh:*)",
+            "Bash(git diff:*)",
+            "Bash(git log:*)",
+            "Bash(git show:*)",
+            "Read",
+            "Glob",
+            "Grep"
+          ]
+        }
+      }
+```
+
+> **Note:** If you see `"permission_denials_count"` in the workflow output with a non-zero value, this typically means the plugin was blocked from using required tools. Add the permissions listed above to resolve this.
+
 ## Requirements
 
 - Git repository with GitHub integration

--- a/plugins/plugin-dev/.claude-plugin/plugin.json
+++ b/plugins/plugin-dev/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "plugin-dev",
+  "version": "0.1.0",
+  "description": "Comprehensive toolkit for developing Claude Code plugins with expert guidance on hooks, MCP integration, plugin structure, and marketplace publishing",
+  "author": {
+    "name": "Daisy Hollman",
+    "email": "daisy@anthropic.com"
+  }
+}

--- a/plugins/security-guidance/README.md
+++ b/plugins/security-guidance/README.md
@@ -1,0 +1,70 @@
+# Security Guidance Plugin
+
+Automated security reminder hook that warns about potential security issues when editing files, including command injection, XSS, and unsafe code patterns.
+
+## Overview
+
+The Security Guidance Plugin uses a PreToolUse hook to detect common security anti-patterns in file edits and writes. When a potential vulnerability is detected, it blocks the tool execution with a detailed warning, ensuring the developer is aware of the risk before proceeding.
+
+## How It Works
+
+The plugin intercepts `Edit`, `Write`, and `MultiEdit` tool calls and checks:
+
+1. **File path patterns** - e.g., GitHub Actions workflow files trigger injection warnings
+2. **Content patterns** - e.g., `eval()`, `innerHTML`, `os.system` in new code
+
+When a security pattern is matched for the first time in a session, the hook:
+- Blocks the tool execution (exit code 2)
+- Displays a detailed warning with the vulnerability type and safe alternatives
+- Records the warning so it won't block the same file+pattern combination again in the same session
+
+## Security Patterns Detected
+
+| Pattern | Risk | Files |
+|---------|------|-------|
+| GitHub Actions workflow injection | Command injection via untrusted inputs | `.github/workflows/*.yml` |
+| `child_process.exec` / `execSync` | Shell injection | Any JS/TS file |
+| `new Function()` | Code injection | Any JS/TS file |
+| `eval()` | Arbitrary code execution | Any file |
+| `dangerouslySetInnerHTML` | XSS | React/JSX files |
+| `document.write()` | XSS | Any JS/TS file |
+| `.innerHTML =` | XSS | Any JS/TS file |
+| `pickle` | Arbitrary code execution via deserialization | Python files |
+| `os.system` | Shell injection | Python files |
+
+## Configuration
+
+The plugin can be disabled by setting the `ENABLE_SECURITY_REMINDER` environment variable:
+
+```bash
+# Disable security reminders
+export ENABLE_SECURITY_REMINDER=0
+```
+
+By default, security reminders are enabled (`ENABLE_SECURITY_REMINDER=1`).
+
+## Session Behavior
+
+- Warnings are shown **once per file per pattern** within a session
+- State is tracked in `~/.claude/security_warnings_state_<session_id>.json`
+- State files older than 30 days are automatically cleaned up
+
+## Installation
+
+This plugin is included in the Claude Code plugin marketplace.
+
+```bash
+claude plugin install security-guidance@claude-code-plugins
+```
+
+## Requirements
+
+- Python 3 (for the hook script)
+
+## Author
+
+David Dworken (dworken@anthropic.com)
+
+## Version
+
+1.0.0


### PR DESCRIPTION
## Summary

- **Add missing `plugin.json` to `plugin-dev` plugin** — the only plugin out of 13 without a `.claude-plugin/plugin.json` manifest, breaking structural consistency
- **Add missing `README.md` to `security-guidance` plugin** — the only plugin out of 13 without documentation; covers all 9 security patterns, configuration, and session behavior
- **Document required tool permissions for `code-review` plugin in CI/CD** — addresses #26227 where the plugin silently completes without posting review comments when required tool permissions are missing

## Context

While auditing the plugins directory for structural consistency, I found that:

1. Every plugin has `.claude-plugin/plugin.json` **except** `plugin-dev` — this was added using the same format as all other plugins, with metadata from the existing README (author: Daisy Hollman, version: 0.1.0)
2. Every plugin has `README.md` **except** `security-guidance` — the new README documents all 9 security patterns detected by the hook, the `ENABLE_SECURITY_REMINDER` env var, and session-scoped warning behavior
3. Issue #26227 reports that the code-review plugin silently fails in CI/CD when required tool permissions are not granted — added a "Required Permissions for CI/CD" section with the exact permission list and a complete GitHub Actions workflow example

## Test plan

- [ ] Verify `plugin-dev/.claude-plugin/plugin.json` matches the format of other plugins (name, version, description, author fields)
- [ ] Verify `security-guidance/README.md` accurately describes the hook behavior by cross-referencing with `security_reminder_hook.py`
- [ ] Verify the `code-review` README permissions list matches what the plugin actually needs (cross-reference with `commands/code-review.md` allowed-tools)
- [ ] Verify no existing files were accidentally modified beyond the `code-review/README.md` edit