### PR TITLE
fix: Use jq for safe JSON escaping in log-issue-events workflow

### DIFF
--- a/.github/workflows/log-issue-events.yml
+++ b/.github/workflows/log-issue-events.yml
@@ -18,23 +18,36 @@ jobs:
           ISSUE_TITLE: ${{ github.event.issue.title }}
           AUTHOR: ${{ github.event.issue.user.login }}
           CREATED_AT: ${{ github.event.issue.created_at }}
+          EVENT_ACTION: ${{ github.event.action }}
         run: |
-          # All values are now safely passed via environment variables
-          # No direct templating in the shell script to prevent injection attacks
-          
-          curl -X POST "https://events.statsigapi.net/v1/log_event" \
+          # Use jq to safely construct JSON, handling special characters
+          # in issue titles (newlines, backslashes, quotes, tabs, etc.)
+
+          EVENT_NAME="github_issue_${EVENT_ACTION}"
+
+          PAYLOAD=$(jq -n \
+            --arg event_name "$EVENT_NAME" \
+            --arg issue_number "$ISSUE_NUMBER" \
+            --arg repository "$REPO" \
+            --arg title "$ISSUE_TITLE" \
+            --arg author "$AUTHOR" \
+            --arg created_at "$CREATED_AT" \
+            --argjson time "$(date +%s)000" \
+            '{
+              events: [{
+                eventName: $event_name,
+                metadata: {
+                  issue_number: $issue_number,
+                  repository: $repository,
+                  title: $title,
+                  author: $author,
+                  created_at: $created_at
+                },
+                time: $time
+              }]
+            }')
+
+          curl -s -X POST "https://events.statsigapi.net/v1/log_event" \
             -H "Content-Type: application/json" \
             -H "statsig-api-key: $STATSIG_API_KEY" \
-            -d '{
-              "events": [{
-                "eventName": "github_issue_created",
-                "metadata": {
-                  "issue_number": "'"$ISSUE_NUMBER"'",
-                  "repository": "'"$REPO"'",
-                  "title": "'"$(echo "$ISSUE_TITLE" | sed "s/\"/\\\\\"/g")"'",
-                  "author": "'"$AUTHOR"'",
-                  "created_at": "'"$CREATED_AT"'"
-                },
-                "time": '"$(date +%s)000"'
-              }]
-            }'
+            -d "$PAYLOAD"


### PR DESCRIPTION
## Summary

- Replace fragile `sed`-based quote escaping with `jq` for constructing the Statsig JSON payload in `log-issue-events.yml`
- Fix hardcoded `eventName` that always sent `github_issue_created` even for `closed` events

## Problem

The current workflow constructs a JSON payload using shell string interpolation with `sed` to escape double quotes:

```bash
"title": "'"$(echo "$ISSUE_TITLE" | sed "s/\"/\\\\\"/g")"'"
```

This only escapes `"` but fails to handle:
- **Backslashes** (`\`) — should be escaped first in JSON but aren't
- **Newlines** — break the JSON string across lines
- **Tabs and control characters** — invalid in unescaped JSON strings

Any issue title containing these characters produces malformed JSON, causing the Statsig API request to silently fail.

Additionally, the workflow triggers on both `opened` and `closed` issue events (line 5) but hardcodes `eventName: "github_issue_created"` — closed events are logged with the wrong event name.

## Fix

- Use `jq -n --arg` to construct the entire JSON payload, which correctly escapes all special characters per RFC 8259
- Derive `eventName` dynamically from `github.event.action` (`github_issue_opened` / `github_issue_closed`)
- `jq` is pre-installed on all `ubuntu-latest` GitHub Actions runners

## Test plan

- [ ] Verify YAML syntax is valid (confirmed locally with `python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Verify `jq` is available on `ubuntu-latest` runners (it is — [pre-installed](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md))
- [ ] Test with issue title containing quotes: `Test "quoted" title`
- [ ] Test with issue title containing backslash: `Fix path\to\file`
- [ ] Test with issue title containing newline (unlikely but possible via API)
- [ ] Verify closed events now log as `github_issue_closed` instead of `github_issue_created`