### PR TITLE
fix: Filter bot comments in auto-close duplicates script

### DIFF
--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -201,7 +201,9 @@ async function autoCloseDuplicates(): Promise<void> {
     );
 
     const commentsAfterDupe = comments.filter(
-      (comment) => new Date(comment.created_at) > dupeCommentDate
+      (comment) =>
+        new Date(comment.created_at) > dupeCommentDate &&
+        comment.user.type !== "Bot"
     );
     console.log(
       `[DEBUG] Issue #${issue.number} - ${commentsAfterDupe.length} comments after duplicate detection`
@@ -209,7 +211,7 @@ async function autoCloseDuplicates(): Promise<void> {
 
     if (commentsAfterDupe.length > 0) {
       console.log(
-        `[DEBUG] Issue #${issue.number} - has activity after duplicate comment, skipping`
+        `[DEBUG] Issue #${issue.number} - has human activity after duplicate comment, skipping`
       );
       continue;
     }


### PR DESCRIPTION
## Summary

- Fix the `commentsAfterDupe` filter to exclude bot comments, so only human activity prevents auto-closure of duplicate issues

## Problem

In `scripts/auto-close-duplicates.ts` (line 203-205), the script checks for comments posted after the duplicate detection comment to decide whether to skip auto-closure:

```typescript
const commentsAfterDupe = comments.filter(
  (comment) => new Date(comment.created_at) > dupeCommentDate
);
```

This includes **all** comments, including bot comments from:
- `github-actions[bot]` (lifecycle label comments from `lifecycle-comment.ts`)
- CI/CD notification bots
- Label automation bots

These bot comments incorrectly prevent auto-closure of genuine duplicate issues, because the script interprets them as "human disagreement."

## Fix

Add `comment.user.type !== "Bot"` to the filter, matching the pattern already used in `sweep.ts` (line 132):

```typescript
const hasHumanComment = comments.some((c) => c.user && c.user.type !== "Bot");
```

The `GitHubComment` interface (line 16-21) already includes `user: { type: string }`, so no type changes are needed.

Also updated the debug log message from "has activity" to "has human activity" for clarity.

## Test plan

- [ ] Verify the `GitHubComment` interface already has `user.type` field (line 20)
- [ ] Verify `sweep.ts` uses the same `user.type !== "Bot"` pattern (line 132)
- [ ] Confirm that bot comments (e.g., from lifecycle-comment.ts) will no longer block auto-closure
- [ ] Confirm that human comments still correctly prevent auto-closure