### PR TITLE
fix: Surface dispatch failures in issue-opened workflow

### DIFF
--- a/.github/workflows/issue-opened-dispatch.yml
+++ b/.github/workflows/issue-opened-dispatch.yml
@@ -24,5 +24,6 @@ jobs:
           gh api repos/${TARGET_REPO}/dispatches \
             -f event_type=issue_opened \
             -f client_payload[issue_url]="${ISSUE_URL}" || {
+              echo "::warning::Failed to dispatch issue_opened event for issue #${ISSUE_NUMBER} to ${TARGET_REPO:-<not set>}"
               exit 0
             }


### PR DESCRIPTION
## Summary

- Add a GitHub Actions warning annotation when the dispatch API call fails, replacing the completely silent error handler

## Problem

In `.github/workflows/issue-opened-dispatch.yml` (lines 24-28), the error handler silently swallows all failures:

```bash
gh api repos/${TARGET_REPO}/dispatches \
  -f event_type=issue_opened \
  -f client_payload[issue_url]="${ISSUE_URL}" || {
    exit 0
  }
```

When `gh api` fails due to:
- Missing `ISSUE_OPENED_DISPATCH_TARGET_REPO` secret
- Missing `ISSUE_OPENED_DISPATCH_TOKEN` secret
- Invalid target repository
- GitHub API errors or rate limiting

The workflow reports **success** with zero indication that the dispatch was dropped. Downstream automation silently breaks with no way to diagnose the issue.

## Fix

Add `echo "::warning::..."` before `exit 0` to surface failures as GitHub Actions warning annotations. This:
- Shows a visible warning in the workflow run UI
- Uses `${TARGET_REPO:-<not set>}` to help diagnose missing secrets
- Preserves `exit 0` since the dispatch is non-critical and shouldn't fail the workflow

## Test plan

- [ ] Verify YAML is valid (confirmed with `python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Verify `::warning::` annotation format matches [GitHub Actions documentation](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-warning-message)
- [ ] Confirm the workflow still exits 0 on dispatch failure (non-breaking)
- [ ] Confirm `${TARGET_REPO:-<not set>}` correctly shows `<not set>` when the secret is missing