### PR TITLE
fix: Add timeout to GitHub API curl in firewall init

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -42,7 +42,7 @@ ipset create allowed-domains hash:net
 
 # Fetch GitHub meta information and aggregate + add their IP ranges
 echo "Fetching GitHub IP ranges..."
-gh_ranges=$(curl -s https://api.github.com/meta)
+gh_ranges=$(curl -s --connect-timeout 10 --max-time 30 https://api.github.com/meta)
 if [ -z "$gh_ranges" ]; then
     echo "ERROR: Failed to fetch GitHub IP ranges"
     exit 1


### PR DESCRIPTION
## Summary
- Add `--connect-timeout 10 --max-time 30` to the curl call fetching GitHub IP ranges in `.devcontainer/init-firewall.sh`

## Problem
Line 45: `curl -s https://api.github.com/meta` has no timeout. If the GitHub API is slow or unreachable, the devcontainer startup hangs indefinitely with no feedback.

## Test plan
- [ ] Verify curl syntax is correct with `bash -n init-firewall.sh`
- [ ] Confirm devcontainer starts normally when GitHub API is reachable
- [ ] Confirm devcontainer fails fast (within 30s) with clear error when GitHub API is unreachable