### PR TITLE
fix: Warn instead of exit on DNS failure in firewall init

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -76,8 +76,8 @@ for domain in \
     echo "Resolving $domain..."
     ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}')
     if [ -z "$ips" ]; then
-        echo "ERROR: Failed to resolve $domain"
-        exit 1
+        echo "WARNING: Failed to resolve $domain, skipping"
+        continue
     fi
     
     while read -r ip; do


### PR DESCRIPTION
## Summary
- Change DNS resolution failure from hard exit to warning+continue in `.devcontainer/init-firewall.sh`

## Problem
Lines 78-80: If any whitelisted domain fails DNS resolution, the entire devcontainer fails to start. A transient DNS blip for a non-critical domain (e.g., sentry.io, statsig.com) blocks all development.

## Fix
Replace `exit 1` with `continue` and change "ERROR" to "WARNING". The domain is skipped and the container starts — critical domains (GitHub, Anthropic API) are validated earlier in the script.

## Test plan
- [ ] Verify script syntax with `bash -n init-firewall.sh`
- [ ] Confirm container starts when all domains resolve
- [ ] Confirm container starts with warning when a non-critical domain fails DNS