### PR TITLE
fix: Correct model name Sonnet 4.0 to Sonnet 4 in migration plugin

### DIFF
--- a/plugins/claude-opus-4-5-migration/skills/claude-opus-4-5-migration/SKILL.md
+++ b/plugins/claude-opus-4-5-migration/skills/claude-opus-4-5-migration/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: claude-opus-4-5-migration
-description: Migrate prompts and code from Claude Sonnet 4.0, Sonnet 4.5, or Opus 4.1 to Opus 4.5. Use when the user wants to update their codebase, prompts, or API calls to use Opus 4.5. Handles model string updates and prompt adjustments for known Opus 4.5 behavioral differences. Does NOT migrate Haiku 4.5.
+description: Migrate prompts and code from Claude Sonnet 4, Sonnet 4.5, or Opus 4.1 to Opus 4.5. Use when the user wants to update their codebase, prompts, or API calls to use Opus 4.5. Handles model string updates and prompt adjustments for known Opus 4.5 behavioral differences. Does NOT migrate Haiku 4.5.
 ---
 
 # Opus 4.5 Migration Guide
 
-One-shot migration from Sonnet 4.0, Sonnet 4.5, or Opus 4.1 to Opus 4.5.
+One-shot migration from Sonnet 4, Sonnet 4.5, or Opus 4.1 to Opus 4.5.
 
 ## Migration Workflow
 
@@ -41,7 +41,7 @@ Remove the `context-1m-2025-08-07` beta header if present—it is not yet suppor
 
 | Source Model | Anthropic API (1P) | AWS Bedrock | Google Vertex AI |
 |--------------|-------------------|-------------|------------------|
-| Sonnet 4.0 | `claude-sonnet-4-20250514` | `anthropic.claude-sonnet-4-20250514-v1:0` | `claude-sonnet-4@20250514` |
+| Sonnet 4 | `claude-sonnet-4-20250514` | `anthropic.claude-sonnet-4-20250514-v1:0` | `claude-sonnet-4@20250514` |
 | Sonnet 4.5 | `claude-sonnet-4-5-20250929` | `anthropic.claude-sonnet-4-5-20250929-v1:0` | `claude-sonnet-4-5@20250929` |
 | Opus 4.1 | `claude-opus-4-1-20250422` | `anthropic.claude-opus-4-1-20250422-v1:0` | `claude-opus-4-1@20250422` |
 


### PR DESCRIPTION
## Summary
- Fix incorrect model name "Sonnet 4.0" to "Sonnet 4" in `plugins/claude-opus-4-5-migration/skills/claude-opus-4-5-migration/SKILL.md`

## Problem
The skill references "Claude Sonnet 4.0" and "Sonnet 4.0" in the description and body. The model is officially named "Claude Sonnet 4" — the model string is `claude-sonnet-4-20250514` with no ".0" suffix. The ".0" convention does not exist in Anthropic model naming.

## Test plan
- [ ] Verify the model string table still shows `claude-sonnet-4-20250514` (unchanged)
- [ ] Confirm all 3 occurrences of "Sonnet 4.0" are replaced with "Sonnet 4"