### PR TITLE
fix: Add missing sandbox enabled key to settings-strict.json

### DIFF
--- a/examples/settings/settings-strict.json
+++ b/examples/settings/settings-strict.json
@@ -13,6 +13,7 @@
   "allowManagedHooksOnly": true,
   "strictKnownMarketplaces": [],
   "sandbox": {
+    "enabled": true,
     "autoAllowBashIfSandboxed": false,
     "excludedCommands": [],
     "network": {


### PR DESCRIPTION
## Summary
- Add `"enabled": true` to sandbox config in `examples/settings/settings-strict.json`

## Problem
`settings-strict.json` includes a full sandbox configuration block but is missing the `"enabled": true` key. `settings-bash-sandbox.json` has this key. Without it, the sandbox configuration may not activate even though the config is present.

## Test plan
- [ ] Verify JSON is valid
- [ ] Compare with `settings-bash-sandbox.json` to confirm the key matches