### PR TITLE
fix: Fix typo in settings examples README

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -1,6 +1,6 @@
 # Settings Examples
 
-Example Claude Code settings files, primarily intended for organization-wide deployments. Use these are starting points — adjust them to fit your needs.
+Example Claude Code settings files, primarily intended for organization-wide deployments. Use these as starting points — adjust them to fit your needs.
 
 These may be applied at any level of the [settings hierarchy](https://code.claude.com/docs/en/settings#settings-files), though certain properties only take effect if specified in enterprise settings (e.g. `strictKnownMarketplaces`, `allowManagedHooksOnly`, `allowManagedPermissionRulesOnly`).
 


### PR DESCRIPTION
## Summary
- Fix typo on line 3 of `examples/settings/README.md`: "these are" → "these as"

## Before
> Use these are starting points — adjust them to fit your needs.

## After
> Use these as starting points — adjust them to fit your needs.