### PR TITLE
fix: Exclude YAML comments from allowed_non_write_users check

### DIFF
--- a/.github/workflows/non-write-users-check.yml
+++ b/.github/workflows/non-write-users-check.yml
@@ -21,7 +21,7 @@ jobs:
             exit 0
           fi
 
-          MATCHES=$(echo "$DIFF" | grep "^+.*allowed_non_write_users" || true)
+          MATCHES=$(echo "$DIFF" | grep "^+" | grep -v "^+#" | grep -v "^+.*#.*allowed_non_write_users" | grep "allowed_non_write_users" || true)
 
           if [ -z "$MATCHES" ]; then
             exit 0


### PR DESCRIPTION
## Summary
- Update the grep pattern in `non-write-users-check.yml` to exclude commented-out YAML lines

## Problem
Line 24: `grep "^+.*allowed_non_write_users"` matches any added line containing the string, including YAML comments like `# allowed_non_write_users: ...` and inline comments. This triggers false positive security warnings on PRs that discuss the setting without enabling it.

## Fix
Filter the diff through multiple grep stages to exclude:
- Lines starting with `+#` (YAML comments)
- Lines where `allowed_non_write_users` appears after an inline `#` comment marker

## Test plan
- [ ] Verify YAML syntax is valid
- [ ] Confirm actual `allowed_non_write_users:` config lines still trigger the warning
- [ ] Confirm `# allowed_non_write_users:` comment lines do NOT trigger the warning