### PR TITLE
fix: Use Optional type hint for nullable parameter in hookify

### DIFF
--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -180,7 +180,7 @@ class RuleEngine:
             return False
 
     def _extract_field(self, field: str, tool_name: str,
-                      tool_input: Dict[str, Any], input_data: Dict[str, Any] = None) -> Optional[str]:
+                      tool_input: Dict[str, Any], input_data: Optional[Dict[str, Any]] = None) -> Optional[str]:
         """Extract field value from tool input or hook input data.
 
         Args:


### PR DESCRIPTION
## Summary
- Fix type hint in `plugins/hookify/core/rule_engine.py` line 183

## Problem
The `input_data` parameter defaults to `None` but is typed as `Dict[str, Any]`:
```python
def _extract_field(self, field: str, tool_name: str,
                  tool_input: Dict[str, Any], input_data: Dict[str, Any] = None) -> Optional[str]:
```

Per PEP 484, a parameter that can be `None` must be typed as `Optional[Dict[str, Any]]`. The `Optional` import already exists on line 7.

## Test plan
- [ ] Verify `Optional` is imported (line 7: `from typing import List, Dict, Any, Optional`)
- [ ] Verify the function still works correctly (no behavioral change)