### PR TITLE
fix: Validate IP octet ranges in firewall init script

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -55,7 +55,8 @@ fi
 
 echo "Processing GitHub IPs..."
 while read -r cidr; do
-    if [[ ! "$cidr" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$ ]]; then
+    if [[ ! "$cidr" =~ ^([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})/([0-9]{1,2})$ ]] \
+       || (( BASH_REMATCH[1] > 255 || BASH_REMATCH[2] > 255 || BASH_REMATCH[3] > 255 || BASH_REMATCH[4] > 255 || BASH_REMATCH[5] > 32 )); then
         echo "ERROR: Invalid CIDR range from GitHub meta: $cidr"
         exit 1
     fi
@@ -81,7 +82,8 @@ for domain in \
     fi
     
     while read -r ip; do
-        if [[ ! "$ip" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+        if [[ ! "$ip" =~ ^([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$ ]] \
+           || (( BASH_REMATCH[1] > 255 || BASH_REMATCH[2] > 255 || BASH_REMATCH[3] > 255 || BASH_REMATCH[4] > 255 )); then
             echo "ERROR: Invalid IP from DNS for $domain: $ip"
             exit 1
         fi


### PR DESCRIPTION
## Summary
- Add arithmetic range checks to IP/CIDR validation in `.devcontainer/init-firewall.sh`

## Problem
The regex on lines 58 and 84 accepts values like `999.999.999.999/99` because it only validates digit count (1-3 digits per octet) without checking the actual numeric range. Values above 255 for octets or above 32 for prefix length are invalid.

## Fix
After the regex match, use `BASH_REMATCH` capture groups with arithmetic comparison to verify:
- Each octet is <= 255
- CIDR prefix length is <= 32

## Test plan
- [ ] Verify bash syntax with `bash -n init-firewall.sh`
- [ ] Valid IPs like `192.168.1.0/24` pass validation
- [ ] Invalid IPs like `999.1.2.3/24` are rejected
- [ ] Invalid CIDR like `1.2.3.4/33` is rejected