### PR TITLE
fix: Add SHA256 checksum verification for git-delta download

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -49,8 +49,12 @@ RUN mkdir -p /workspace /home/node/.claude && \
 WORKDIR /workspace
 
 ARG GIT_DELTA_VERSION=0.18.2
+ARG GIT_DELTA_SHA256_AMD64=4b54b8fa76e28c2cff4c1bfb2b77f22f39057c67bfbc5f7e52c4f03c5c5e5b49
+ARG GIT_DELTA_SHA256_ARM64=e3cf310fc4b25603003f0c68fd64e2e05b65b8ef9d58c25e12ca4a2a7e3e1d5e
 RUN ARCH=$(dpkg --print-architecture) && \
-  wget "https://github.com/dandavison/delta/releases/download/${GIT_DELTA_VERSION}/git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" && \
+  wget -q "https://github.com/dandavison/delta/releases/download/${GIT_DELTA_VERSION}/git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" && \
+  if [ "$ARCH" = "amd64" ]; then EXPECTED_SHA="$GIT_DELTA_SHA256_AMD64"; else EXPECTED_SHA="$GIT_DELTA_SHA256_ARM64"; fi && \
+  echo "$EXPECTED_SHA  git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" | sha256sum -c - && \
   sudo dpkg -i "git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" && \
   rm "git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb"
 


### PR DESCRIPTION
## Summary
- Add SHA256 checksum verification when downloading git-delta in `.devcontainer/Dockerfile`

## Problem
The Dockerfile downloads `git-delta` from GitHub releases without verifying file integrity. A corrupted or tampered download would be installed silently.

## Fix
Add `sha256sum -c` verification after download, with separate checksums for amd64 and arm64 architectures. The build fails immediately if the checksum doesn't match.

**Note:** The SHA256 values in this PR are placeholders and should be updated to the actual checksums for git-delta v0.18.2 before merging. To get the real checksums:
```bash
wget -q https://github.com/dandavison/delta/releases/download/0.18.2/git-delta_0.18.2_amd64.deb
sha256sum git-delta_0.18.2_amd64.deb
```

## Test plan
- [ ] Verify Dockerfile syntax
- [ ] Update SHA256 values to match actual release artifacts
- [ ] Confirm build succeeds with correct checksums
- [ ] Confirm build fails with incorrect checksums