### PR TITLE
fix: Parse actual subnet from routing table instead of assuming /24

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -90,14 +90,20 @@ for domain in \
     done < <(echo "$ips")
 done
 
-# Get host IP from default route
-HOST_IP=$(ip route | grep default | cut -d" " -f3)
+# Get host IP and network from default route
+DEFAULT_ROUTE=$(ip route | grep default | head -1)
+HOST_IP=$(echo "$DEFAULT_ROUTE" | awk '{print $3}')
 if [ -z "$HOST_IP" ]; then
     echo "ERROR: Failed to detect host IP"
     exit 1
 fi
 
-HOST_NETWORK=$(echo "$HOST_IP" | sed "s/\.[0-9]*$/.0\/24/")
+# Parse the actual subnet from the routing table instead of assuming /24
+HOST_NETWORK=$(ip route | grep "src $HOST_IP" | grep -v default | head -1 | awk '{print $1}')
+if [ -z "$HOST_NETWORK" ]; then
+    # Fallback to /24 if route parsing fails
+    HOST_NETWORK=$(echo "$HOST_IP" | sed "s/\.[0-9]*$/.0\/24/")
+fi
 echo "Host network detected as: $HOST_NETWORK"
 
 # Set up remaining iptables rules


### PR DESCRIPTION
## Summary
- Replace hardcoded `/24` subnet assumption with actual routing table parsing in `.devcontainer/init-firewall.sh`

## Problem
Line 100: `HOST_NETWORK=$(echo "$HOST_IP" | sed "s/\.[0-9]*$/.0\/24/")` assumes the host network is always a /24 subnet. This fails on networks with different configurations (e.g., /16, /20, /28), blocking container-to-host communication.

## Fix
Parse the actual subnet CIDR from `ip route` output using the host IP as a lookup key. Falls back to the original /24 assumption if route parsing fails, maintaining backward compatibility.

## Test plan
- [ ] Verify bash syntax with `bash -n init-firewall.sh`
- [ ] Confirm correct subnet detection on /24 networks (most common)
- [ ] Confirm correct subnet detection on non-/24 networks
- [ ] Confirm /24 fallback works when route parsing returns empty