### PR TITLE
fix: Update stale Task tool reference to Agent in 3 plugin commands

### DIFF
--- a/plugins/hookify/commands/hookify.md
+++ b/plugins/hookify/commands/hookify.md
@@ -1,7 +1,7 @@
 ---
 description: Create hooks to prevent unwanted behaviors from conversation analysis or explicit instructions
 argument-hint: Optional specific behavior to address
-allowed-tools: ["Read", "Write", "AskUserQuestion", "Task", "Grep", "TodoWrite", "Skill"]
+allowed-tools: ["Read", "Write", "AskUserQuestion", "Agent", "Grep", "TodoWrite", "Skill"]
 ---
 
 # Hookify - Create Hooks from Unwanted Behaviors

--- a/plugins/plugin-dev/commands/create-plugin.md
+++ b/plugins/plugin-dev/commands/create-plugin.md
@@ -1,7 +1,7 @@
 ---
 description: Guided end-to-end plugin creation workflow with component design, implementation, and validation
 argument-hint: Optional plugin description
-allowed-tools: ["Read", "Write", "Grep", "Glob", "Bash", "TodoWrite", "AskUserQuestion", "Skill", "Task"]
+allowed-tools: ["Read", "Write", "Grep", "Glob", "Bash", "TodoWrite", "AskUserQuestion", "Skill", "Agent"]
 ---
 
 # Plugin Creation Workflow

--- a/plugins/pr-review-toolkit/commands/review-pr.md
+++ b/plugins/pr-review-toolkit/commands/review-pr.md
@@ -1,7 +1,7 @@
 ---
 description: "Comprehensive PR review using specialized agents"
 argument-hint: "[review-aspects]"
-allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
+allowed-tools: ["Bash", "Glob", "Grep", "Read", "Agent"]
 ---
 
 # Comprehensive PR Review


### PR DESCRIPTION
## Summary

- Update `"Task"` to `"Agent"` in `allowed-tools` frontmatter across 3 plugin commands

## Problem

The `Task` tool was renamed to `Agent` in v2.1.63 (ref: #29677). Three plugin commands still reference the old name in their `allowed-tools`:

| Plugin | File | Before | After |
|--------|------|--------|-------|
| pr-review-toolkit | `commands/review-pr.md` | `"Task"` | `"Agent"` |
| hookify | `commands/hookify.md` | `"Task"` | `"Agent"` |
| plugin-dev | `commands/create-plugin.md` | `"Task"` | `"Agent"` |

Found via: `grep -r '"Task"' plugins/*/commands/*.md`

## Test plan

- [ ] Verify no other command files reference `"Task"` (only these 3 matched)
- [ ] Confirm `"Agent"` is the correct tool name in current Claude Code
- [ ] Test that pr-review-toolkit can still launch subagents after the rename