### PR TITLE
Validate plugin catalog in CI

### DIFF
--- a/.github/workflows/validate-plugin-catalog.yml
+++ b/.github/workflows/validate-plugin-catalog.yml
@@ -1,0 +1,34 @@
+name: Validate Plugin Catalog
+description: Verify bundled plugin metadata stays in sync across the catalog
+
+on:
+  pull_request:
+    paths:
+      - ".claude-plugin/marketplace.json"
+      - "plugins/**"
+      - "scripts/validate-plugin-catalog.mjs"
+  push:
+    branches:
+      - main
+    paths:
+      - ".claude-plugin/marketplace.json"
+      - "plugins/**"
+      - "scripts/validate-plugin-catalog.mjs"
+  workflow_dispatch:
+
+jobs:
+  validate-plugin-catalog:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Validate plugin catalog
+        run: node scripts/validate-plugin-catalog.mjs

--- a/.github/workflows/validate-plugin-catalog.yml
+++ b/.github/workflows/validate-plugin-catalog.yml
@@ -1,5 +1,4 @@
 name: Validate Plugin Catalog
-description: Verify bundled plugin metadata stays in sync across the catalog
 
 on:
   pull_request:

--- a/plugins/plugin-dev/.claude-plugin/plugin.json
+++ b/plugins/plugin-dev/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "plugin-dev",
+  "version": "0.1.0",
+  "description": "Comprehensive toolkit for developing Claude Code plugins. Includes 7 expert skills covering hooks, MCP integration, commands, agents, and best practices. AI-assisted plugin creation and validation.",
+  "author": {
+    "name": "Daisy Hollman",
+    "email": "daisy@anthropic.com"
+  }
+}

--- a/plugins/security-guidance/README.md
+++ b/plugins/security-guidance/README.md
@@ -1,0 +1,22 @@
+# Security Guidance
+
+Security reminder plugin for Claude Code that warns about risky code patterns before tool execution.
+
+## What It Includes
+
+- **Hook:** `PreToolUse`
+- **Handler:** `hooks/security_reminder_hook.py`
+- **Coverage:** command injection, XSS, `eval`, dangerous HTML rendering, pickle deserialization, `os.system`, and similar high-risk patterns
+
+## Usage
+
+Install the plugin, then let the hook run automatically whenever Claude Code prepares an edit or command that matches one of the protected patterns.
+
+## Files
+
+```text
+security-guidance/
+├── .claude-plugin/plugin.json
+├── hooks/hooks.json
+└── hooks/security_reminder_hook.py
+```

--- a/scripts/validate-plugin-catalog.mjs
+++ b/scripts/validate-plugin-catalog.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+const pluginsRoot = path.join(repoRoot, "plugins");
+const pluginsReadmePath = path.join(pluginsRoot, "README.md");
+const marketplacePath = path.join(repoRoot, ".claude-plugin", "marketplace.json");
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function listPluginDirectories(rootPath) {
+  return fs
+    .readdirSync(rootPath, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function parsePluginNamesFromReadme(markdown) {
+  const matches = [...markdown.matchAll(/^\|\s+\[([^\]]+)\]\(\.\/([^)]+)\/\)\s+\|/gm)];
+  return matches
+    .map(([, name, href]) => {
+      const normalizedHref = href.replace(/\/$/, "");
+      if (name !== normalizedHref) {
+        throw new Error(
+          `plugins/README.md row name "${name}" does not match linked directory "${normalizedHref}"`
+        );
+      }
+      return name;
+    })
+    .sort();
+}
+
+function compareSets(actual, expected, label, errors) {
+  const actualSet = new Set(actual);
+  const expectedSet = new Set(expected);
+
+  for (const value of actualSet) {
+    if (!expectedSet.has(value)) {
+      errors.push(`${label}: unexpected entry "${value}"`);
+    }
+  }
+
+  for (const value of expectedSet) {
+    if (!actualSet.has(value)) {
+      errors.push(`${label}: missing entry "${value}"`);
+    }
+  }
+}
+
+function validatePlugin(pluginName, marketplaceEntries, errors) {
+  const pluginRoot = path.join(pluginsRoot, pluginName);
+  const readmePath = path.join(pluginRoot, "README.md");
+  const manifestPath = path.join(pluginRoot, ".claude-plugin", "plugin.json");
+
+  if (!fs.existsSync(readmePath)) {
+    errors.push(`plugins/${pluginName}: missing README.md`);
+  }
+
+  if (!fs.existsSync(manifestPath)) {
+    errors.push(`plugins/${pluginName}: missing .claude-plugin/plugin.json`);
+    return;
+  }
+
+  const manifest = readJson(manifestPath);
+  if (manifest.name !== pluginName) {
+    errors.push(
+      `plugins/${pluginName}: manifest name "${manifest.name}" does not match directory name`
+    );
+  }
+
+  const marketplaceEntry = marketplaceEntries.get(pluginName);
+  if (!marketplaceEntry) {
+    errors.push(`marketplace.json: missing plugin entry for "${pluginName}"`);
+    return;
+  }
+
+  const expectedSource = `./plugins/${pluginName}`;
+  if (marketplaceEntry.source !== expectedSource) {
+    errors.push(
+      `marketplace.json: plugin "${pluginName}" should use source "${expectedSource}", got "${marketplaceEntry.source}"`
+    );
+  }
+}
+
+function main() {
+  const pluginDirectories = listPluginDirectories(pluginsRoot);
+  const pluginsReadme = fs.readFileSync(pluginsReadmePath, "utf8");
+  const readmePlugins = parsePluginNamesFromReadme(pluginsReadme);
+  const marketplace = readJson(marketplacePath);
+  const marketplacePlugins = [...marketplace.plugins]
+    .map((plugin) => plugin.name)
+    .sort();
+  const marketplaceEntries = new Map(
+    marketplace.plugins.map((plugin) => [plugin.name, plugin])
+  );
+
+  const errors = [];
+
+  compareSets(readmePlugins, pluginDirectories, "plugins/README.md", errors);
+  compareSets(marketplacePlugins, pluginDirectories, "marketplace.json", errors);
+
+  for (const pluginName of pluginDirectories) {
+    validatePlugin(pluginName, marketplaceEntries, errors);
+  }
+
+  if (errors.length > 0) {
+    console.error("Plugin catalog validation failed:");
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`Plugin catalog validation passed for ${pluginDirectories.length} plugins.`);
+}
+
+main();


### PR DESCRIPTION
## What
Add a lightweight `scripts/validate-plugin-catalog.mjs` validator and a GitHub Actions workflow that runs it whenever marketplace metadata or bundled plugins change.

Normalize the current catalog by adding the missing `plugin-dev` manifest and the missing `security-guidance` README so the validator passes on the current tree.

## Why
The plugin catalog spans plugin directories, per-plugin manifests, `plugins/README.md`, and `.claude-plugin/marketplace.json`, but nothing in CI checked that those sources stayed aligned.

That made it easy for catalog drift to land silently and break plugin discoverability for both humans and agents.

## How to verify
```bash
node scripts/validate-plugin-catalog.mjs
```

## Notes
The validator currently checks for missing plugin READMEs, missing manifests, mismatched manifest names, mismatched marketplace sources, and set drift between plugin directories, `plugins/README.md`, and `marketplace.json`.