### PR TITLE
Upgrade dedupe to Sonnet 4.6

### DIFF
--- a/.github/workflows/claude-dedupe-issues.yml
+++ b/.github/workflows/claude-dedupe-issues.yml
@@ -31,7 +31,7 @@ jobs:
           allowed_non_write_users: "*"
           prompt: "/dedupe ${{ github.repository }}/issues/${{ github.event.issue.number || inputs.issue_number }}"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--model claude-sonnet-4-5-20250929"
+          claude_args: "--model claude-sonnet-4-6"
 
       - name: Log duplicate comment event to Statsig
         if: always()


### PR DESCRIPTION
## What
Update the issue-dedupe workflow to run Claude Code with `claude-sonnet-4-6` instead of the older Sonnet 4.5 model string.

## Why
This workflow is instruction-heavy and benefits directly from the current Sonnet baseline for stronger reliability and prompt following.

Keeping the model string current also removes one more piece of avoidable drift from the repository.

## How to verify
```bash
rg 'claude-sonnet-4-6|claude-sonnet-4-5-20250929' .github/workflows/claude-dedupe-issues.yml
```

## Notes
Scope is intentionally limited to the workflow model selection.