### PR TITLE
Tighten dedupe guidance

### DIFF
--- a/.claude/commands/dedupe.md
+++ b/.claude/commands/dedupe.md
@@ -5,13 +5,21 @@ description: Find duplicate GitHub issues
 
 Find up to 3 likely duplicate issues for a given GitHub issue.
 
+Precision matters more than recall here. Prefer posting 0 duplicates over posting weak matches.
+
 To do this, follow these steps precisely:
 
-1. Use an agent to check if the Github issue (a) is closed, (b) does not need to be deduped (eg. because it is broad product feedback without a specific solution, or positive feedback), or (c) already has a duplicates comment that you made earlier. If so, do not proceed.
-2. Use an agent to view a Github issue, and ask the agent to return a summary of the issue
-3. Then, launch 5 parallel agents to search Github for duplicates of this issue, using diverse keywords and search approaches, using the summary from #1
-4. Next, feed the results from #1 and #2 into another agent, so that it can filter out false positives, that are likely not actually duplicates of the original issue. If there are no duplicates remaining, do not proceed.
-5. Finally, use the comment script to post duplicates:
+1. Use an agent to check if the GitHub issue (a) is closed, (b) does not need to be deduped (for example broad product feedback, positive feedback, or a request without a concrete bug/feature target), or (c) already has a duplicates comment that you made earlier. If any of those are true, do not proceed.
+2. Use an agent to view the GitHub issue and return a compact summary with:
+   - the concrete problem
+   - user-visible impact
+   - repro clues, environment, platform, or provider details
+   - explicit keywords that should and should not match
+3. Launch 5 parallel agents to search GitHub for duplicates of this issue using diverse keywords and search approaches grounded in the summary from step 2.
+4. Feed the issue summary and search results into another agent so it can filter out false positives. Keep a candidate only when the underlying problem is the same, not merely the same area of the product.
+5. Re-open the base issue and each candidate issue before posting. If any candidate is already closed for a different reason, only keep it if the description still clearly matches the same root issue.
+6. If there are no high-confidence duplicates remaining, do not proceed.
+7. Finally, use the comment script to post duplicates:
    ```
    ./scripts/comment-on-duplicates.sh --base-issue <issue-number> --potential-duplicates <dup1> <dup2> <dup3>
    ```
@@ -25,3 +33,8 @@ Notes (be sure to tell this to your agents, too):
   - `./scripts/gh.sh search issues "query" --limit 10` — search for issues
 - Do not use other tools, beyond `./scripts/gh.sh` and the comment script (eg. don't use other MCP servers, file edit, etc.)
 - Make a todo list first
+- Treat title similarity as a weak hint, never as sufficient evidence on its own
+- Reject candidates that differ materially in platform, provider, environment, or requested behavior
+- Prefer 1-2 precise matches over filling all 3 slots
+- Do not improvise alternate workflows, extra scripts, or direct API calls
+- If confidence is below high, do not leave a duplicate comment

--- a/.claude/commands/dedupe.md
+++ b/.claude/commands/dedupe.md
@@ -17,7 +17,7 @@ To do this, follow these steps precisely:
    - explicit keywords that should and should not match
 3. Launch 5 parallel agents to search GitHub for duplicates of this issue using diverse keywords and search approaches grounded in the summary from step 2.
 4. Feed the issue summary and search results into another agent so it can filter out false positives. Keep a candidate only when the underlying problem is the same, not merely the same area of the product.
-5. Re-open the base issue and each candidate issue before posting. If any candidate is already closed for a different reason, only keep it if the description still clearly matches the same root issue.
+5. Re-read the base issue and each candidate issue before posting. If any candidate is already closed for a different reason, only keep it if the description still clearly matches the same root issue.
 6. If there are no high-confidence duplicates remaining, do not proceed.
 7. Finally, use the comment script to post duplicates:
    ```


### PR DESCRIPTION
## What
Strengthen `.claude/commands/dedupe.md` with higher-precision duplicate-detection guidance.

The updated command now requires a structured issue summary, explicit filtering on root-cause match, stronger rejection rules for platform/provider mismatches, and a hard stop when confidence is not high.

## Why
False-positive duplicate comments are more damaging than missed matches in this workflow.

Clearer guardrails improve consistency across agents and reduce the chance that title similarity or vague product overlap turns into a duplicate comment.

## How to verify
```bash
rg 'Precision matters more than recall here|Treat title similarity as a weak hint|Do not improvise alternate workflows|If confidence is below high' .claude/commands/dedupe.md
```

## Notes
The change only tightens instructions; it does not alter workflow permissions or add new tools.