### PR TITLE
feat: add /create-test command and plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -136,6 +136,17 @@
       "category": "development"
     },
     {
+      "name": "create-test",
+      "description": "Automatically generate unit test files from source code analysis with framework detection (Jest, Vitest, Mocha, pytest, go-test), dependency mocking, and structured test suites",
+      "version": "1.0.0",
+      "author": {
+        "name": "Claude Code",
+        "email": "support@anthropic.com"
+      },
+      "source": "./plugins/create-test",
+      "category": "development"
+    },
+    {
       "name": "security-guidance",
       "description": "Security reminder hook that warns about potential security issues when editing files, including command injection, XSS, and unsafe code patterns",
       "version": "1.0.0",

--- a/.claude/commands/create-test.md
+++ b/.claude/commands/create-test.md
@@ -1,0 +1,146 @@
+---
+description: Analyze a source file and generate a comprehensive unit test file with automatic framework detection, dependency mocking, and structured test suites
+argument-hint: <file-path> [--framework jest|vitest|mocha|pytest|go-test] [--output <path>] [--preview] [--force]
+allowed-tools: ["Read", "Write", "Grep", "Glob", "Bash", "TodoWrite", "Task"]
+---
+
+Generate a unit test file for the given source file by analyzing its structure and following the project's existing testing conventions.
+
+**Arguments:** $ARGUMENTS
+
+---
+
+## Setup
+
+Create a todo list with these phases:
+- [ ] Parse arguments
+- [ ] Validate source file
+- [ ] Detect test framework
+- [ ] Determine output path
+- [ ] Check for existing test file
+- [ ] Analyze source file (source-analyzer agent)
+- [ ] Generate test file (test-generator agent)
+- [ ] Preview (if --preview)
+- [ ] Write test file
+
+---
+
+## Phase 1: Parse Arguments
+
+From `$ARGUMENTS`, extract:
+- `file_path` — the first positional argument (e.g., `src/services/authService.ts`)
+- `--framework <value>` — optional framework override: `jest`, `vitest`, `mocha`, `pytest`, or `go-test`
+- `--output <value>` — optional custom path for the generated test file
+- `--preview` — flag: show the generated test before writing it
+- `--force` — flag: overwrite an existing test file
+
+If `file_path` is missing or empty, report: "Usage: /create-test <file-path> [options]" and stop.
+
+---
+
+## Phase 2: Validate Source File
+
+Read the file at `file_path`. If the file does not exist or cannot be read, report the error and stop.
+
+---
+
+## Phase 3: Detect Test Framework
+
+Skip this phase if `--framework` was explicitly provided.
+
+Search the project root for configuration files and detect the framework:
+
+1. If `package.json` exists, read it and check `devDependencies` and `dependencies`:
+   - `"vitest"` present → **vitest**
+   - `"jest"` or `"@jest/core"` or `"ts-jest"` present → **jest**
+   - `"mocha"` present → **mocha**
+2. If `requirements.txt` or `pyproject.toml` exists, check for `pytest` → **pytest**
+3. If `go.mod` exists → **go-test**
+4. If nothing is detected, default to **jest**
+
+---
+
+## Phase 4: Determine Output Path
+
+If `--output` was provided, use that path as the output. Skip to Phase 5.
+
+Otherwise, determine the output path automatically:
+
+**1. Naming convention** (based on framework and language):
+- TypeScript/JavaScript (jest, vitest, mocha): `authService.ts` → `authService.test.ts` or `authService.spec.ts`
+  - Check whether existing test files in the project use `.test.` or `.spec.` suffix and match that convention. Default to `.test.`.
+- Python (pytest): `auth_service.py` → `test_auth_service.py`
+- Go (go-test): `auth_service.go` → `auth_service_test.go`
+
+**2. Test file location** (check in this order):
+- Look for a `__tests__/` directory adjacent to the source file or in the source file's parent. If found, place the test there.
+- Look for a root-level `tests/` or `test/` directory mirroring the source path (e.g., `src/services/authService.ts` → `tests/services/authService.test.ts`). If found, use it.
+- Check if other test files exist alongside source files in the same directory (colocated pattern). If found, collocate the new test.
+- Default: place the test file in the same directory as the source file.
+
+---
+
+## Phase 5: Check for Existing Test File
+
+Check if a file already exists at the output path.
+
+If it exists and `--force` is **not** set:
+- Report: "Test file already exists at `<output_path>`. Use --force to overwrite."
+- Stop.
+
+---
+
+## Phase 6: Analyze Source File
+
+Launch the **source-analyzer** agent. Provide it with:
+- The full file path
+- The full file contents
+- The detected language/extension
+
+The agent returns a structured analysis. Record the output — you will pass it to the test-generator in Phase 7.
+
+---
+
+## Phase 7: Generate Test File
+
+Launch the **test-generator** agent. Provide it with:
+- The structured analysis from Phase 6
+- The detected (or specified) framework name
+- The original source file path and its full contents
+- The output test file path
+- The naming conventions observed in the project (from Phase 4)
+
+The agent returns the complete, ready-to-write test file content. Record this content.
+
+---
+
+## Phase 8: Preview
+
+If `--preview` was specified, display the generated test content in a code block. Then ask the user:
+"Write this test file to `<output_path>`?"
+
+If the user says no, stop.
+
+---
+
+## Phase 9: Write Test File
+
+Write the generated test content to the output path.
+
+Report success:
+```
+✓ Test file created: <output_path>
+  Framework: <framework>
+  Source:    <file_path>
+```
+
+List any key TODOs that the developer should complete (mocks, assertions, test data).
+
+---
+
+## Notes
+
+- Never overwrite an existing test file unless `--force` is explicitly set
+- All generated tests include `TODO` comments to guide developers completing the implementation
+- The command mirrors the project's existing test conventions rather than imposing new ones
+- External imports (databases, APIs, HTTP clients) are mocked with placeholder stubs

--- a/plugins/create-test/.claude-plugin/plugin.json
+++ b/plugins/create-test/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "create-test",
+  "version": "1.0.0",
+  "description": "Automatically generate unit test files for source files with framework detection, dependency mocking, and structured test suites",
+  "author": {
+    "name": "Claude Code",
+    "email": "support@anthropic.com"
+  }
+}

--- a/plugins/create-test/README.md
+++ b/plugins/create-test/README.md
@@ -1,0 +1,301 @@
+# create-test
+
+A Claude Code plugin that analyzes a source file and automatically generates a corresponding unit test file — complete with framework detection, dependency mocking, and structured test suites.
+
+---
+
+## Features
+
+- **Automatic framework detection** — reads `package.json`, `pyproject.toml`, `requirements.txt`, or `go.mod` to pick the right test framework
+- **Smart output path detection** — mirrors the project's existing test structure (`__tests__/`, `tests/`, or colocated)
+- **Structured test generation** — groups tests by function/class with happy path, edge cases, and error cases
+- **Dependency mocking** — identifies external imports (databases, HTTP clients, queues) and generates mock stubs
+- **Language support** — TypeScript, JavaScript, Python, Go
+- **Non-destructive by default** — will not overwrite existing test files unless `--force` is set
+
+---
+
+## Installation
+
+Copy this plugin directory to your Claude Code plugins folder or reference it via `--plugin-dir`:
+
+```bash
+cc --plugin-dir /path/to/create-test
+```
+
+Or install globally in your Claude Code configuration.
+
+---
+
+## Usage
+
+```
+/create-test <file-path> [options]
+```
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--framework <name>` | Override detected framework (`jest`, `vitest`, `mocha`, `pytest`, `go-test`) |
+| `--output <path>` | Custom output path for the generated test file |
+| `--preview` | Show the generated test before writing it to disk |
+| `--force` | Overwrite an existing test file |
+
+### Examples
+
+```bash
+# Basic usage — auto-detect everything
+/create-test src/services/authService.ts
+
+# Override framework
+/create-test src/utils/dateHelpers.ts --framework vitest
+
+# Custom output location
+/create-test src/api/userController.ts --output tests/unit/userController.test.ts
+
+# Preview before writing
+/create-test src/lib/validator.ts --preview
+
+# Overwrite an existing test
+/create-test src/services/authService.ts --force
+```
+
+---
+
+## Framework Detection Logic
+
+| Project file | Framework detected |
+|---|---|
+| `package.json` with `vitest` | vitest |
+| `package.json` with `jest` / `ts-jest` | jest |
+| `package.json` with `mocha` | mocha |
+| `requirements.txt` / `pyproject.toml` with `pytest` | pytest |
+| `go.mod` present | go-test |
+| *(none of the above)* | jest (default) |
+
+---
+
+## Test File Naming Conventions
+
+| Language | Source file | Test file |
+|---|---|---|
+| TypeScript / JS | `authService.ts` | `authService.test.ts` |
+| TypeScript / JS (spec) | `authService.ts` | `authService.spec.ts` |
+| Python | `auth_service.py` | `test_auth_service.py` |
+| Go | `auth_service.go` | `auth_service_test.go` |
+
+---
+
+## Example: Generated Jest Test
+
+**Source file:** `src/services/authService.ts`
+
+```typescript
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+import { db } from '../database';
+
+export interface LoginInput {
+  email: string;
+  password: string;
+}
+
+export interface AuthToken {
+  token: string;
+  expiresAt: Date;
+}
+
+export async function login(input: LoginInput): Promise<AuthToken> {
+  const user = await db.users.findByEmail(input.email);
+  if (!user) throw new Error('User not found');
+
+  const valid = await bcrypt.compare(input.password, user.passwordHash);
+  if (!valid) throw new Error('Invalid credentials');
+
+  const token = jwt.sign({ userId: user.id }, process.env.JWT_SECRET!, { expiresIn: '1h' });
+  return { token, expiresAt: new Date(Date.now() + 3600_000) };
+}
+
+export async function logout(userId: string): Promise<void> {
+  await db.sessions.deleteByUserId(userId);
+}
+```
+
+**Generated:** `src/services/authService.test.ts`
+
+```typescript
+import { login, logout, LoginInput } from './authService';
+
+// Mock external dependencies
+jest.mock('../database');
+jest.mock('bcrypt');
+jest.mock('jsonwebtoken');
+
+import { db } from '../database';
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+
+const mockDb = db as jest.Mocked<typeof db>;
+const mockBcrypt = bcrypt as jest.Mocked<typeof bcrypt>;
+const mockJwt = jwt as jest.Mocked<typeof jwt>;
+
+describe('AuthService', () => {
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.JWT_SECRET = 'test-secret';
+  });
+
+  // ── login ────────────────────────────────────────────────────────────────
+
+  describe('login', () => {
+
+    it('should return an auth token for valid credentials', async () => {
+      // Arrange
+      // TODO: configure mock user record
+      const mockUser = { id: 'user-1', email: 'user@example.com', passwordHash: 'hashed' };
+      (mockDb.users.findByEmail as jest.Mock).mockResolvedValue(mockUser);
+      (mockBcrypt.compare as jest.Mock).mockResolvedValue(true);
+      (mockJwt.sign as jest.Mock).mockReturnValue('signed-token');
+
+      const input: LoginInput = {
+        email: 'user@example.com',
+        // TODO: provide test password
+        password: 'correct-password',
+      };
+
+      // Act
+      const result = await login(input);
+
+      // Assert
+      expect(result.token).toBe('signed-token');
+      expect(result.expiresAt).toBeInstanceOf(Date);
+      // TODO: assert expiresAt is approximately 1 hour from now
+    });
+
+    it('should throw when the user is not found', async () => {
+      // Arrange
+      (mockDb.users.findByEmail as jest.Mock).mockResolvedValue(null);
+
+      const input: LoginInput = {
+        email: 'unknown@example.com',
+        password: 'any-password',
+      };
+
+      // Act & Assert
+      await expect(login(input)).rejects.toThrow('User not found');
+    });
+
+    it('should throw when the password is incorrect', async () => {
+      // Arrange
+      const mockUser = { id: 'user-1', email: 'user@example.com', passwordHash: 'hashed' };
+      (mockDb.users.findByEmail as jest.Mock).mockResolvedValue(mockUser);
+      (mockBcrypt.compare as jest.Mock).mockResolvedValue(false);
+
+      const input: LoginInput = {
+        email: 'user@example.com',
+        password: 'wrong-password',
+      };
+
+      // Act & Assert
+      await expect(login(input)).rejects.toThrow('Invalid credentials');
+    });
+
+    it('should propagate database errors', async () => {
+      // Arrange
+      (mockDb.users.findByEmail as jest.Mock).mockRejectedValue(new Error('DB connection failed'));
+
+      const input: LoginInput = {
+        email: 'user@example.com',
+        password: 'password',
+      };
+
+      // Act & Assert
+      await expect(login(input)).rejects.toThrow('DB connection failed');
+    });
+
+  });
+
+  // ── logout ───────────────────────────────────────────────────────────────
+
+  describe('logout', () => {
+
+    it('should delete the user session', async () => {
+      // Arrange
+      (mockDb.sessions.deleteByUserId as jest.Mock).mockResolvedValue(undefined);
+      // TODO: provide a realistic user ID
+      const userId = 'user-1';
+
+      // Act
+      await logout(userId);
+
+      // Assert
+      expect(mockDb.sessions.deleteByUserId).toHaveBeenCalledWith(userId);
+      expect(mockDb.sessions.deleteByUserId).toHaveBeenCalledTimes(1);
+    });
+
+    it('should propagate errors from the session store', async () => {
+      // Arrange
+      (mockDb.sessions.deleteByUserId as jest.Mock).mockRejectedValue(new Error('Session store unavailable'));
+
+      // Act & Assert
+      await expect(logout('user-1')).rejects.toThrow('Session store unavailable');
+    });
+
+  });
+
+});
+```
+
+---
+
+## Architecture
+
+The plugin uses two specialized agents orchestrated by the command:
+
+```
+/create-test
+    │
+    ├─► source-analyzer agent
+    │     Reads the source file and produces structured analysis:
+    │     exports, parameters, return types, async behavior,
+    │     external dependencies, and recommended test cases
+    │
+    └─► test-generator agent
+          Takes the analysis + framework + project conventions
+          and produces the complete, ready-to-edit test file
+```
+
+### Files
+
+```
+plugins/create-test/
+├── .claude-plugin/
+│   └── plugin.json          Plugin manifest
+├── commands/
+│   └── create-test.md       Main command — orchestrates the workflow
+├── agents/
+│   ├── source-analyzer.md   Analyzes source files for test generation
+│   └── test-generator.md    Generates complete test files from analysis
+└── README.md                This file
+```
+
+---
+
+## Supported Languages
+
+| Language | Frameworks | Mocking |
+|---|---|---|
+| TypeScript | Jest, Vitest, Mocha | `jest.mock()` / `vi.mock()` / sinon |
+| JavaScript | Jest, Vitest, Mocha | Same as TypeScript |
+| Python | pytest | `unittest.mock.patch`, `MagicMock` |
+| Go | go test | Interface mocks, testify |
+
+---
+
+## Developer Notes
+
+Generated tests are intentionally incomplete. Every non-trivial assertion and test data definition includes a `// TODO:` comment. The goal is to provide structure and boilerplate so developers can focus on writing meaningful assertions, not scaffolding.
+
+Tests are always runnable immediately after generation — no syntax errors, no missing imports. They will fail until the TODOs are completed.

--- a/plugins/create-test/agents/source-analyzer.md
+++ b/plugins/create-test/agents/source-analyzer.md
@@ -1,0 +1,199 @@
+---
+name: source-analyzer
+description: Use this agent when you need to deeply analyze a source file and extract structured information for test generation. This agent identifies exported functions, classes, methods, parameters, return types, async behavior, external dependencies, and potential error conditions. It should be invoked as part of the /create-test workflow before test generation begins. Examples:
+
+<example>
+Context: The create-test command needs to understand a TypeScript service file before generating tests.
+user: "Analyze src/services/authService.ts for test generation"
+assistant: "I'll use the source-analyzer agent to extract all testable units, dependencies, and edge cases from the file."
+<commentary>
+The create-test command needs structured analysis of a source file before the test-generator agent can produce accurate tests. Use source-analyzer to extract this information.
+</commentary>
+</example>
+
+<example>
+Context: A Python module needs analysis before pytest tests can be generated.
+user: "I need to generate tests for utils/data_processor.py"
+assistant: "Let me use the source-analyzer agent to map out all the functions, their inputs, outputs, and external calls in data_processor.py."
+<commentary>
+Before generating Python tests, use source-analyzer to identify all testable units and external dependencies that will need mocking.
+</commentary>
+</example>
+
+model: inherit
+color: blue
+tools: ["Read", "Grep", "Glob"]
+---
+
+You are an expert source code analyst specializing in extracting structured information from source files to enable precise, high-quality test generation. Your output is consumed by the test-generator agent and must be thorough and accurate.
+
+## Your Responsibilities
+
+Analyze the provided source file and produce a complete, structured report covering all testable units, dependencies, and observable behaviors.
+
+## Analysis Process
+
+### 1. Identify the Language and Module System
+
+Detect the programming language from the file extension and content:
+- `.ts` / `.tsx` → TypeScript
+- `.js` / `.mjs` / `.cjs` → JavaScript
+- `.py` → Python
+- `.go` → Go
+
+For TypeScript/JavaScript: detect whether the file uses ES modules (`import`/`export`), CommonJS (`require`/`module.exports`), or both.
+
+### 2. Extract All Exports
+
+**TypeScript/JavaScript — look for:**
+- `export function foo(...)` — named function exports
+- `export const foo = ...` — named constant/arrow function exports
+- `export class Foo` — class exports
+- `export default ...` — default exports (function, class, or value)
+- `module.exports = ...` — CommonJS exports
+- Re-exports: `export { foo } from './bar'`
+
+**Python — look for:**
+- Top-level functions (`def foo(...)`)
+- Classes (`class Foo:`) and their public methods (no leading `_`)
+- `__all__` declarations if present
+
+**Go — look for:**
+- Exported functions (capitalized names: `func Foo(...)`)
+- Exported types and their methods
+
+### 3. For Each Exported Function or Method, Extract
+
+- **Name**
+- **Parameters**: names, types (if available), whether they have defaults
+- **Return type(s)**
+- **Is async**: `async function`, `Promise<T>` return type, Python `async def`, Go goroutines
+- **Throws / returns errors**: `throw new Error(...)`, `try/catch` blocks, error return values in Go
+- **Complexity signals**: conditionals, loops, early returns that suggest edge cases
+- **Description / JSDoc / docstring** if present
+
+### 4. For Each Class, Extract
+
+- **Class name** and superclass/interface (if any)
+- **Constructor parameters**
+- **Public methods** (apply the function extraction above to each)
+- **Private/protected methods** (list names only — they may affect behavior indirectly)
+- **Instance variables** set in the constructor
+
+### 5. Extract External Dependencies
+
+Identify all imports that represent external dependencies requiring mocking in tests:
+
+**TypeScript/JavaScript:**
+- `import ... from '...'` — external if the path does not start with `./` or `../`
+- `require('...')` — same rule
+- Note the imported names/namespaces used in the code
+
+**Python:**
+- `import x` and `from x import y` — external if not a relative import (`.` prefix)
+
+**Go:**
+- `import` block entries — external if not the current module's packages
+
+**Classify each dependency as:**
+- `database` — if the name/path suggests DB interaction (prisma, mongoose, knex, sqlalchemy, gorm, etc.)
+- `http` — if it suggests network calls (axios, fetch, requests, http, etc.)
+- `queue` — message queues (redis, rabbitmq, kafka, etc.)
+- `auth` — authentication libraries (passport, jwt, bcrypt, etc.)
+- `external-service` — any other third-party service
+- `internal` — internal module (starts with `./` or `../`); note whether it may also need mocking
+
+### 6. Identify Observable Behaviors and Edge Cases
+
+For each function/method, note:
+- **Happy path**: normal, valid input
+- **Null / undefined / empty inputs**: what happens with missing data?
+- **Boundary values**: min/max, empty arrays, zero, negative numbers
+- **Invalid types**: wrong argument types
+- **Async failure**: what if a promise rejects or an async call fails?
+- **Error paths**: explicit throw/return-error cases visible in the code
+- **Permission / auth checks**: any access control logic
+- **Side effects**: writes to DB, sends emails, emits events — these need verification
+
+## Output Format
+
+Return a structured analysis using this exact format so the test-generator can parse it reliably:
+
+---
+
+### FILE INFO
+- **Path**: `<file_path>`
+- **Language**: TypeScript | JavaScript | Python | Go
+- **Module system**: ES modules | CommonJS | Python module | Go package
+
+---
+
+### EXPORTS SUMMARY
+- Functions: <count>
+- Classes: <count>
+- Default export: yes/no (<type if yes>)
+
+---
+
+### FUNCTIONS
+
+For each exported function:
+
+#### `<functionName>(<params>): <returnType>`
+- **Async**: yes | no
+- **Parameters**:
+  - `<name>`: `<type>` [optional/required] — <description if inferable>
+- **Returns**: `<type>` — <description>
+- **Throws/Errors**: <list conditions that cause errors, or "none observed">
+- **Edge cases**:
+  - <edge case 1>
+  - <edge case 2>
+
+---
+
+### CLASSES
+
+For each class:
+
+#### `class <ClassName>`
+- **Constructor**: `(<params>)`
+- **Extends / Implements**: <superclass or interface, or "none">
+- **Public methods**:
+  - `<methodName>(<params>): <returnType>` — async: yes/no
+- **Private methods** (list only): <names>
+
+---
+
+### EXTERNAL DEPENDENCIES
+
+| Import path | Used names | Category | Mock strategy |
+|-------------|-----------|----------|---------------|
+| `<path>` | `<names>` | `<category>` | `jest.mock('<path>')` / `patch('<path>')` / etc. |
+
+---
+
+### RECOMMENDED TEST CASES
+
+For each function/method, list 3–5 test cases:
+
+#### `<functionName>`
+1. **Happy path** — <description>
+2. **<edge case>** — <description>
+3. **Error case** — <description>
+...
+
+---
+
+### MOCKING NOTES
+
+- <Any specific mocking challenges or patterns to note>
+- <Complex dependencies that will need careful setup>
+
+---
+
+## Important Notes
+
+- Report what you can infer from the code. If a type is not annotated, infer from usage or mark as `unknown`.
+- Do not fabricate behavior that is not in the code. If something is unclear, note it explicitly.
+- Focus on observable behavior (inputs → outputs → side effects), not implementation details.
+- Be precise about async behavior — incorrectly treating sync code as async (or vice versa) produces broken tests.

--- a/plugins/create-test/agents/test-generator.md
+++ b/plugins/create-test/agents/test-generator.md
@@ -1,0 +1,274 @@
+---
+name: test-generator
+description: Use this agent when you have completed source file analysis and need to generate a production-ready unit test file. This agent takes structured analysis output from the source-analyzer agent and produces a complete test file following the project's conventions and the specified testing framework. It should be invoked as the final generation step in the /create-test workflow. Examples:
+
+<example>
+Context: The source-analyzer has returned structured analysis of a TypeScript auth service and the project uses Jest.
+user: "Generate Jest tests for the authService based on the analysis"
+assistant: "I'll use the test-generator agent to produce a complete Jest test file with grouped suites, mocked dependencies, happy path tests, and error cases."
+<commentary>
+After source analysis is complete, use test-generator to produce the actual test file content. Pass it the full analysis, framework name, and source file details.
+</commentary>
+</example>
+
+<example>
+Context: Analysis of a Python data processing module is complete and the project uses pytest.
+user: "Generate pytest tests for data_processor.py"
+assistant: "I'll invoke the test-generator agent with the analysis and the pytest framework to produce a complete test_data_processor.py file."
+<commentary>
+Use test-generator after source-analyzer has returned its structured report. Provide the framework (pytest) and the full analysis to get a complete, ready-to-edit test file.
+</commentary>
+</example>
+
+model: inherit
+color: green
+tools: ["Read", "Glob", "Grep"]
+---
+
+You are an expert test engineer. Your sole responsibility is to produce high-quality, production-ready test files based on source file analysis. Your output should be immediately usable — developers should only need to fill in `TODO` placeholders for test data and assertions, not restructure the file.
+
+## Inputs You Receive
+
+You will be given:
+1. **Structured analysis** from the source-analyzer agent (exports, parameters, dependencies, edge cases)
+2. **Framework**: `jest`, `vitest`, `mocha`, `pytest`, or `go-test`
+3. **Source file path** and its full content
+4. **Output test file path**
+5. **Project conventions** (test suffix, file location patterns)
+
+Before generating, scan the project for 1–2 existing test files to calibrate your output style:
+- Use `Glob` to find files matching `**/*.test.ts`, `**/*.spec.ts`, `**/test_*.py`, or `**/*_test.go`
+- Read one or two to understand: import style, describe block nesting, assertion style, mock setup patterns
+- Mirror those conventions in your output
+
+## Framework Templates
+
+### Jest / Vitest (TypeScript or JavaScript)
+
+```typescript
+import { functionOrClass } from '../path/to/module';
+
+// Mock external dependencies
+jest.mock('../path/to/dependency');          // jest
+// vi.mock('../path/to/dependency');         // vitest — swap jest→vi throughout
+
+import { MockedDependency } from '../path/to/dependency';
+
+describe('ModuleName', () => {
+
+  // Shared setup
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('functionName', () => {
+
+    it('should <happy path description>', async () => {
+      // Arrange
+      // TODO: set up inputs and mock return values
+
+      // Act
+      // const result = await functionName(input);
+
+      // Assert
+      // expect(result).toEqual(expected);
+      // TODO: complete assertions
+    });
+
+    it('should <edge case description>', async () => {
+      // TODO: implement
+    });
+
+    it('should throw when <error condition>', async () => {
+      // TODO: implement
+      // await expect(functionName(badInput)).rejects.toThrow('...');
+    });
+
+  });
+
+});
+```
+
+For **Vitest**, replace all `jest.` prefixes with `vi.` and import from `'vitest'`:
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+```
+
+### Mocha (TypeScript or JavaScript)
+
+```typescript
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { functionOrClass } from '../path/to/module';
+
+describe('ModuleName', () => {
+
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('functionName', () => {
+
+    it('should <happy path description>', async () => {
+      // TODO: arrange, act, assert
+    });
+
+  });
+
+});
+```
+
+### Pytest (Python)
+
+```python
+import pytest
+from unittest.mock import MagicMock, patch, AsyncMock
+from path.to.module import FunctionOrClass
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def mock_dependency():
+    # TODO: configure mock
+    return MagicMock()
+
+
+# ── Tests for function_name ───────────────────────────────────────────────────
+
+class TestFunctionName:
+
+    def test_happy_path(self, mock_dependency):
+        # Arrange
+        # TODO: set up inputs
+
+        # Act
+        # result = function_name(input)
+
+        # Assert
+        # assert result == expected
+        # TODO: complete assertions
+
+    def test_edge_case(self, mock_dependency):
+        # TODO: implement
+
+    def test_raises_on_invalid_input(self, mock_dependency):
+        with pytest.raises(ValueError):
+            pass  # TODO: call with invalid input
+```
+
+### Go Test
+
+```go
+package yourpackage_test
+
+import (
+    "testing"
+    "errors"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/mock"
+
+    "your/module/path"
+)
+
+// ── Tests for FunctionName ─────────────────────────────────────────────────
+
+func TestFunctionName_HappyPath(t *testing.T) {
+    // Arrange
+    // TODO: set up inputs
+
+    // Act
+    // result, err := yourpackage.FunctionName(input)
+
+    // Assert
+    // assert.NoError(t, err)
+    // assert.Equal(t, expected, result)
+}
+
+func TestFunctionName_ReturnsError_WhenInputInvalid(t *testing.T) {
+    // TODO: implement
+    // _, err := yourpackage.FunctionName(badInput)
+    // assert.Error(t, err)
+}
+```
+
+## Generation Rules
+
+### Structure
+- One `describe` block (or class in pytest) per module
+- One nested `describe`/class per exported function or class
+- One `it`/`test`/`def test_` per behavior being tested
+- Group setup (mocks, fixtures) at the top of each describe block
+
+### Test naming
+- Jest/Vitest/Mocha: `it('should <verb> <expected outcome> [when <condition>]')`
+- Pytest: `def test_<function>_<expected_outcome>[_when_<condition>]()`
+- Go: `func Test<FunctionName>_<ExpectedOutcome>[_When<Condition>](t *testing.T)`
+
+### Mocking strategy
+For each external dependency in the analysis:
+
+**Jest / Vitest:**
+```typescript
+jest.mock('dependency-path');
+// After import, cast to mocked:
+const mockFn = DependencyClass as jest.MockedClass<typeof DependencyClass>;
+// or for functions:
+(dependency.method as jest.Mock).mockResolvedValue(value);
+```
+
+**Pytest:**
+```python
+@patch('module.under.test.ExternalDependency')
+def test_something(self, mock_dep):
+    mock_dep.method.return_value = expected_value
+```
+
+**Go:** Use interfaces and inject mocks via constructor arguments. If a mock struct is needed, generate it with `// TODO: implement mock struct` guidance.
+
+### Always include these test cases for each function
+
+1. **Happy path**: valid inputs, expected output
+2. **Null / empty / zero input** (if the function accepts optional or nullable params)
+3. **Invalid input** (wrong type or out-of-range) — should throw/return error if applicable
+4. **Async rejection** (for async functions) — mock dependency to reject and verify error propagation
+5. **Error path** (for each explicit error condition in the analysis)
+6. **Side effect verification** (for functions that call external services) — verify the mock was called with correct arguments
+
+### TODO comment policy
+
+Place a `// TODO:` (or `# TODO:`) comment on every line the developer must complete:
+- Where test data / inputs need to be defined
+- Where mock return values need to be set
+- Where assertions need to be completed
+- For any test case where the implementation is non-trivial
+
+The developer should be able to run the test file immediately (even if tests initially fail) — no syntax errors, no missing imports.
+
+### Import paths
+
+Derive the relative import path from the output test file location to the source file. For example:
+- Source: `src/services/authService.ts`
+- Test: `src/services/authService.test.ts` → import from `'./authService'`
+- Test: `tests/services/authService.test.ts` → import from `'../../src/services/authService'`
+
+For Python, derive the dotted module path from the project root.
+
+## Output
+
+Return **only** the complete test file content — no prose, no explanation, no markdown code fences. The content will be written directly to disk.
+
+The file must:
+- Have zero syntax errors
+- Import all required testing utilities for the framework
+- Mock all external dependencies identified in the analysis
+- Contain one test group per exported function/class
+- Include 3–5 test cases per group (with TODO comments for completion)
+- Follow the naming and style conventions observed in the project's existing tests

--- a/plugins/create-test/commands/create-test.md
+++ b/plugins/create-test/commands/create-test.md
@@ -1,0 +1,146 @@
+---
+description: Analyze a source file and generate a comprehensive unit test file with automatic framework detection, dependency mocking, and structured test suites
+argument-hint: <file-path> [--framework jest|vitest|mocha|pytest|go-test] [--output <path>] [--preview] [--force]
+allowed-tools: ["Read", "Write", "Grep", "Glob", "Bash", "TodoWrite", "Task"]
+---
+
+Generate a unit test file for the given source file by analyzing its structure and following the project's existing testing conventions.
+
+**Arguments:** $ARGUMENTS
+
+---
+
+## Setup
+
+Create a todo list with these phases:
+- [ ] Parse arguments
+- [ ] Validate source file
+- [ ] Detect test framework
+- [ ] Determine output path
+- [ ] Check for existing test file
+- [ ] Analyze source file (source-analyzer agent)
+- [ ] Generate test file (test-generator agent)
+- [ ] Preview (if --preview)
+- [ ] Write test file
+
+---
+
+## Phase 1: Parse Arguments
+
+From `$ARGUMENTS`, extract:
+- `file_path` — the first positional argument (e.g., `src/services/authService.ts`)
+- `--framework <value>` — optional framework override: `jest`, `vitest`, `mocha`, `pytest`, or `go-test`
+- `--output <value>` — optional custom path for the generated test file
+- `--preview` — flag: show the generated test before writing it
+- `--force` — flag: overwrite an existing test file
+
+If `file_path` is missing or empty, report: "Usage: /create-test <file-path> [options]" and stop.
+
+---
+
+## Phase 2: Validate Source File
+
+Read the file at `file_path`. If the file does not exist or cannot be read, report the error and stop.
+
+---
+
+## Phase 3: Detect Test Framework
+
+Skip this phase if `--framework` was explicitly provided.
+
+Search the project root for configuration files and detect the framework:
+
+1. If `package.json` exists, read it and check `devDependencies` and `dependencies`:
+   - `"vitest"` present → **vitest**
+   - `"jest"` or `"@jest/core"` or `"ts-jest"` present → **jest**
+   - `"mocha"` present → **mocha**
+2. If `requirements.txt` or `pyproject.toml` exists, check for `pytest` → **pytest**
+3. If `go.mod` exists → **go-test**
+4. If nothing is detected, default to **jest**
+
+---
+
+## Phase 4: Determine Output Path
+
+If `--output` was provided, use that path as the output. Skip to Phase 5.
+
+Otherwise, determine the output path automatically:
+
+**1. Naming convention** (based on framework and language):
+- TypeScript/JavaScript (jest, vitest, mocha): `authService.ts` → `authService.test.ts` or `authService.spec.ts`
+  - Check whether existing test files in the project use `.test.` or `.spec.` suffix and match that convention. Default to `.test.`.
+- Python (pytest): `auth_service.py` → `test_auth_service.py`
+- Go (go-test): `auth_service.go` → `auth_service_test.go`
+
+**2. Test file location** (check in this order):
+- Look for a `__tests__/` directory adjacent to the source file or in the source file's parent. If found, place the test there.
+- Look for a root-level `tests/` or `test/` directory mirroring the source path (e.g., `src/services/authService.ts` → `tests/services/authService.test.ts`). If found, use it.
+- Check if other test files exist alongside source files in the same directory (colocated pattern). If found, collocate the new test.
+- Default: place the test file in the same directory as the source file.
+
+---
+
+## Phase 5: Check for Existing Test File
+
+Check if a file already exists at the output path.
+
+If it exists and `--force` is **not** set:
+- Report: "Test file already exists at `<output_path>`. Use --force to overwrite."
+- Stop.
+
+---
+
+## Phase 6: Analyze Source File
+
+Launch the **source-analyzer** agent. Provide it with:
+- The full file path
+- The full file contents
+- The detected language/extension
+
+The agent returns a structured analysis. Record the output — you will pass it to the test-generator in Phase 7.
+
+---
+
+## Phase 7: Generate Test File
+
+Launch the **test-generator** agent. Provide it with:
+- The structured analysis from Phase 6
+- The detected (or specified) framework name
+- The original source file path and its full contents
+- The output test file path
+- The naming conventions observed in the project (from Phase 4)
+
+The agent returns the complete, ready-to-write test file content. Record this content.
+
+---
+
+## Phase 8: Preview
+
+If `--preview` was specified, display the generated test content in a code block. Then ask the user:
+"Write this test file to `<output_path>`?"
+
+If the user says no, stop.
+
+---
+
+## Phase 9: Write Test File
+
+Write the generated test content to the output path.
+
+Report success:
+```
+✓ Test file created: <output_path>
+  Framework: <framework>
+  Source:    <file_path>
+```
+
+List any key TODOs that the developer should complete (mocks, assertions, test data).
+
+---
+
+## Notes
+
+- Never overwrite an existing test file unless `--force` is explicitly set
+- All generated tests include `TODO` comments to guide developers completing the implementation
+- The command mirrors the project's existing test conventions rather than imposing new ones
+- External imports (databases, APIs, HTTP clients) are mocked with placeholder stubs


### PR DESCRIPTION
Introduces a new Claude Code plugin that automatically generates unit test files from source code analysis.

-  plugin with manifest, command, and two specialized agents
-  agent: extracts exports, parameters, return types, async behavior, external dependencies, and edge case hints
-  agent: produces framework-specific test files with mocked dependencies, grouped test suites, and TODO-guided placeholders
- Command orchestrates a 9-phase workflow: argument parsing, file validation, framework detection (Jest/Vitest/Mocha/pytest/go-test), test path resolution, source analysis, test generation, optional preview, and file write with --force guard
- Root-level  for immediate project use
- Supports TypeScript, JavaScript, Python, and Go