### PR TITLE
fix(hookify): correct field mapping for stop and prompt events

### DIFF
--- a/plugins/hookify/core/config_loader.py
+++ b/plugins/hookify/core/config_loader.py
@@ -63,6 +63,10 @@ class Rule:
                 field = 'command'
             elif event == 'file':
                 field = 'new_text'
+            elif event == 'stop':
+                field = 'reason'
+            elif event == 'prompt':
+                field = 'user_prompt'
             else:
                 field = 'content'
 


### PR DESCRIPTION
Fixes #32153

## Root cause

`Rule.from_dict()` in `plugins/hookify/core/config_loader.py` converts a simple `pattern` field into a `Condition` by inferring which field to match against based on the event type. The `else` branch was catching `stop` and `prompt` events and mapping them to `field='content'`, but `_extract_field()` in `rule_engine.py` has no handler for `content` on those events — it expects `reason` for Stop and `user_prompt` for UserPromptSubmit. This caused `_extract_field()` to return `None`, so pattern matching always silently failed.

## Fix

Add explicit branches before the `else` fallback:

```python
elif event == 'stop':
    field = 'reason'
elif event == 'prompt':
    field = 'user_prompt'
```

## Test plan

- [ ] Create a hookify rule with `event: stop` and a simple `pattern` — verify it now matches when Claude stops
- [ ] Create a hookify rule with `event: prompt` and a simple `pattern` — verify it now matches on user input
- [ ] Existing `event: bash` and `event: file` rules continue to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)