### PR TITLE
feat: Add tmp-cleanup plugin to mitigate /tmp file leak (#8856)

### DIFF
--- a/plugins/tmp-cleanup/.claude-plugin/plugin.json
+++ b/plugins/tmp-cleanup/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "tmp-cleanup",
+  "version": "1.0.0",
+  "description": "Cleans up orphaned claude-{hex}-cwd temp files that accumulate due to missing cleanup in the Bash tool. Addresses GitHub Issue #8856.",
+  "author": {
+    "name": "Community",
+    "url": "https://github.com/anthropics/claude-code/issues/8856"
+  }
+}

--- a/plugins/tmp-cleanup/README.md
+++ b/plugins/tmp-cleanup/README.md
@@ -1,0 +1,48 @@
+# tmp-cleanup
+
+Workaround plugin for [GitHub Issue #8856](https://github.com/anthropics/claude-code/issues/8856): Missing cleanup for `/tmp/claude-*-cwd` working directory tracking files.
+
+## Problem
+
+Every Bash tool invocation creates a `/tmp/claude-{4-hex}-cwd` file (22 bytes) to track the working directory after command execution. These files are **never deleted** by the runtime, causing accumulation of hundreds of files per day.
+
+## Solution
+
+This plugin installs two hooks:
+
+| Hook | Event | Behavior |
+|------|-------|----------|
+| `tmp_cleanup_post_tool.py` | **PostToolUse** (Bash only) | Removes files older than 60 seconds |
+| `tmp_cleanup_stop.py` | **Stop** (session exit) | Removes stale files (same threshold, safe for concurrent sessions) |
+
+### Safety measures
+
+- **Symlink protection**: Uses `os.lstat()` — never follows symlinks in `/tmp`
+- **Regular file check**: Only deletes regular files, skips directories/pipes/devices
+- **Strict pattern**: Validates filenames match `claude-[0-9a-f]{4}-cwd` exactly
+- **Stale threshold**: Only deletes files older than 60 seconds to avoid racing with the runtime
+- **Concurrent session safe**: Both hooks use the same threshold, never deletes files other sessions may need
+- **Timeout**: 10-second timeout prevents blocking Claude Code on slow filesystems
+
+## Supported Platforms
+
+- **Linux**: Full support
+- **macOS**: Full support (uses `tempfile.gettempdir()` to resolve `/private/tmp`)
+- **Windows**: No effect (Claude Code on Windows uses a different temp path pattern)
+
+## Installation
+
+Add to your project's `.claude/settings.json`:
+
+```json
+{
+  "plugins": [
+    "/path/to/claude-code/plugins/tmp-cleanup"
+  ]
+}
+```
+
+## Requirements
+
+- Python 3.6+
+- Claude Code with hooks support

--- a/plugins/tmp-cleanup/hooks/cwd_file_cleanup.py
+++ b/plugins/tmp-cleanup/hooks/cwd_file_cleanup.py
@@ -1,0 +1,62 @@
+"""
+Shared cleanup logic for tmp-cleanup hooks.
+Addresses GitHub Issue #8856: Missing cleanup for claude-{hex}-cwd temp files.
+"""
+
+import glob
+import json
+import os
+import re
+import stat
+import sys
+import tempfile
+import time
+
+STALE_THRESHOLD_SECONDS = 60
+
+TMP_DIR = tempfile.gettempdir()
+TMP_PATTERN = os.path.join(TMP_DIR, "claude-????-cwd")
+FILENAME_RE = re.compile(r"^claude-[0-9a-f]{4}-cwd$")
+
+
+def cleanup_stale_cwd_files():
+    """Remove claude-{4hex}-cwd files older than the threshold.
+
+    Safety measures:
+    - Uses lstat to avoid following symlinks (prevents /tmp symlink attacks)
+    - Only deletes regular files (skips directories, pipes, etc.)
+    - Validates filename matches exact 4-hex-char pattern
+    - Skips files newer than STALE_THRESHOLD_SECONDS
+
+    Returns:
+        Number of files cleaned up.
+    """
+    now = time.time()
+    cleaned = 0
+
+    for filepath in glob.glob(TMP_PATTERN):
+        try:
+            basename = os.path.basename(filepath)
+            if not FILENAME_RE.match(basename):
+                continue
+
+            st = os.lstat(filepath)
+            if stat.S_ISLNK(st.st_mode) or not stat.S_ISREG(st.st_mode):
+                continue
+
+            if now - st.st_mtime > STALE_THRESHOLD_SECONDS:
+                os.unlink(filepath)
+                cleaned += 1
+        except OSError:
+            pass
+
+    return cleaned
+
+
+def run_hook():
+    """Common hook entry point: consume stdin, run cleanup, output result."""
+    sys.stdin.read()
+    cleaned = cleanup_stale_cwd_files()
+    if cleaned > 0:
+        print(json.dumps({"systemMessage": f"tmp-cleanup: removed {cleaned} stale cwd file(s)"}))
+    sys.exit(0)

--- a/plugins/tmp-cleanup/hooks/hooks.json
+++ b/plugins/tmp-cleanup/hooks/hooks.json
@@ -1,0 +1,28 @@
+{
+  "description": "Cleanup hook for claude-{hex}-cwd temp file leak (GitHub Issue #8856)",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/tmp_cleanup_post_tool.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/tmp_cleanup_stop.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/tmp-cleanup/hooks/tmp_cleanup_post_tool.py
+++ b/plugins/tmp-cleanup/hooks/tmp_cleanup_post_tool.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""
+Claude Code Hook: tmp-cleanup (PostToolUse)
+============================================
+Cleans orphaned claude-{hex}-cwd files after Bash tool execution.
+Addresses GitHub Issue #8856: Missing cleanup for working directory tracking files.
+
+Each Bash tool invocation creates a temporary file to track the working directory.
+These files are never deleted by the runtime, accumulating hundreds per day.
+
+This hook runs after each Bash tool call and removes stale files (older than
+60 seconds) to prevent accumulation while preserving any file the runtime
+may still need for the current command.
+"""
+
+import json
+import os
+import sys
+
+try:
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    from cwd_file_cleanup import run_hook
+except ImportError as e:
+    sys.stdin.read()
+    print(json.dumps({"systemMessage": f"tmp-cleanup: failed to load — {e}"}))
+    sys.exit(0)
+
+if __name__ == "__main__":
+    run_hook()

--- a/plugins/tmp-cleanup/hooks/tmp_cleanup_stop.py
+++ b/plugins/tmp-cleanup/hooks/tmp_cleanup_stop.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""
+Claude Code Hook: tmp-cleanup (Stop)
+=====================================
+Cleanup of stale claude-{hex}-cwd files on session exit.
+Addresses GitHub Issue #8856.
+
+Uses the same stale-threshold approach as the PostToolUse hook to avoid
+deleting files that belong to other concurrent Claude Code sessions.
+"""
+
+import json
+import os
+import sys
+
+try:
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    from cwd_file_cleanup import run_hook
+except ImportError as e:
+    sys.stdin.read()
+    print(json.dumps({"systemMessage": f"tmp-cleanup: failed to load — {e}"}))
+    sys.exit(0)
+
+if __name__ == "__main__":
+    run_hook()


### PR DESCRIPTION
## Summary

Adds a new **tmp-cleanup** plugin that mitigates [#8856](https://github.com/anthropics/claude-code/issues/8856) — the accumulation of orphaned `/tmp/claude-{hex}-cwd` files created by the Bash tool.

As documented in #8856, every Bash tool invocation creates a temporary file to track the working directory, but `fs.unlink` is never called afterward. Users report 174+ files per day accumulating indefinitely until `systemd-tmpfiles-clean` runs (Linux) or manual cleanup.

**This plugin does not patch the core runtime** (which is closed-source). It provides a hook-based workaround that cleans up stale files automatically.

## What it does

Two hooks, sharing a common module:

| Hook | Event | Behavior |
|------|-------|----------|
| `tmp_cleanup_post_tool.py` | PostToolUse (Bash only) | Deletes matching files older than 60 seconds |
| `tmp_cleanup_stop.py` | Stop (session exit) | Same stale-threshold cleanup on exit |

Both hooks use the same 60-second staleness threshold. Neither hook performs unconditional deletion — files from concurrent Claude Code sessions are preserved.

## Safety measures

Each of these was specifically tested (see Test Plan below):

- **Symlink protection**: `os.lstat()` checks before `os.unlink()` — symlinks are detected and skipped, never followed. Prevents the classic `/tmp` symlink attack on shared systems.
- **Regular file validation**: `stat.S_ISREG()` check ensures only regular files are deleted (not directories, pipes, devices).
- **Strict filename matching**: Two-layer validation — `glob("claude-????-cwd")` narrows to exactly 4 wildcard characters, then `re.compile(r"^claude-[0-9a-f]{4}-cwd$")` validates the basename contains only lowercase hex.
- **Stale threshold**: Only files with `mtime` older than 60 seconds are removed. The runtime reads the file immediately after command execution, so a 60-second window provides ample safety margin.
- **Concurrent session safe**: Because both hooks use the stale threshold (not unconditional deletion), files actively in use by other sessions are preserved.
- **Timeout**: 10-second timeout on both hooks in `hooks.json` prevents blocking Claude Code if `/tmp` is slow or contains many files.
- **Graceful failure**: `try/except ImportError` on module import with JSON `systemMessage` fallback. `try/except OSError` on all file operations. Hook failures don't affect Claude Code operation.
- **Cross-platform**: Uses `tempfile.gettempdir()` instead of hardcoded `/tmp`. Works on Linux (`/tmp`) and macOS (`/private/tmp`). On Windows the plugin has no effect (no matching files exist).

## Files added (6 files, 201 lines)

```
plugins/tmp-cleanup/
├── .claude-plugin/
│   └── plugin.json                  # Plugin metadata
├── hooks/
│   ├── hooks.json                   # Hook event configuration
│   ├── cwd_file_cleanup.py          # Shared cleanup logic (all safety checks here)
│   ├── tmp_cleanup_post_tool.py     # PostToolUse entry point
│   └── tmp_cleanup_stop.py          # Stop entry point
└── README.md
```

## Convention compliance

- Follows the same plugin structure as `security-guidance`, `hookify`, and other existing plugins
- `hooks.json` format matches existing plugins (with `timeout` field as used by `hookify`)
- Stop hook omits `matcher` field (consistent with `hookify` and `ralph-wiggum` Stop hooks)
- Entry point scripts include `#!/usr/bin/env python3` shebang (consistent with `security-guidance`)
- JSON `systemMessage` output for observability

## Limitations (stated explicitly)

- **This is a workaround, not a fix.** The root cause is in the minified `cli.js` runtime where `fs.unlink` is never called after reading the cwd file. Only an Anthropic engineer with source access can fix the actual leak.
- **Windows**: The plugin has no effect on Windows because Claude Code on Windows uses different temp path patterns.
- **TOCTOU window**: There is a theoretical time-of-check/time-of-use gap between `os.lstat()` and `os.unlink()`. This is not practically exploitable — `os.unlink()` on a symlink removes the link (not the target), and hardlink creation in `/tmp` is restricted on modern Linux (kernel 3.6+, `fs.protected_hardlinks=1`) and macOS.
- **First install with large backlog**: If a user has thousands of accumulated files, the first few cleanup runs may take longer than usual. The 10-second timeout ensures Claude Code is never blocked.

## Test plan

All tests were run and passed locally (Python 3.14, macOS Darwin 25.2.0):

- [x] **Syntax validation**: `py_compile` passes on all 3 Python files
- [x] **JSON validation**: `json.load()` passes on `hooks.json` and `plugin.json`
- [x] **Import test**: `from cwd_file_cleanup import run_hook` succeeds
- [x] **Import guard test**: Both hook files contain `try/except ImportError` with JSON fallback
- [x] **Symlink protection test**: Created a symlink in a temp directory, confirmed `os.lstat()` detects it and skips deletion, confirmed the symlink target file is preserved
- [x] **Pattern strictness test**: Validated regex against 7 cases — accepts `claude-abcd-cwd` and `claude-1234-cwd`, rejects `claude-ABCD-cwd` (uppercase), `claude-abcde-cwd` (5 chars), `claude-abc-cwd` (3 chars), `claude-my-backup-cwd` (arbitrary string), `claude--cwd` (empty)
- [x] **Stale vs fresh test**: Created 25 simulated files, set 15 to 120s old and 10 to current time. Cleanup correctly removed exactly 15 stale files and preserved all 10 fresh files
- [x] **Timeout present**: Verified both hooks have `"timeout": 10` in `hooks.json`
- [x] **Convention compliance**: Verified Stop hook has no `matcher` field, both entry points have shebangs, no hardcoded `/tmp` in metadata files
- [x] **Cross-platform path**: Verified `tempfile.gettempdir()` resolves correctly on macOS

Closes #8856

🤖 Generated with [Claude Code](https://claude.com/claude-code)