### PR TITLE
fix(commit-commands): handle initial commit when no commits exist yet

### DIFF
--- a/plugins/commit-commands/commands/commit.md
+++ b/plugins/commit-commands/commands/commit.md
@@ -6,9 +6,9 @@ description: Create a git commit
 ## Context
 
 - Current git status: !`git status`
-- Current git diff (staged and unstaged changes): !`git diff HEAD`
+- Current git diff (staged and unstaged changes): !`git diff HEAD 2>/dev/null || git diff --cached`
 - Current branch: !`git branch --show-current`
-- Recent commits: !`git log --oneline -10`
+- Recent commits: !`git log --oneline -10 2>/dev/null || echo "No commits yet (initial commit)"`
 
 ## Your task
 


### PR DESCRIPTION
## Summary
- Fix `/commit-commands:commit` failing with `fatal: your current branch does not have any commits yet`

## Changes
- `plugins/commit-commands/commands/commit.md`: Add error handling for repos with no commits
  - `git diff HEAD` falls back to `git diff --cached` (shows staged changes without HEAD)
  - `git log --oneline -10` falls back to `"No commits yet (initial commit)"`

## Testing
Tested in a fresh `git init` repo with no commits:
- `git diff HEAD 2>/dev/null || git diff --cached` — shows staged diff correctly
- `git log --oneline -10 2>/dev/null || echo "No commits yet (initial commit)"` — shows fallback message
- Both commands still work normally in repos with existing commits

Fixes #24881