### PR TITLE
fix(ralph-loop): escape special characters in ARGUMENTS to prevent bash injection (#33309)

### DIFF
--- a/plugins/ralph-wiggum/commands/ralph-loop.md
+++ b/plugins/ralph-wiggum/commands/ralph-loop.md
@@ -1,16 +1,23 @@
 ---
 description: "Start Ralph Wiggum loop in current session"
 argument-hint: "PROMPT [--max-iterations N] [--completion-promise TEXT]"
-allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh:*)"]
+allowed-tools: ["Write", "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh:*)"]
 hide-from-slash-command-tool: "true"
 ---
-
 # Ralph Loop Command
+
+Write the arguments to a temp file to avoid shell injection issues with
+special characters (backticks, dollar signs, etc.) in the prompt:
+
+```write
+.claude/ralph-args.tmp
+$ARGUMENTS
+```
 
 Execute the setup script to initialize the Ralph loop:
 
 ```!
-"${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh" $ARGUMENTS
+"${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh" --prompt-file .claude/ralph-args.tmp
 ```
 
 Please work on the task. When you try to exit, the Ralph loop will feed the SAME PROMPT back to you for the next iteration. You'll see your previous work in files and git history, allowing you to iterate and improve.


### PR DESCRIPTION
Prompts containing backticks (e.g. "fix the `foo` function") are passed raw to bash via $ARGUMENTS, triggering Claude Code's security check: "Command contains backticks for command substitution".
Fix: Add Write to allowed-tools and write $ARGUMENTS to .claude/ralph-args.tmp before calling the script. The script receives a --prompt-file path instead of a raw string, avoiding all shell interpretation of the prompt content.
Fixes #33309. Related: #16669, #16163.