### PR TITLE
docs: add workaround for false-positive update banner on brew/winget

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,36 @@ For more installation options, uninstall steps, and troubleshooting, see the [se
 
 2. Navigate to your project directory and run `claude`.
 
+## Known Issue: False-Positive Update Banner (Homebrew/WinGet)
+
+Some users installed via Homebrew or WinGet may see:
+
+`Update available! Run: brew upgrade claude-code`
+
+or
+
+`Update available! Run: winget upgrade Anthropic.ClaudeCode`
+
+even when their package manager reports no update.
+
+This can happen when the latest npm release is newer than the latest package
+available in Homebrew cask/WinGet. The notification resolves automatically once
+those package registries catch up.
+
+Temporary workaround:
+
+- Set `DISABLE_AUTOUPDATER=1` to hide update notifications.
+
+Examples:
+
+```bash
+DISABLE_AUTOUPDATER=1 claude
+```
+
+```powershell
+$env:DISABLE_AUTOUPDATER=1; claude
+```
+
 ## Plugins
 
 This repository includes several Claude Code plugins that extend functionality with custom commands and agents. See the [plugins directory](./plugins/README.md) for detailed documentation on available plugins.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For more installation options, uninstall steps, and troubleshooting, see the [se
 
 2. Navigate to your project directory and run `claude`.
 
-## Known Issue: False-Positive Update Banner (Homebrew/WinGet)
+## Known issue with false-positive update banner (Homebrew/WinGet)
 
 Some users installed via Homebrew or WinGet may see:
 
@@ -64,6 +64,8 @@ those package registries catch up.
 Temporary workaround:
 
 - Set `DISABLE_AUTOUPDATER=1` to hide update notifications.
+- This also suppresses legitimate update notifications, so use it only as a
+    temporary workaround.
 
 Examples:
 
@@ -73,6 +75,16 @@ DISABLE_AUTOUPDATER=1 claude
 
 ```powershell
 $env:DISABLE_AUTOUPDATER=1; claude
+```
+
+To re-enable update notifications:
+
+```bash
+unset DISABLE_AUTOUPDATER
+```
+
+```powershell
+Remove-Item Env:DISABLE_AUTOUPDATER
 ```
 
 ## Plugins


### PR DESCRIPTION
## Summary
- adds a known-issue note for false-positive `Update available` banners on Homebrew and WinGet installs
- explains the version-channel mismatch (npm latest vs package manager registry lag)
- documents temporary workaround: `DISABLE_AUTOUPDATER=1`

## Context
Fixes confusion reported in #18047 (and related duplicates) where users see an update prompt but `brew upgrade` or `winget upgrade` reports no newer package version.

## Why docs
The public repository currently does not include the runtime updater implementation, so this change provides immediate user guidance while a runtime fix is developed in the appropriate codebase.