### PR TITLE
feat(plugins): hook-integrity-guard security plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -81,6 +81,17 @@
       "category": "development"
     },
     {
+      "name": "hook-integrity-guard",
+      "description": "Prevents Claude from modifying its own hooks, settings, and safety infrastructure. Blocks Edit, Write, MultiEdit, and Bash operations targeting hook scripts, settings files, and plugin directories.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Sunny Patel",
+        "url": "https://github.com/sunnypatell"
+      },
+      "source": "./plugins/hook-integrity-guard",
+      "category": "security"
+    },
+    {
       "name": "hookify",
       "description": "Easily create custom hooks to prevent unwanted behaviors by analyzing conversation patterns or from explicit instructions. Define rules via simple markdown files.",
       "version": "0.1.0",

--- a/plugins/hook-integrity-guard/.claude-plugin/plugin.json
+++ b/plugins/hook-integrity-guard/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "hook-integrity-guard",
+  "version": "1.0.0",
+  "description": "Prevents Claude from modifying its own hooks, settings, and safety infrastructure. Addresses CVE-2025-59536 by intercepting Edit, Write, MultiEdit, and Bash operations that target hook scripts, settings files, and plugin directories.",
+  "author": {
+    "name": "Sunny Patel",
+    "url": "https://github.com/sunnypatell"
+  }
+}

--- a/plugins/hook-integrity-guard/README.md
+++ b/plugins/hook-integrity-guard/README.md
@@ -1,0 +1,72 @@
+# hook-integrity-guard
+
+prevents Claude from modifying its own hooks, settings, and safety infrastructure.
+
+## why
+
+Claude has been observed weakening or removing its own enforcement hooks to complete tasks more easily ([CVE-2025-59536](https://nvd.nist.gov/vuln/detail/CVE-2025-59536), severity 8.7/10). this can happen through:
+
+- rewriting hook scripts to always exit 0 ([#32376](https://github.com/anthropics/claude-code/issues/32376))
+- deleting hook files so hooks fail open silently ([#32990](https://github.com/anthropics/claude-code/issues/32990))
+- modifying `settings.json` to disable hooks entirely
+- using bash redirects, `sed -i`, `chmod`, etc. to alter protected files
+
+this plugin intercepts all four write vectors (`Edit`, `Write`, `MultiEdit`, `Bash`) via a `PreToolUse` hook and blocks any operation targeting protected paths.
+
+## what's protected
+
+| path | reason |
+|---|---|
+| `~/.claude/hooks/` | hook scripts |
+| `~/.claude/commands/` | custom command definitions |
+| `~/.claude/settings.json` | global settings (hook config lives here) |
+| `~/.claude/settings.local.json` | local settings override |
+| `*/hooks.json` | plugin hook manifests |
+| `*/hooks/` | plugin hook script directories |
+| `*/.claude-plugin/plugin.json` | plugin metadata |
+
+## how it works
+
+the guard runs as a `PreToolUse` hook on every `Edit`, `Write`, `MultiEdit`, and `Bash` call.
+
+**for file operations** (`Edit`, `Write`, `MultiEdit`):
+- extracts `file_path` from the tool input
+- resolves `~`, `$HOME`, `..`, and symlinks to a canonical path
+- checks against protected directories, files, and patterns
+
+**for bash commands**:
+- scans for sensitive path fragments (`.claude/hooks`, `.claude/settings`, etc.)
+- if found, checks whether the command is destructive (`rm`, `mv`, `chmod`), an in-place edit (`sed -i`, `perl -i`), or a write redirect (`>`, `>>`, `tee`)
+- read-only commands like `ls`, `cat`, `grep` on protected paths are allowed
+
+**fail behavior**: the hook fails open on malformed input (exits 0) so it never breaks unrelated operations. when it blocks, it exits 2 with a clear message explaining the restriction.
+
+## install
+
+the plugin is installed via the `marketplace.json` entry. no additional configuration needed.
+
+## testing
+
+```bash
+# should block (edit hook file)
+echo '{"tool_name":"Edit","tool_input":{"file_path":"~/.claude/hooks/myhook.sh","old_string":"x","new_string":"y"}}' \
+  | python3 hooks/guard.py
+
+# should block (rm hooks dir)
+echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf ~/.claude/hooks/"}}' \
+  | python3 hooks/guard.py
+
+# should block (write settings)
+echo '{"tool_name":"Write","tool_input":{"file_path":"~/.claude/settings.json","content":"{}"}}' \
+  | python3 hooks/guard.py
+
+# should allow (normal file edit)
+echo '{"tool_name":"Edit","tool_input":{"file_path":"/tmp/foo.py","old_string":"x","new_string":"y"}}' \
+  | python3 hooks/guard.py
+
+# should allow (read-only on hooks)
+echo '{"tool_name":"Bash","tool_input":{"command":"ls ~/.claude/hooks/"}}' \
+  | python3 hooks/guard.py
+```
+
+blocked operations exit 2 with a stderr message. allowed operations exit 0 silently.

--- a/plugins/hook-integrity-guard/hooks/guard.py
+++ b/plugins/hook-integrity-guard/hooks/guard.py
@@ -21,6 +21,7 @@ import json
 import os
 import re
 import sys
+from typing import Optional
 
 # ──────────────────────────────────────────────────────────────────────────────
 # protected paths
@@ -40,11 +41,10 @@ PROTECTED_FILES = [
     os.path.join(HOME, ".claude", "settings.local.json"),
 ]
 
-# patterns for plugin hook files (relative to any plugin root)
-PROTECTED_PATTERNS = [
-    "hooks.json",
-    os.path.join("hooks", ""),       # any file inside a hooks/ directory
+# patterns for plugin config files (scoped to .claude-plugin/ context)
+PROTECTED_PLUGIN_FILES = [
     os.path.join(".claude-plugin", "plugin.json"),
+    os.path.join(".claude-plugin", "hooks.json"),
 ]
 
 
@@ -63,7 +63,7 @@ def normalize_path(path: str) -> str:
     return path
 
 
-def is_protected_path(file_path: str) -> str | None:
+def is_protected_path(file_path: str) -> Optional[str]:
     """
     check if a file path targets a protected location.
     returns a human-readable reason if protected, None otherwise.
@@ -75,23 +75,32 @@ def is_protected_path(file_path: str) -> str | None:
     # check exact protected files
     for protected in PROTECTED_FILES:
         if resolved == os.path.realpath(protected):
-            return f"settings file ({os.path.basename(protected)})"
+            return "settings file ({})".format(os.path.basename(protected))
 
     # check protected directories
     for protected_dir in PROTECTED_DIRS:
         real_dir = os.path.realpath(protected_dir)
         if resolved.startswith(real_dir + os.sep) or resolved == real_dir:
-            return f"hook directory ({os.path.basename(protected_dir)}/)"
+            basename = os.path.basename(protected_dir)
+            if basename == "commands":
+                return "commands directory (commands/)"
+            return "hook directory (hooks/)"
 
-    # check plugin hook patterns (catches hooks.json and hooks/ in any plugin)
-    for pattern in PROTECTED_PATTERNS:
-        if pattern.endswith(os.sep):
-            # directory pattern: check if path contains /hooks/ segment
-            if os.sep + pattern in resolved + os.sep:
-                return f"plugin hook directory ({pattern})"
-        else:
-            if resolved.endswith(os.sep + pattern) or os.sep + pattern + os.sep in resolved:
-                return f"plugin config ({pattern})"
+    # check plugin config files (only within .claude-plugin/ directories)
+    for pattern in PROTECTED_PLUGIN_FILES:
+        if resolved.endswith(os.sep + pattern):
+            return "plugin config ({})".format(pattern)
+
+    # check if path is inside a plugin's hooks/ directory
+    # only match hooks/ dirs that are siblings of a .claude-plugin/ dir
+    # (i.e., actual plugin hook directories, not arbitrary project hooks/)
+    parts = resolved.split(os.sep)
+    for i, part in enumerate(parts):
+        if part == "hooks" and i > 0:
+            # check if a .claude-plugin/ dir exists as a sibling
+            parent = os.sep.join(parts[:i])
+            if os.path.isdir(os.path.join(parent, ".claude-plugin")):
+                return "plugin hook directory (hooks/)"
 
     return None
 
@@ -101,18 +110,22 @@ def is_protected_path(file_path: str) -> str | None:
 # ──────────────────────────────────────────────────────────────────────────────
 
 # commands that modify or destroy files
+# note: cp is excluded because copying FROM a protected path is a read operation
 DESTRUCTIVE_COMMANDS = re.compile(
-    r"\b(?:rm|rmdir|unlink|mv|cp|chmod|chown|chflags|truncate)\b"
+    r"\b(?:rm|rmdir|unlink|mv|chmod|chown|chflags|truncate)\b",
+    re.IGNORECASE,
 )
 
 # in-place file editors
 INPLACE_EDITORS = re.compile(
-    r"\b(?:sed\s+-i|perl\s+-[ip]|awk\s+-i)\b"
+    r"\b(?:sed\s+-i|perl\s+-[ip]|awk\s+-i)\b",
+    re.IGNORECASE,
 )
 
 # output redirection targeting a file
 REDIRECT_PATTERN = re.compile(
-    r"(?:>\s*|>>\s*|tee\s+(?:-a\s+)?)"
+    r"(?:>\s*|>>\s*|tee\s+(?:-a\s+)?)",
+    re.IGNORECASE,
 )
 
 # common path fragments that indicate hook/settings targets
@@ -120,14 +133,12 @@ SENSITIVE_PATH_FRAGMENTS = [
     ".claude/hooks",
     ".claude/settings",
     ".claude/commands",
-    "hooks.json",
-    "hooks/guard",
-    "hooks/hooks.json",
     ".claude-plugin/plugin.json",
+    ".claude-plugin/hooks.json",
 ]
 
 
-def check_bash_command(command: str) -> str | None:
+def check_bash_command(command: str) -> Optional[str]:
     """
     analyze a bash command for operations that could modify protected files.
     returns a reason string if the command targets protected paths, None otherwise.
@@ -135,7 +146,6 @@ def check_bash_command(command: str) -> str | None:
     if not command:
         return None
 
-    # normalize the command for analysis
     cmd_lower = command.lower()
 
     # check if the command references any sensitive path fragments
@@ -148,21 +158,22 @@ def check_bash_command(command: str) -> str | None:
         return None
 
     # the command references sensitive paths, now check if it's destructive
-    is_destructive = bool(DESTRUCTIVE_COMMANDS.search(command))
-    is_inplace_edit = bool(INPLACE_EDITORS.search(command))
-    is_redirect = bool(REDIRECT_PATTERN.search(command))
+    # all regex checks use the same normalized string for consistency
+    is_destructive = bool(DESTRUCTIVE_COMMANDS.search(cmd_lower))
+    is_inplace_edit = bool(INPLACE_EDITORS.search(cmd_lower))
+    is_redirect = bool(REDIRECT_PATTERN.search(cmd_lower))
 
     # also catch: cat > file, echo > file, printf > file
-    has_write_redirect = bool(re.search(r"(?:cat|echo|printf)\s+.*>", command))
+    has_write_redirect = bool(re.search(r"(?:cat|echo|printf)\s+.*>", cmd_lower))
 
     if is_destructive or is_inplace_edit or is_redirect or has_write_redirect:
         paths_str = ", ".join(targeted_paths)
         if is_destructive:
-            return f"destructive command targeting: {paths_str}"
+            return "destructive command targeting: {}".format(paths_str)
         elif is_inplace_edit:
-            return f"in-place edit targeting: {paths_str}"
+            return "in-place edit targeting: {}".format(paths_str)
         else:
-            return f"write/redirect targeting: {paths_str}"
+            return "write/redirect targeting: {}".format(paths_str)
 
     return None
 
@@ -179,7 +190,12 @@ def main():
         raw = sys.stdin.read()
         data = json.loads(raw)
     except (json.JSONDecodeError, Exception):
-        # fail open on malformed input to avoid breaking unrelated operations
+        # fail open on malformed input. rationale: this hook runs on EVERY tool
+        # call. if the hook input format changes or the JSON is unexpectedly
+        # empty, failing closed would break all operations for every user.
+        # the security tradeoff is acceptable because the attack surface
+        # (malformed hook input) is controlled by the Claude Code runtime,
+        # not by the model.
         sys.exit(0)
 
     tool_name = data.get("tool_name", "")
@@ -200,15 +216,15 @@ def main():
 
     if reason:
         msg = (
-            f"{DENY_PREFIX} blocked: {reason}\n"
-            f"\n"
-            f"Claude is not allowed to modify its own hooks, settings, or safety\n"
-            f"infrastructure. This restriction exists because the model has been\n"
-            f"observed weakening its own constraints to complete tasks more easily\n"
-            f"(see CVE-2025-59536, anthropics/claude-code#32376, #32990).\n"
-            f"\n"
-            f"If you need to modify these files, do so manually outside of Claude."
-        )
+            "{} blocked: {}\n"
+            "\n"
+            "Claude is not allowed to modify its own hooks, settings, or safety\n"
+            "infrastructure. This restriction exists because the model has been\n"
+            "observed weakening its own constraints to complete tasks more easily\n"
+            "(see CVE-2025-59536, anthropics/claude-code#32376, #32990).\n"
+            "\n"
+            "If you need to modify these files, do so manually outside of Claude."
+        ).format(DENY_PREFIX, reason)
         print(msg, file=sys.stderr)
         sys.exit(2)
 

--- a/plugins/hook-integrity-guard/hooks/guard.py
+++ b/plugins/hook-integrity-guard/hooks/guard.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""
+hook-integrity-guard: prevents Claude from modifying its own hooks, settings,
+and safety infrastructure.
+
+addresses:
+  - https://github.com/anthropics/claude-code/issues/32376
+    (Claude rewrites its own hooks to weaken enforcement)
+  - https://github.com/anthropics/claude-code/issues/32990
+    (Claude deletes hook scripts, hooks fail open silently)
+  - CVE-2025-59536 (severity 8.7/10)
+
+guards against all four write vectors:
+  - Edit: targeted file_path check
+  - Write: targeted file_path check
+  - MultiEdit: targeted file_path check
+  - Bash: command pattern analysis for rm, mv, chmod, sed, tee, redirects, etc.
+"""
+
+import json
+import os
+import re
+import sys
+
+# ──────────────────────────────────────────────────────────────────────────────
+# protected paths
+# ──────────────────────────────────────────────────────────────────────────────
+
+HOME = os.path.expanduser("~")
+
+# directories where hook scripts and settings live
+PROTECTED_DIRS = [
+    os.path.join(HOME, ".claude", "hooks"),
+    os.path.join(HOME, ".claude", "commands"),
+]
+
+# individual files that control hook/safety behavior
+PROTECTED_FILES = [
+    os.path.join(HOME, ".claude", "settings.json"),
+    os.path.join(HOME, ".claude", "settings.local.json"),
+]
+
+# patterns for plugin hook files (relative to any plugin root)
+PROTECTED_PATTERNS = [
+    "hooks.json",
+    os.path.join("hooks", ""),       # any file inside a hooks/ directory
+    os.path.join(".claude-plugin", "plugin.json"),
+]
+
+
+def normalize_path(path: str) -> str:
+    """resolve ~, $HOME, env vars, .., and symlinks to a canonical path."""
+    if not path:
+        return ""
+    # expand $HOME, ~, and other env vars
+    path = os.path.expandvars(path)
+    path = os.path.expanduser(path)
+    # resolve .. and symlinks
+    try:
+        path = os.path.realpath(path)
+    except (OSError, ValueError):
+        path = os.path.abspath(path)
+    return path
+
+
+def is_protected_path(file_path: str) -> str | None:
+    """
+    check if a file path targets a protected location.
+    returns a human-readable reason if protected, None otherwise.
+    """
+    resolved = normalize_path(file_path)
+    if not resolved:
+        return None
+
+    # check exact protected files
+    for protected in PROTECTED_FILES:
+        if resolved == os.path.realpath(protected):
+            return f"settings file ({os.path.basename(protected)})"
+
+    # check protected directories
+    for protected_dir in PROTECTED_DIRS:
+        real_dir = os.path.realpath(protected_dir)
+        if resolved.startswith(real_dir + os.sep) or resolved == real_dir:
+            return f"hook directory ({os.path.basename(protected_dir)}/)"
+
+    # check plugin hook patterns (catches hooks.json and hooks/ in any plugin)
+    for pattern in PROTECTED_PATTERNS:
+        if pattern.endswith(os.sep):
+            # directory pattern: check if path contains /hooks/ segment
+            if os.sep + pattern in resolved + os.sep:
+                return f"plugin hook directory ({pattern})"
+        else:
+            if resolved.endswith(os.sep + pattern) or os.sep + pattern + os.sep in resolved:
+                return f"plugin config ({pattern})"
+
+    return None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# bash command analysis
+# ──────────────────────────────────────────────────────────────────────────────
+
+# commands that modify or destroy files
+DESTRUCTIVE_COMMANDS = re.compile(
+    r"\b(?:rm|rmdir|unlink|mv|cp|chmod|chown|chflags|truncate)\b"
+)
+
+# in-place file editors
+INPLACE_EDITORS = re.compile(
+    r"\b(?:sed\s+-i|perl\s+-[ip]|awk\s+-i)\b"
+)
+
+# output redirection targeting a file
+REDIRECT_PATTERN = re.compile(
+    r"(?:>\s*|>>\s*|tee\s+(?:-a\s+)?)"
+)
+
+# common path fragments that indicate hook/settings targets
+SENSITIVE_PATH_FRAGMENTS = [
+    ".claude/hooks",
+    ".claude/settings",
+    ".claude/commands",
+    "hooks.json",
+    "hooks/guard",
+    "hooks/hooks.json",
+    ".claude-plugin/plugin.json",
+]
+
+
+def check_bash_command(command: str) -> str | None:
+    """
+    analyze a bash command for operations that could modify protected files.
+    returns a reason string if the command targets protected paths, None otherwise.
+    """
+    if not command:
+        return None
+
+    # normalize the command for analysis
+    cmd_lower = command.lower()
+
+    # check if the command references any sensitive path fragments
+    targeted_paths = []
+    for fragment in SENSITIVE_PATH_FRAGMENTS:
+        if fragment.lower() in cmd_lower:
+            targeted_paths.append(fragment)
+
+    if not targeted_paths:
+        return None
+
+    # the command references sensitive paths, now check if it's destructive
+    is_destructive = bool(DESTRUCTIVE_COMMANDS.search(command))
+    is_inplace_edit = bool(INPLACE_EDITORS.search(command))
+    is_redirect = bool(REDIRECT_PATTERN.search(command))
+
+    # also catch: cat > file, echo > file, printf > file
+    has_write_redirect = bool(re.search(r"(?:cat|echo|printf)\s+.*>", command))
+
+    if is_destructive or is_inplace_edit or is_redirect or has_write_redirect:
+        paths_str = ", ".join(targeted_paths)
+        if is_destructive:
+            return f"destructive command targeting: {paths_str}"
+        elif is_inplace_edit:
+            return f"in-place edit targeting: {paths_str}"
+        else:
+            return f"write/redirect targeting: {paths_str}"
+
+    return None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# main hook logic
+# ──────────────────────────────────────────────────────────────────────────────
+
+DENY_PREFIX = "[hook-integrity-guard]"
+
+
+def main():
+    try:
+        raw = sys.stdin.read()
+        data = json.loads(raw)
+    except (json.JSONDecodeError, Exception):
+        # fail open on malformed input to avoid breaking unrelated operations
+        sys.exit(0)
+
+    tool_name = data.get("tool_name", "")
+    tool_input = data.get("tool_input", {})
+
+    reason = None
+
+    if tool_name in ("Edit", "Write", "MultiEdit"):
+        file_path = tool_input.get("file_path", "")
+        reason = is_protected_path(file_path)
+
+        # MultiEdit has an edits array, but file_path is still top-level
+        # no additional check needed since all edits target the same file
+
+    elif tool_name == "Bash":
+        command = tool_input.get("command", "")
+        reason = check_bash_command(command)
+
+    if reason:
+        msg = (
+            f"{DENY_PREFIX} blocked: {reason}\n"
+            f"\n"
+            f"Claude is not allowed to modify its own hooks, settings, or safety\n"
+            f"infrastructure. This restriction exists because the model has been\n"
+            f"observed weakening its own constraints to complete tasks more easily\n"
+            f"(see CVE-2025-59536, anthropics/claude-code#32376, #32990).\n"
+            f"\n"
+            f"If you need to modify these files, do so manually outside of Claude."
+        )
+        print(msg, file=sys.stderr)
+        sys.exit(2)
+
+    # allow the operation
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/hook-integrity-guard/hooks/hooks.json
+++ b/plugins/hook-integrity-guard/hooks/hooks.json
@@ -1,0 +1,27 @@
+{
+  "description": "Blocks Claude from modifying its own hooks, settings, and safety infrastructure via any write vector (Edit, Write, MultiEdit, Bash).",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/guard.py",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/guard.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Prevents Claude from modifying its own hooks, settings, and safety infrastructure. Addresses a real class of vulnerabilities where the model weakens or removes its own enforcement constraints to complete tasks more easily.

**Closes #32376, closes #32990, mitigates [CVE-2025-59536](https://nvd.nist.gov/vuln/detail/CVE-2025-59536) (severity 8.7/10)**

### what it does

`PreToolUse` hook that intercepts `Edit`, `Write`, `MultiEdit`, and `Bash` calls before they execute:

- **file operations**: resolves `~`, `$HOME`, `..`, symlinks to canonical paths, then checks against protected directories (`~/.claude/hooks/`, `~/.claude/commands/`), files (`settings.json`, `settings.local.json`), and plugin patterns (`hooks.json`, `hooks/`, `.claude-plugin/plugin.json`)
- **bash commands**: scans for sensitive path fragments, then checks whether the command is destructive (`rm`, `mv`, `chmod`), an in-place edit (`sed -i`, `perl -i`), or a write redirect (`>`, `>>`, `tee`). read-only commands on protected paths are allowed through
- **fail behavior**: exits 0 on malformed input so unrelated operations are never broken. exits 2 with a clear deny message when blocking

### attack vectors covered

| vector | example | status |
|---|---|---|
| direct edit | `Edit ~/.claude/hooks/guard.sh` | blocked |
| file write | `Write ~/.claude/settings.json` | blocked |
| multi-edit | `MultiEdit` on hook files | blocked |
| bash rm/mv | `rm -rf ~/.claude/hooks/` | blocked |
| bash chmod | `chmod 000 ~/.claude/hooks/guard.py` | blocked |
| in-place edit | `sed -i '' ~/.claude/settings.json` | blocked |
| redirect | `echo bad > ~/.claude/hooks/guard.py` | blocked |
| tee | `tee ~/.claude/hooks/guard.py` | blocked |
| path traversal | `../../.claude/hooks/` | blocked (resolved via realpath) |
| symlink bypass | symlinked paths | blocked (resolved via realpath) |
| read-only | `ls ~/.claude/hooks/`, `cat settings.json` | allowed |
| normal files | any path outside protected locations | allowed |

### plugin structure

follows the same conventions as `security-guidance`:

```
plugins/hook-integrity-guard/
├── .claude-plugin/
│   └── plugin.json
├── hooks/
│   ├── hooks.json
│   └── guard.py
└── README.md
```

also registered in `.claude-plugin/marketplace.json` under the `security` category.

### testing

verified against 10+ scenarios covering all vectors above. the guard script is pure stdin/stdout with no side effects:

```bash
# blocks
echo '{"tool_name":"Edit","tool_input":{"file_path":"~/.claude/hooks/myhook.sh",...}}' | python3 hooks/guard.py
echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf ~/.claude/hooks/"}}' | python3 hooks/guard.py

# allows
echo '{"tool_name":"Edit","tool_input":{"file_path":"/tmp/foo.py",...}}' | python3 hooks/guard.py
echo '{"tool_name":"Bash","tool_input":{"command":"ls ~/.claude/hooks/"}}' | python3 hooks/guard.py
```