### PR TITLE
fix(code-review): reduced permission prompts, prevented unnecessary cd calls

### DIFF
--- a/plugins/code-review/commands/code-review.md
+++ b/plugins/code-review/commands/code-review.md
@@ -1,13 +1,15 @@
 ---
-allowed-tools: Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*), mcp__github_inline_comment__create_inline_comment
+allowed-tools: Bash(gh:*), Bash(git diff:*), Bash(git log:*), Bash(git blame:*), Bash(git show:*), Bash(git rev-parse:*), Read, Grep, Glob, mcp__github_inline_comment__create_inline_comment
 description: Code review a pull request
 ---
 
 Provide a code review for the given pull request.
 
-**Agent assumptions (applies to all agents and subagents):**
-- All tools are functional and will work without error. Do not test tools or make exploratory calls. Make sure this is clear to every subagent that is launched.
+**Agent assumptions (applies to all agents and subagents). Relay these rules to EVERY subagent you launch:**
+- All tools are functional and will work without error. Do not test tools or make exploratory calls.
 - Only call a tool if it is required to complete the task. Every tool call should have a clear purpose.
+- **NEVER prefix bash commands with `cd`.** The working directory is already correct. Run commands directly (e.g., `gh pr diff 123`, NOT `cd /path && gh pr diff 123`). This applies to all commands including `gh`, `git`, and any other CLI tools. Chaining `cd` with commands triggers unnecessary permission prompts and degrades the review experience.
+- Use `Read` or `Grep` to inspect files instead of `cat` or `grep` bash commands.
 
 To do this, follow these steps precisely:
 


### PR DESCRIPTION
the code-review plugin generates hundreds of permission prompts per review because sub-agents prefix every command with `cd /path && ...`, which triggers the compound command security check. this makes the plugin essentially unusable without constant babysitting.

fixes #33357, related to #28240, #30832, #30213

### changes

**expanded `allowed-tools`** to match what review agents actually need:

```diff
- allowed-tools: Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*)
+ allowed-tools: Bash(gh:*), Bash(git diff:*), Bash(git log:*), Bash(git blame:*), Bash(git show:*), Bash(git rev-parse:*), Read, Grep, Glob
```

the old list only covered specific `gh` subcommands. agents that needed `git blame`, `git log`, `git show`, or file reads (`Read`, `Grep`, `Glob`) would trigger permission prompts on every call. the `gh` patterns were also unnecessarily granular since all subcommands are safe in a review context.

**added explicit no-cd instruction** to agent assumptions:

```
NEVER prefix bash commands with cd. The working directory is already correct.
Run commands directly (e.g., gh pr diff 123, NOT cd /path && gh pr diff 123).
```

this is relayed to every sub-agent and directly prevents the `cd && command` chaining that triggers the runtime's "compound commands with cd and git require approval" security check. users in #28240 confirmed that explicit instructions in CLAUDE.md reduce the behavior, but putting it in the plugin's command prompt is more reliable than relying on per-repo CLAUDE.md files.

**added Read/Grep preference** over cat/grep bash commands, which avoids unnecessary Bash tool calls entirely.

### why this works

the permission explosion has two causes:

1. agents generate `cd /cwd && gh pr diff ...` even though the cwd is already correct. the runtime flags this as a security concern (bare repo attack prevention). the no-cd instruction stops this at the source
2. agents need `git blame`, `git log`, etc. for context analysis but these weren't in `allowed-tools`, forcing approval on every call. expanding the list pre-approves these safe read-only operations

the runtime's `cd` detection is being addressed separately (#28240), but this plugin-level fix provides immediate relief.