### PR TITLE
fix: Update Dockerfile to use native installer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:24.14
 
 ARG TZ
 ENV TZ="$TZ"
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   jq \
   nano \
   vim \
+  curl \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Ensure default node user has access to /usr/local/share
@@ -79,7 +80,8 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
   -x
 
 # Install Claude
-RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
+RUN curl -fsSL https://claude.ai/install.sh | bash
+ENV PATH=/home/$USERNAME/.local/bin:$PATH
 
 
 # Copy and set up firewall script


### PR DESCRIPTION
This pull request updates `.devcontainer/Dockerfile` to use `node 24.14` and install claude code from native installer instead of deprecated npm install.