### PR TITLE
feat(code-review): pass confirmed=true when posting inline comments

### DIFF
--- a/plugins/code-review/commands/code-review.md
+++ b/plugins/code-review/commands/code-review.md
@@ -68,7 +68,7 @@ Note: Still review Claude generated PR's.
 
 8. Create a list of all comments that you plan on leaving. This is only for you to make sure you are comfortable with the comments. Do not post this list anywhere.
 
-9. Post inline comments for each issue using `mcp__github_inline_comment__create_inline_comment`. For each comment:
+9. Post inline comments for each issue using `mcp__github_inline_comment__create_inline_comment` with `confirmed: true`. For each comment:
    - Provide a brief description of the issue
    - For small, self-contained fixes, include a committable suggestion block
    - For larger fixes (6+ lines, structural changes, or changes spanning multiple locations), describe the issue and suggested fix without a suggestion block


### PR DESCRIPTION
## Problem

Subagents inherit `mcp__github_inline_comment__create_inline_comment` and post test/probe comments on customer PRs after hitting GraphQL permission errors. Recurring since Dec 2025 despite prompt-level guards.

## Fix

The inline-comment MCP tool (via anthropics/claude-code-action#1048) now has a `confirmed` parameter:
- `confirmed: true` → posts immediately
- omitted → posts by default UNLESS body matches obvious probe patterns (buffered instead)
- `confirmed: false` → always buffered

This PR updates step 9 to pass `confirmed: true` when posting final review comments.

Subagent probes that don't pass `confirmed` either:
- Match the probe pattern → buffered harmlessly
- Don't match → still post (residual risk, but the main reported phrasings are caught)

## Why this works for existing customers

Both claude-code-action (via `@v1` tag) and this skill (loaded at runtime from plugin marketplace) auto-update. Existing customers with old workflow YAML get the fix without re-installing.

## Backward compatibility

Against older versions of claude-code-action that don't have the `confirmed` param, Zod strips unknown fields and the comment posts as before.

Companion action PR: anthropics/claude-code-action#1048