### PR TITLE
feat: add voice-mode plugin with /voice command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -145,6 +145,17 @@
       },
       "source": "./plugins/security-guidance",
       "category": "security"
+    },
+    {
+      "name": "voice-mode",
+      "description": "Adds a /voice command to enable, disable, or check the status of voice mode",
+      "version": "1.0.0",
+      "author": {
+        "name": "Anthropic",
+        "email": "support@anthropic.com"
+      },
+      "source": "./plugins/voice-mode",
+      "category": "accessibility"
     }
   ]
 }

--- a/plugins/voice-mode/.claude-plugin/plugin.json
+++ b/plugins/voice-mode/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "voice-mode",
+  "description": "Adds a /voice command to enable, disable, or check the status of voice mode",
+  "version": "1.0.0",
+  "author": {
+    "name": "Anthropic",
+    "email": "support@anthropic.com"
+  },
+  "keywords": ["voice", "voice-mode", "accessibility"]
+}

--- a/plugins/voice-mode/commands/voice.md
+++ b/plugins/voice-mode/commands/voice.md
@@ -1,0 +1,28 @@
+---
+description: Enable, disable, or check the status of voice mode
+allowed-tools: Read, Bash(cat:*), Bash(jq:*)
+model: haiku
+---
+
+The user wants to manage voice mode. Voice mode is controlled by the `voiceEnabled` setting in `~/.claude/settings.json` or `~/.claude/settings.local.json`.
+
+## Steps
+
+1. Read `~/.claude/settings.json` (or `~/.claude/settings.local.json`) to check the current value of `voiceEnabled`.
+
+2. Based on the user's argument (`$ARGUMENTS`) and the current state:
+
+   - **No argument or "on" or "enable"**: If voice mode is already enabled, tell the user. Otherwise, set `voiceEnabled` to `true` in `~/.claude/settings.local.json` (create the file if it doesn't exist, merge with existing settings if it does).
+   - **"off" or "disable"**: Set `voiceEnabled` to `false` in `~/.claude/settings.local.json`.
+   - **"status"**: Report whether voice mode is currently enabled or disabled.
+
+3. After making changes, tell the user:
+   - What changed
+   - That they need to restart Claude Code for the change to take effect
+   - That voice mode uses push-to-talk (default: hold spacebar) once enabled
+
+## Important
+
+- Use `~/.claude/settings.local.json` for writes (user-local, not committed to version control)
+- Preserve any existing settings in the file when writing — do not overwrite the entire file
+- If `jq` is not available, fall back to reading the file and providing manual instructions


### PR DESCRIPTION
## Summary

Adds a `voice-mode` plugin with a `/voice` command so the startup banner instruction actually works for plugin-enabled users.

The startup banner says `✻ Voice mode is now available · /voice to enable`, but on some versions this returns **"Unknown skill: voice"**. This plugin bridges that gap by providing a `/voice` command that manages `voiceEnabled` in `~/.claude/settings.local.json`.

Closes #33914

## What's included

- **`plugins/voice-mode/commands/voice.md`** — Slash command supporting `/voice`, `/voice on`, `/voice off`, and `/voice status`
- **`plugins/voice-mode/.claude-plugin/plugin.json`** — Plugin manifest
- **Marketplace registration** — Added to `.claude-plugin/marketplace.json` under the `accessibility` category

## Design decisions

- **Writes to `settings.local.json`** (not `settings.json`) to respect the user-local / version-controlled split
- **Preserves existing settings** via `jq` merge (`'. + {"voiceEnabled": true}'`), never overwrites the file
- **Falls back gracefully** if `jq` is unavailable — provides manual instructions instead of failing
- **Uses `model: haiku`** since the operation is simple (read JSON, toggle a boolean, write JSON)

## Note on built-in `/voice`

Recent Claude Code versions (tested on v2.1.74) appear to have a built-in `/voice` command that writes to `settings.json`. This plugin serves as:
- A **fallback** for versions where `/voice` is not yet recognized
- A **reference implementation** showing how settings-toggling commands can be packaged as plugins
- A **discoverable workaround** users can install today via `/plugin install voice-mode`

## Test plan

- [x] Plugin JSON and marketplace JSON are valid
- [x] Command frontmatter parses correctly (description, allowed-tools, model)
- [x] Enable: `jq '. + {"voiceEnabled": true}'` sets the flag without dropping existing keys
- [x] Disable: `jq '. + {"voiceEnabled": false}'` sets the flag without dropping existing keys
- [x] Idempotent: enabling when already enabled is a no-op
- [x] Full toggle cycle preserves all original settings keys
- [x] Creating `settings.local.json` from scratch produces valid JSON
- [x] Marketplace entry points to a valid source directory
- [ ] End-to-end: `/plugin install voice-mode` → `/voice` enables voice mode (requires interactive session)

## Validation results

| # | Test | Result |
|---|------|--------|
| 1 | Status check reads `voiceEnabled` | PASS |
| 2 | Enable sets `voiceEnabled: true` | PASS |
| 3 | Existing settings preserved after enable | PASS |
| 4 | Idempotent enable (no-op when already on) | PASS |
| 5 | Disable sets `voiceEnabled: false` | PASS |
| 6 | Re-enable after disable | PASS |
| 7 | All original keys survive full toggle cycle | PASS |
| 8 | Create settings file from scratch | PASS |
| 9 | Command frontmatter valid | PASS |
| 10 | Marketplace entry valid and path exists | PASS |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)