### PR TITLE
Add sensitive-file-guard plugin to protect infrastructure files

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -25,6 +25,7 @@ Learn more in the [official plugins documentation](https://docs.claude.com/en/do
 | [pr-review-toolkit](./pr-review-toolkit/) | Comprehensive PR review agents specializing in comments, tests, error handling, type design, code quality, and code simplification | **Command:** `/pr-review-toolkit:review-pr` - Run with optional review aspects (comments, tests, errors, types, code, simplify, all)<br>**Agents:** `comment-analyzer`, `pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer`, `code-reviewer`, `code-simplifier` |
 | [ralph-wiggum](./ralph-wiggum/) | Interactive self-referential AI loops for iterative development. Claude works on the same task repeatedly until completion | **Commands:** `/ralph-loop`, `/cancel-ralph` - Start/stop autonomous iteration loops<br>**Hook:** Stop - Intercepts exit attempts to continue iteration |
 | [security-guidance](./security-guidance/) | Security reminder hook that warns about potential security issues when editing files | **Hook:** PreToolUse - Monitors 9 security patterns including command injection, XSS, eval usage, dangerous HTML, pickle deserialization, and os.system calls |
+| [sensitive-file-guard](./sensitive-file-guard/) | Protects sensitive infrastructure files (.env, lockfiles, CI/CD configs, container configs, crypto keys) from accidental overwrites | **Hook:** PreToolUse - Blocks modifications to environment files, lockfiles, CI/CD pipelines, container configs, infrastructure-as-code, deployment configs, and cryptographic keys |
 
 ## Installation
 

--- a/plugins/sensitive-file-guard/.claude-plugin/plugin.json
+++ b/plugins/sensitive-file-guard/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "sensitive-file-guard",
+  "version": "1.0.0",
+  "description": "PreToolUse hook that protects sensitive infrastructure files (.env, lockfiles, CI configs, Docker configs, SSH keys) from accidental overwrites",
+  "author": {
+    "name": "teee32",
+    "email": "3318867918@qq.com"
+  }
+}

--- a/plugins/sensitive-file-guard/README.md
+++ b/plugins/sensitive-file-guard/README.md
@@ -1,0 +1,93 @@
+# Sensitive File Guard Plugin
+
+Prevents accidental modification of sensitive infrastructure files — environment configs, lockfiles, CI/CD pipelines, container configs, cryptographic keys, and deployment settings.
+
+## Overview
+
+Claude Code is incredibly helpful for editing code, but certain files should rarely be modified directly. A misplaced edit to a `.env` file can leak secrets, a lockfile edit can break reproducible builds, and a CI config change can disrupt deployment pipelines.
+
+This plugin intercepts `Write`, `Edit`, and `MultiEdit` operations and warns before allowing changes to these critical files. On first encounter in a session, the operation is blocked with a clear warning. After the user confirms intent, subsequent edits to the same file proceed without interruption.
+
+## Protected File Categories
+
+| Category | Files |
+|----------|-------|
+| **Environment files** | `.env`, `.env.local`, `.env.development`, `.env.staging`, `.env.production`, `.env.test`, `.env.example` |
+| **Lockfiles** | `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lockb`, `Gemfile.lock`, `Pipfile.lock`, `poetry.lock`, `composer.lock`, `go.sum`, `Cargo.lock`, `mix.lock`, `pubspec.lock`, `flake.lock` |
+| **CI/CD configs** | `.github/workflows/*.yml`, `.gitlab-ci.yml`, `.circleci/config.yml`, `Jenkinsfile`, `.travis.yml`, `appveyor.yml`, `bitbucket-pipelines.yml`, `azure-pipelines.yml`, `cloudbuild.yaml` |
+| **Container configs** | `Dockerfile`, `docker-compose.yml`, `docker-compose.override.yml`, `.dockerignore` |
+| **Infrastructure** | `terraform.tfstate`, `*.tfvars`, `*.tf` (in `terraform/` dirs), `k8s/*.yml`, `kubernetes/*.yml` |
+| **Crypto keys** | `*.pem`, `*.key`, `*.crt`, `*.cer`, `*.p12`, `*.pfx`, `id_rsa`, `id_ed25519`, `authorized_keys` |
+| **Deployment configs** | `vercel.json`, `netlify.toml`, `fly.toml`, `render.yaml`, `railway.toml`, `Procfile`, `app.yaml` |
+
+## How It Works
+
+1. **Intercepts file operations** — The hook runs before every `Write`, `Edit`, and `MultiEdit` tool call.
+2. **Checks against protected patterns** — Files are matched by exact name, extension, or directory path.
+3. **Blocks on first encounter** — If a protected file is detected for the first time in the session, the operation is blocked (exit code 2) with a descriptive warning.
+4. **Session-scoped memory** — Once the user confirms intent, subsequent edits to the same file are allowed for the rest of the session.
+5. **Automatic cleanup** — State files older than 30 days are periodically removed.
+
+## Configuration
+
+### Disabling the Guard
+
+Set the environment variable to disable protection:
+
+```bash
+SENSITIVE_FILE_GUARD_ENABLED=0
+```
+
+### Debug Logging
+
+Debug logs are written to:
+
+```
+/tmp/sensitive-file-guard-log.txt
+```
+
+## Installation
+
+This plugin is included in the Claude Code repository. To use it in your project:
+
+1. Install Claude Code
+2. Use the `/plugin` command to install, or configure in `.claude/settings.json`:
+
+```json
+{
+  "plugins": ["sensitive-file-guard"]
+}
+```
+
+## Example Warning
+
+When attempting to edit a protected file, you'll see:
+
+```
+⚠️  SENSITIVE FILE GUARD — Modification Blocked
+
+  File:   /project/.env.production
+  Reason: Environment variable file: .env.production
+
+This file is classified as a sensitive infrastructure file. Accidental
+modifications can break deployments, leak secrets, or cause dependency
+conflicts.
+
+To proceed, explicitly confirm you intend to modify this file.
+```
+
+## Relationship to Other Plugins
+
+| Plugin | Focus |
+|--------|-------|
+| **security-guidance** | Warns about security *patterns in code* (eval, innerHTML, command injection) |
+| **data-protection** | Protects *ML training data* (checkpoints, model weights, training results) |
+| **sensitive-file-guard** | Protects *infrastructure files* (env configs, lockfiles, CI pipelines, keys) |
+
+## Author
+
+teee32 (3318867918@qq.com)
+
+## Version
+
+1.0.0

--- a/plugins/sensitive-file-guard/hooks/hooks.json
+++ b/plugins/sensitive-file-guard/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Protects sensitive infrastructure files from accidental overwrites",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/sensitive_file_guard_hook.py"
+          }
+        ],
+        "matcher": "Write|Edit|MultiEdit"
+      }
+    ]
+  }
+}

--- a/plugins/sensitive-file-guard/hooks/sensitive_file_guard_hook.py
+++ b/plugins/sensitive-file-guard/hooks/sensitive_file_guard_hook.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""
+Sensitive File Guard Hook for Claude Code
+
+This hook intercepts Write, Edit, and MultiEdit operations to protect
+sensitive infrastructure files from accidental overwrites.
+
+Protected file categories:
+- Environment files (.env, .env.local, .env.production, etc.)
+- Lockfiles (package-lock.json, yarn.lock, pnpm-lock.yaml, etc.)
+- CI/CD configs (.github/workflows/*.yml, .gitlab-ci.yml, etc.)
+- Container configs (Dockerfile, docker-compose.yml, etc.)
+- Infrastructure as Code (terraform.tfstate, *.tfvars)
+- SSH/Crypto keys (*.pem, *.key, id_rsa, id_ed25519)
+- Deployment configs (vercel.json, netlify.toml, fly.toml, etc.)
+"""
+
+import json
+import os
+import random
+import sys
+from datetime import datetime
+
+# Debug log file
+DEBUG_LOG_FILE = "/tmp/sensitive-file-guard-log.txt"
+
+
+def debug_log(message):
+    """Append debug message to log file with timestamp."""
+    try:
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+        with open(DEBUG_LOG_FILE, "a") as f:
+            f.write(f"[{timestamp}] {message}\n")
+    except Exception:
+        pass  # Silently ignore logging errors
+
+
+# ─── Protected File Definitions ──────────────────────────────────────────────
+
+# Exact filenames (case-insensitive) that are always protected
+PROTECTED_FILENAMES = {
+    # Environment files
+    ".env",
+    ".env.local",
+    ".env.development",
+    ".env.staging",
+    ".env.production",
+    ".env.test",
+    ".env.example",
+    # Lockfiles
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "bun.lockb",
+    "gemfile.lock",
+    "pipfile.lock",
+    "poetry.lock",
+    "composer.lock",
+    "go.sum",
+    "cargo.lock",
+    "mix.lock",
+    "pubspec.lock",
+    "flake.lock",
+    "shrinkwrap.yaml",
+    # Container configs
+    "dockerfile",
+    "docker-compose.yml",
+    "docker-compose.yaml",
+    "docker-compose.override.yml",
+    "docker-compose.override.yaml",
+    ".dockerignore",
+    # CI/CD configs
+    ".gitlab-ci.yml",
+    "jenkinsfile",
+    ".travis.yml",
+    "appveyor.yml",
+    "bitbucket-pipelines.yml",
+    "azure-pipelines.yml",
+    "cloudbuild.yaml",
+    "cloudbuild.yml",
+    # Infrastructure
+    "terraform.tfstate",
+    "terraform.tfstate.backup",
+    # Deployment configs
+    "vercel.json",
+    "netlify.toml",
+    "fly.toml",
+    "render.yaml",
+    "railway.toml",
+    "procfile",
+    "app.yaml",
+    "app.yml",
+    # SSH/Crypto key filenames
+    "id_rsa",
+    "id_rsa.pub",
+    "id_ed25519",
+    "id_ed25519.pub",
+    "id_ecdsa",
+    "id_ecdsa.pub",
+    "authorized_keys",
+    "known_hosts",
+}
+
+# File extensions that indicate sensitive files
+PROTECTED_EXTENSIONS = {
+    ".pem",
+    ".key",
+    ".crt",
+    ".cer",
+    ".p12",
+    ".pfx",
+    ".jks",
+    ".keystore",
+    ".tfvars",
+}
+
+# Path patterns for files that are protected based on their directory
+# Each entry is (directory_substring, filename_extension_or_pattern)
+PROTECTED_PATH_PATTERNS = [
+    # GitHub Actions workflows
+    (".github/workflows/", ".yml"),
+    (".github/workflows/", ".yaml"),
+    # CircleCI
+    (".circleci/", "config.yml"),
+    (".circleci/", "config.yaml"),
+    # Kubernetes
+    ("k8s/", ".yml"),
+    ("k8s/", ".yaml"),
+    ("kubernetes/", ".yml"),
+    ("kubernetes/", ".yaml"),
+    # Terraform
+    ("terraform/", ".tf"),
+    ("terraform/", ".tfvars"),
+]
+
+# Category labels for user-friendly messages
+FILE_CATEGORIES = {
+    ".env": "Environment variable file",
+    "lockfile": "Package lockfile",
+    "container": "Container configuration",
+    "ci_cd": "CI/CD pipeline configuration",
+    "infrastructure": "Infrastructure configuration",
+    "deployment": "Deployment configuration",
+    "crypto": "SSH/Cryptographic key file",
+}
+
+
+def get_file_category(file_path, filename):
+    """Determine the category of a protected file for display purposes."""
+    lower_name = filename.lower()
+    _, ext = os.path.splitext(lower_name)
+    normalized_path = file_path.replace("\\", "/").lstrip("/")
+
+    if lower_name.startswith(".env"):
+        return FILE_CATEGORIES[".env"]
+    if "lock" in lower_name or lower_name in {
+        "go.sum",
+        "shrinkwrap.yaml",
+    }:
+        return FILE_CATEGORIES["lockfile"]
+    if "docker" in lower_name or lower_name == ".dockerignore":
+        return FILE_CATEGORIES["container"]
+    if any(
+        ci in lower_name
+        for ci in [
+            "gitlab-ci",
+            "jenkins",
+            "travis",
+            "appveyor",
+            "pipelines",
+            "cloudbuild",
+        ]
+    ):
+        return FILE_CATEGORIES["ci_cd"]
+    if ".github/workflows/" in normalized_path or ".circleci/" in normalized_path:
+        return FILE_CATEGORIES["ci_cd"]
+    if ext in PROTECTED_EXTENSIONS:
+        if ext in {".pem", ".key", ".crt", ".cer", ".p12", ".pfx", ".jks", ".keystore"}:
+            return FILE_CATEGORIES["crypto"]
+        if ext == ".tfvars":
+            return FILE_CATEGORIES["infrastructure"]
+    if lower_name in {"terraform.tfstate", "terraform.tfstate.backup"}:
+        return FILE_CATEGORIES["infrastructure"]
+    if lower_name in {
+        "vercel.json",
+        "netlify.toml",
+        "fly.toml",
+        "render.yaml",
+        "railway.toml",
+        "procfile",
+        "app.yaml",
+        "app.yml",
+    }:
+        return FILE_CATEGORIES["deployment"]
+    if any(
+        p in normalized_path for p in ["k8s/", "kubernetes/", "terraform/"]
+    ):
+        return FILE_CATEGORIES["infrastructure"]
+
+    return "Sensitive file"
+
+
+def is_protected_file(file_path):
+    """
+    Check if a file path matches a protected file pattern.
+
+    Returns:
+        (is_protected, reason): Tuple of whether file is protected and why.
+    """
+    if not file_path:
+        return False, ""
+
+    # Normalize path
+    normalized_path = file_path.replace("\\", "/").lstrip("/")
+    filename = os.path.basename(normalized_path)
+    lower_filename = filename.lower()
+    _, ext = os.path.splitext(lower_filename)
+
+    # Check exact filename match (case-insensitive)
+    if lower_filename in PROTECTED_FILENAMES:
+        category = get_file_category(file_path, filename)
+        return True, f"{category}: {filename}"
+
+    # Check extension match
+    if ext in PROTECTED_EXTENSIONS:
+        category = get_file_category(file_path, filename)
+        return True, f"{category}: {filename} ({ext} extension)"
+
+    # Check path pattern match
+    for dir_pattern, file_pattern in PROTECTED_PATH_PATTERNS:
+        if dir_pattern in normalized_path:
+            if file_pattern.startswith("."):
+                # Extension match
+                if lower_filename.endswith(file_pattern):
+                    category = get_file_category(file_path, filename)
+                    return True, f"{category}: {filename} (in {dir_pattern})"
+            else:
+                # Exact filename match within directory
+                if lower_filename == file_pattern:
+                    category = get_file_category(file_path, filename)
+                    return True, f"{category}: {filename} (in {dir_pattern})"
+
+    return False, ""
+
+
+# ─── State Management ────────────────────────────────────────────────────────
+
+
+def get_state_file(session_id):
+    """Get session-specific state file path."""
+    return os.path.expanduser(
+        f"~/.claude/sensitive_file_guard_state_{session_id}.json"
+    )
+
+
+def cleanup_old_state_files():
+    """Remove state files older than 30 days."""
+    try:
+        state_dir = os.path.expanduser("~/.claude")
+        if not os.path.exists(state_dir):
+            return
+
+        current_time = datetime.now().timestamp()
+        thirty_days_ago = current_time - (30 * 24 * 60 * 60)
+
+        for filename in os.listdir(state_dir):
+            if filename.startswith(
+                "sensitive_file_guard_state_"
+            ) and filename.endswith(".json"):
+                file_path = os.path.join(state_dir, filename)
+                try:
+                    file_mtime = os.path.getmtime(file_path)
+                    if file_mtime < thirty_days_ago:
+                        os.remove(file_path)
+                except (OSError, IOError):
+                    pass
+    except Exception:
+        pass  # Silently ignore cleanup errors
+
+
+def load_state(session_id):
+    """Load the set of already-warned file keys for this session."""
+    state_file = get_state_file(session_id)
+    if os.path.exists(state_file):
+        try:
+            with open(state_file, "r") as f:
+                return set(json.load(f))
+        except (json.JSONDecodeError, IOError):
+            return set()
+    return set()
+
+
+def save_state(session_id, shown_warnings):
+    """Persist the set of already-warned file keys for this session."""
+    state_file = get_state_file(session_id)
+    try:
+        os.makedirs(os.path.dirname(state_file), exist_ok=True)
+        with open(state_file, "w") as f:
+            json.dump(list(shown_warnings), f)
+    except IOError as e:
+        debug_log(f"Failed to save state file: {e}")
+
+
+# ─── Input Extraction ────────────────────────────────────────────────────────
+
+
+def extract_file_path(tool_name, tool_input):
+    """Extract the target file path from the tool input."""
+    return tool_input.get("file_path", "")
+
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+
+def main():
+    """Main hook function."""
+    # Check if guard is enabled (can be disabled via env var)
+    guard_enabled = os.environ.get("SENSITIVE_FILE_GUARD_ENABLED", "1")
+    if guard_enabled == "0":
+        debug_log("Sensitive file guard disabled by environment variable")
+        sys.exit(0)
+
+    # Periodically clean up old state files (10% chance per run)
+    if random.random() < 0.1:
+        cleanup_old_state_files()
+
+    # Read input from stdin
+    try:
+        raw_input = sys.stdin.read()
+        input_data = json.loads(raw_input)
+    except json.JSONDecodeError as e:
+        debug_log(f"JSON decode error: {e}")
+        sys.exit(0)  # Allow tool to proceed if we can't parse input
+
+    # Extract tool information
+    session_id = input_data.get("session_id", "default")
+    tool_name = input_data.get("tool_name", "")
+    tool_input = input_data.get("tool_input", {})
+
+    # Only process file-modifying tools
+    if tool_name not in ["Write", "Edit", "MultiEdit"]:
+        sys.exit(0)
+
+    # Extract file path
+    file_path = extract_file_path(tool_name, tool_input)
+    if not file_path:
+        sys.exit(0)
+
+    # Check if this is a protected file
+    is_protected, reason = is_protected_file(file_path)
+
+    if not is_protected:
+        sys.exit(0)
+
+    # Create unique warning key
+    warning_key = f"{file_path}"
+
+    # Load existing warnings for this session
+    shown_warnings = load_state(session_id)
+
+    # Skip if already warned in this session
+    if warning_key in shown_warnings:
+        debug_log(f"Already warned about {file_path}, allowing")
+        sys.exit(0)
+
+    # Record this warning
+    shown_warnings.add(warning_key)
+    save_state(session_id, shown_warnings)
+
+    # Build warning message
+    warning_message = f"""⚠️  SENSITIVE FILE GUARD — Modification Blocked
+
+  File:   {file_path}
+  Reason: {reason}
+
+This file is classified as a sensitive infrastructure file. Accidental
+modifications can break deployments, leak secrets, or cause dependency
+conflicts.
+
+Common risks:
+  • .env files may contain API keys and secrets
+  • Lockfiles ensure reproducible builds — manual edits cause drift
+  • CI/CD configs control deployment pipelines
+  • Crypto keys are irreplaceable credentials
+
+To proceed, explicitly confirm you intend to modify this file.
+To disable this guard, set SENSITIVE_FILE_GUARD_ENABLED=0."""
+
+    # Output warning to stderr and block the operation
+    print(warning_message, file=sys.stderr)
+    sys.exit(2)  # Exit code 2 blocks the tool in PreToolUse hooks
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR adds a new **sensitive-file-guard** plugin that protects critical infrastructure files from accidental overwrites via a `PreToolUse` hook.

### Motivation

One of the most commonly reported pain points is Claude Code accidentally modifying sensitive infrastructure files — `.env` configs containing secrets, package lockfiles that ensure reproducible builds, CI/CD pipeline definitions, and cryptographic key files. This plugin fills the gap between the existing `security-guidance` plugin (which warns about security patterns *in code*) and the `data-protection` plugin (which protects ML training data).

### Protected File Categories

| Category | Examples |
|----------|----------|
| **Environment files** | `.env`, `.env.local`, `.env.production` |
| **Lockfiles** | `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `Cargo.lock`, `go.sum`, etc. |
| **CI/CD configs** | `.github/workflows/*.yml`, `.gitlab-ci.yml`, `Jenkinsfile` |
| **Container configs** | `Dockerfile`, `docker-compose.yml`, `.dockerignore` |
| **Infrastructure** | `terraform.tfstate`, `*.tfvars`, `k8s/*.yml` |
| **Crypto keys** | `*.pem`, `*.key`, `id_rsa`, `id_ed25519` |
| **Deployment** | `vercel.json`, `netlify.toml`, `fly.toml`, `render.yaml` |

### How It Works

1. Intercepts `Write`, `Edit`, and `MultiEdit` tool calls via `PreToolUse` hook
2. Checks file path against protected patterns (exact name, extension, directory path)
3. Blocks on first encounter per session (exit code 2) with a descriptive warning
4. After user confirms intent, allows subsequent edits to the same file for the rest of the session
5. Configurable via `SENSITIVE_FILE_GUARD_ENABLED=0` environment variable

### Files Changed

- `plugins/sensitive-file-guard/.claude-plugin/plugin.json` — Plugin metadata
- `plugins/sensitive-file-guard/hooks/hooks.json` — Hook configuration
- `plugins/sensitive-file-guard/hooks/sensitive_file_guard_hook.py` — Core hook logic
- `plugins/sensitive-file-guard/README.md` — Documentation
- `plugins/README.md` — Added table entry

### Test Plan

All tests pass:

| Test | Input | Expected | Result |
|------|-------|----------|--------|
| `.env` file | `Write .env` | Exit 2 + warning | ✅ |
| Normal file | `Write app.js` | Exit 0 | ✅ |
| Lockfile | `Write package-lock.json` | Exit 2 + warning | ✅ |
| CI workflow | `Write .github/workflows/ci.yml` | Exit 2 + warning | ✅ |
| Invalid JSON | bad input | Exit 0 (graceful) | ✅ |
| Crypto key | `Edit server.pem` | Exit 2 + warning | ✅ |
| Disabled | `ENABLED=0` + `.env` | Exit 0 | ✅ |

### Plugin Structure

Follows the exact same pattern as `security-guidance`:
```
sensitive-file-guard/
├── .claude-plugin/
│   └── plugin.json
├── hooks/
│   ├── hooks.json
│   └── sensitive_file_guard_hook.py
└── README.md
```

Co-Authored-By: Claude <noreply@anthropic.com>