### PR TITLE
Harden sensitive file guard confirmation flow

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -25,6 +25,7 @@ Learn more in the [official plugins documentation](https://docs.claude.com/en/do
 | [pr-review-toolkit](./pr-review-toolkit/) | Comprehensive PR review agents specializing in comments, tests, error handling, type design, code quality, and code simplification | **Command:** `/pr-review-toolkit:review-pr` - Run with optional review aspects (comments, tests, errors, types, code, simplify, all)<br>**Agents:** `comment-analyzer`, `pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer`, `code-reviewer`, `code-simplifier` |
 | [ralph-wiggum](./ralph-wiggum/) | Interactive self-referential AI loops for iterative development. Claude works on the same task repeatedly until completion | **Commands:** `/ralph-loop`, `/cancel-ralph` - Start/stop autonomous iteration loops<br>**Hook:** Stop - Intercepts exit attempts to continue iteration |
 | [security-guidance](./security-guidance/) | Security reminder hook that warns about potential security issues when editing files | **Hook:** PreToolUse - Monitors 9 security patterns including command injection, XSS, eval usage, dangerous HTML, pickle deserialization, and os.system calls |
+| [sensitive-file-guard](./sensitive-file-guard/) | Protects sensitive infrastructure files (.env, lockfiles, CI/CD configs, container configs, crypto keys) from accidental overwrites | **Hook:** PreToolUse - Blocks modifications to environment files, lockfiles, CI/CD pipelines, container configs, infrastructure-as-code, deployment configs, and cryptographic keys |
 
 ## Installation
 

--- a/plugins/sensitive-file-guard/.claude-plugin/plugin.json
+++ b/plugins/sensitive-file-guard/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "sensitive-file-guard",
+  "version": "1.0.0",
+  "description": "PreToolUse hook that protects sensitive infrastructure files (.env, lockfiles, CI configs, Docker configs, SSH keys) from accidental overwrites",
+  "author": {
+    "name": "teee32",
+    "email": "3318867918@qq.com"
+  }
+}

--- a/plugins/sensitive-file-guard/README.md
+++ b/plugins/sensitive-file-guard/README.md
@@ -1,0 +1,93 @@
+# Sensitive File Guard Plugin
+
+Prevents accidental modification of sensitive infrastructure files — environment configs, lockfiles, CI/CD pipelines, container configs, cryptographic keys, and deployment settings.
+
+## Overview
+
+Claude Code is incredibly helpful for editing code, but certain files should rarely be modified directly. A misplaced edit to a `.env` file can leak secrets, a lockfile edit can break reproducible builds, and a CI config change can disrupt deployment pipelines.
+
+This plugin intercepts `Write`, `Edit`, and `MultiEdit` operations and warns before allowing changes to these critical files. On first encounter in a session, the operation is blocked with a clear warning. After the user confirms intent, subsequent edits to the same file proceed without interruption.
+
+## Protected File Categories
+
+| Category | Files |
+|----------|-------|
+| **Environment files** | `.env`, `.env.local`, `.env.development`, `.env.staging`, `.env.production`, `.env.test`, `.env.example` |
+| **Lockfiles** | `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lockb`, `Gemfile.lock`, `Pipfile.lock`, `poetry.lock`, `composer.lock`, `go.sum`, `Cargo.lock`, `mix.lock`, `pubspec.lock`, `flake.lock` |
+| **CI/CD configs** | `.github/workflows/*.yml`, `.gitlab-ci.yml`, `.circleci/config.yml`, `Jenkinsfile`, `.travis.yml`, `appveyor.yml`, `bitbucket-pipelines.yml`, `azure-pipelines.yml`, `cloudbuild.yaml` |
+| **Container configs** | `Dockerfile`, `docker-compose.yml`, `docker-compose.override.yml`, `.dockerignore` |
+| **Infrastructure** | `terraform.tfstate`, `*.tfvars`, `*.tf` (in `terraform/` dirs), `k8s/*.yml`, `kubernetes/*.yml` |
+| **Crypto keys** | `*.pem`, `*.key`, `*.crt`, `*.cer`, `*.p12`, `*.pfx`, `id_rsa`, `id_ed25519`, `authorized_keys` |
+| **Deployment configs** | `vercel.json`, `netlify.toml`, `fly.toml`, `render.yaml`, `railway.toml`, `Procfile`, `app.yaml` |
+
+## How It Works
+
+1. **Intercepts file operations** — The hook runs before every `Write`, `Edit`, and `MultiEdit` tool call.
+2. **Checks against protected patterns** — Files are matched by exact name, extension, or directory path.
+3. **Blocks on first encounter** — If a protected file is detected for the first time in the session, the operation is blocked (exit code 2) with a descriptive warning.
+4. **Session-scoped memory** — Once the user confirms intent, subsequent edits to the same file are allowed for the rest of the session.
+5. **Automatic cleanup** — State files older than 30 days are periodically removed.
+
+## Configuration
+
+### Disabling the Guard
+
+Set the environment variable to disable protection:
+
+```bash
+SENSITIVE_FILE_GUARD_ENABLED=0
+```
+
+### Debug Logging
+
+Debug logs are written to:
+
+```
+/tmp/sensitive-file-guard-log.txt
+```
+
+## Installation
+
+This plugin is included in the Claude Code repository. To use it in your project:
+
+1. Install Claude Code
+2. Use the `/plugin` command to install, or configure in `.claude/settings.json`:
+
+```json
+{
+  "plugins": ["sensitive-file-guard"]
+}
+```
+
+## Example Warning
+
+When attempting to edit a protected file, you'll see:
+
+```
+⚠️  SENSITIVE FILE GUARD — Modification Blocked
+
+  File:   /project/.env.production
+  Reason: Environment variable file: .env.production
+
+This file is classified as a sensitive infrastructure file. Accidental
+modifications can break deployments, leak secrets, or cause dependency
+conflicts.
+
+To proceed, explicitly confirm you intend to modify this file.
+```
+
+## Relationship to Other Plugins
+
+| Plugin | Focus |
+|--------|-------|
+| **security-guidance** | Warns about security *patterns in code* (eval, innerHTML, command injection) |
+| **data-protection** | Protects *ML training data* (checkpoints, model weights, training results) |
+| **sensitive-file-guard** | Protects *infrastructure files* (env configs, lockfiles, CI pipelines, keys) |
+
+## Author
+
+teee32 (3318867918@qq.com)
+
+## Version
+
+1.0.0

--- a/plugins/sensitive-file-guard/README.md
+++ b/plugins/sensitive-file-guard/README.md
@@ -6,27 +6,34 @@ Prevents accidental modification of sensitive infrastructure files — environme
 
 Claude Code is incredibly helpful for editing code, but certain files should rarely be modified directly. A misplaced edit to a `.env` file can leak secrets, a lockfile edit can break reproducible builds, and a CI config change can disrupt deployment pipelines.
 
-This plugin intercepts `Write`, `Edit`, and `MultiEdit` operations and warns before allowing changes to these critical files. On first encounter in a session, the operation is blocked with a clear warning. After the user confirms intent, subsequent edits to the same file proceed without interruption.
+This plugin intercepts `Write`, `Edit`, and `MultiEdit` operations and applies a risk-based decision:
+
+- High-risk files are hard-blocked with a structured `deny` decision
+- Medium-risk files trigger a structured `ask` confirmation prompt
+- Medium-risk files are added to a session allowlist only after the exact asked tool call succeeds, so later edits to that same file can proceed without another prompt
 
 ## Protected File Categories
 
-| Category | Files |
+| Category | Risk | Files |
 |----------|-------|
-| **Environment files** | `.env`, `.env.local`, `.env.development`, `.env.staging`, `.env.production`, `.env.test`, `.env.example` |
-| **Lockfiles** | `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lockb`, `Gemfile.lock`, `Pipfile.lock`, `poetry.lock`, `composer.lock`, `go.sum`, `Cargo.lock`, `mix.lock`, `pubspec.lock`, `flake.lock` |
-| **CI/CD configs** | `.github/workflows/*.yml`, `.gitlab-ci.yml`, `.circleci/config.yml`, `Jenkinsfile`, `.travis.yml`, `appveyor.yml`, `bitbucket-pipelines.yml`, `azure-pipelines.yml`, `cloudbuild.yaml` |
-| **Container configs** | `Dockerfile`, `docker-compose.yml`, `docker-compose.override.yml`, `.dockerignore` |
-| **Infrastructure** | `terraform.tfstate`, `*.tfvars`, `*.tf` (in `terraform/` dirs), `k8s/*.yml`, `kubernetes/*.yml` |
-| **Crypto keys** | `*.pem`, `*.key`, `*.crt`, `*.cer`, `*.p12`, `*.pfx`, `id_rsa`, `id_ed25519`, `authorized_keys` |
-| **Deployment configs** | `vercel.json`, `netlify.toml`, `fly.toml`, `render.yaml`, `railway.toml`, `Procfile`, `app.yaml` |
+| **Environment files** | `deny` for real `.env*`, `ask` for `.env.example` | `.env`, `.env.local`, `.env.development`, `.env.staging`, `.env.production`, `.env.test`, `.env.example` |
+| **Lockfiles** | `ask` | `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lockb`, `Gemfile.lock`, `Pipfile.lock`, `poetry.lock`, `composer.lock`, `go.sum`, `Cargo.lock`, `mix.lock`, `pubspec.lock`, `flake.lock` |
+| **CI/CD configs** | `ask` | `.github/workflows/*.yml`, `.gitlab-ci.yml`, `.circleci/config.yml`, `Jenkinsfile`, `.travis.yml`, `appveyor.yml`, `bitbucket-pipelines.yml`, `azure-pipelines.yml`, `cloudbuild.yaml` |
+| **Container configs** | `ask` | `Dockerfile`, `docker-compose.yml`, `docker-compose.override.yml`, `.dockerignore` |
+| **Infrastructure** | `deny` for `terraform.tfstate*`, `ask` for `*.tfvars`, `*.tf` in `terraform/`, `k8s/*.yml`, `kubernetes/*.yml` | `terraform.tfstate`, `*.tfvars`, `*.tf` (in `terraform/` dirs), `k8s/*.yml`, `kubernetes/*.yml` |
+| **Crypto keys** | `deny` for private key material, `ask` for public certs / public keys | `*.pem`, `*.key`, `*.crt`, `*.cer`, `*.p12`, `*.pfx`, `id_rsa`, `id_ed25519`, `authorized_keys` |
+| **Deployment configs** | `ask` | `vercel.json`, `netlify.toml`, `fly.toml`, `render.yaml`, `railway.toml`, `Procfile`, `app.yaml` |
 
 ## How It Works
 
-1. **Intercepts file operations** — The hook runs before every `Write`, `Edit`, and `MultiEdit` tool call.
+1. **Intercepts file operations** — `PreToolUse` evaluates every `Write`, `Edit`, and `MultiEdit` call.
 2. **Checks against protected patterns** — Files are matched by exact name, extension, or directory path.
-3. **Blocks on first encounter** — If a protected file is detected for the first time in the session, the operation is blocked (exit code 2) with a descriptive warning.
-4. **Session-scoped memory** — Once the user confirms intent, subsequent edits to the same file are allowed for the rest of the session.
-5. **Automatic cleanup** — State files older than 30 days are periodically removed.
+3. **Returns structured hook decisions** — High-risk files return `deny`; medium-risk files return `ask`.
+4. **Tracks asked tool calls** — `PreToolUse` marks medium-risk edits as pending confirmation using the current tool call ID.
+5. **Confirms before allowlisting** — `PostToolUse` only allowlists a file when that exact pending tool call succeeds.
+6. **Cleans up failed edits** — `PostToolUseFailure` clears pending confirmation state so failed runs never become trusted.
+7. **Session-scoped memory** — Once a medium-risk file is truly confirmed, later edits to the same file are auto-allowed for the rest of the session.
+8. **Automatic cleanup** — State files older than 30 days are periodically removed.
 
 ## Configuration
 
@@ -61,19 +68,13 @@ This plugin is included in the Claude Code repository. To use it in your project
 
 ## Example Warning
 
-When attempting to edit a protected file, you'll see:
+When attempting to edit a medium-risk protected file, you'll get a confirmation prompt with a reason like:
 
 ```
-⚠️  SENSITIVE FILE GUARD — Modification Blocked
-
-  File:   /project/.env.production
-  Reason: Environment variable file: .env.production
-
-This file is classified as a sensitive infrastructure file. Accidental
-modifications can break deployments, leak secrets, or cause dependency
-conflicts.
-
-To proceed, explicitly confirm you intend to modify this file.
+Sensitive File Guard requires confirmation before editing
+Container configuration: Dockerfile.
+If you approve and the edit runs, this file will be auto-allowed
+for the rest of the session.
 ```
 
 ## Relationship to Other Plugins

--- a/plugins/sensitive-file-guard/hooks/hooks.json
+++ b/plugins/sensitive-file-guard/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Protects sensitive infrastructure files from accidental overwrites",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/sensitive_file_guard_hook.py"
+          }
+        ],
+        "matcher": "Write|Edit|MultiEdit"
+      }
+    ]
+  }
+}

--- a/plugins/sensitive-file-guard/hooks/hooks.json
+++ b/plugins/sensitive-file-guard/hooks/hooks.json
@@ -6,7 +6,29 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/sensitive_file_guard_hook.py"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/run_sensitive_file_guard.sh\""
+          }
+        ],
+        "matcher": "Write|Edit|MultiEdit"
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/run_sensitive_file_guard.sh\""
+          }
+        ],
+        "matcher": "Write|Edit|MultiEdit"
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/run_sensitive_file_guard.sh\""
           }
         ],
         "matcher": "Write|Edit|MultiEdit"

--- a/plugins/sensitive-file-guard/hooks/run_sensitive_file_guard.sh
+++ b/plugins/sensitive-file-guard/hooks/run_sensitive_file_guard.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK_SCRIPT="${SCRIPT_DIR}/sensitive_file_guard_hook.py"
+
+if command -v python3 >/dev/null 2>&1; then
+  exec python3 "$HOOK_SCRIPT"
+fi
+
+if command -v python >/dev/null 2>&1; then
+  exec python "$HOOK_SCRIPT"
+fi
+
+if command -v py >/dev/null 2>&1; then
+  exec py -3 "$HOOK_SCRIPT"
+fi
+
+echo "Sensitive File Guard requires Python 3, but no compatible interpreter was found." >&2
+exit 1

--- a/plugins/sensitive-file-guard/hooks/sensitive_file_guard_hook.py
+++ b/plugins/sensitive-file-guard/hooks/sensitive_file_guard_hook.py
@@ -1,19 +1,16 @@
 #!/usr/bin/env python3
 """
-Sensitive File Guard Hook for Claude Code
+Sensitive File Guard Hook for Claude Code.
 
-This hook intercepts Write, Edit, and MultiEdit operations to protect
-sensitive infrastructure files from accidental overwrites.
+This hook uses structured PreToolUse decisions:
+- deny for high-risk files such as .env secrets, private keys, and tfstate
+- ask for medium-risk infrastructure files such as Dockerfiles and k8s manifests
+- allow for medium-risk files that were already confirmed in-session
 
-Protected file categories:
-- Environment files (.env, .env.local, .env.production, etc.)
-- Lockfiles (package-lock.json, yarn.lock, pnpm-lock.yaml, etc.)
-- CI/CD configs (.github/workflows/*.yml, .gitlab-ci.yml, etc.)
-- Container configs (Dockerfile, docker-compose.yml, etc.)
-- Infrastructure as Code (terraform.tfstate, *.tfvars)
-- SSH/Crypto keys (*.pem, *.key, id_rsa, id_ed25519)
-- Deployment configs (vercel.json, netlify.toml, fly.toml, etc.)
+Confirmed files are recorded only after a matching asked tool call succeeds.
 """
+
+from __future__ import annotations
 
 import json
 import os
@@ -23,119 +20,24 @@ from datetime import datetime
 
 # Debug log file
 DEBUG_LOG_FILE = "/tmp/sensitive-file-guard-log.txt"
+STATE_VERSION = 2
+ASK = "ask"
+ALLOW = "allow"
+DENY = "deny"
 
 
 def debug_log(message):
     """Append debug message to log file with timestamp."""
     try:
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
-        with open(DEBUG_LOG_FILE, "a") as f:
-            f.write(f"[{timestamp}] {message}\n")
+        with open(DEBUG_LOG_FILE, "a", encoding="utf-8") as file_handle:
+            file_handle.write(f"[{timestamp}] {message}\n")
     except Exception:
-        pass  # Silently ignore logging errors
+        pass
 
 
-# ─── Protected File Definitions ──────────────────────────────────────────────
-
-# Exact filenames (case-insensitive) that are always protected
-PROTECTED_FILENAMES = {
-    # Environment files
-    ".env",
-    ".env.local",
-    ".env.development",
-    ".env.staging",
-    ".env.production",
-    ".env.test",
-    ".env.example",
-    # Lockfiles
-    "package-lock.json",
-    "yarn.lock",
-    "pnpm-lock.yaml",
-    "bun.lockb",
-    "gemfile.lock",
-    "pipfile.lock",
-    "poetry.lock",
-    "composer.lock",
-    "go.sum",
-    "cargo.lock",
-    "mix.lock",
-    "pubspec.lock",
-    "flake.lock",
-    "shrinkwrap.yaml",
-    # Container configs
-    "dockerfile",
-    "docker-compose.yml",
-    "docker-compose.yaml",
-    "docker-compose.override.yml",
-    "docker-compose.override.yaml",
-    ".dockerignore",
-    # CI/CD configs
-    ".gitlab-ci.yml",
-    "jenkinsfile",
-    ".travis.yml",
-    "appveyor.yml",
-    "bitbucket-pipelines.yml",
-    "azure-pipelines.yml",
-    "cloudbuild.yaml",
-    "cloudbuild.yml",
-    # Infrastructure
-    "terraform.tfstate",
-    "terraform.tfstate.backup",
-    # Deployment configs
-    "vercel.json",
-    "netlify.toml",
-    "fly.toml",
-    "render.yaml",
-    "railway.toml",
-    "procfile",
-    "app.yaml",
-    "app.yml",
-    # SSH/Crypto key filenames
-    "id_rsa",
-    "id_rsa.pub",
-    "id_ed25519",
-    "id_ed25519.pub",
-    "id_ecdsa",
-    "id_ecdsa.pub",
-    "authorized_keys",
-    "known_hosts",
-}
-
-# File extensions that indicate sensitive files
-PROTECTED_EXTENSIONS = {
-    ".pem",
-    ".key",
-    ".crt",
-    ".cer",
-    ".p12",
-    ".pfx",
-    ".jks",
-    ".keystore",
-    ".tfvars",
-}
-
-# Path patterns for files that are protected based on their directory
-# Each entry is (directory_substring, filename_extension_or_pattern)
-PROTECTED_PATH_PATTERNS = [
-    # GitHub Actions workflows
-    (".github/workflows/", ".yml"),
-    (".github/workflows/", ".yaml"),
-    # CircleCI
-    (".circleci/", "config.yml"),
-    (".circleci/", "config.yaml"),
-    # Kubernetes
-    ("k8s/", ".yml"),
-    ("k8s/", ".yaml"),
-    ("kubernetes/", ".yml"),
-    ("kubernetes/", ".yaml"),
-    # Terraform
-    ("terraform/", ".tf"),
-    ("terraform/", ".tfvars"),
-]
-
-# Category labels for user-friendly messages
 FILE_CATEGORIES = {
-    ".env": "Environment variable file",
+    "environment": "Environment variable file",
     "lockfile": "Package lockfile",
     "container": "Container configuration",
     "ci_cd": "CI/CD pipeline configuration",
@@ -144,106 +46,108 @@ FILE_CATEGORIES = {
     "crypto": "SSH/Cryptographic key file",
 }
 
+EXACT_FILE_RULES = {
+    # Environment files
+    ".env": ("environment", DENY),
+    ".env.local": ("environment", DENY),
+    ".env.development": ("environment", DENY),
+    ".env.staging": ("environment", DENY),
+    ".env.production": ("environment", DENY),
+    ".env.test": ("environment", DENY),
+    ".env.example": ("environment", ASK),
+    # Lockfiles
+    "package-lock.json": ("lockfile", ASK),
+    "yarn.lock": ("lockfile", ASK),
+    "pnpm-lock.yaml": ("lockfile", ASK),
+    "bun.lockb": ("lockfile", ASK),
+    "gemfile.lock": ("lockfile", ASK),
+    "pipfile.lock": ("lockfile", ASK),
+    "poetry.lock": ("lockfile", ASK),
+    "composer.lock": ("lockfile", ASK),
+    "go.sum": ("lockfile", ASK),
+    "cargo.lock": ("lockfile", ASK),
+    "mix.lock": ("lockfile", ASK),
+    "pubspec.lock": ("lockfile", ASK),
+    "flake.lock": ("lockfile", ASK),
+    "shrinkwrap.yaml": ("lockfile", ASK),
+    # Container configs
+    "dockerfile": ("container", ASK),
+    "docker-compose.yml": ("container", ASK),
+    "docker-compose.yaml": ("container", ASK),
+    "docker-compose.override.yml": ("container", ASK),
+    "docker-compose.override.yaml": ("container", ASK),
+    ".dockerignore": ("container", ASK),
+    # CI/CD configs
+    ".gitlab-ci.yml": ("ci_cd", ASK),
+    "jenkinsfile": ("ci_cd", ASK),
+    ".travis.yml": ("ci_cd", ASK),
+    "appveyor.yml": ("ci_cd", ASK),
+    "bitbucket-pipelines.yml": ("ci_cd", ASK),
+    "azure-pipelines.yml": ("ci_cd", ASK),
+    "cloudbuild.yaml": ("ci_cd", ASK),
+    "cloudbuild.yml": ("ci_cd", ASK),
+    # Infrastructure state
+    "terraform.tfstate": ("infrastructure", DENY),
+    "terraform.tfstate.backup": ("infrastructure", DENY),
+    # Deployment configs
+    "vercel.json": ("deployment", ASK),
+    "netlify.toml": ("deployment", ASK),
+    "fly.toml": ("deployment", ASK),
+    "render.yaml": ("deployment", ASK),
+    "railway.toml": ("deployment", ASK),
+    "procfile": ("deployment", ASK),
+    "app.yaml": ("deployment", ASK),
+    "app.yml": ("deployment", ASK),
+    # SSH/Crypto key filenames
+    "id_rsa": ("crypto", DENY),
+    "id_rsa.pub": ("crypto", ASK),
+    "id_ed25519": ("crypto", DENY),
+    "id_ed25519.pub": ("crypto", ASK),
+    "id_ecdsa": ("crypto", DENY),
+    "id_ecdsa.pub": ("crypto", ASK),
+    "authorized_keys": ("crypto", DENY),
+    "known_hosts": ("crypto", ASK),
+}
 
-def get_file_category(file_path, filename):
-    """Determine the category of a protected file for display purposes."""
-    lower_name = filename.lower()
-    _, ext = os.path.splitext(lower_name)
-    normalized_path = file_path.replace("\\", "/").lstrip("/")
+EXTENSION_RULES = {
+    ".pem": ("crypto", DENY),
+    ".key": ("crypto", DENY),
+    ".crt": ("crypto", ASK),
+    ".cer": ("crypto", ASK),
+    ".p12": ("crypto", DENY),
+    ".pfx": ("crypto", DENY),
+    ".jks": ("crypto", DENY),
+    ".keystore": ("crypto", DENY),
+    ".tfvars": ("infrastructure", ASK),
+}
 
-    if lower_name.startswith(".env"):
-        return FILE_CATEGORIES[".env"]
-    if "lock" in lower_name or lower_name in {
-        "go.sum",
-        "shrinkwrap.yaml",
-    }:
-        return FILE_CATEGORIES["lockfile"]
-    if "docker" in lower_name or lower_name == ".dockerignore":
-        return FILE_CATEGORIES["container"]
-    if any(
-        ci in lower_name
-        for ci in [
-            "gitlab-ci",
-            "jenkins",
-            "travis",
-            "appveyor",
-            "pipelines",
-            "cloudbuild",
-        ]
-    ):
-        return FILE_CATEGORIES["ci_cd"]
-    if ".github/workflows/" in normalized_path or ".circleci/" in normalized_path:
-        return FILE_CATEGORIES["ci_cd"]
-    if ext in PROTECTED_EXTENSIONS:
-        if ext in {".pem", ".key", ".crt", ".cer", ".p12", ".pfx", ".jks", ".keystore"}:
-            return FILE_CATEGORIES["crypto"]
-        if ext == ".tfvars":
-            return FILE_CATEGORIES["infrastructure"]
-    if lower_name in {"terraform.tfstate", "terraform.tfstate.backup"}:
-        return FILE_CATEGORIES["infrastructure"]
-    if lower_name in {
-        "vercel.json",
-        "netlify.toml",
-        "fly.toml",
-        "render.yaml",
-        "railway.toml",
-        "procfile",
-        "app.yaml",
-        "app.yml",
-    }:
-        return FILE_CATEGORIES["deployment"]
-    if any(
-        p in normalized_path for p in ["k8s/", "kubernetes/", "terraform/"]
-    ):
-        return FILE_CATEGORIES["infrastructure"]
-
-    return "Sensitive file"
+PATH_RULES = [
+    (".github/workflows/", ".yml", "ci_cd", ASK),
+    (".github/workflows/", ".yaml", "ci_cd", ASK),
+    (".circleci/", "config.yml", "ci_cd", ASK),
+    (".circleci/", "config.yaml", "ci_cd", ASK),
+    ("k8s/", ".yml", "infrastructure", ASK),
+    ("k8s/", ".yaml", "infrastructure", ASK),
+    ("kubernetes/", ".yml", "infrastructure", ASK),
+    ("kubernetes/", ".yaml", "infrastructure", ASK),
+    ("terraform/", ".tf", "infrastructure", ASK),
+    ("terraform/", ".tfvars", "infrastructure", ASK),
+]
 
 
-def is_protected_file(file_path):
-    """
-    Check if a file path matches a protected file pattern.
-
-    Returns:
-        (is_protected, reason): Tuple of whether file is protected and why.
-    """
+def normalize_path(file_path, cwd=""):
+    """Normalize a path for matching and session allowlisting."""
     if not file_path:
-        return False, ""
+        return ""
 
-    # Normalize path
-    normalized_path = file_path.replace("\\", "/").lstrip("/")
-    filename = os.path.basename(normalized_path)
-    lower_filename = filename.lower()
-    _, ext = os.path.splitext(lower_filename)
+    normalized = os.path.expanduser(file_path)
+    if cwd and not os.path.isabs(normalized):
+        normalized = os.path.join(cwd, normalized)
 
-    # Check exact filename match (case-insensitive)
-    if lower_filename in PROTECTED_FILENAMES:
-        category = get_file_category(file_path, filename)
-        return True, f"{category}: {filename}"
-
-    # Check extension match
-    if ext in PROTECTED_EXTENSIONS:
-        category = get_file_category(file_path, filename)
-        return True, f"{category}: {filename} ({ext} extension)"
-
-    # Check path pattern match
-    for dir_pattern, file_pattern in PROTECTED_PATH_PATTERNS:
-        if dir_pattern in normalized_path:
-            if file_pattern.startswith("."):
-                # Extension match
-                if lower_filename.endswith(file_pattern):
-                    category = get_file_category(file_path, filename)
-                    return True, f"{category}: {filename} (in {dir_pattern})"
-            else:
-                # Exact filename match within directory
-                if lower_filename == file_pattern:
-                    category = get_file_category(file_path, filename)
-                    return True, f"{category}: {filename} (in {dir_pattern})"
-
-    return False, ""
-
-
-# ─── State Management ────────────────────────────────────────────────────────
+    normalized = os.path.abspath(normalized)
+    normalized = os.path.normpath(normalized)
+    normalized = os.path.normcase(normalized)
+    return normalized.replace("\\", "/")
 
 
 def get_state_file(session_id):
@@ -275,120 +179,305 @@ def cleanup_old_state_files():
                 except (OSError, IOError):
                     pass
     except Exception:
-        pass  # Silently ignore cleanup errors
+        pass
 
 
 def load_state(session_id):
-    """Load the set of already-warned file keys for this session."""
+    """Load session state while ignoring legacy warning-only state."""
     state_file = get_state_file(session_id)
-    if os.path.exists(state_file):
-        try:
-            with open(state_file, "r") as f:
-                return set(json.load(f))
-        except (json.JSONDecodeError, IOError):
-            return set()
-    return set()
+    if not os.path.exists(state_file):
+        return {
+            "version": STATE_VERSION,
+            "allowed_files": set(),
+            "pending_requests": {},
+        }
+
+    try:
+        with open(state_file, "r", encoding="utf-8") as file_handle:
+            raw_state = json.load(file_handle)
+    except (json.JSONDecodeError, IOError):
+        return {
+            "version": STATE_VERSION,
+            "allowed_files": set(),
+            "pending_requests": {},
+        }
+
+    if isinstance(raw_state, list):
+        # Legacy versions stored "warned" files, which must not be treated as confirmed.
+        return {
+            "version": STATE_VERSION,
+            "allowed_files": set(),
+            "pending_requests": {},
+        }
+
+    allowed_files = raw_state.get("allowed_files", [])
+    if not isinstance(allowed_files, list):
+        allowed_files = []
+
+    pending_requests = raw_state.get("pending_requests", {})
+    if not isinstance(pending_requests, dict):
+        pending_requests = {}
+
+    return {
+        "version": STATE_VERSION,
+        "allowed_files": set(allowed_files),
+        "pending_requests": pending_requests,
+    }
 
 
-def save_state(session_id, shown_warnings):
-    """Persist the set of already-warned file keys for this session."""
+def save_state(session_id, state):
+    """Persist session allowlist state."""
     state_file = get_state_file(session_id)
+    payload = {
+        "version": STATE_VERSION,
+        "allowed_files": sorted(state["allowed_files"]),
+        "pending_requests": state["pending_requests"],
+    }
     try:
         os.makedirs(os.path.dirname(state_file), exist_ok=True)
-        with open(state_file, "w") as f:
-            json.dump(list(shown_warnings), f)
-    except IOError as e:
-        debug_log(f"Failed to save state file: {e}")
+        with open(state_file, "w", encoding="utf-8") as file_handle:
+            json.dump(payload, file_handle)
+    except IOError as error:
+        debug_log(f"Failed to save state file: {error}")
 
 
-# ─── Input Extraction ────────────────────────────────────────────────────────
+def build_reason(category, filename, detail=""):
+    """Create a user-facing reason string."""
+    category_label = FILE_CATEGORIES.get(category, "Sensitive file")
+    if detail:
+        return f"{category_label}: {filename} ({detail})"
+    return f"{category_label}: {filename}"
 
 
-def extract_file_path(tool_name, tool_input):
-    """Extract the target file path from the tool input."""
+def classify_file(file_path, cwd=""):
+    """
+    Classify a file path if it matches a protected rule.
+
+    Returns:
+        dict with path, filename, category, risk, reason, or None.
+    """
+    normalized_path = normalize_path(file_path, cwd)
+    if not normalized_path:
+        return None
+
+    filename = os.path.basename(normalized_path)
+    lower_filename = filename.lower()
+    _, extension = os.path.splitext(lower_filename)
+
+    if lower_filename in EXACT_FILE_RULES:
+        category, risk = EXACT_FILE_RULES[lower_filename]
+        return {
+            "path": normalized_path,
+            "filename": filename,
+            "category": category,
+            "risk": risk,
+            "reason": build_reason(category, filename),
+        }
+
+    if extension in EXTENSION_RULES:
+        category, risk = EXTENSION_RULES[extension]
+        return {
+            "path": normalized_path,
+            "filename": filename,
+            "category": category,
+            "risk": risk,
+            "reason": build_reason(category, filename, f"{extension} extension"),
+        }
+
+    for directory_pattern, filename_pattern, category, risk in PATH_RULES:
+        if directory_pattern not in normalized_path:
+            continue
+
+        if filename_pattern.startswith("."):
+            if lower_filename.endswith(filename_pattern):
+                return {
+                    "path": normalized_path,
+                    "filename": filename,
+                    "category": category,
+                    "risk": risk,
+                    "reason": build_reason(
+                        category, filename, f"in {directory_pattern}"
+                    ),
+                }
+            continue
+
+        if lower_filename == filename_pattern:
+            return {
+                "path": normalized_path,
+                "filename": filename,
+                "category": category,
+                "risk": risk,
+                "reason": build_reason(category, filename, f"in {directory_pattern}"),
+            }
+
+    return None
+
+
+def extract_file_path(tool_input):
+    """Extract a file path from Write/Edit/MultiEdit input."""
+    if not isinstance(tool_input, dict):
+        return ""
     return tool_input.get("file_path", "")
 
 
-# ─── Main ─────────────────────────────────────────────────────────────────────
+def extract_tool_use_id(input_data):
+    """Extract the current tool call ID if present."""
+    tool_use_id = input_data.get("tool_use_id", "")
+    if isinstance(tool_use_id, str):
+        return tool_use_id
+    return ""
+
+
+def emit_json(payload):
+    """Emit hook JSON to stdout."""
+    json.dump(payload, sys.stdout)
+    sys.stdout.write("\n")
+
+
+def emit_pretool_decision(permission_decision, reason):
+    """Emit a structured PreToolUse decision."""
+    emit_json(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": permission_decision,
+                "permissionDecisionReason": reason,
+            }
+        }
+    )
+
+
+def handle_pre_tool_use(input_data):
+    """Handle PreToolUse by deny/ask/allow based on file risk and session state."""
+    session_id = input_data.get("session_id", "default")
+    cwd = input_data.get("cwd", "")
+    tool_input = input_data.get("tool_input", {})
+    file_path = extract_file_path(tool_input)
+    if not file_path:
+        return
+
+    match = classify_file(file_path, cwd)
+    if not match:
+        return
+
+    state = load_state(session_id)
+    file_key = match["path"]
+    tool_use_id = extract_tool_use_id(input_data)
+
+    if match["risk"] == DENY:
+        emit_pretool_decision(
+            DENY,
+            (
+                f"Sensitive File Guard blocked {match['reason']}. "
+                "Use a safer workflow than direct Claude edits for secrets, private keys, or tfstate files."
+            ),
+        )
+        return
+
+    if file_key in state["allowed_files"]:
+        emit_pretool_decision(
+            ALLOW,
+            f"Previously confirmed this session: {match['reason']}",
+        )
+        return
+
+    if tool_use_id:
+        state["pending_requests"][tool_use_id] = {
+            "path": file_key,
+            "reason": match["reason"],
+        }
+        save_state(session_id, state)
+
+    emit_pretool_decision(
+        ASK,
+        (
+            f"Sensitive File Guard requires confirmation before editing {match['reason']}. "
+            "If you approve and the edit runs, this file will be auto-allowed for the rest of the session."
+        ),
+    )
+
+
+def handle_post_tool_use(input_data):
+    """Record confirmed medium-risk files only after the edit reaches PostToolUse."""
+    session_id = input_data.get("session_id", "default")
+    cwd = input_data.get("cwd", "")
+    tool_input = input_data.get("tool_input", {})
+    file_path = extract_file_path(tool_input)
+    if not file_path:
+        return
+
+    tool_use_id = extract_tool_use_id(input_data)
+    match = classify_file(file_path, cwd)
+    if not match or match["risk"] != ASK or not tool_use_id:
+        return
+
+    state = load_state(session_id)
+    file_key = match["path"]
+    pending_request = state["pending_requests"].pop(tool_use_id, None)
+
+    if not pending_request:
+        save_state(session_id, state)
+        return
+
+    if pending_request.get("path") != file_key:
+        save_state(session_id, state)
+        debug_log(
+            f"Skipped allowlisting due to path mismatch for tool call {tool_use_id}: "
+            f"pending={pending_request.get('path')} current={file_key}"
+        )
+        return
+
+    if file_key in state["allowed_files"]:
+        save_state(session_id, state)
+        return
+
+    state["allowed_files"].add(file_key)
+    save_state(session_id, state)
+    debug_log(f"Recorded confirmed sensitive file for session allowlist: {file_key}")
+
+
+def handle_post_tool_use_failure(input_data):
+    """Clear pending confirmation state when an asked tool call fails."""
+    session_id = input_data.get("session_id", "default")
+    tool_use_id = extract_tool_use_id(input_data)
+    if not tool_use_id:
+        return
+
+    state = load_state(session_id)
+    if tool_use_id not in state["pending_requests"]:
+        return
+
+    state["pending_requests"].pop(tool_use_id, None)
+    save_state(session_id, state)
+    debug_log(f"Cleared pending sensitive file request after failure: {tool_use_id}")
 
 
 def main():
     """Main hook function."""
-    # Check if guard is enabled (can be disabled via env var)
-    guard_enabled = os.environ.get("SENSITIVE_FILE_GUARD_ENABLED", "1")
-    if guard_enabled == "0":
+    if os.environ.get("SENSITIVE_FILE_GUARD_ENABLED", "1") == "0":
         debug_log("Sensitive file guard disabled by environment variable")
-        sys.exit(0)
+        return
 
-    # Periodically clean up old state files (10% chance per run)
     if random.random() < 0.1:
         cleanup_old_state_files()
 
-    # Read input from stdin
     try:
-        raw_input = sys.stdin.read()
-        input_data = json.loads(raw_input)
-    except json.JSONDecodeError as e:
-        debug_log(f"JSON decode error: {e}")
-        sys.exit(0)  # Allow tool to proceed if we can't parse input
+        input_data = json.load(sys.stdin)
+    except json.JSONDecodeError as error:
+        debug_log(f"JSON decode error: {error}")
+        return
 
-    # Extract tool information
-    session_id = input_data.get("session_id", "default")
     tool_name = input_data.get("tool_name", "")
-    tool_input = input_data.get("tool_input", {})
-
-    # Only process file-modifying tools
     if tool_name not in ["Write", "Edit", "MultiEdit"]:
-        sys.exit(0)
+        return
 
-    # Extract file path
-    file_path = extract_file_path(tool_name, tool_input)
-    if not file_path:
-        sys.exit(0)
-
-    # Check if this is a protected file
-    is_protected, reason = is_protected_file(file_path)
-
-    if not is_protected:
-        sys.exit(0)
-
-    # Create unique warning key
-    warning_key = f"{file_path}"
-
-    # Load existing warnings for this session
-    shown_warnings = load_state(session_id)
-
-    # Skip if already warned in this session
-    if warning_key in shown_warnings:
-        debug_log(f"Already warned about {file_path}, allowing")
-        sys.exit(0)
-
-    # Record this warning
-    shown_warnings.add(warning_key)
-    save_state(session_id, shown_warnings)
-
-    # Build warning message
-    warning_message = f"""⚠️  SENSITIVE FILE GUARD — Modification Blocked
-
-  File:   {file_path}
-  Reason: {reason}
-
-This file is classified as a sensitive infrastructure file. Accidental
-modifications can break deployments, leak secrets, or cause dependency
-conflicts.
-
-Common risks:
-  • .env files may contain API keys and secrets
-  • Lockfiles ensure reproducible builds — manual edits cause drift
-  • CI/CD configs control deployment pipelines
-  • Crypto keys are irreplaceable credentials
-
-To proceed, explicitly confirm you intend to modify this file.
-To disable this guard, set SENSITIVE_FILE_GUARD_ENABLED=0."""
-
-    # Output warning to stderr and block the operation
-    print(warning_message, file=sys.stderr)
-    sys.exit(2)  # Exit code 2 blocks the tool in PreToolUse hooks
+    hook_event_name = input_data.get("hook_event_name", "PreToolUse")
+    if hook_event_name == "PreToolUse":
+        handle_pre_tool_use(input_data)
+    elif hook_event_name == "PostToolUse":
+        handle_post_tool_use(input_data)
+    elif hook_event_name == "PostToolUseFailure":
+        handle_post_tool_use_failure(input_data)
 
 
 if __name__ == "__main__":

--- a/plugins/sensitive-file-guard/hooks/sensitive_file_guard_hook.py
+++ b/plugins/sensitive-file-guard/hooks/sensitive_file_guard_hook.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""
+Sensitive File Guard Hook for Claude Code
+
+This hook intercepts Write, Edit, and MultiEdit operations to protect
+sensitive infrastructure files from accidental overwrites.
+
+Protected file categories:
+- Environment files (.env, .env.local, .env.production, etc.)
+- Lockfiles (package-lock.json, yarn.lock, pnpm-lock.yaml, etc.)
+- CI/CD configs (.github/workflows/*.yml, .gitlab-ci.yml, etc.)
+- Container configs (Dockerfile, docker-compose.yml, etc.)
+- Infrastructure as Code (terraform.tfstate, *.tfvars)
+- SSH/Crypto keys (*.pem, *.key, id_rsa, id_ed25519)
+- Deployment configs (vercel.json, netlify.toml, fly.toml, etc.)
+"""
+
+import json
+import os
+import random
+import sys
+from datetime import datetime
+
+# Debug log file
+DEBUG_LOG_FILE = "/tmp/sensitive-file-guard-log.txt"
+
+
+def debug_log(message):
+    """Append debug message to log file with timestamp."""
+    try:
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+        with open(DEBUG_LOG_FILE, "a") as f:
+            f.write(f"[{timestamp}] {message}\n")
+    except Exception:
+        pass  # Silently ignore logging errors
+
+
+# ─── Protected File Definitions ──────────────────────────────────────────────
+
+# Exact filenames (case-insensitive) that are always protected
+PROTECTED_FILENAMES = {
+    # Environment files
+    ".env",
+    ".env.local",
+    ".env.development",
+    ".env.staging",
+    ".env.production",
+    ".env.test",
+    ".env.example",
+    # Lockfiles
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "bun.lockb",
+    "gemfile.lock",
+    "pipfile.lock",
+    "poetry.lock",
+    "composer.lock",
+    "go.sum",
+    "cargo.lock",
+    "mix.lock",
+    "pubspec.lock",
+    "flake.lock",
+    "shrinkwrap.yaml",
+    # Container configs
+    "dockerfile",
+    "docker-compose.yml",
+    "docker-compose.yaml",
+    "docker-compose.override.yml",
+    "docker-compose.override.yaml",
+    ".dockerignore",
+    # CI/CD configs
+    ".gitlab-ci.yml",
+    "jenkinsfile",
+    ".travis.yml",
+    "appveyor.yml",
+    "bitbucket-pipelines.yml",
+    "azure-pipelines.yml",
+    "cloudbuild.yaml",
+    "cloudbuild.yml",
+    # Infrastructure
+    "terraform.tfstate",
+    "terraform.tfstate.backup",
+    # Deployment configs
+    "vercel.json",
+    "netlify.toml",
+    "fly.toml",
+    "render.yaml",
+    "railway.toml",
+    "procfile",
+    "app.yaml",
+    "app.yml",
+    # SSH/Crypto key filenames
+    "id_rsa",
+    "id_rsa.pub",
+    "id_ed25519",
+    "id_ed25519.pub",
+    "id_ecdsa",
+    "id_ecdsa.pub",
+    "authorized_keys",
+    "known_hosts",
+}
+
+# File extensions that indicate sensitive files
+PROTECTED_EXTENSIONS = {
+    ".pem",
+    ".key",
+    ".crt",
+    ".cer",
+    ".p12",
+    ".pfx",
+    ".jks",
+    ".keystore",
+    ".tfvars",
+}
+
+# Path patterns for files that are protected based on their directory
+# Each entry is (directory_substring, filename_extension_or_pattern)
+PROTECTED_PATH_PATTERNS = [
+    # GitHub Actions workflows
+    (".github/workflows/", ".yml"),
+    (".github/workflows/", ".yaml"),
+    # CircleCI
+    (".circleci/", "config.yml"),
+    (".circleci/", "config.yaml"),
+    # Kubernetes
+    ("k8s/", ".yml"),
+    ("k8s/", ".yaml"),
+    ("kubernetes/", ".yml"),
+    ("kubernetes/", ".yaml"),
+    # Terraform
+    ("terraform/", ".tf"),
+    ("terraform/", ".tfvars"),
+]
+
+# Category labels for user-friendly messages
+FILE_CATEGORIES = {
+    ".env": "Environment variable file",
+    "lockfile": "Package lockfile",
+    "container": "Container configuration",
+    "ci_cd": "CI/CD pipeline configuration",
+    "infrastructure": "Infrastructure configuration",
+    "deployment": "Deployment configuration",
+    "crypto": "SSH/Cryptographic key file",
+}
+
+
+def get_file_category(file_path, filename):
+    """Determine the category of a protected file for display purposes."""
+    lower_name = filename.lower()
+    _, ext = os.path.splitext(lower_name)
+    normalized_path = file_path.replace("\\", "/").lstrip("/")
+
+    if lower_name.startswith(".env"):
+        return FILE_CATEGORIES[".env"]
+    if "lock" in lower_name or lower_name in {
+        "go.sum",
+        "shrinkwrap.yaml",
+    }:
+        return FILE_CATEGORIES["lockfile"]
+    if "docker" in lower_name or lower_name == ".dockerignore":
+        return FILE_CATEGORIES["container"]
+    if any(
+        ci in lower_name
+        for ci in [
+            "gitlab-ci",
+            "jenkins",
+            "travis",
+            "appveyor",
+            "pipelines",
+            "cloudbuild",
+        ]
+    ):
+        return FILE_CATEGORIES["ci_cd"]
+    if ".github/workflows/" in normalized_path or ".circleci/" in normalized_path:
+        return FILE_CATEGORIES["ci_cd"]
+    if ext in PROTECTED_EXTENSIONS:
+        if ext in {".pem", ".key", ".crt", ".cer", ".p12", ".pfx", ".jks", ".keystore"}:
+            return FILE_CATEGORIES["crypto"]
+        if ext == ".tfvars":
+            return FILE_CATEGORIES["infrastructure"]
+    if lower_name in {"terraform.tfstate", "terraform.tfstate.backup"}:
+        return FILE_CATEGORIES["infrastructure"]
+    if lower_name in {
+        "vercel.json",
+        "netlify.toml",
+        "fly.toml",
+        "render.yaml",
+        "railway.toml",
+        "procfile",
+        "app.yaml",
+        "app.yml",
+    }:
+        return FILE_CATEGORIES["deployment"]
+    if any(
+        p in normalized_path for p in ["k8s/", "kubernetes/", "terraform/"]
+    ):
+        return FILE_CATEGORIES["infrastructure"]
+
+    return "Sensitive file"
+
+
+def is_protected_file(file_path):
+    """
+    Check if a file path matches a protected file pattern.
+
+    Returns:
+        (is_protected, reason): Tuple of whether file is protected and why.
+    """
+    if not file_path:
+        return False, ""
+
+    # Normalize path
+    normalized_path = file_path.replace("\\", "/").lstrip("/")
+    filename = os.path.basename(normalized_path)
+    lower_filename = filename.lower()
+    _, ext = os.path.splitext(lower_filename)
+
+    # Check exact filename match (case-insensitive)
+    if lower_filename in PROTECTED_FILENAMES:
+        category = get_file_category(file_path, filename)
+        return True, f"{category}: {filename}"
+
+    # Check extension match
+    if ext in PROTECTED_EXTENSIONS:
+        category = get_file_category(file_path, filename)
+        return True, f"{category}: {filename} ({ext} extension)"
+
+    # Check path pattern match
+    for dir_pattern, file_pattern in PROTECTED_PATH_PATTERNS:
+        if dir_pattern in normalized_path:
+            if file_pattern.startswith("."):
+                # Extension match
+                if lower_filename.endswith(file_pattern):
+                    category = get_file_category(file_path, filename)
+                    return True, f"{category}: {filename} (in {dir_pattern})"
+            else:
+                # Exact filename match within directory
+                if lower_filename == file_pattern:
+                    category = get_file_category(file_path, filename)
+                    return True, f"{category}: {filename} (in {dir_pattern})"
+
+    return False, ""
+
+
+# ─── State Management ────────────────────────────────────────────────────────
+
+
+def get_state_file(session_id):
+    """Get session-specific state file path."""
+    return os.path.expanduser(
+        f"~/.claude/sensitive_file_guard_state_{session_id}.json"
+    )
+
+
+def cleanup_old_state_files():
+    """Remove state files older than 30 days."""
+    try:
+        state_dir = os.path.expanduser("~/.claude")
+        if not os.path.exists(state_dir):
+            return
+
+        current_time = datetime.now().timestamp()
+        thirty_days_ago = current_time - (30 * 24 * 60 * 60)
+
+        for filename in os.listdir(state_dir):
+            if filename.startswith(
+                "sensitive_file_guard_state_"
+            ) and filename.endswith(".json"):
+                file_path = os.path.join(state_dir, filename)
+                try:
+                    file_mtime = os.path.getmtime(file_path)
+                    if file_mtime < thirty_days_ago:
+                        os.remove(file_path)
+                except (OSError, IOError):
+                    pass
+    except Exception:
+        pass  # Silently ignore cleanup errors
+
+
+def load_state(session_id):
+    """Load the set of already-warned file keys for this session."""
+    state_file = get_state_file(session_id)
+    if os.path.exists(state_file):
+        try:
+            with open(state_file, "r") as f:
+                return set(json.load(f))
+        except (json.JSONDecodeError, IOError):
+            return set()
+    return set()
+
+
+def save_state(session_id, shown_warnings):
+    """Persist the set of already-warned file keys for this session."""
+    state_file = get_state_file(session_id)
+    try:
+        os.makedirs(os.path.dirname(state_file), exist_ok=True)
+        with open(state_file, "w") as f:
+            json.dump(list(shown_warnings), f)
+    except IOError as e:
+        debug_log(f"Failed to save state file: {e}")
+
+
+# ─── Input Extraction ────────────────────────────────────────────────────────
+
+
+def extract_file_path(tool_name, tool_input):
+    """Extract the target file path from the tool input."""
+    return tool_input.get("file_path", "")
+
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+
+def main():
+    """Main hook function."""
+    # Check if guard is enabled (can be disabled via env var)
+    guard_enabled = os.environ.get("SENSITIVE_FILE_GUARD_ENABLED", "1")
+    if guard_enabled == "0":
+        debug_log("Sensitive file guard disabled by environment variable")
+        sys.exit(0)
+
+    # Periodically clean up old state files (10% chance per run)
+    if random.random() < 0.1:
+        cleanup_old_state_files()
+
+    # Read input from stdin
+    try:
+        raw_input = sys.stdin.read()
+        input_data = json.loads(raw_input)
+    except json.JSONDecodeError as e:
+        debug_log(f"JSON decode error: {e}")
+        sys.exit(0)  # Allow tool to proceed if we can't parse input
+
+    # Extract tool information
+    session_id = input_data.get("session_id", "default")
+    tool_name = input_data.get("tool_name", "")
+    tool_input = input_data.get("tool_input", {})
+
+    # Only process file-modifying tools
+    if tool_name not in ["Write", "Edit", "MultiEdit"]:
+        sys.exit(0)
+
+    # Extract file path
+    file_path = extract_file_path(tool_name, tool_input)
+    if not file_path:
+        sys.exit(0)
+
+    # Check if this is a protected file
+    is_protected, reason = is_protected_file(file_path)
+
+    if not is_protected:
+        sys.exit(0)
+
+    # Create unique warning key
+    warning_key = f"{file_path}"
+
+    # Load existing warnings for this session
+    shown_warnings = load_state(session_id)
+
+    # Skip if already warned in this session
+    if warning_key in shown_warnings:
+        debug_log(f"Already warned about {file_path}, allowing")
+        sys.exit(0)
+
+    # Record this warning
+    shown_warnings.add(warning_key)
+    save_state(session_id, shown_warnings)
+
+    # Build warning message
+    warning_message = f"""⚠️  SENSITIVE FILE GUARD — Modification Blocked
+
+  File:   {file_path}
+  Reason: {reason}
+
+This file is classified as a sensitive infrastructure file. Accidental
+modifications can break deployments, leak secrets, or cause dependency
+conflicts.
+
+Common risks:
+  • .env files may contain API keys and secrets
+  • Lockfiles ensure reproducible builds — manual edits cause drift
+  • CI/CD configs control deployment pipelines
+  • Crypto keys are irreplaceable credentials
+
+To proceed, explicitly confirm you intend to modify this file.
+To disable this guard, set SENSITIVE_FILE_GUARD_ENABLED=0."""
+
+    # Output warning to stderr and block the operation
+    print(warning_message, file=sys.stderr)
+    sys.exit(2)  # Exit code 2 blocks the tool in PreToolUse hooks
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/sensitive-file-guard/hooks/test_sensitive_file_guard_hook.py
+++ b/plugins/sensitive-file-guard/hooks/test_sensitive_file_guard_hook.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Focused regression tests for the sensitive file guard hook."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+HOOK_SCRIPT = Path(__file__).with_name("sensitive_file_guard_hook.py")
+WRAPPER_SCRIPT = Path(__file__).with_name("run_sensitive_file_guard.sh")
+
+
+def normalize_expected_path(base_dir, file_path):
+    """Mirror the hook's normalization rules for assertions."""
+    return os.path.normcase(
+        os.path.abspath(os.path.join(str(base_dir), file_path))
+    ).replace("\\", "/")
+
+
+def run_hook(payload, home_dir):
+    """Execute the hook script with a temporary HOME for isolated state."""
+    env = os.environ.copy()
+    env["HOME"] = str(home_dir)
+    env["PYTHONIOENCODING"] = "utf-8"
+
+    return subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+def load_state(home_dir, session_id):
+    """Load session state from the temp HOME, if it exists."""
+    state_file = (
+        Path(home_dir)
+        / ".claude"
+        / f"sensitive_file_guard_state_{session_id}.json"
+    )
+    if not state_file.exists():
+        return None
+    return json.loads(state_file.read_text(encoding="utf-8"))
+
+
+class SensitiveFileGuardHookTests(unittest.TestCase):
+    def test_wrapper_supports_quoted_paths(self):
+        with tempfile.TemporaryDirectory() as home_dir, tempfile.TemporaryDirectory() as temp_root:
+            wrapper_root = Path(temp_root) / "guard with spaces"
+            wrapper_root.mkdir(parents=True, exist_ok=True)
+            wrapper_copy = wrapper_root / "run_sensitive_file_guard.sh"
+            hook_copy = wrapper_root / "sensitive_file_guard_hook.py"
+            shutil.copy2(WRAPPER_SCRIPT, wrapper_copy)
+            shutil.copy2(HOOK_SCRIPT, hook_copy)
+
+            payload = {
+                "hook_event_name": "PreToolUse",
+                "session_id": "quoted-wrapper",
+                "cwd": temp_root,
+                "tool_use_id": "wrapper-1",
+                "tool_name": "Edit",
+                "tool_input": {"file_path": "Dockerfile"},
+            }
+
+            env = os.environ.copy()
+            env["HOME"] = str(home_dir)
+            env["PYTHONIOENCODING"] = "utf-8"
+            result = subprocess.run(
+                ["bash", str(wrapper_copy)],
+                input=json.dumps(payload),
+                text=True,
+                capture_output=True,
+                env=env,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(
+                json.loads(result.stdout)["hookSpecificOutput"]["permissionDecision"],
+                "ask",
+            )
+
+    def test_env_file_is_denied_without_allowlisting(self):
+        with tempfile.TemporaryDirectory() as home_dir, tempfile.TemporaryDirectory() as project_dir:
+            payload = {
+                "hook_event_name": "PreToolUse",
+                "session_id": "deny-env",
+                "cwd": project_dir,
+                "tool_use_id": "deny-env-1",
+                "tool_name": "Edit",
+                "tool_input": {"file_path": ".env"},
+            }
+
+            result = run_hook(payload, home_dir)
+
+            self.assertEqual(result.returncode, 0)
+            output = json.loads(result.stdout)
+            self.assertEqual(
+                output["hookSpecificOutput"]["permissionDecision"],
+                "deny",
+            )
+            self.assertIsNone(load_state(home_dir, "deny-env"))
+
+    def test_medium_risk_file_is_allowlisted_only_after_post_tool_use(self):
+        with tempfile.TemporaryDirectory() as home_dir, tempfile.TemporaryDirectory() as project_dir:
+            session_id = "dockerfile-session"
+            file_path = "Dockerfile"
+
+            pretool_payload = {
+                "hook_event_name": "PreToolUse",
+                "session_id": session_id,
+                "cwd": project_dir,
+                "tool_use_id": "dockerfile-1",
+                "tool_name": "Write",
+                "tool_input": {"file_path": file_path, "content": "FROM alpine:3.20\n"},
+            }
+
+            first_result = run_hook(pretool_payload, home_dir)
+            self.assertEqual(first_result.returncode, 0)
+            first_output = json.loads(first_result.stdout)
+            self.assertEqual(
+                first_output["hookSpecificOutput"]["permissionDecision"],
+                "ask",
+            )
+            pending_state = load_state(home_dir, session_id)
+            self.assertIsNotNone(pending_state)
+            self.assertIn("dockerfile-1", pending_state["pending_requests"])
+
+            posttool_payload = {
+                "hook_event_name": "PostToolUse",
+                "session_id": session_id,
+                "cwd": project_dir,
+                "tool_use_id": "dockerfile-1",
+                "tool_name": "Write",
+                "tool_input": {"file_path": file_path, "content": "FROM alpine:3.20\n"},
+                "tool_result": "Write completed successfully",
+            }
+
+            post_result = run_hook(posttool_payload, home_dir)
+            self.assertEqual(post_result.returncode, 0)
+            self.assertEqual(post_result.stdout, "")
+
+            state = load_state(home_dir, session_id)
+            self.assertIsNotNone(state)
+            allowed_files = state["allowed_files"]
+            expected_path = normalize_expected_path(project_dir, file_path)
+            self.assertIn(expected_path, allowed_files)
+            self.assertEqual(state["pending_requests"], {})
+
+            second_result = run_hook(pretool_payload, home_dir)
+            second_output = json.loads(second_result.stdout)
+            self.assertEqual(
+                second_output["hookSpecificOutput"]["permissionDecision"],
+                "allow",
+            )
+
+    def test_post_tool_use_without_matching_pending_request_does_not_allowlist(self):
+        with tempfile.TemporaryDirectory() as home_dir, tempfile.TemporaryDirectory() as project_dir:
+            session_id = "missing-pending"
+            payload = {
+                "hook_event_name": "PostToolUse",
+                "session_id": session_id,
+                "cwd": project_dir,
+                "tool_use_id": "orphan-call",
+                "tool_name": "Edit",
+                "tool_input": {"file_path": "Dockerfile"},
+                "tool_result": "Edit completed successfully",
+            }
+
+            result = run_hook(payload, home_dir)
+
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, "")
+            state = load_state(home_dir, session_id)
+            self.assertIsNotNone(state)
+            self.assertEqual(state["allowed_files"], [])
+            self.assertEqual(state["pending_requests"], {})
+
+    def test_post_tool_use_failure_clears_pending_request(self):
+        with tempfile.TemporaryDirectory() as home_dir, tempfile.TemporaryDirectory() as project_dir:
+            session_id = "failure-path"
+            pretool_payload = {
+                "hook_event_name": "PreToolUse",
+                "session_id": session_id,
+                "cwd": project_dir,
+                "tool_use_id": "fail-1",
+                "tool_name": "Edit",
+                "tool_input": {"file_path": "Dockerfile"},
+            }
+            failure_payload = {
+                "hook_event_name": "PostToolUseFailure",
+                "session_id": session_id,
+                "cwd": project_dir,
+                "tool_use_id": "fail-1",
+                "tool_name": "Edit",
+                "tool_input": {"file_path": "Dockerfile"},
+                "tool_response": {"success": False, "error": "write failed"},
+            }
+
+            first_result = run_hook(pretool_payload, home_dir)
+            self.assertEqual(
+                json.loads(first_result.stdout)["hookSpecificOutput"]["permissionDecision"],
+                "ask",
+            )
+            state_before = load_state(home_dir, session_id)
+            self.assertIn("fail-1", state_before["pending_requests"])
+
+            failure_result = run_hook(failure_payload, home_dir)
+            self.assertEqual(failure_result.returncode, 0)
+            self.assertEqual(failure_result.stdout, "")
+
+            state_after = load_state(home_dir, session_id)
+            self.assertEqual(state_after["pending_requests"], {})
+            self.assertEqual(state_after["allowed_files"], [])
+
+    def test_infrastructure_code_asks_while_tfstate_denies(self):
+        with tempfile.TemporaryDirectory() as home_dir, tempfile.TemporaryDirectory() as project_dir:
+            ask_payload = {
+                "hook_event_name": "PreToolUse",
+                "session_id": "terraform-ask",
+                "cwd": project_dir,
+                "tool_use_id": "terraform-ask-1",
+                "tool_name": "Edit",
+                "tool_input": {"file_path": "terraform/main.tf"},
+            }
+            deny_payload = {
+                "hook_event_name": "PreToolUse",
+                "session_id": "terraform-deny",
+                "cwd": project_dir,
+                "tool_use_id": "terraform-deny-1",
+                "tool_name": "Edit",
+                "tool_input": {"file_path": "terraform.tfstate"},
+            }
+
+            ask_result = run_hook(ask_payload, home_dir)
+            deny_result = run_hook(deny_payload, home_dir)
+
+            self.assertEqual(
+                json.loads(ask_result.stdout)["hookSpecificOutput"]["permissionDecision"],
+                "ask",
+            )
+            self.assertEqual(
+                json.loads(deny_result.stdout)["hookSpecificOutput"]["permissionDecision"],
+                "deny",
+            )
+
+    def test_legacy_warning_state_is_not_treated_as_confirmation(self):
+        with tempfile.TemporaryDirectory() as home_dir, tempfile.TemporaryDirectory() as project_dir:
+            session_id = "legacy-state"
+            state_dir = Path(home_dir) / ".claude"
+            state_dir.mkdir(parents=True, exist_ok=True)
+            legacy_state_file = state_dir / f"sensitive_file_guard_state_{session_id}.json"
+            legacy_state_file.write_text(
+                json.dumps([normalize_expected_path(project_dir, "Dockerfile")]),
+                encoding="utf-8",
+            )
+
+            payload = {
+                "hook_event_name": "PreToolUse",
+                "session_id": session_id,
+                "cwd": project_dir,
+                "tool_use_id": "legacy-state-1",
+                "tool_name": "Edit",
+                "tool_input": {"file_path": "Dockerfile"},
+            }
+
+            result = run_hook(payload, home_dir)
+
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(
+                json.loads(result.stdout)["hookSpecificOutput"]["permissionDecision"],
+                "ask",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- switch sensitive-file-guard to structured PreToolUse permission decisions with deny/ask/allow risk levels
- only allowlist medium-risk files after the exact asked tool call succeeds, and clear pending state on failure
- add a quoted shell wrapper for Python resolution across python3/python/py and add focused regression tests

## Testing
- python3 plugins/sensitive-file-guard/hooks/test_sensitive_file_guard_hook.py
- extracted `.hooks` from `plugins/sensitive-file-guard/hooks/hooks.json` and validated with `plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh`
