### PR TITLE
TEST-3001: Add HTML comment to top of README.md

### DIFF
--- a/.opspilot/sprint-tasks.json
+++ b/.opspilot/sprint-tasks.json
@@ -1,9 +1,9 @@
 {
   "version": 1,
-  "task_key": "TEST-3001",
+  "task_key": "TEST-3002",
   "task_summary": "Add a comment to the top of README.md",
   "created_at": "2026-03-16T07:42:29.067648+00:00",
-  "updated_at": "2026-03-16T07:42:29.067760+00:00",
+  "updated_at": "2026-03-16T08:15:00.000000+00:00",
   "features": [
     {
       "id": "f1",

--- a/.opspilot/sprint-tasks.json
+++ b/.opspilot/sprint-tasks.json
@@ -1,9 +1,9 @@
 {
   "version": 1,
-  "task_key": "TEST-3004",
+  "task_key": "TEST-3005",
   "task_summary": "Add a comment to the top of README.md",
   "created_at": "2026-03-16T08:51:08.000000+00:00",
-  "updated_at": "2026-03-16T08:51:08.000000+00:00",
+  "updated_at": "2026-03-16T09:00:00.000000+00:00",
   "features": [
     {
       "id": "f1",
@@ -15,7 +15,7 @@
       "verification_steps": [
         "head -3 README.md"
       ],
-      "status": "passed",
+      "status": "in_progress",
       "priority": 1,
       "estimated_files": [
         "README.md"

--- a/.opspilot/sprint-tasks.json
+++ b/.opspilot/sprint-tasks.json
@@ -1,9 +1,9 @@
 {
   "version": 1,
-  "task_key": "TEST-3003",
+  "task_key": "TEST-3004",
   "task_summary": "Add a comment to the top of README.md",
-  "created_at": "2026-03-16T08:20:00.000000+00:00",
-  "updated_at": "2026-03-16T08:25:00.000000+00:00",
+  "created_at": "2026-03-16T08:51:08.000000+00:00",
+  "updated_at": "2026-03-16T08:51:08.000000+00:00",
   "features": [
     {
       "id": "f1",
@@ -15,7 +15,7 @@
       "verification_steps": [
         "head -3 README.md"
       ],
-      "status": "passed",
+      "status": "in_progress",
       "priority": 1,
       "estimated_files": [
         "README.md"

--- a/.opspilot/sprint-tasks.json
+++ b/.opspilot/sprint-tasks.json
@@ -15,7 +15,7 @@
       "verification_steps": [
         "head -3 README.md"
       ],
-      "status": "in_progress",
+      "status": "passed",
       "priority": 1,
       "estimated_files": [
         "README.md"

--- a/.opspilot/sprint-tasks.json
+++ b/.opspilot/sprint-tasks.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "task_key": "TEST-3001",
+  "task_summary": "Add a comment to the top of README.md",
+  "created_at": "2026-03-16T07:42:29.067648+00:00",
+  "updated_at": "2026-03-16T07:42:29.067760+00:00",
+  "features": [
+    {
+      "id": "f1",
+      "title": "Add HTML comment to top of README.md",
+      "description": "Prepend <!-- Updated by OpsPilot test --> as the first line of README.md with a trailing blank line before the existing content",
+      "files": [
+        "README.md"
+      ],
+      "verification_steps": [
+        "head -3 README.md"
+      ],
+      "status": "in_progress",
+      "priority": 1,
+      "estimated_files": [
+        "README.md"
+      ]
+    }
+  ],
+  "session_log": []
+}

--- a/.opspilot/sprint-tasks.json
+++ b/.opspilot/sprint-tasks.json
@@ -1,9 +1,9 @@
 {
   "version": 1,
-  "task_key": "TEST-3002",
+  "task_key": "TEST-3003",
   "task_summary": "Add a comment to the top of README.md",
-  "created_at": "2026-03-16T07:42:29.067648+00:00",
-  "updated_at": "2026-03-16T08:15:00.000000+00:00",
+  "created_at": "2026-03-16T08:20:00.000000+00:00",
+  "updated_at": "2026-03-16T08:25:00.000000+00:00",
   "features": [
     {
       "id": "f1",

--- a/.opspilot/sprint-tasks.json
+++ b/.opspilot/sprint-tasks.json
@@ -15,7 +15,7 @@
       "verification_steps": [
         "head -3 README.md"
       ],
-      "status": "passed",
+      "status": "in_progress",
       "priority": 1,
       "estimated_files": [
         "README.md"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- Updated by OpsPilot test -->
+
 # Claude Code
 
 ![](https://img.shields.io/badge/Node.js-18%2B-brightgreen?style=flat-square) [![npm]](https://www.npmjs.com/package/@anthropic-ai/claude-code)


### PR DESCRIPTION
## Summary
- Prepends `<!-- Updated by OpsPilot test -->` as line 1 of `README.md`
- Followed by a blank line before the existing `# Claude Code` heading

## Test plan
- [x] `head -3 README.md` shows the comment on line 1, blank line on line 2, `# Claude Code` on line 3
- [x] No functional code changes — static Markdown only

🤖 Generated with [Claude Code](https://claude.com/claude-code)