### PR TITLE
TEST-3002: Add HTML comment to top of README.md

### DIFF
--- a/.opspilot/sprint-tasks.json
+++ b/.opspilot/sprint-tasks.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "task_key": "TEST-3002",
+  "task_summary": "Add a comment to the top of README.md",
+  "created_at": "2026-03-16T07:42:29.067648+00:00",
+  "updated_at": "2026-03-16T08:20:00.000000+00:00",
+  "features": [
+    {
+      "id": "f1",
+      "title": "Add HTML comment to top of README.md",
+      "description": "Prepend <!-- Updated by OpsPilot test --> as the first line of README.md with a trailing blank line before the existing content",
+      "files": [
+        "README.md"
+      ],
+      "verification_steps": [
+        "head -3 README.md"
+      ],
+      "status": "passed",
+      "priority": 1,
+      "estimated_files": [
+        "README.md"
+      ]
+    }
+  ],
+  "session_log": []
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- Updated by OpsPilot test -->
+
 # Claude Code
 
 ![](https://img.shields.io/badge/Node.js-18%2B-brightgreen?style=flat-square) [![npm]](https://www.npmjs.com/package/@anthropic-ai/claude-code)


### PR DESCRIPTION
## Summary
- Prepends `<!-- Updated by OpsPilot test -->` as line 1 of `README.md`
- Blank line separator before existing `# Claude Code` heading
- No functional code changes — static Markdown file only

## Test plan
- [ ] `head -3 README.md` confirms line 1 is `<!-- Updated by OpsPilot test -->`
- [ ] Line 3 is `# Claude Code` (existing heading preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)