### PR TITLE
docs(plugins): add Community Plugins section to README

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -60,6 +60,17 @@ plugin-name/
 └── README.md                # Plugin documentation
 ```
 
+## Community Plugins
+
+Community-built plugins and hooks that extend Claude Code:
+
+| Name | Description |
+|------|-------------|
+| [Bouncer](https://github.com/buildingopen/bouncer) | Independent quality gate using Gemini to audit Claude Code output via Stop hook. Scores responses 1-10 and blocks until quality threshold is met. Includes on-demand `/bouncer` skill with deep audit mode. |
+| [claude-code-hooks-mastery](https://github.com/disler/claude-code-hooks-mastery) | Comprehensive collection of hook examples and patterns for all hook lifecycle events. |
+
+*To add your plugin, open a PR adding it to this table.*
+
 ## Contributing
 
 When adding new plugins to this directory:


### PR DESCRIPTION
## Summary

The plugins README mentions that "many more plugins are available through community marketplaces" but doesn't link any. This adds a **Community Plugins** table for external projects that extend Claude Code.

Starting entries:
- **Bouncer** - Independent quality gate using Gemini to audit Claude Code output via Stop hook
- **claude-code-hooks-mastery** - Comprehensive hook examples and patterns

The table includes an invite for others to add their plugins via PR, which should help grow the ecosystem documentation.

## Changes

- Added "Community Plugins" section to `plugins/README.md` with a table of external community projects
- No code changes, documentation only