### PR TITLE
feat: add automatic GitHub/GitLab detection and GitLab support for /code-review

### DIFF
--- a/plugins/code-review/README.md
+++ b/plugins/code-review/README.md
@@ -1,28 +1,29 @@
 # Code Review Plugin
 
-Automated code review for pull requests using multiple specialized agents with confidence-based scoring to filter false positives.
+Automated code review for pull requests (GitHub) and merge requests (GitLab) using multiple specialized agents with confidence-based scoring to filter false positives.
 
 ## Overview
 
-The Code Review Plugin automates pull request review by launching multiple agents in parallel to independently audit changes from different perspectives. It uses confidence scoring to filter out false positives, ensuring only high-quality, actionable feedback is posted.
+The Code Review Plugin automates PR/MR review by launching multiple agents in parallel to independently audit changes from different perspectives. It supports both GitHub and GitLab (including self-hosted instances), automatically detecting the platform from the git remote. It uses confidence scoring to filter out false positives, ensuring only high-quality, actionable feedback is posted.
 
 ## Commands
 
 ### `/code-review`
 
-Performs automated code review on a pull request using multiple specialized agents.
+Performs automated code review on a pull request (GitHub) or merge request (GitLab) using multiple specialized agents.
 
 **What it does:**
-1. Checks if review is needed (skips closed, draft, trivial, or already-reviewed PRs)
-2. Gathers relevant CLAUDE.md guideline files from the repository
-3. Summarizes the pull request changes
-4. Launches 4 parallel agents to independently review:
+1. Detects the platform (GitHub or GitLab) from the git remote
+2. Checks if review is needed (skips closed, draft, trivial, or already-reviewed PR/MRs)
+3. Gathers relevant CLAUDE.md guideline files from the repository
+4. Summarizes the PR/MR changes
+5. Launches 4 parallel agents to independently review:
    - **Agents #1 & #2**: Audit for CLAUDE.md compliance
    - **Agent #3**: Scan for obvious bugs in changes
    - **Agent #4**: Analyze git blame/history for context-based issues
-5. Scores each issue 0-100 for confidence level
-6. Filters out issues below 80 confidence threshold
-7. Outputs review (to terminal by default, or as PR comment with `--comment` flag)
+6. Scores each issue 0-100 for confidence level
+7. Filters out issues below 80 confidence threshold
+8. Outputs review (to terminal by default, or as PR/MR comment with `--comment` flag)
 
 **Usage:**
 ```bash
@@ -30,30 +31,32 @@ Performs automated code review on a pull request using multiple specialized agen
 ```
 
 **Options:**
-- `--comment`: Post the review as a comment on the pull request (default: outputs to terminal only)
+- `--comment`: Post the review as a comment on the PR/MR (default: outputs to terminal only)
 
 **Example workflow:**
 ```bash
-# On a PR branch, run locally (outputs to terminal):
+# On a PR/MR branch, run locally (outputs to terminal):
 /code-review
 
-# Post review as PR comment:
+# Post review as PR/MR comment:
 /code-review --comment
 
 # Claude will:
+# - Auto-detect GitHub or GitLab from git remote
 # - Launch 4 review agents in parallel
 # - Score each issue for confidence
-# - Output issues ≥80 confidence (to terminal or PR depending on flag)
+# - Output issues ≥80 confidence (to terminal or PR/MR depending on flag)
 # - Skip if no high-confidence issues found
 ```
 
 **Features:**
+- **GitHub and GitLab support** with automatic platform detection (including self-hosted instances)
 - Multiple independent agents for comprehensive review
 - Confidence-based scoring reduces false positives (threshold: 80)
 - CLAUDE.md compliance checking with explicit guideline verification
 - Bug detection focused on changes (not pre-existing issues)
 - Historical context analysis via git blame
-- Automatic skipping of closed, draft, or already-reviewed PRs
+- Automatic skipping of closed, draft, or already-reviewed PR/MRs
 - Links directly to code with full SHA and line ranges
 
 **Review comment format:**
@@ -99,34 +102,34 @@ This plugin is included in the Claude Code repository. The command is automatica
 ### Using `/code-review`
 - Maintain clear CLAUDE.md files for better compliance checking
 - Trust the 80+ confidence threshold - false positives are filtered
-- Run on all non-trivial pull requests
+- Run on all non-trivial pull requests / merge requests
 - Review agent findings as a starting point for human review
 - Update CLAUDE.md based on recurring review patterns
 
 ### When to use
-- All pull requests with meaningful changes
-- PRs touching critical code paths
-- PRs from multiple contributors
-- PRs where guideline compliance matters
+- All pull requests / merge requests with meaningful changes
+- PR/MRs touching critical code paths
+- PR/MRs from multiple contributors
+- PR/MRs where guideline compliance matters
 
 ### When not to use
-- Closed or draft PRs (automatically skipped anyway)
-- Trivial automated PRs (automatically skipped)
+- Closed or draft PR/MRs (automatically skipped anyway)
+- Trivial automated PR/MRs (automatically skipped)
 - Urgent hotfixes requiring immediate merge
-- PRs already reviewed (automatically skipped)
+- PR/MRs already reviewed (automatically skipped)
 
 ## Workflow Integration
 
-### Standard PR review workflow:
+### Standard review workflow (GitHub or GitLab):
 ```bash
-# Create PR with changes
+# Create PR/MR with changes
 # Run local review (outputs to terminal)
 /code-review
 
 # Review the automated feedback
 # Make any necessary fixes
 
-# Optionally post as PR comment
+# Optionally post as PR/MR comment
 /code-review --comment
 
 # Merge when ready
@@ -134,7 +137,7 @@ This plugin is included in the Claude Code repository. The command is automatica
 
 ### As part of CI/CD:
 ```bash
-# Trigger on PR creation or update
+# Trigger on PR/MR creation or update
 # Use --comment flag to post review comments
 /code-review --comment
 # Skip if review already exists
@@ -142,9 +145,12 @@ This plugin is included in the Claude Code repository. The command is automatica
 
 ## Requirements
 
-- Git repository with GitHub integration
-- GitHub CLI (`gh`) installed and authenticated
+- Git repository with a GitHub or GitLab remote
+- **For GitHub**: GitHub CLI (`gh`) installed and authenticated
+- **For GitLab**: GitLab CLI (`glab`) installed and authenticated
 - CLAUDE.md files (optional but recommended for guideline checking)
+
+The plugin automatically detects the platform from the git remote URL. For self-hosted instances, it probes the API to distinguish between GitHub Enterprise and GitLab CE/EE.
 
 ## Troubleshooting
 
@@ -172,24 +178,32 @@ This plugin is included in the Claude Code repository. The command is automatica
 
 **Solution**:
 Check if:
-- PR is closed (reviews skipped)
-- PR is draft (reviews skipped)
-- PR is trivial/automated (reviews skipped)
-- PR already has review (reviews skipped)
+- PR/MR is closed (reviews skipped)
+- PR/MR is draft (reviews skipped)
+- PR/MR is trivial/automated (reviews skipped)
+- PR/MR already has review (reviews skipped)
 - No issues scored ≥80 (no comment needed)
 
 ### Link formatting broken
 
-**Issue**: Code links don't render correctly in GitHub
+**Issue**: Code links don't render correctly
 
 **Solution**:
-Links must follow this exact format:
+Links must follow the exact format for the detected platform:
+
+GitHub:
 ```
 https://github.com/owner/repo/blob/[full-sha]/path/file.ext#L[start]-L[end]
+```
+
+GitLab:
+```
+https://gitlab.com/owner/repo/-/blob/[full-sha]/path/file.ext#L[start]-[end]
 ```
 - Must use full SHA (not abbreviated)
 - Must use `#L` notation
 - Must include line range with at least 1 line of context
+- GitLab uses `/-/blob/` and omits the second `L` in ranges
 
 ### GitHub CLI not working
 
@@ -200,20 +214,29 @@ https://github.com/owner/repo/blob/[full-sha]/path/file.ext#L[start]-L[end]
 - Authenticate: `gh auth login`
 - Verify repository has GitHub remote
 
+### GitLab CLI not working
+
+**Issue**: `glab` commands fail
+
+**Solution**:
+- Install GitLab CLI: `brew install glab` (macOS) or see [GLab installation](https://gitlab.com/gitlab-org/cli#installation)
+- Authenticate: `glab auth login`
+- Verify repository has GitLab remote
+
 ## Tips
 
 - **Write specific CLAUDE.md files**: Clear guidelines = better reviews
-- **Include context in PRs**: Helps agents understand intent
+- **Include context in PR/MRs**: Helps agents understand intent
 - **Use confidence scores**: Issues ≥80 are usually correct
 - **Iterate on guidelines**: Update CLAUDE.md based on patterns
-- **Review automatically**: Set up as part of PR workflow
+- **Review automatically**: Set up as part of PR/MR workflow
 - **Trust the filtering**: Threshold prevents noise
 
 ## Configuration
 
 ### Adjusting confidence threshold
 
-The default threshold is 80. To adjust, modify the command file at `commands/code-review.md`:
+The default threshold is 80. To adjust, modify `commands/code-review.md`:
 ```markdown
 Filter out any issues with a score less than 80.
 ```
@@ -242,12 +265,19 @@ Edit `commands/code-review.md` to add or modify agent tasks:
 - Threshold (default 80) filters low-confidence issues
 - For CLAUDE.md issues: verifies guideline explicitly mentions it
 
-### GitHub integration
-Uses `gh` CLI for:
+### Platform integration
+
+**GitHub** — uses `gh` CLI for:
 - Viewing PR details and diffs
 - Fetching repository data
 - Reading git blame and history
-- Posting review comments
+- Posting review comments (via `gh pr comment` and `mcp__github_inline_comment`)
+
+**GitLab** — uses `glab` CLI for:
+- Viewing MR details and diffs
+- Fetching repository data
+- Reading git blame and history
+- Posting review comments (via `glab mr note` and `glab api` for inline discussions)
 
 ## Author
 

--- a/plugins/code-review/commands/code-review.md
+++ b/plugins/code-review/commands/code-review.md
@@ -1,9 +1,9 @@
 ---
-allowed-tools: Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*), mcp__github_inline_comment__create_inline_comment
-description: Code review a pull request
+allowed-tools: Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*), Bash(glab mr view:*), Bash(glab mr diff:*), Bash(glab mr note:*), Bash(glab mr list:*), Bash(glab api:*), Bash(git remote:*), Bash(git branch:*), Bash(git log:*), Bash(git blame:*), Bash(git diff:*), Bash(git rev-parse:*), Bash(curl -s:*), mcp__github_inline_comment__create_inline_comment
+description: Code review a pull request or merge request
 ---
 
-Provide a code review for the given pull request.
+Provide a code review for the current pull request (GitHub) or merge request (GitLab).
 
 **Agent assumptions (applies to all agents and subagents):**
 - All tools are functional and will work without error. Do not test tools or make exploratory calls. Make sure this is clear to every subagent that is launched.
@@ -11,23 +11,40 @@ Provide a code review for the given pull request.
 
 To do this, follow these steps precisely:
 
-1. Launch a haiku agent to check if any of the following are true:
-   - The pull request is closed
-   - The pull request is a draft
-   - The pull request does not need code review (e.g. automated PR, trivial change that is obviously correct)
-   - Claude has already commented on this PR (check `gh pr view <PR> --comments` for comments left by claude)
+1. Detect the platform. Do NOT use a subagent — run these commands directly yourself (2-3 commands max):
+   a. Run `git remote get-url origin`. Parse the host from the URL (HTTPS: `https://host/owner/repo.git`, SSH: `git@host:owner/repo.git`).
+   b. If host is `github.com` → GitHub. If host is `gitlab.com` → GitLab. Otherwise run `curl -s -o /dev/null -w "%{http_code}" https://<host>/api/v4/version` — if `200` → GitLab, else → GitHub Enterprise. If unclear, ask the user.
+   c. Verify auth with exactly one command: `gh auth status` (GitHub) or `glab auth status` (GitLab). If it fails, tell the user to install/authenticate and stop.
+
+   Based on the detected platform, use the matching values from the table below for ALL subsequent steps. Refer to these as PLATFORM values:
+
+   | Value            | GitHub                                  | GitLab                                  |
+   |------------------|-----------------------------------------|-----------------------------------------|
+   | CLI              | `gh`                                    | `glab`                                  |
+   | Term             | PR                                      | MR                                      |
+   | View command     | `gh pr view`                            | `glab mr view`                          |
+   | Diff command     | `gh pr diff`                            | `glab mr diff`                          |
+   | Comment command  | `gh pr comment`                         | `glab mr note`                          |
+   | Comments check   | `gh pr view <ID> --comments`            | `glab mr view <ID> --comments`          |
+   | Link format      | `https://github.com/owner/repo/blob/<sha>/path#L<start>-L<end>` | `https://<host>/owner/repo/-/blob/<sha>/path#L<start>-<end>` |
+
+2. Launch a haiku agent to check if any of the following are true:
+   - The PR/MR is closed or merged
+   - The PR/MR is a draft
+   - The PR/MR does not need code review (e.g. automated, trivial change that is obviously correct)
+   - Claude has already commented (use PLATFORM comments check command)
 
    If any condition is true, stop and do not proceed.
 
-Note: Still review Claude generated PR's.
+Note: Still review Claude-generated PR/MRs.
 
-2. Launch a haiku agent to return a list of file paths (not their contents) for all relevant CLAUDE.md files including:
+3. Launch a haiku agent to return a list of file paths (not their contents) for all relevant CLAUDE.md files including:
    - The root CLAUDE.md file, if it exists
-   - Any CLAUDE.md files in directories containing files modified by the pull request
+   - Any CLAUDE.md files in directories containing files modified by the PR/MR
 
-3. Launch a sonnet agent to view the pull request and return a summary of the changes
+4. Launch a sonnet agent to view the PR/MR and return a summary of the changes. Use PLATFORM view and diff commands.
 
-4. Launch 4 agents in parallel to independently review the changes. Each agent should return the list of issues, where each issue includes a description and the reason it was flagged (e.g. "CLAUDE.md adherence", "bug"). The agents should do the following:
+5. Launch 4 agents in parallel to independently review the changes. Each agent should return the list of issues, where each issue includes a description and the reason it was flagged (e.g. "CLAUDE.md adherence", "bug"). The agents should do the following:
 
    Agents 1 + 2: CLAUDE.md compliance sonnet agents
    Audit changes for CLAUDE.md compliance in parallel. Note: When evaluating CLAUDE.md compliance for a file, you should only consider CLAUDE.md files that share a file path with the file or parents.
@@ -50,33 +67,48 @@ Note: Still review Claude generated PR's.
 
    If you are not certain an issue is real, do not flag it. False positives erode trust and waste reviewer time.
 
-   In addition to the above, each subagent should be told the PR title and description. This will help provide context regarding the author's intent.
+   In addition to the above, each subagent should be told the PR/MR title and description. This will help provide context regarding the author's intent.
 
-5. For each issue found in the previous step by agents 3 and 4, launch parallel subagents to validate the issue. These subagents should get the PR title and description along with a description of the issue. The agent's job is to review the issue to validate that the stated issue is truly an issue with high confidence. For example, if an issue such as "variable is not defined" was flagged, the subagent's job would be to validate that is actually true in the code. Another example would be CLAUDE.md issues. The agent should validate that the CLAUDE.md rule that was violated is scoped for this file and is actually violated. Use Opus subagents for bugs and logic issues, and sonnet agents for CLAUDE.md violations.
+6. For each issue found in the previous step by agents 3 and 4, launch parallel subagents to validate the issue. These subagents should get the PR/MR title and description along with a description of the issue. The agent's job is to review the issue to validate that the stated issue is truly an issue with high confidence. For example, if an issue such as "variable is not defined" was flagged, the subagent's job would be to validate that is actually true in the code. Another example would be CLAUDE.md issues. The agent should validate that the CLAUDE.md rule that was violated is scoped for this file and is actually violated. Use Opus subagents for bugs and logic issues, and sonnet agents for CLAUDE.md violations.
 
-6. Filter out any issues that were not validated in step 5. This step will give us our list of high signal issues for our review.
+7. Filter out any issues that were not validated in step 6. This step will give us our list of high signal issues for our review.
 
-7. Output a summary of the review findings to the terminal:
+8. Output a summary of the review findings to the terminal:
    - If issues were found, list each issue with a brief description.
    - If no issues were found, state: "No issues found. Checked for bugs and CLAUDE.md compliance."
 
-   If `--comment` argument was NOT provided, stop here. Do not post any GitHub comments.
+   If `--comment` argument was NOT provided, stop here. Do not post any comments.
 
-   If `--comment` argument IS provided and NO issues were found, post a summary comment using `gh pr comment` and stop.
+   If `--comment` argument IS provided and NO issues were found, post a summary comment using PLATFORM comment command and stop.
 
-   If `--comment` argument IS provided and issues were found, continue to step 8.
+   If `--comment` argument IS provided and issues were found, continue to step 9.
 
-8. Create a list of all comments that you plan on leaving. This is only for you to make sure you are comfortable with the comments. Do not post this list anywhere.
+9. Create a list of all comments that you plan on leaving. This is only for you to make sure you are comfortable with the comments. Do not post this list anywhere.
 
-9. Post inline comments for each issue using `mcp__github_inline_comment__create_inline_comment` with `confirmed: true`. For each comment:
-   - Provide a brief description of the issue
-   - For small, self-contained fixes, include a committable suggestion block
-   - For larger fixes (6+ lines, structural changes, or changes spanning multiple locations), describe the issue and suggested fix without a suggestion block
-   - Never post a committable suggestion UNLESS committing the suggestion fixes the issue entirely. If follow up steps are required, do not leave a committable suggestion.
+10. Post inline comments for each issue. For each comment:
+    - Provide a brief description of the issue
+    - For small, self-contained fixes, include a committable suggestion block
+    - For larger fixes (6+ lines, structural changes, or changes spanning multiple locations), describe the issue and suggested fix without a suggestion block
+    - Never post a committable suggestion UNLESS committing the suggestion fixes the issue entirely. If follow up steps are required, do not leave a committable suggestion.
 
-   **IMPORTANT: Only post ONE comment per unique issue. Do not post duplicate comments.**
+    **How to post inline comments by platform:**
 
-Use this list when evaluating issues in Steps 4 and 5 (these are false positives, do NOT flag):
+    - **GitHub**: Use `mcp__github_inline_comment__create_inline_comment` with `confirmed: true`.
+    - **GitLab**: First fetch the MR diff refs by running `glab api projects/<url-encoded-fullpath>/merge_requests/<MR_IID>` and extract `diff_refs.base_sha`, `diff_refs.start_sha`, and `diff_refs.head_sha`. Then post each inline comment using:
+      ```
+      glab api projects/<url-encoded-fullpath>/merge_requests/<MR_IID>/discussions -X POST \
+        -f body="<comment>" \
+        -f "position[position_type]=text" \
+        -f "position[base_sha]=<base_sha>" \
+        -f "position[start_sha]=<start_sha>" \
+        -f "position[head_sha]=<head_sha>" \
+        -f "position[new_path]=<file_path>" \
+        -f "position[new_line]=<line_number>"
+      ```
+
+    **IMPORTANT: Only post ONE comment per unique issue. Do not post duplicate comments.**
+
+Use this list when evaluating issues in Steps 5 and 6 (these are false positives, do NOT flag):
 
 - Pre-existing issues
 - Something that appears to be a bug but is actually correct
@@ -87,7 +119,7 @@ Use this list when evaluating issues in Steps 4 and 5 (these are false positives
 
 Notes:
 
-- Use gh CLI to interact with GitHub (e.g., fetch pull requests, create comments). Do not use web fetch.
+- Use PLATFORM CLI to interact with the platform (e.g., fetch PR/MRs, create comments). Do not use web fetch.
 - Create a todo list before starting.
 - You must cite and link each issue in inline comments (e.g., if referring to a CLAUDE.md, include a link to it).
 - If no issues are found and `--comment` argument is provided, post a comment with the following format:
@@ -100,10 +132,11 @@ No issues found. Checked for bugs and CLAUDE.md compliance.
 
 ---
 
-- When linking to code in inline comments, follow the following format precisely, otherwise the Markdown preview won't render correctly: https://github.com/anthropics/claude-code/blob/c21d3c10bc8e898b7ac1a2d745bdc9bc4e423afe/package.json#L10-L15
-  - Requires full git sha
-  - You must provide the full sha. Commands like `https://github.com/owner/repo/blob/$(git rev-parse HEAD)/foo/bar` will not work, since your comment will be directly rendered in Markdown.
+- When linking to code in inline comments, use PLATFORM link format precisely, otherwise the Markdown preview won't render correctly.
+  GitHub example: https://github.com/anthropics/claude-code/blob/c21d3c10bc8e898b7ac1a2d745bdc9bc4e423afe/package.json#L10-L15
+  GitLab example: https://gitlab.com/owner/repo/-/blob/c21d3c10bc8e898b7ac1a2d745bdc9bc4e423afe/package.json#L10-15
+  - Requires full git sha (not abbreviated)
+  - You must provide the full sha. Commands like `$(git rev-parse HEAD)` will not work, since your comment will be directly rendered in Markdown.
   - Repo name must match the repo you're code reviewing
-  - # sign after the file name
-  - Line range format is L[start]-L[end]
+  - Use the host from step 1
   - Provide at least 1 line of context before and after, centered on the line you are commenting about (eg. if you are commenting about lines 5-6, you should link to `L4-7`)


### PR DESCRIPTION
This PR adds multi-platform support to the `/code-review` command so it can work with both GitHub and GitLab (including self-hosted GitLab instances) without duplicating logic.

Addresses https://github.com/anthropics/claude-code/issues/26932

### Changes

* Automatic platform detection from the repository `origin` remote URL
* Support for **GitHub (`gh`) and GitLab (`glab`) CLIs**
* Detection of **self-hosted GitLab** by probing `/api/v4/version`
* Introduction of a **platform context table** that parameterizes:

  * CLI commands
  * diff viewing
  * comment posting
  * link formats
* Refactoring to keep a **single command implementation** with no duplicated logic
* README updates with GitLab requirements, troubleshooting steps, and link format documentation

### How it works

When `/code-review` runs, it first determines the platform:

1. `git remote get-url origin` → extract the host
2. Host matching:

   * `github.com` → GitHub
   * `gitlab.com` → GitLab
   * other host → probe `https://<host>/api/v4/version` to detect self-hosted GitLab
3. Verify CLI authentication:

   * `gh auth status` (GitHub)
   * `glab auth status` (GitLab)

A **platform context table** defines the platform-specific values (CLI tool, diff commands, comment commands, link format).