### PR TITLE
Fix: Remove 'set -u' to handle empty PROMPT_PARTS array in ralph-loop

### DIFF
--- a/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
+++ b/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
@@ -3,7 +3,7 @@
 # Ralph Loop Setup Script
 # Creates state file for in-session Ralph loop
 
-set -euo pipefail
+set -eo pipefail
 
 # Parse arguments
 PROMPT_PARTS=()


### PR DESCRIPTION
When running /ralph-loop without arguments, the empty PROMPT_PARTS array caused an 'unbound variable' error due to 'set -u' flag. Removing the '-u' flag allows the script to reach the validation logic that properly reports the missing prompt error.

Fixes: PROMPT_PARTS[*]: unbound variable