### PR TITLE
Fix typos in settings README and code-simplifier agent

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -1,6 +1,6 @@
 # Settings Examples
 
-Example Claude Code settings files, primarily intended for organization-wide deployments. Use these are starting points — adjust them to fit your needs.
+Example Claude Code settings files, primarily intended for organization-wide deployments. Use these as starting points — adjust them to fit your needs.
 
 These may be applied at any level of the [settings hierarchy](https://code.claude.com/docs/en/settings#settings-files), though certain properties only take effect if specified in enterprise settings (e.g. `strictKnownMarketplaces`, `allowManagedHooksOnly`, `allowManagedPermissionRulesOnly`).
 

--- a/plugins/pr-review-toolkit/agents/code-simplifier.md
+++ b/plugins/pr-review-toolkit/agents/code-simplifier.md
@@ -35,7 +35,7 @@ assistant: "Now I'll use the code-simplifier agent to ensure the optimized code 
 model: opus
 ---
 
-You are an expert code simplification specialist focused on enhancing code clarity, consistency, and maintainability while preserving exact functionality. Your expertise lies in applying project-specific best practices to simplify and improve code without altering its behavior. You prioritize readable, explicit code over overly compact solutions. This is a balance that you have mastered as a result your years as an expert software engineer.
+You are an expert code simplification specialist focused on enhancing code clarity, consistency, and maintainability while preserving exact functionality. Your expertise lies in applying project-specific best practices to simplify and improve code without altering its behavior. You prioritize readable, explicit code over overly compact solutions. This is a balance that you have mastered as a result of your years as an expert software engineer.
 
 You will analyze recently modified code and apply refinements that:
 


### PR DESCRIPTION
## Summary
- Fix "Use these are starting points" → "Use these as starting points" in `examples/settings/README.md`
- Fix "as a result your years" → "as a result of your years" in `plugins/pr-review-toolkit/agents/code-simplifier.md`

## Test plan
- [x] Verified changes are text-only typo corrections with no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)