### PR TITLE
fix(plugins): use portable shebangs in shell scripts

### DIFF
--- a/plugins/plugin-dev/skills/agent-development/scripts/validate-agent.sh
+++ b/plugins/plugin-dev/skills/agent-development/scripts/validate-agent.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Agent File Validator
 # Validates agent markdown files for correct structure and content
 

--- a/plugins/plugin-dev/skills/hook-development/examples/load-context.sh
+++ b/plugins/plugin-dev/skills/hook-development/examples/load-context.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Example SessionStart hook for loading project context
 # This script detects project type and sets environment variables
 

--- a/plugins/plugin-dev/skills/hook-development/examples/validate-bash.sh
+++ b/plugins/plugin-dev/skills/hook-development/examples/validate-bash.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Example PreToolUse hook for validating Bash commands
 # This script demonstrates bash command validation patterns
 

--- a/plugins/plugin-dev/skills/hook-development/scripts/hook-linter.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/hook-linter.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook Linter
 # Checks hook scripts for common issues and best practices
 

--- a/plugins/plugin-dev/skills/hook-development/scripts/test-hook.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/test-hook.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook Testing Helper
 # Tests a hook with sample input and shows output
 

--- a/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hook Schema Validator
 # Validates hooks.json structure and checks for common issues
 

--- a/plugins/plugin-dev/skills/plugin-settings/examples/read-settings-hook.sh
+++ b/plugins/plugin-dev/skills/plugin-settings/examples/read-settings-hook.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Example hook that reads plugin settings from .claude/my-plugin.local.md
 # Demonstrates the complete pattern for settings-driven hook behavior
 

--- a/plugins/plugin-dev/skills/plugin-settings/scripts/parse-frontmatter.sh
+++ b/plugins/plugin-dev/skills/plugin-settings/scripts/parse-frontmatter.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Frontmatter Parser Utility
 # Extracts YAML frontmatter from .local.md files
 

--- a/plugins/plugin-dev/skills/plugin-settings/scripts/validate-settings.sh
+++ b/plugins/plugin-dev/skills/plugin-settings/scripts/validate-settings.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Settings File Validator
 # Validates .claude/plugin-name.local.md structure
 

--- a/plugins/ralph-wiggum/hooks/stop-hook.sh
+++ b/plugins/ralph-wiggum/hooks/stop-hook.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Ralph Wiggum Stop Hook
 # Prevents session exit when a ralph-loop is active

--- a/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
+++ b/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Ralph Loop Setup Script
 # Creates state file for in-session Ralph loop


### PR DESCRIPTION
Plugin hooks fail on systems where bash is not at `/bin/bash` (ex. on NixOS it lives under /nix/store)

11 plugin scripts still use `#!/bin/bash` while others already use the portable `#!/usr/bin/env bash` 

This aligns the rest.

Partial fix in #11029.