### PR TITLE
Add worktree-guardian plugin: detect orphaned agent worktrees with unsaved work

### DIFF
--- a/plugins/worktree-guardian/.claude-plugin/plugin.json
+++ b/plugins/worktree-guardian/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "worktree-guardian",
+  "version": "1.0.0",
+  "description": "Detects orphaned agent worktrees with uncommitted or unpushed work at session start, preventing silent data loss from stale cleanup"
+}

--- a/plugins/worktree-guardian/README.md
+++ b/plugins/worktree-guardian/README.md
@@ -1,0 +1,66 @@
+# worktree-guardian
+
+Detects orphaned agent worktrees with uncommitted or unpushed work at session start, preventing silent data loss from stale worktree cleanup.
+
+## Problem
+
+When agents use `isolation: "worktree"`, their work can be silently deleted by the stale worktree cleanup if the agent's commits were never pushed to a remote. Three specific scenarios cause this (see [#35862](https://github.com/anthropics/claude-code/issues/35862)):
+
+1. **Resumed worktrees** use the current HEAD as the cleanup baseline instead of the original base commit — if a second agent makes no new commits, the first agent's work is deleted
+2. **Stale cleanup** has no registry of active agent worktrees and can race with long-running agents
+3. **Stale cleanup** uses `git status --porcelain -uno`, which ignores untracked files
+
+## How It Works
+
+### SessionStart hook
+
+On every session start, the plugin scans `.claude/worktrees/agent-*` for worktrees with:
+- Uncommitted changes (including untracked files — unlike the built-in check)
+- Commits not on any remote branch
+- Commits ahead of the merge-base with the default branch
+
+If any are found, it prints a warning with the worktree path, branch name, and a `git push` recovery command.
+
+### `/worktree-audit` command
+
+Run `/worktree-audit` to manually check all agent worktrees and optionally push their branches to protect them.
+
+## Installation
+
+```bash
+claude /plugin worktree-guardian
+```
+
+Or add to `.claude/settings.json`:
+
+```json
+{
+  "enabledPlugins": {
+    "worktree-guardian": true
+  }
+}
+```
+
+## Example Output
+
+```
+worktree-guardian: agent worktrees with unsaved work detected
+
+  /home/user/project/.claude/worktrees/agent-a1b2c3d4
+    branch: worktree-agent-a1b2c3d4 | 3 unpushed commit(s)
+    recover: cd /home/user/project/.claude/worktrees/agent-a1b2c3d4 && git push -u origin worktree-agent-a1b2c3d4
+
+  Run 'git push' in each worktree above to protect the work from cleanup.
+  See: https://github.com/anthropics/claude-code/issues/35862
+```
+
+## Complementary Workaround
+
+For maximum protection, also add this to your project's `CLAUDE.md`:
+
+```
+When working in a worktree (isolation: "worktree"), push your branch before
+reporting completion: git push -u origin $(git branch --show-current)
+```
+
+This ensures the built-in `rev-list HEAD --not --remotes` check always detects the work.

--- a/plugins/worktree-guardian/commands/worktree-audit.md
+++ b/plugins/worktree-guardian/commands/worktree-audit.md
@@ -1,0 +1,11 @@
+Run a full audit of all agent worktrees in this repository.
+
+For each worktree under `.claude/worktrees/agent-*`:
+
+1. Check `git status --porcelain` for uncommitted changes (including untracked files)
+2. Check `git rev-list --count HEAD --not --remotes` for unpushed commits
+3. Check `git rev-list --count $(git merge-base HEAD origin/main)..HEAD` for diverged commits
+4. Report the branch name, path, and recovery command for any worktree with unsaved work
+
+If any worktrees have unsaved work, offer to push their branches to protect them.
+If all worktrees are clean, report that no action is needed.

--- a/plugins/worktree-guardian/hooks/hooks.json
+++ b/plugins/worktree-guardian/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Scans for agent worktrees with uncommitted or unpushed work at session start",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/worktree_guardian.sh"
+          }
+        ],
+        "matcher": ""
+      }
+    ]
+  }
+}

--- a/plugins/worktree-guardian/hooks/worktree_guardian.sh
+++ b/plugins/worktree-guardian/hooks/worktree_guardian.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# worktree-guardian: Detect agent worktrees with uncommitted or unpushed work.
+#
+# Runs at session start. Scans .claude/worktrees/ for agent-created worktrees
+# and warns if any contain work that would be lost by stale cleanup.
+#
+# Protects against:
+#   - Committed-but-not-pushed work (invisible to rev-list --not --remotes)
+#   - Uncommitted changes from interrupted agents
+#   - Untracked files invisible to status --porcelain -uno
+#
+# See: https://github.com/anthropics/claude-code/issues/35862
+
+set -euo pipefail
+
+git_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+worktree_dir="${git_root}/.claude/worktrees"
+
+[ -d "$worktree_dir" ] || exit 0
+
+found_issues=0
+
+for entry in "$worktree_dir"/agent-*; do
+    [ -d "$entry" ] || continue
+
+    name=$(basename "$entry")
+    branch="worktree-${name}"
+
+    # Check for uncommitted changes (including untracked files)
+    uncommitted=$(git -C "$entry" status --porcelain 2>/dev/null || echo "")
+
+    # Check for commits not on any remote
+    local_commits=$(git -C "$entry" rev-list --count HEAD --not --remotes 2>/dev/null || echo "0")
+
+    # Check for commits ahead of merge-base with default branch
+    default_branch=$(git -C "$entry" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || echo "main")
+    merge_base=$(git -C "$entry" merge-base HEAD "origin/${default_branch}" 2>/dev/null || echo "")
+    ahead=0
+    if [ -n "$merge_base" ]; then
+        ahead=$(git -C "$entry" rev-list --count "${merge_base}..HEAD" 2>/dev/null || echo "0")
+    fi
+
+    has_uncommitted=false
+    has_unpushed=false
+
+    if [ -n "$uncommitted" ]; then
+        has_uncommitted=true
+    fi
+
+    if [ "$local_commits" -gt 0 ] || [ "$ahead" -gt 0 ]; then
+        has_unpushed=true
+    fi
+
+    if [ "$has_uncommitted" = true ] || [ "$has_unpushed" = true ]; then
+        if [ "$found_issues" -eq 0 ]; then
+            echo "" >&2
+            echo "worktree-guardian: agent worktrees with unsaved work detected" >&2
+            echo "" >&2
+        fi
+
+        detail=""
+        if [ "$has_uncommitted" = true ] && [ "$has_unpushed" = true ]; then
+            file_count=$(echo "$uncommitted" | wc -l | tr -d ' ')
+            detail="${ahead} unpushed commit(s), ${file_count} uncommitted file(s)"
+        elif [ "$has_unpushed" = true ]; then
+            detail="${ahead} unpushed commit(s)"
+        else
+            file_count=$(echo "$uncommitted" | wc -l | tr -d ' ')
+            detail="${file_count} uncommitted file(s)"
+        fi
+
+        echo "  ${entry}" >&2
+        echo "    branch: ${branch} | ${detail}" >&2
+        echo "    recover: cd ${entry} && git push -u origin ${branch}" >&2
+        echo "" >&2
+
+        found_issues=$((found_issues + 1))
+    fi
+done
+
+if [ "$found_issues" -gt 0 ]; then
+    echo "  Run 'git push' in each worktree above to protect the work from cleanup." >&2
+    echo "  See: https://github.com/anthropics/claude-code/issues/35862" >&2
+    echo "" >&2
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- SessionStart hook that scans `.claude/worktrees/agent-*` for uncommitted changes, untracked files, and unpushed commits — warning before stale cleanup can silently delete them
- `/worktree-audit` command for manual worktree inspection
- Defense-in-depth against three data-loss vectors documented in #35862

## Motivation

Agent worktrees created with `isolation: "worktree"` can have committed work silently destroyed by the stale cleanup under specific conditions ([#35862](https://github.com/anthropics/claude-code/issues/35862)). While those core bugs need internal fixes, this plugin provides immediate protection by detecting at-risk worktrees at session start and giving users a recovery command (`git push`).

## What It Does

On every session start, the hook checks each `agent-*` worktree for:
1. Uncommitted changes (including untracked files — unlike the built-in `-uno` check)
2. Commits not on any remote branch
3. Commits ahead of the merge-base with the default branch

If any worktree has unsaved work, the hook prints the path, branch, and a `git push` recovery command to stderr.

## Example Output

```
worktree-guardian: agent worktrees with unsaved work detected

  /home/user/project/.claude/worktrees/agent-a1b2c3d4
    branch: worktree-agent-a1b2c3d4 | 1 unpushed commit(s), 1 uncommitted file(s)
    recover: cd /home/user/project/.claude/worktrees/agent-a1b2c3d4 && git push -u origin worktree-agent-a1b2c3d4

  Run 'git push' in each worktree above to protect the work from cleanup.
  See: https://github.com/anthropics/claude-code/issues/35862
```

## Test Plan

- [x] Tested with agent worktree containing unpushed commits — correctly detected
- [x] Tested with untracked files (invisible to `-uno`) — correctly detected
- [x] Tested with clean worktree — no output, exits silently
- [x] Tested outside a git repo — exits silently (exit 0)
- [x] Tested with no `.claude/worktrees/` directory — exits silently
- [x] Hook exits 0 in all cases (informational only, never blocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)