### PR TITLE
fix: Add IPv6 firewall rules to devcontainer init script

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -14,6 +14,13 @@ iptables -t mangle -F
 iptables -t mangle -X
 ipset destroy allowed-domains 2>/dev/null || true
 
+# Flush existing IPv6 rules
+ip6tables -F
+ip6tables -X
+ip6tables -t mangle -F
+ip6tables -t mangle -X
+ipset destroy allowed-domains-v6 2>/dev/null || true
+
 # 2. Selectively restore ONLY internal Docker DNS resolution
 if [ -n "$DOCKER_DNS_RULES" ]; then
     echo "Restoring Docker DNS rules..."
@@ -25,20 +32,29 @@ else
 fi
 
 # First allow DNS and localhost before any restrictions
-# Allow outbound DNS
+# Allow outbound DNS (IPv4)
 iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
-# Allow inbound DNS responses
+# Allow inbound DNS responses (IPv4)
 iptables -A INPUT -p udp --sport 53 -j ACCEPT
-# Allow outbound SSH
+# Allow outbound SSH (IPv4)
 iptables -A OUTPUT -p tcp --dport 22 -j ACCEPT
-# Allow inbound SSH responses
+# Allow inbound SSH responses (IPv4)
 iptables -A INPUT -p tcp --sport 22 -m state --state ESTABLISHED -j ACCEPT
-# Allow localhost
+# Allow localhost (IPv4)
 iptables -A INPUT -i lo -j ACCEPT
 iptables -A OUTPUT -o lo -j ACCEPT
 
-# Create ipset with CIDR support
+# Allow DNS, SSH, and localhost (IPv6)
+ip6tables -A OUTPUT -p udp --dport 53 -j ACCEPT
+ip6tables -A INPUT -p udp --sport 53 -j ACCEPT
+ip6tables -A OUTPUT -p tcp --dport 22 -j ACCEPT
+ip6tables -A INPUT -p tcp --sport 22 -m state --state ESTABLISHED -j ACCEPT
+ip6tables -A INPUT -i lo -j ACCEPT
+ip6tables -A OUTPUT -o lo -j ACCEPT
+
+# Create ipsets with CIDR support
 ipset create allowed-domains hash:net
+ipset create allowed-domains-v6 hash:net family inet6
 
 # Fetch GitHub meta information and aggregate + add their IP ranges
 echo "Fetching GitHub IP ranges..."
@@ -53,7 +69,7 @@ if ! echo "$gh_ranges" | jq -e '.web and .api and .git' >/dev/null; then
     exit 1
 fi
 
-echo "Processing GitHub IPs..."
+echo "Processing GitHub IPv4 ranges..."
 while read -r cidr; do
     if [[ ! "$cidr" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$ ]]; then
         echo "ERROR: Invalid CIDR range from GitHub meta: $cidr"
@@ -61,7 +77,16 @@ while read -r cidr; do
     fi
     echo "Adding GitHub range $cidr"
     ipset add allowed-domains "$cidr"
-done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
+done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | grep -v ':' | aggregate -q)
+
+echo "Processing GitHub IPv6 ranges..."
+while read -r cidr; do
+    if [[ ! "$cidr" =~ : ]]; then
+        continue  # Skip non-IPv6 entries
+    fi
+    echo "Adding GitHub IPv6 range $cidr"
+    ipset add allowed-domains-v6 "$cidr"
+done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | grep ':' | sort -u)
 
 # Resolve and add other allowed domains
 for domain in \
@@ -74,6 +99,8 @@ for domain in \
     "vscode.blob.core.windows.net" \
     "update.code.visualstudio.com"; do
     echo "Resolving $domain..."
+
+    # Resolve IPv4 (A records)
     ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}')
     if [ -z "$ips" ]; then
         echo "ERROR: Failed to resolve $domain"
@@ -88,6 +115,19 @@ for domain in \
         echo "Adding $ip for $domain"
         ipset add allowed-domains "$ip"
     done < <(echo "$ips")
+
+    # Resolve IPv6 (AAAA records)
+    ipv6s=$(dig +noall +answer AAAA "$domain" | awk '$4 == "AAAA" {print $5}')
+    if [ -n "$ipv6s" ]; then
+        while read -r ip6; do
+            if [[ ! "$ip6" =~ : ]]; then
+                echo "WARNING: Invalid IPv6 from DNS for $domain: $ip6"
+                continue
+            fi
+            echo "Adding IPv6 $ip6 for $domain"
+            ipset add allowed-domains-v6 "$ip6"
+        done < <(echo "$ipv6s")
+    fi
 done
 
 # Get host IP from default route
@@ -100,26 +140,50 @@ fi
 HOST_NETWORK=$(echo "$HOST_IP" | sed "s/\.[0-9]*$/.0\/24/")
 echo "Host network detected as: $HOST_NETWORK"
 
-# Set up remaining iptables rules
+# Set up remaining iptables rules (IPv4)
 iptables -A INPUT -s "$HOST_NETWORK" -j ACCEPT
 iptables -A OUTPUT -d "$HOST_NETWORK" -j ACCEPT
 
-# Set default policies to DROP first
+# Set default policies to DROP (IPv4)
 iptables -P INPUT DROP
 iptables -P FORWARD DROP
 iptables -P OUTPUT DROP
 
-# First allow established connections for already approved traffic
+# Allow established connections (IPv4)
 iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 
-# Then allow only specific outbound traffic to allowed domains
+# Allow only specific outbound traffic to allowed domains (IPv4)
 iptables -A OUTPUT -m set --match-set allowed-domains dst -j ACCEPT
 
-# Explicitly REJECT all other outbound traffic for immediate feedback
+# Explicitly REJECT all other outbound traffic for immediate feedback (IPv4)
 iptables -A OUTPUT -j REJECT --reject-with icmp-admin-prohibited
 
-echo "Firewall configuration complete"
+# Set up IPv6 rules
+# Allow link-local traffic (required for IPv6 neighbor discovery)
+ip6tables -A INPUT -s fe80::/10 -j ACCEPT
+ip6tables -A OUTPUT -d fe80::/10 -j ACCEPT
+
+# Allow ICMPv6 (required for IPv6 to function: neighbor discovery, router ads, etc.)
+ip6tables -A INPUT -p ipv6-icmp -j ACCEPT
+ip6tables -A OUTPUT -p ipv6-icmp -j ACCEPT
+
+# Set default policies to DROP (IPv6)
+ip6tables -P INPUT DROP
+ip6tables -P FORWARD DROP
+ip6tables -P OUTPUT DROP
+
+# Allow established connections (IPv6)
+ip6tables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+ip6tables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+# Allow only specific outbound traffic to allowed domains (IPv6)
+ip6tables -A OUTPUT -m set --match-set allowed-domains-v6 dst -j ACCEPT
+
+# Explicitly REJECT all other outbound IPv6 traffic for immediate feedback
+ip6tables -A OUTPUT -j REJECT --reject-with icmp6-adm-prohibited
+
+echo "Firewall configuration complete (IPv4 and IPv6)"
 echo "Verifying firewall rules..."
 if curl --connect-timeout 5 https://example.com >/dev/null 2>&1; then
     echo "ERROR: Firewall verification failed - was able to reach https://example.com"


### PR DESCRIPTION
The existing firewall only restricts IPv4 traffic, leaving IPv6 completely open. This adds ip6tables rules that mirror the IPv4 policy: whitelist allowed domains via AAAA record resolution and GitHub's IPv6 CIDR ranges, allow link-local and ICMPv6 for neighbor discovery, and drop all other IPv6 traffic 

Flushes ip6tables rules and allowed-domains-v6 ipset on startup
Mirrors all IPv4 base rules (DNS, SSH, localhost) with ip6tables equivalents
Creates allowed-domains-v6 ipset with family inet6
Filters GitHub /meta API response for IPv6 CIDRs (e.g., 2a0a:a440::/29, 2606:50c0::/32)
Resolves AAAA records for all whitelisted domains
Allows link-local (fe80::/10) and ICMPv6 (required for neighbor discovery)
Sets DROP default policy and REJECT with icmp6-adm-prohibited for immediate feedback
Non-breaking: IPv6 AAAA resolution is optional (warns but continues if a domain has no AAAA records)