### PR TITLE
fix: ralph-wiggum stop hook JSON response uses 'ok' field per schema

### DIFF
--- a/plugins/ralph-wiggum/hooks/stop-hook.sh
+++ b/plugins/ralph-wiggum/hooks/stop-hook.sh
@@ -168,7 +168,7 @@ jq -n \
   --arg prompt "$PROMPT_TEXT" \
   --arg msg "$SYSTEM_MSG" \
   '{
-    "decision": "block",
+    "ok": false,
     "reason": $prompt,
     "systemMessage": $msg
   }'


### PR DESCRIPTION
## Summary
- The ralph-wiggum Stop hook outputs `{"decision": "block", ...}` on line 171 of `plugins/ralph-wiggum/hooks/stop-hook.sh`
- The Claude Code Stop hook schema requires `{"ok": boolean}` with an optional `"reason"` string
- This mismatch causes Claude Code to reject the hook response with: `Invalid request format. Stop hook requires JSON response matching schema: {"ok": boolean}`
- Fix: replace `"decision": "block"` with `"ok": false`

Same bug and fix as anthropics/claude-plugins-official#752 (ralph-loop plugin).

## Test plan
- [ ] Start a ralph-wiggum loop session
- [ ] Let it reach a natural stop point — the stop hook should block exit and feed the prompt back
- [ ] Verify no "Invalid request format" errors in the hook output

🤖 Generated with [Claude Code](https://claude.com/claude-code)