### PR TITLE
feat: add git-branch-info plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -145,6 +145,16 @@
       },
       "source": "./plugins/security-guidance",
       "category": "security"
+    },
+    {
+      "name": "git-branch-info",
+      "description": "Displays current git branch and status info at session start and on demand, keeping branch context always visible",
+      "version": "1.0.0",
+      "author": {
+        "name": "Nick"
+      },
+      "source": "./plugins/git-branch-info",
+      "category": "productivity"
     }
   ]
 }

--- a/plugins/git-branch-info/.claude-plugin/plugin.json
+++ b/plugins/git-branch-info/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "git-branch-info",
+  "version": "1.0.0",
+  "description": "Displays current git branch and status info at session start and on demand, making branch context always visible",
+  "author": {
+    "name": "Nick",
+    "email": ""
+  }
+}

--- a/plugins/git-branch-info/README.md
+++ b/plugins/git-branch-info/README.md
@@ -1,0 +1,17 @@
+# git-branch-info
+
+Makes git branch information always visible in Claude Code sessions.
+
+## What it does
+
+- **Session Start**: Shows current branch, dirty state, and ahead/behind status when you start a session
+- **Every Prompt**: Injects the current branch as context so Claude always knows which branch you're on
+- **`/branch` command**: On-demand detailed git status (branches, commits, upstream tracking)
+
+## Why
+
+Claude Code doesn't natively show which git branch you're working on. This plugin fills that gap by ensuring branch context is always present — similar to how a terminal prompt shows your branch.
+
+## Install
+
+Copy or symlink this plugin directory into your Claude Code plugins path.

--- a/plugins/git-branch-info/commands/branch.md
+++ b/plugins/git-branch-info/commands/branch.md
@@ -1,0 +1,24 @@
+---
+allowed-tools: Bash(git:*)
+description: Show detailed git branch and repository info
+---
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- All local branches: !`git branch -v`
+- Remote tracking: !`git remote -v`
+- Status: !`git status --short`
+- Recent commits on this branch: !`git log --oneline -5`
+- Upstream status: !`git rev-list --left-right --count HEAD...@{upstream} 2>/dev/null || echo "no upstream"`
+
+## Your task
+
+Present a clean, concise summary of the git state. Show:
+1. Current branch (highlighted)
+2. Whether there are uncommitted changes
+3. Ahead/behind upstream status
+4. Recent commits (last 5)
+5. Other local branches
+
+Keep it short and scannable.

--- a/plugins/git-branch-info/hooks-handlers/prompt-submit.sh
+++ b/plugins/git-branch-info/hooks-handlers/prompt-submit.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Injects current branch as context on each user prompt
+# This ensures Claude always knows the active branch, even after switches
+
+branch=$(git branch --show-current 2>/dev/null)
+
+if [ -z "$branch" ]; then
+  exit 0
+fi
+
+dirty=""
+if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+  dirty="*"
+fi
+
+cat << EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "UserPromptSubmit",
+    "additionalContext": "[git] ${branch}${dirty}"
+  }
+}
+EOF

--- a/plugins/git-branch-info/hooks-handlers/session-start.sh
+++ b/plugins/git-branch-info/hooks-handlers/session-start.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Detect git branch and status at session start
+# Returns additionalContext so Claude is always aware of the git state
+
+branch=$(git branch --show-current 2>/dev/null)
+
+if [ -z "$branch" ]; then
+  # Not in a git repo
+  cat << 'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "This directory is not a git repository."
+  }
+}
+EOF
+  exit 0
+fi
+
+# Gather useful git info
+dirty=""
+if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+  dirty=" (dirty)"
+fi
+
+ahead_behind=$(git rev-list --left-right --count HEAD...@{upstream} 2>/dev/null)
+if [ -n "$ahead_behind" ]; then
+  ahead=$(echo "$ahead_behind" | cut -f1)
+  behind=$(echo "$ahead_behind" | cut -f2)
+  sync=""
+  [ "$ahead" -gt 0 ] && sync=" +${ahead}"
+  [ "$behind" -gt 0 ] && sync="${sync} -${behind}"
+else
+  sync=""
+fi
+
+last_commit=$(git log --oneline -1 2>/dev/null)
+
+cat << EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "[git-branch-info] Branch: ${branch}${dirty}${sync} | Last commit: ${last_commit}"
+  }
+}
+EOF

--- a/plugins/git-branch-info/hooks/hooks.json
+++ b/plugins/git-branch-info/hooks/hooks.json
@@ -1,0 +1,25 @@
+{
+  "description": "Shows git branch info at session start and injects branch context on each prompt",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks-handlers/session-start.sh"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks-handlers/prompt-submit.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a new `git-branch-info` plugin that makes git branch context always visible in Claude Code sessions
- **SessionStart hook**: displays branch name, dirty state, ahead/behind upstream, and last commit when a session begins
- **UserPromptSubmit hook**: injects compact branch info (`[git] main*`) as context on every prompt, so Claude always knows the active branch
- **`/branch` command**: on-demand detailed summary of git state (branches, recent commits, upstream tracking)

## Motivation

Claude Code currently doesn't show which git branch you're working on — unlike a normal terminal prompt. This plugin fills that gap using the hook system, ensuring branch awareness is always present during sessions.

## Test plan

- [x] Tested `session-start.sh` outputs valid JSON with correct branch info
- [x] Tested `prompt-submit.sh` outputs valid JSON with compact branch context
- [x] Tested in git repo: `claude --plugin-dir ./plugins/git-branch-info --print "what branch am I on?"` — correctly identifies branch
- [x] Tested `/git-branch-info:branch` command — returns detailed git status summary
- [x] Tested in non-git directory: hook gracefully returns "not a git repository"