### PR TITLE
Fix Pre/PostToolUse message not being shown to Claude

### DIFF
--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -75,7 +75,8 @@ class RuleEngine:
                         "hookEventName": hook_event,
                         "permissionDecision": "deny",
                         "permissionDecisionReason": combined_message
-                    },
+                        },
+                    "systemMessage": combined_message
                 }
             else:
                 # For other events, just show message

--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -73,9 +73,9 @@ class RuleEngine:
                 return {
                     "hookSpecificOutput": {
                         "hookEventName": hook_event,
-                        "permissionDecision": "deny"
+                        "permissionDecision": "deny",
+                        "permissionDecisionReason": combined_message
                     },
-                    "systemMessage": combined_message
                 }
             else:
                 # For other events, just show message


### PR DESCRIPTION
The hookify plugin puts the block message in systemMessage, which Claude Code shows to the user only. It should use permissionDecisionReason inside hookSpecificOutput, which is the field Claude actually sees.

In rule_engine.py:61-78, the current code for PreToolUse blocking:
```
  return {
      "hookSpecificOutput": {
          "hookEventName": hook_event,
          "permissionDecision": "deny"
      },
      "systemMessage": combined_message   # ← User-only! Claude never sees this
  }
```
  Per Claude Code documentation:

| Field |Who sees it       |
|-|-|
| hookSpecificOutput.permissionDecisionReason| Claude (in context) |
| systemMessage | User only (not Claude) |

##  Root Cause Verification

  Causation test: If permissionDecisionReason is added, Claude will receive the block message content (MCP instructions) and can act on it. This resolves the symptom of Claude ignoring the hook.

  Evidence completeness: This explains ALL symptoms:
  - Hook triggers → permissionDecision: "deny" works correctly
  - Command is blocked → deny is processed
  - User sees message in terminal → systemMessage goes to user
  - Claude doesn't follow instructions → permissionDecisionReason is missing, so Claude gets only generic "Blocked by hook"


## Resolution Plan

Fix in rule_engine.py:72-78 — change the PreToolUse/PostToolUse block to:
```
  return {
      "hookSpecificOutput": {
          "hookEventName": hook_event,
          "permissionDecision": "deny",
          "permissionDecisionReason": combined_message  # ← Claude sees this
      }
  }
```