### PR TITLE
Add tmp-cwd-cleanup plugin: Stop hook for /tmp/claude-*-cwd leak (#8856)

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -25,6 +25,7 @@ Learn more in the [official plugins documentation](https://docs.claude.com/en/do
 | [pr-review-toolkit](./pr-review-toolkit/) | Comprehensive PR review agents specializing in comments, tests, error handling, type design, code quality, and code simplification | **Command:** `/pr-review-toolkit:review-pr` - Run with optional review aspects (comments, tests, errors, types, code, simplify, all)<br>**Agents:** `comment-analyzer`, `pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer`, `code-reviewer`, `code-simplifier` |
 | [ralph-wiggum](./ralph-wiggum/) | Interactive self-referential AI loops for iterative development. Claude works on the same task repeatedly until completion | **Commands:** `/ralph-loop`, `/cancel-ralph` - Start/stop autonomous iteration loops<br>**Hook:** Stop - Intercepts exit attempts to continue iteration |
 | [security-guidance](./security-guidance/) | Security reminder hook that warns about potential security issues when editing files | **Hook:** PreToolUse - Monitors 9 security patterns including command injection, XSS, eval usage, dangerous HTML, pickle deserialization, and os.system calls |
+| [tmp-cwd-cleanup](./tmp-cwd-cleanup/) | Cleans up orphaned `/tmp/claude-*-cwd` files on session exit, working around a Bash tool memory leak ([#8856](https://github.com/anthropics/claude-code/issues/8856)) | **Hook:** Stop - Deletes accumulated working-directory tracking files owned by the current user |
 
 ## Installation
 

--- a/plugins/tmp-cwd-cleanup/.claude-plugin/plugin.json
+++ b/plugins/tmp-cwd-cleanup/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "tmp-cwd-cleanup",
+  "version": "1.0.0",
+  "description": "Cleans up orphaned /tmp/claude-*-cwd working directory tracking files on session stop, working around a memory leak in the Bash tool (issue #8856)",
+  "author": {
+    "name": "Claude Code Community",
+    "email": ""
+  }
+}

--- a/plugins/tmp-cwd-cleanup/README.md
+++ b/plugins/tmp-cwd-cleanup/README.md
@@ -1,0 +1,41 @@
+# tmp-cwd-cleanup
+
+A workaround plugin for [issue #8856](https://github.com/anthropics/claude-code/issues/8856): the Bash tool creates a `/tmp/claude-<hex>-cwd` file after every shell command to track the working directory, but never deletes it. On active systems these files accumulate into the thousands and eventually slow down `/tmp` lookups.
+
+## What it does
+
+Registers a **Stop hook** that deletes all `/tmp/claude-*-cwd` files owned by the current user when the Claude Code session ends.
+
+```
+/tmp/claude-02a6-cwd   (22 bytes — deleted on exit)
+/tmp/claude-1f3b-cwd   (22 bytes — deleted on exit)
+...
+```
+
+## Installation
+
+Install via the `/plugin` command inside Claude Code:
+
+```
+/plugin install tmp-cwd-cleanup
+```
+
+Or add it manually to your `.claude/settings.json`:
+
+```json
+{
+  "plugins": ["tmp-cwd-cleanup"]
+}
+```
+
+## Notes
+
+- Only removes files owned by the **current user** (safe on shared systems).
+- Exits `0` so it never blocks session teardown.
+- This plugin is a stopgap; the proper fix is to call `unlinkSync` in the Bash tool implementation immediately after reading the cwd file ([upstream tracking issue #8856](https://github.com/anthropics/claude-code/issues/8856)).
+
+## Hook
+
+| Event | Matcher | Effect |
+|-------|---------|--------|
+| `Stop` | _(all)_ | Deletes `/tmp/claude-*-cwd` files owned by current user |

--- a/plugins/tmp-cwd-cleanup/hooks/cleanup_cwd_files.py
+++ b/plugins/tmp-cwd-cleanup/hooks/cleanup_cwd_files.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Stop hook: clean up orphaned /tmp/claude-*-cwd files.
+
+The Bash tool writes a small temp file to /tmp/claude-<hex>-cwd after each
+command to capture the resulting working directory, but never deletes it.
+On active systems these files accumulate into the thousands and eventually
+slow down /tmp lookups (see issue #8856).
+
+This hook runs on session Stop and removes any such files owned by the
+current user, providing a clean-up path until the upstream fix lands.
+"""
+
+import glob
+import json
+import os
+import sys
+
+
+def main() -> None:
+    # Consume stdin (required by the hook protocol) but we don't need it.
+    try:
+        json.load(sys.stdin)
+    except Exception:
+        pass
+
+    uid = os.getuid() if hasattr(os, "getuid") else None  # no-op on Windows
+    removed = 0
+    errors = 0
+
+    for path in glob.glob("/tmp/claude-*-cwd"):
+        try:
+            # Only remove files owned by the current user (safety check).
+            if uid is not None and os.stat(path).st_uid != uid:
+                continue
+            if os.path.isfile(path):
+                os.unlink(path)
+                removed += 1
+        except OSError:
+            errors += 1
+
+    # Exit 0 so the Stop event is never blocked.
+    # Optionally surface a brief summary via systemMessage.
+    if removed > 0:
+        result = {"systemMessage": f"tmp-cwd-cleanup: removed {removed} orphaned file(s)."}
+        if errors:
+            result["systemMessage"] += f" ({errors} error(s) skipped)"
+        print(json.dumps(result))
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/tmp-cwd-cleanup/hooks/hooks.json
+++ b/plugins/tmp-cwd-cleanup/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "description": "Cleans up orphaned /tmp/claude-*-cwd working directory tracking files when the session stops",
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/cleanup_cwd_files.py"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new `tmp-cwd-cleanup` plugin that works around the memory leak described in #8856.

**The bug:** The Bash tool appends `pwd -P >| /tmp/claude-<hex>-cwd` to every shell command to track the working directory after execution, but `unlinkSync` is never called on the file. On active systems, users report **174+ orphaned files per 12 hours** that accumulate indefinitely until the OS clears `/tmp` (daily on most distros).

**This plugin:** Registers a `Stop` hook that deletes all `/tmp/claude-*-cwd` files owned by the current user when the session ends.

```
/tmp/claude-02a6-cwd  (22 bytes) → deleted on Stop
/tmp/claude-1f3b-cwd  (22 bytes) → deleted on Stop
...
```

Key properties:
- Only removes files **owned by the current user** (safe on multi-user/shared systems)
- Always exits `0` — never blocks session teardown
- ~50 lines of straightforward Python with no dependencies

This is an explicit stopgap: the `README.md` and inline comment both point to the upstream fix (`unlinkSync` after reading the cwd file) and note this plugin can be removed once that lands.

## Files changed

| File | Purpose |
|------|---------|
| `plugins/tmp-cwd-cleanup/.claude-plugin/plugin.json` | Plugin metadata |
| `plugins/tmp-cwd-cleanup/hooks/hooks.json` | Registers Stop hook |
| `plugins/tmp-cwd-cleanup/hooks/cleanup_cwd_files.py` | Cleanup logic |
| `plugins/tmp-cwd-cleanup/README.md` | User-facing docs |
| `plugins/README.md` | Added entry to the plugin table |

## Test plan

- [ ] Trigger several Bash tool calls; confirm `/tmp/claude-*-cwd` files accumulate as expected
- [ ] Install the plugin and end the session; confirm files are removed
- [ ] Verify no files belonging to other users are touched (UID check)
- [ ] Verify session teardown is not delayed or blocked (exit code is always 0)

Closes #8856 (workaround until upstream `unlinkSync` fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)