### PR TITLE
feat(plugins): add spinner-customization plugin

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -25,6 +25,7 @@ Learn more in the [official plugins documentation](https://docs.claude.com/en/do
 | [pr-review-toolkit](./pr-review-toolkit/) | Comprehensive PR review agents specializing in comments, tests, error handling, type design, code quality, and code simplification | **Command:** `/pr-review-toolkit:review-pr` - Run with optional review aspects (comments, tests, errors, types, code, simplify, all)<br>**Agents:** `comment-analyzer`, `pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer`, `code-reviewer`, `code-simplifier` |
 | [ralph-wiggum](./ralph-wiggum/) | Interactive self-referential AI loops for iterative development. Claude works on the same task repeatedly until completion | **Commands:** `/ralph-loop`, `/cancel-ralph` - Start/stop autonomous iteration loops<br>**Hook:** Stop - Intercepts exit attempts to continue iteration |
 | [security-guidance](./security-guidance/) | Security reminder hook that warns about potential security issues when editing files | **Hook:** PreToolUse - Monitors 9 security patterns including command injection, XSS, eval usage, dangerous HTML, pickle deserialization, and os.system calls |
+| [spinner-customization](./spinner-customization/) | Switch between spinner verb modes (quirky, plain, minimal, none) without editing settings manually | **Commands:** `/spinner-mode` - Set spinner verb style, `/spinner-preview` - Preview all available modes |
 
 ## Installation
 

--- a/plugins/spinner-customization/.claude-plugin/plugin.json
+++ b/plugins/spinner-customization/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "spinner-customization",
+  "version": "1.0.0",
+  "description": "Switch between spinner verb modes (quirky, plain, minimal, none) without manually editing settings.json",
+  "author": {
+    "name": "Ignoramuss",
+    "email": ""
+  }
+}

--- a/plugins/spinner-customization/README.md
+++ b/plugins/spinner-customization/README.md
@@ -1,0 +1,55 @@
+# Spinner Customization Plugin
+
+Switch between spinner verb modes without manually editing `settings.json`.
+
+Addresses [#34700](https://github.com/anthropics/claude-code/issues/34700) — users who find the default quirky spinner verbs ("Bloviating", "Perambulating", etc.) distracting can switch to professional, minimal, or silent alternatives with a single command.
+
+## Commands
+
+### `/spinner-mode [quirky|plain|minimal|none]`
+
+Sets the spinner verb style by updating `spinnerVerbs` in `~/.claude/settings.json`.
+
+| Mode | Verbs | Use case |
+|------|-------|----------|
+| `quirky` | Default playful verbs | Fun, casual usage |
+| `plain` | "Processing", "Analyzing", "Searching", ... | Screen sharing, demos, professional environments |
+| `minimal` | "Working", "Thinking", "Running" | Low distraction |
+| `none` | No text | Spinner icon only |
+
+```bash
+/spinner-mode plain
+```
+
+### `/spinner-preview`
+
+Shows a preview of all available modes and their verb sets.
+
+```bash
+/spinner-preview
+```
+
+## How it works
+
+The plugin uses Claude Code's built-in `spinnerVerbs` setting. The `/spinner-mode` command reads your `~/.claude/settings.json`, updates the `spinnerVerbs` key with the selected verb set, and writes it back — preserving all other settings.
+
+Choosing `quirky` removes the override so the built-in defaults are used.
+
+## Installation
+
+This plugin is included in the Claude Code repository. Copy the `spinner-customization` directory into your project's `.claude/plugins/` folder, or add it to your global plugins directory.
+
+To enable it, add the plugin to your `.claude/settings.json`:
+
+```json
+{
+  "enabledPlugins": ["spinner-customization"]
+}
+```
+
+## Related
+
+- [#34700](https://github.com/anthropics/claude-code/issues/34700) — Allow customizing or disabling spinner/loading messages
+- [#34541](https://github.com/anthropics/claude-code/issues/34541) — Customize spinner animation frames via settings
+- `spinnerVerbs` setting ([CHANGELOG](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md))
+- `spinnerTipsOverride` setting ([CHANGELOG](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md))

--- a/plugins/spinner-customization/commands/spinner-mode.md
+++ b/plugins/spinner-customization/commands/spinner-mode.md
@@ -1,0 +1,90 @@
+---
+allowed-tools: Read, Write
+description: "Switch spinner verb mode: /spinner-mode [quirky|plain|minimal|none]"
+---
+
+## Context
+
+The user wants to change their spinner verb style. The argument provided is: `$ARGUMENTS`
+
+Valid modes:
+- **quirky** — restore the default playful verbs (removes the `spinnerVerbs` override)
+- **plain** — descriptive, professional verbs
+- **minimal** — single-word status indicators
+- **none** — no spinner text at all (empty verbs)
+
+## Spinner verb sets
+
+### plain
+
+```json
+{
+  "spinnerVerbs": {
+    "mode": "replace",
+    "verbs": [
+      "Processing",
+      "Analyzing",
+      "Searching",
+      "Reading",
+      "Writing",
+      "Computing",
+      "Evaluating",
+      "Preparing",
+      "Generating",
+      "Formatting",
+      "Reviewing",
+      "Compiling",
+      "Resolving",
+      "Building",
+      "Scanning",
+      "Indexing",
+      "Checking",
+      "Verifying",
+      "Parsing",
+      "Loading"
+    ]
+  }
+}
+```
+
+### minimal
+
+```json
+{
+  "spinnerVerbs": {
+    "mode": "replace",
+    "verbs": [
+      "Working",
+      "Thinking",
+      "Running"
+    ]
+  }
+}
+```
+
+### none
+
+```json
+{
+  "spinnerVerbs": {
+    "mode": "replace",
+    "verbs": [""]
+  }
+}
+```
+
+### quirky
+
+Remove the `spinnerVerbs` key entirely from settings to restore defaults.
+
+## Your task
+
+1. Validate the argument is one of: `quirky`, `plain`, `minimal`, `none`. If missing or invalid, list the available modes and ask the user to pick one.
+2. Read `~/.claude/settings.json` (create it with `{}` if it does not exist).
+3. Apply the selected mode:
+   - For `quirky`: remove the `spinnerVerbs` key from the settings object.
+   - For `plain`, `minimal`, `none`: set the `spinnerVerbs` key to the corresponding JSON object shown above.
+4. Write the updated settings back to `~/.claude/settings.json`, preserving all other existing settings.
+5. Confirm the change to the user with a one-line summary.
+
+Do not modify any other settings. Do not add comments to the JSON.

--- a/plugins/spinner-customization/commands/spinner-preview.md
+++ b/plugins/spinner-customization/commands/spinner-preview.md
@@ -1,0 +1,26 @@
+---
+allowed-tools: []
+description: Preview all available spinner verb modes
+---
+
+## Your task
+
+Display a formatted preview of all spinner verb modes available via `/spinner-mode`:
+
+**quirky** (default)
+Uses Claude Code's built-in playful verbs like "Bloviating", "Perambulating", "Cogitating", etc.
+
+**plain**
+Processing, Analyzing, Searching, Reading, Writing, Computing, Evaluating, Preparing, Generating, Formatting, Reviewing, Compiling, Resolving, Building, Scanning, Indexing, Checking, Verifying, Parsing, Loading
+
+**minimal**
+Working, Thinking, Running
+
+**none**
+No spinner text displayed.
+
+---
+
+To apply a mode: `/spinner-mode <mode>`
+
+Present this information clearly. Do not use any tools.


### PR DESCRIPTION
## Summary

- Adds a `spinner-customization` plugin with `/spinner-mode` and `/spinner-preview` commands
- Lets users switch between spinner verb styles (quirky, plain, minimal, none) by updating `spinnerVerbs` in `~/.claude/settings.json`
- Follows the `commit-commands` plugin pattern (command-based, scoped `allowed-tools`)

Issue #34700

## How it works

The `/spinner-mode` command reads the user's `~/.claude/settings.json`, sets the `spinnerVerbs` key to a pre-built verb set matching the chosen mode, and writes it back — preserving all other settings. Choosing `quirky` removes the override to restore defaults.

## Test plan

- [ ] Install plugin locally and run `/spinner-preview` — verify all four modes display correctly
- [ ] Run `/spinner-mode plain` — verify `~/.claude/settings.json` is updated with plain verbs and spinner text changes
- [ ] Run `/spinner-mode minimal` — verify only "Working", "Thinking", "Running" appear
- [ ] Run `/spinner-mode none` — verify no spinner text is shown
- [ ] Run `/spinner-mode quirky` — verify `spinnerVerbs` key is removed and defaults restore
- [ ] Run `/spinner-mode` with no argument — verify it prompts for a mode
- [ ] Verify existing settings are preserved when switching modes
- [ ] Run `claude plugin validate plugins/spinner-customization` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)