### PR TITLE
fix: remove client-side scope gate blocking Claude.ai MCP servers

### DIFF
--- a/scripts/fix-21874-scope-check.patch
+++ b/scripts/fix-21874-scope-check.patch
@@ -1,0 +1,71 @@
+--- a/src/claudeai-mcp/fetch-servers.ts (conceptual, from minified cli.js)
++++ b/src/claudeai-mcp/fetch-servers.ts
+@@ Description:
+  Fix #21874: Claude.ai MCPs not showing up due to client-side scope gate.
+
+  The fetchClaudeAiMcpServers() function (minified as $Y6) performs an
+  early return when the OAuth token lacks the "user:mcp_servers" scope.
+  This prevents MCP servers from loading even when the server would
+  accept the request.
+
+  The root cause is that GrowthBook evaluates the
+  "tengu_claudeai_mcp_connectors" feature flag per-user based on
+  anonymousId. When this flag is false, the OAuth server may not grant
+  the scope, and the client then blocks the fetch entirely.
+
+  This patch removes the early return, allowing the fetch to proceed.
+  The server remains the authority on access control.
+
+--- BEFORE (minified cli.js) ---
+
+  $Y6 = z1(async () => {
+    try {
+      if (dY(process.env.ENABLE_CLAUDEAI_MCP_SERVERS))
+        return V("[claudeai-mcp] Disabled via env var"),
+          Q("tengu_claudeai_mcp_eligibility", { state: "disabled_env_var" }),
+          {};
+
+      let A = hA();
+      if (!A?.accessToken)
+        return V("[claudeai-mcp] No access token"),
+          Q("tengu_claudeai_mcp_eligibility", { state: "no_oauth_token" }),
+          {};
+
+-     if (!A.scopes?.includes("user:mcp_servers"))
+-       return V(`[claudeai-mcp] Missing user:mcp_servers scope (...)`),
+-         Q("tengu_claudeai_mcp_eligibility", { state: "missing_scope" }),
+-         {};
+
+      let K = `${iA().BASE_API_URL}/v1/mcp_servers?limit=1000`;
+      // ... fetch and return servers ...
+    } catch {
+      return V("[claudeai-mcp] Fetch failed"), {};
+    }
+  });
+
+--- AFTER (minified cli.js) ---
+
+  $Y6 = z1(async () => {
+    try {
+      if (dY(process.env.ENABLE_CLAUDEAI_MCP_SERVERS))
+        return V("[claudeai-mcp] Disabled via env var"),
+          Q("tengu_claudeai_mcp_eligibility", { state: "disabled_env_var" }),
+          {};
+
+      let A = hA();
+      if (!A?.accessToken)
+        return V("[claudeai-mcp] No access token"),
+          Q("tengu_claudeai_mcp_eligibility", { state: "no_oauth_token" }),
+          {};
+
++     if (!A.scopes?.includes("user:mcp_servers"))
++       V(`[claudeai-mcp] Missing user:mcp_servers scope (...), will attempt fetch`),
++         Q("tengu_claudeai_mcp_eligibility", { state: "missing_scope_retry" });
++     // No early return - proceed with fetch and let the server decide
+
+      let K = `${iA().BASE_API_URL}/v1/mcp_servers?limit=1000`;
+      // ... fetch and return servers ...
+    } catch {
+      return V("[claudeai-mcp] Fetch failed"), {};
+    }
+  });

--- a/scripts/fix-claudeai-mcp-scope-check.py
+++ b/scripts/fix-claudeai-mcp-scope-check.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Fix for GitHub Issue #21874: Claude.ai MCPs not showing up on Claude Code
+
+Root Cause:
+  The claudeai MCP server loading function ($Y6 in minified code) performs a
+  client-side check for the "user:mcp_servers" OAuth scope before attempting
+  to fetch MCP servers from the API. When the GrowthBook feature flag
+  "tengu_claudeai_mcp_connectors" evaluates to false for a user (based on
+  their anonymousId), the OAuth server may not grant the "user:mcp_servers"
+  scope. The client-side check then returns early with an empty object {},
+  preventing any MCP servers from loading - even if the server would actually
+  serve the request.
+
+Fix:
+  Remove the early return on missing "user:mcp_servers" scope. Instead, log a
+  warning and proceed with the API fetch. If the server rejects the request
+  (401/403), the existing catch block returns {} gracefully. If the server
+  accepts the request (because the feature was enabled server-side despite the
+  cached scope not reflecting it), the MCP servers load correctly.
+
+  This is a safe change because:
+  1. The server remains the authority on access control
+  2. The catch block already handles fetch failures
+  3. Stale cached scopes no longer block MCP server discovery
+
+Usage:
+  python3 scripts/fix-claudeai-mcp-scope-check.py [path-to-cli.js]
+
+  If no path is provided, the script will attempt to locate cli.js from
+  the installed Claude Code package.
+"""
+
+import os
+import sys
+import glob
+import shutil
+
+def find_cli_js():
+    """Locate the installed cli.js file."""
+    candidates = []
+
+    # npm global install
+    npm_global = os.path.expanduser("~/.npm/_npx/**/node_modules/@anthropic-ai/claude-code/cli.js")
+    candidates.extend(glob.glob(npm_global, recursive=True))
+
+    # npx cache
+    npx_cache = os.path.expanduser("~/.npm/_npx/**/cli.js")
+    candidates.extend(glob.glob(npx_cache, recursive=True))
+
+    # Homebrew
+    brew_path = "/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js"
+    if os.path.exists(brew_path):
+        candidates.append(brew_path)
+
+    # Standard npm global on Linux
+    linux_path = "/usr/lib/node_modules/@anthropic-ai/claude-code/cli.js"
+    if os.path.exists(linux_path):
+        candidates.append(linux_path)
+
+    # Local node_modules
+    local_path = os.path.join(os.getcwd(), "node_modules/@anthropic-ai/claude-code/cli.js")
+    if os.path.exists(local_path):
+        candidates.append(local_path)
+
+    return candidates
+
+
+def apply_patch(cli_js_path):
+    """Apply the scope-check fix to cli.js."""
+
+    if not os.path.exists(cli_js_path):
+        print(f"ERROR: File not found: {cli_js_path}")
+        return False
+
+    with open(cli_js_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    # The old code: returns empty {} when user:mcp_servers scope is missing.
+    # This prevents MCP servers from loading even if the server would allow it.
+    old_text = (
+        'if(!A.scopes?.includes("user:mcp_servers"))'
+        "return V(`[claudeai-mcp] Missing user:mcp_servers scope "
+        '(scopes=${A.scopes?.join(",")||"none"})`),'
+        'Q("tengu_claudeai_mcp_eligibility",{state:"missing_scope"}),{};'
+    )
+
+    # The new code: logs warning but continues to attempt the API fetch.
+    # If the server rejects, the existing catch block handles it.
+    new_text = (
+        'if(!A.scopes?.includes("user:mcp_servers"))'
+        "V(`[claudeai-mcp] Missing user:mcp_servers scope "
+        '(scopes=${A.scopes?.join(",")||"none"}), will attempt fetch`),'
+        'Q("tengu_claudeai_mcp_eligibility",{state:"missing_scope_retry"});'
+    )
+
+    # Check if already patched
+    if new_text in content:
+        print("Already patched! No changes needed.")
+        return True
+
+    # Find and replace
+    count = content.count(old_text)
+    if count == 0:
+        print("ERROR: Could not find the scope-check code to patch.")
+        print("The installed version may be different from the expected version.")
+        print("Expected pattern (first 80 chars):")
+        print(f"  {old_text[:80]}...")
+        return False
+    elif count > 1:
+        print(f"ERROR: Found {count} occurrences of the pattern (expected 1).")
+        print("Aborting to avoid unintended changes.")
+        return False
+
+    # Create backup
+    backup_path = cli_js_path + ".backup"
+    if not os.path.exists(backup_path):
+        shutil.copy2(cli_js_path, backup_path)
+        print(f"Backup created: {backup_path}")
+
+    # Apply patch
+    patched = content.replace(old_text, new_text, 1)
+
+    with open(cli_js_path, "w", encoding="utf-8") as f:
+        f.write(patched)
+
+    print(f"Patch applied successfully to: {cli_js_path}")
+    print()
+    print("What changed:")
+    print("  BEFORE: Missing user:mcp_servers scope -> return {} (no MCP servers)")
+    print("  AFTER:  Missing user:mcp_servers scope -> log warning, attempt fetch anyway")
+    print()
+    print("The server remains the authority on access control.")
+    print("If the server rejects the request, no MCP servers will load (same as before).")
+    print("If the server accepts, MCP servers will now load correctly.")
+    return True
+
+
+def main():
+    if len(sys.argv) > 1:
+        path = sys.argv[1]
+        if os.path.isfile(path):
+            success = apply_patch(path)
+            sys.exit(0 if success else 1)
+        else:
+            print(f"ERROR: {path} is not a file.")
+            sys.exit(1)
+
+    # Auto-discover cli.js
+    candidates = find_cli_js()
+    if not candidates:
+        print("Could not auto-discover cli.js.")
+        print()
+        print("Usage: python3 fix-claudeai-mcp-scope-check.py <path-to-cli.js>")
+        print()
+        print("To find your cli.js, try:")
+        print("  npm root -g  # then look for @anthropic-ai/claude-code/cli.js")
+        print("  which claude # then trace the symlink")
+        sys.exit(1)
+
+    print(f"Found {len(candidates)} candidate(s):")
+    for c in candidates:
+        print(f"  {c}")
+    print()
+
+    for path in candidates:
+        print(f"Patching: {path}")
+        apply_patch(path)
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-fix-21874.js
+++ b/scripts/test-fix-21874.js
@@ -1,0 +1,200 @@
+/**
+ * Test that the patch correctly changes behavior:
+ * - BEFORE: missing scope -> early return {} (no fetch attempted)
+ * - AFTER:  missing scope -> log warning, continue to fetch
+ *
+ * We extract and test the relevant code path by simulating the
+ * function's behavior with mock dependencies.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+// ── Helpers ──
+
+function extractFetchFn(cliJsContent) {
+  // Find the scope check inside the MCP fetch function.
+  // Use "Missing user:mcp_servers scope" as the unique anchor
+  // (appears only once, inside the $Y6 function).
+  const anchor = "Missing user:mcp_servers scope";
+  const anchorIdx = cliJsContent.indexOf(anchor);
+  if (anchorIdx === -1) throw new Error("Could not find scope check anchor in cli.js");
+
+  const start = Math.max(0, anchorIdx - 500);
+  const end = Math.min(cliJsContent.length, anchorIdx + 500);
+  return cliJsContent.slice(start, end);
+}
+
+function checkHasEarlyReturn(chunk) {
+  // Look for the pattern: includes("user:mcp_servers"))return V(`...Missing
+  // vs: includes("user:mcp_servers"))V(`...Missing
+  const scopeLine = chunk.match(/includes\("user:mcp_servers"\)\)(return\s+V|V)\(/);
+  if (!scopeLine) return null;
+  return scopeLine[1].startsWith("return");
+}
+
+// ── Run tests ──
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (e) {
+    console.error(`  ✗ ${name}: ${e.message}`);
+    failed++;
+  }
+}
+
+function assert(condition, msg) {
+  if (!condition) throw new Error(msg || "Assertion failed");
+}
+
+console.log("=== Testing original (unpatched) cli.js ===\n");
+
+const originalContent = fs.readFileSync(
+  path.join(__dirname, "package/cli.js.orig.js"),
+  "utf-8"
+);
+
+const originalChunk = extractFetchFn(originalContent);
+
+test("Original has early return on missing scope", () => {
+  const hasReturn = checkHasEarlyReturn(originalChunk);
+  assert(hasReturn === true, `Expected early return, got: ${hasReturn}`);
+});
+
+test("Original contains 'missing_scope' state (not retry)", () => {
+  assert(
+    originalChunk.includes('"missing_scope"'),
+    "missing_scope state not found"
+  );
+  assert(
+    !originalChunk.includes('"missing_scope_retry"'),
+    "missing_scope_retry should NOT be in original"
+  );
+});
+
+test("Original returns {} after scope check", () => {
+  // The pattern: Q("tengu_claudeai_mcp_eligibility",{state:"missing_scope"}),{};
+  assert(
+    originalChunk.includes('state:"missing_scope"}),{}'),
+    "Early return {} pattern not found"
+  );
+});
+
+console.log("\n=== Testing patched cli.js ===\n");
+
+const patchedContent = fs.readFileSync(
+  path.join(__dirname, "package/cli.js"),
+  "utf-8"
+);
+
+const patchedChunk = extractFetchFn(patchedContent);
+
+test("Patched does NOT have early return on missing scope", () => {
+  const hasReturn = checkHasEarlyReturn(patchedChunk);
+  assert(hasReturn === false, `Expected no early return, got: ${hasReturn}`);
+});
+
+test("Patched contains 'missing_scope_retry' state", () => {
+  assert(
+    patchedChunk.includes('"missing_scope_retry"'),
+    "missing_scope_retry state not found"
+  );
+});
+
+test("Patched does NOT return {} after scope check", () => {
+  assert(
+    !patchedChunk.includes('state:"missing_scope"}),{}'),
+    "Early return {} pattern should NOT be in patched version"
+  );
+});
+
+test("Patched contains 'will attempt fetch' log message", () => {
+  assert(
+    patchedChunk.includes("will attempt fetch"),
+    "'will attempt fetch' message not found"
+  );
+});
+
+test("Patched still proceeds to fetch URL after scope check", () => {
+  // After the scope check, the code should continue to:
+  // let K=`${iA().BASE_API_URL}/v1/mcp_servers?limit=1000`
+  const scopeIdx = patchedChunk.indexOf("missing_scope_retry");
+  const fetchIdx = patchedChunk.indexOf("/v1/mcp_servers", scopeIdx);
+  assert(fetchIdx > scopeIdx, "Fetch URL should come after scope check");
+});
+
+console.log("\n=== Testing behavioral simulation ===\n");
+
+// Simulate the patched behavior with mocks
+test("Simulated: token with scope -> fetch proceeds", () => {
+  const token = { accessToken: "test", scopes: ["user:inference", "user:mcp_servers"] };
+  const hasScope = token.scopes?.includes("user:mcp_servers");
+  assert(hasScope === true, "Scope should be present");
+  // In both old and new code, fetch proceeds
+});
+
+test("Simulated: token without scope -> old code returns early", () => {
+  const token = { accessToken: "test", scopes: ["user:inference"] };
+  const hasScope = token.scopes?.includes("user:mcp_servers");
+  assert(hasScope === false, "Scope should be missing");
+  // Old code: return {}
+  // We verify the original code has "return" here
+  const hasReturn = checkHasEarlyReturn(originalChunk);
+  assert(hasReturn === true, "Original should return early");
+});
+
+test("Simulated: token without scope -> new code continues to fetch", () => {
+  const token = { accessToken: "test", scopes: ["user:inference"] };
+  const hasScope = token.scopes?.includes("user:mcp_servers");
+  assert(hasScope === false, "Scope should be missing");
+  // New code: log warning, continue
+  const hasReturn = checkHasEarlyReturn(patchedChunk);
+  assert(hasReturn === false, "Patched should NOT return early");
+});
+
+test("Simulated: token with no scopes at all -> new code continues to fetch", () => {
+  const token = { accessToken: "test", scopes: null };
+  const hasScope = token.scopes?.includes("user:mcp_servers");
+  assert(hasScope === undefined || hasScope === false, "Scope should be falsy");
+  // New code still continues (the if block runs but doesn't return)
+  const hasReturn = checkHasEarlyReturn(patchedChunk);
+  assert(hasReturn === false, "Patched should NOT return early");
+});
+
+console.log("\n=== Testing patch script idempotency ===\n");
+
+test("Patch script detects already-patched file", () => {
+  // The patch script checks for new_text in content
+  assert(
+    patchedContent.includes("missing_scope_retry"),
+    "Patched file should contain retry marker"
+  );
+  assert(
+    !patchedContent.includes('state:"missing_scope"}),{}'),
+    "Patched file should not contain old early-return"
+  );
+});
+
+test("Patch script would find target in original file", () => {
+  const oldText =
+    'if(!A.scopes?.includes("user:mcp_servers"))' +
+    "return V(`[claudeai-mcp] Missing user:mcp_servers scope " +
+    '(scopes=${A.scopes?.join(",")||"none"})`),' +
+    'Q("tengu_claudeai_mcp_eligibility",{state:"missing_scope"}),{};';
+  assert(originalContent.includes(oldText), "Original should contain old text");
+  assert(!patchedContent.includes(oldText), "Patched should not contain old text");
+});
+
+// ── Summary ──
+
+console.log(`\n${"=".repeat(50)}`);
+console.log(`Results: ${passed} passed, ${failed} failed`);
+console.log("=".repeat(50));
+
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Fixes #21874

- Removes the client-side early return in the Claude.ai MCP server loading function when the `user:mcp_servers` OAuth scope is missing
- Instead of blocking the fetch entirely, logs a warning and proceeds with the API request
- The server remains the authority on access control — if it rejects, the existing catch block returns `{}` gracefully

## Root Cause Analysis

The `fetchClaudeAiMcpServers` function (minified as `$Y6` in `cli.js`) checks if the OAuth token includes the `user:mcp_servers` scope before attempting to fetch MCP servers. When the GrowthBook feature flag `tengu_claudeai_mcp_connectors` evaluates to `false` for a user (based on their `anonymousId`), the OAuth server may not grant this scope. The client-side check then returns an empty object `{}`, preventing any MCP servers from loading.

This affects users inconsistently because:
- The GrowthBook evaluation is per-`anonymousId`, so the same account on different machines can get different results
- The cached scope from the initial OAuth flow persists, and even token refreshes may not upgrade the scope
- No client-side workaround exists (manually editing `~/.claude.json` is overwritten on restart)

## Changes

### Patch Script (`scripts/fix-claudeai-mcp-scope-check.py`)
A Python script that patches the installed `cli.js` to remove the early return:

```python
# Before: returns {} immediately if scope is missing
if(!A.scopes?.includes("user:mcp_servers"))
  return V(`[claudeai-mcp] Missing user:mcp_servers scope ...`),
    Q("tengu_claudeai_mcp_eligibility", {state: "missing_scope"}), {};

# After: logs warning but continues to attempt the fetch
if(!A.scopes?.includes("user:mcp_servers"))
  V(`[claudeai-mcp] Missing user:mcp_servers scope ..., will attempt fetch`),
    Q("tengu_claudeai_mcp_eligibility", {state: "missing_scope_retry"});
```

### Conceptual Diff (`scripts/fix-21874-scope-check.patch`)
Documents the exact change in context of the surrounding code.

## Why This Is Safe

1. **Server authority preserved**: The API endpoint `/v1/mcp_servers` will return 401/403 if the user truly isn't authorized
2. **Existing error handling**: The `catch` block already handles fetch failures by returning `{}`
3. **No regression for authorized users**: Users with the scope still work exactly the same
4. **Better UX for edge cases**: Users whose server-side flag was updated but whose cached scope is stale will now get their MCP servers

## Recommended Source Code Fix

The corresponding change in the TypeScript source (not available in this repo) would be in the `fetchClaudeAiMcpServers` function — replace the early `return {}` with a log-and-continue:

```typescript
// Before
if (!oauthToken.scopes?.includes("user:mcp_servers")) {
  log("[claudeai-mcp] Missing user:mcp_servers scope");
  telemetry("tengu_claudeai_mcp_eligibility", { state: "missing_scope" });
  return {};
}

// After
if (!oauthToken.scopes?.includes("user:mcp_servers")) {
  log("[claudeai-mcp] Missing user:mcp_servers scope, will attempt fetch");
  telemetry("tengu_claudeai_mcp_eligibility", { state: "missing_scope_retry" });
  // Continue — let the server decide
}
```

## Test plan

- [ ] Apply patch to an installation where MCP servers are not showing up
- [ ] Verify MCP servers load after the patch (if the user is authorized server-side)
- [ ] Verify no regression for users where MCP servers already work
- [ ] Verify that users who are truly unauthorized still see no servers (server returns 401/403, catch block handles it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)