### PR TITLE
hookify: add StopFailure hook support + credit balance error example

### DIFF
--- a/plugins/hookify/README.md
+++ b/plugins/hookify/README.md
@@ -124,6 +124,7 @@ Ensure credentials are not hardcoded and file is in .gitignore.
 - **`bash`**: Triggers on Bash tool commands
 - **`file`**: Triggers on Edit, Write, MultiEdit tools
 - **`stop`**: Triggers when Claude wants to stop (for completion checks)
+- **`stop_failure`**: Triggers when the turn ends due to an API error (rate limit, auth failure, credit balance, etc.)
 - **`prompt`**: Triggers on user prompt submission
 - **`all`**: Triggers on all events
 
@@ -207,6 +208,34 @@ Before stopping, please run tests to verify your changes work correctly.
 
 **This blocks Claude from stopping** if no test commands appear in the session transcript. Enable only when you want strict enforcement.
 
+### Example 4: Credit Balance Error Guidance
+
+```markdown
+---
+name: credit-balance-error
+enabled: true
+event: stop_failure
+pattern: "credit.balance|credit_balance|balance.too.low|insufficient.fund"
+action: warn
+---
+
+💳 **Credit Balance Too Low**
+
+Your Anthropic API credit balance ran out. Steps to resume:
+
+1. Add funds at https://platform.claude.com/settings/billing
+2. Restart Claude Code — the balance status is cached locally and will not
+   refresh until you start a new session.
+
+If you've already topped up and the error persists, run:
+  claude logout && claude login
+```
+
+**This surfaces actionable guidance** when an API credit balance error occurs. A
+ready-to-use copy of this rule is in
+`plugins/hookify/examples/credit-balance-error.local.md`; copy it to
+`.claude/hookify.credit-balance-error.local.md` in your project to enable it.
+
 ## Advanced Usage
 
 ### Multiple Conditions
@@ -256,7 +285,12 @@ Use environment variables instead of hardcoded values.
 - `user_prompt`: The user's submitted prompt text
 
 **For stop events:**
-- Use general matching on session state
+- `reason`: Why the stop was triggered (for `stop` and `stop_failure` events)
+- Use `transcript` field for matching against session history
+
+**For stop_failure events:**
+- `reason`: The API error reason (e.g. `"credit_balance_too_low"`)
+- Use `transcript` field for matching against session history
 
 ## Management
 

--- a/plugins/hookify/core/config_loader.py
+++ b/plugins/hookify/core/config_loader.py
@@ -63,6 +63,8 @@ class Rule:
                 field = 'command'
             elif event == 'file':
                 field = 'new_text'
+            elif event in ('stop', 'stop_failure'):
+                field = 'reason'
             else:
                 field = 'content'
 

--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -69,6 +69,13 @@ class RuleEngine:
                     "reason": combined_message,
                     "systemMessage": combined_message
                 }
+            elif hook_event == 'StopFailure':
+                # The turn already failed; surface the message to the user.
+                # Include reason for consistency with the Stop event format.
+                return {
+                    "reason": combined_message,
+                    "systemMessage": combined_message
+                }
             elif hook_event in ['PreToolUse', 'PostToolUse']:
                 return {
                     "hookSpecificOutput": {

--- a/plugins/hookify/examples/credit-balance-error.local.md
+++ b/plugins/hookify/examples/credit-balance-error.local.md
@@ -1,0 +1,26 @@
+---
+name: credit-balance-error
+enabled: true
+event: stop_failure
+pattern: "credit.balance|credit_balance|balance.too.low|insufficient.fund"
+action: warn
+---
+
+💳 **Credit Balance Too Low**
+
+Your Anthropic API credit balance ran out and Claude Code has stopped.
+
+**Steps to resume:**
+
+1. **Add funds** at https://platform.claude.com/settings/billing
+2. **Restart Claude Code** — the balance status is cached locally and will not
+   refresh until you start a new session.
+
+If you've already topped up and the error persists:
+- Quit Claude Code completely and reopen it.
+- Run `claude logout` then `claude login` to reset your credentials.
+
+> **Note:** This is a known issue in older versions of Claude Code. Updating to
+> the latest version (`claude update` or reinstall via the installer) includes
+> fixes for stale cache behaviour that can cause this error to linger after a
+> top-up.

--- a/plugins/hookify/hooks/hooks.json
+++ b/plugins/hookify/hooks/hooks.json
@@ -34,6 +34,17 @@
         ]
       }
     ],
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/stop_failure.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [

--- a/plugins/hookify/hooks/stop_failure.py
+++ b/plugins/hookify/hooks/stop_failure.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""StopFailure hook executor for hookify plugin.
+
+This script is called by Claude Code when the turn ends due to an API error
+(e.g. rate limit, auth failure, credit balance too low, etc.).
+It reads .claude/hookify.*.local.md files and evaluates stop_failure rules.
+"""
+
+import os
+import sys
+import json
+
+# CRITICAL: Add plugin root to Python path for imports
+PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
+if PLUGIN_ROOT:
+    parent_dir = os.path.dirname(PLUGIN_ROOT)
+    if parent_dir not in sys.path:
+        sys.path.insert(0, parent_dir)
+    if PLUGIN_ROOT not in sys.path:
+        sys.path.insert(0, PLUGIN_ROOT)
+
+try:
+    from hookify.core.config_loader import load_rules
+    from hookify.core.rule_engine import RuleEngine
+except ImportError as e:
+    error_msg = {"systemMessage": f"Hookify import error: {e}"}
+    print(json.dumps(error_msg), file=sys.stdout)
+    sys.exit(0)
+
+
+def main():
+    """Main entry point for StopFailure hook."""
+    try:
+        # Read input from stdin
+        input_data = json.load(sys.stdin)
+
+        # Tag the event so the rule engine can format the response correctly
+        input_data['hook_event_name'] = 'StopFailure'
+
+        # Load stop_failure rules
+        rules = load_rules(event='stop_failure')
+
+        # Evaluate rules
+        engine = RuleEngine()
+        result = engine.evaluate_rules(rules, input_data)
+
+        # Always output JSON (even if empty)
+        print(json.dumps(result), file=sys.stdout)
+
+    except Exception as e:
+        # On any error, allow the operation
+        error_output = {
+            "systemMessage": f"Hookify error: {str(e)}"
+        }
+        print(json.dumps(error_output), file=sys.stdout)
+
+    finally:
+        # ALWAYS exit 0
+        sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Claude Code's StopFailure hook fires on API errors (rate limit, auth failure, credit balance exhaustion, etc.) but hookify had no support for it, leaving users with no way to configure a response to these failures.

Fix for issue -  https://github.com/anthropics/claude-code/issues/31537

Changes
hooks/hooks.json — registers StopFailure event, routing it to a new stop_failure.py handler
hooks/stop_failure.py — new handler mirroring stop.py; loads stop_failure rules and evaluates them against the API error payload
core/rule_engine.py — adds StopFailure branch to the response-format switch (reason + systemMessage for blocking rules, consistent with Stop; warnings emit systemMessage only since the turn already ended)
core/config_loader.py — stop and stop_failure events now resolve the default pattern field to reason instead of content
examples/credit-balance-error.local.md — ready-to-use rule targeting credit balance errors; guides user to add funds and restart to clear the locally cached balance state
README.md — documents stop_failure event type, available fields (reason, transcript), and the new example
Usage
Drop the example into .claude/ to enable it:

cp plugins/hookify/examples/credit-balance-error.local.md \
   .claude/hookify.credit-balance-error.local.md
Or author a custom stop_failure rule directly:

---
name: my-api-error-handler
enabled: true
event: stop_failure
pattern: "rate_limit|credit_balance"
action: warn
---
API quota hit — check https://platform.claude.com/settings/billing