### PR TITLE
docs: fix truncated /plan entry in v2.1.72 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,7 +260,7 @@
 
 - Fixed tool search to activate even with `ANTHROPIC_BASE_URL` as long as `ENABLE_TOOL_SEARCH` is set.
 - Added `w` key in `/copy` to write the focused selection directly to a file, bypassing the clipboard (useful over SSH)
-- Added optional description argument to `/plan` (e.g., `/plan fix the auth bug`) that enters plan mode and immediately starts
+- Added optional description argument to `/plan` (e.g., `/plan fix the auth bug`) that enters plan mode and immediately starts planning from that prompt
 - Added `ExitWorktree` tool to leave an `EnterWorktree` session
 - Added `CLAUDE_CODE_DISABLE_CRON` environment variable to immediately stop scheduled cron jobs mid-session
 - Added `lsof`, `pgrep`, `tput`, `ss`, `fd`, and `fdfind` to the bash auto-approval allowlist, reducing permission prompts for common read-only operations


### PR DESCRIPTION
The bullet point for the `/plan` description argument in the v2.1.72 changelog was cut off mid-sentence:

> Added optional description argument to `/plan` (e.g., `/plan fix the auth bug`) that enters plan mode and immediately starts

Completed the sentence to match the actual behavior (`shouldQuery: true` fires when a non-empty, non-`open` argument is passed).

Relates to #32677