### PR TITLE
feat(devcontainer):  use authenticated request to GitHub API in firewall script if GH_TOKEN is set

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -86,6 +86,7 @@ RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
 COPY init-firewall.sh /usr/local/bin/
 USER root
 RUN chmod +x /usr/local/bin/init-firewall.sh && \
-  echo "node ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh" > /etc/sudoers.d/node-firewall && \
+  echo "Defaults env_keep += \"GH_TOKEN\"" > /etc/sudoers.d/node-firewall && \
+  echo "node ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh" >> /etc/sudoers.d/node-firewall && \
   chmod 0440 /etc/sudoers.d/node-firewall
 USER node

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -50,8 +50,11 @@
     "CLAUDE_CONFIG_DIR": "/home/node/.claude",
     "POWERLEVEL9K_DISABLE_GITSTATUS": "true"
   },
+  "remoteEnv": {
+    "GH_TOKEN": "${localEnv:GH_TOKEN}"
+  },
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",
-  "postStartCommand": "sudo /usr/local/bin/init-firewall.sh",
+  "postStartCommand": "sudo GH_TOKEN=${GH_TOKEN} /usr/local/bin/init-firewall.sh",
   "waitFor": "postStartCommand"
 }

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -41,8 +41,14 @@ iptables -A OUTPUT -o lo -j ACCEPT
 ipset create allowed-domains hash:net
 
 # Fetch GitHub meta information and aggregate + add their IP ranges
-echo "Fetching GitHub IP ranges..."
-gh_ranges=$(curl -s https://api.github.com/meta)
+if [ -z "${GH_TOKEN}" ]; then
+    echo "Fetching GitHub IP ranges..."
+    gh_ranges=$(curl -s https://api.github.com/meta)
+else
+    echo "Fetching GitHub IP ranges with authentication..."
+    gh_ranges=$(curl -H "Authorization: Bearer ${GH_TOKEN}" -s https://api.github.com/meta)
+fi
+
 if [ -z "$gh_ranges" ]; then
     echo "ERROR: Failed to fetch GitHub IP ranges"
     exit 1


### PR DESCRIPTION
# Problem

Using the devcontainer in an environment with multiple other users or services that access GitHub's API without authentication but behind a shared IP address may prevent the firewall to initialize successfully due to hitting GitHub's API rate limits.

# Solution

Use a bearer token (e.g. GitHub Personal Access Token) if the `GH_TOKEN` environment variable is set, to fetch the list of GitHub IP addresses. Otherwise try unauthenticated request. 

# Implementation Details

* Set `GH_TOKEN` in remote environment based on it's local environment value.
* Allow inheritance of `GH_TOKEN` variable when executing `sudo`
* Set `GH_TOKEN` when executing `init-firewall.sh`
*  Decide how to query GitHub API based on `GH_TOKEN` value 

# Tests

* Run without `GH_TOKEN` set: Output of `init-firewall.sh` contains `Fetching GitHub IP ranges...`
* Run with valid `GH_TOKEN` set: Output of `init-firewall.sh` contains `Fetching GitHub IP ranges with authentication...`
* Run with invalid `GH_TOKEN` set: `init-firewall.sh` fails at `Fetching GitHub IP ranges with authentication...` 