### PR TITLE
feat: add session-rename plugin with /rename command

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -25,6 +25,7 @@ Learn more in the [official plugins documentation](https://docs.claude.com/en/do
 | [pr-review-toolkit](./pr-review-toolkit/) | Comprehensive PR review agents specializing in comments, tests, error handling, type design, code quality, and code simplification | **Command:** `/pr-review-toolkit:review-pr` - Run with optional review aspects (comments, tests, errors, types, code, simplify, all)<br>**Agents:** `comment-analyzer`, `pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer`, `code-reviewer`, `code-simplifier` |
 | [ralph-wiggum](./ralph-wiggum/) | Interactive self-referential AI loops for iterative development. Claude works on the same task repeatedly until completion | **Commands:** `/ralph-loop`, `/cancel-ralph` - Start/stop autonomous iteration loops<br>**Hook:** Stop - Intercepts exit attempts to continue iteration |
 | [security-guidance](./security-guidance/) | Security reminder hook that warns about potential security issues when editing files | **Hook:** PreToolUse - Monitors 9 security patterns including command injection, XSS, eval usage, dangerous HTML, pickle deserialization, and os.system calls |
+| [session-rename](./session-rename/) | Rename sessions for easier identification in `/resume` | **Command:** `/rename` - Set a custom title for the current session via `.meta.json` sidecar files |
 
 ## Installation
 

--- a/plugins/session-rename/.claude-plugin/plugin.json
+++ b/plugins/session-rename/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "session-rename",
+  "description": "Rename Claude Code sessions for easier identification in /resume",
+  "version": "1.0.0",
+  "author": {
+    "name": "Anthropic",
+    "email": "support@anthropic.com"
+  }
+}

--- a/plugins/session-rename/README.md
+++ b/plugins/session-rename/README.md
@@ -1,0 +1,55 @@
+# Session Rename Plugin
+
+Rename Claude Code sessions for easier identification when using `/resume`.
+
+## Problem
+
+Claude Code sessions are auto-named based on date and context (e.g., "Mar 24 – Analyst meta"), but there is no way to rename them. When working on multiple tasks, sessions accumulate with generic names, making it hard to find past conversations.
+
+See [#38173](https://github.com/anthropics/claude-code/issues/38173) for the full feature request.
+
+## Commands
+
+### `/rename <new-name>`
+
+Renames the current session by creating a `.meta.json` sidecar file alongside the session's `.jsonl` file.
+
+**Usage:**
+```
+/rename Fix authentication bug
+/rename Sprint 47 planning
+/rename
+```
+
+If called without arguments, prompts for a name interactively.
+
+## How It Works
+
+1. Locates the current session's `.jsonl` file in `~/.claude/projects/{encodedPath}/`
+2. Creates or updates a `{sessionId}.meta.json` file with the structure:
+   ```json
+   {
+     "title": "User-provided session name",
+     "renamed_at": "2026-03-24T09:00:00Z",
+     "auto_title": null
+   }
+   ```
+3. The `.jsonl` file is never modified — the metadata file is a non-breaking sidecar
+
+## Integration Path
+
+This plugin establishes a `.meta.json` convention that the core CLI can adopt to:
+- Display custom titles in `/resume` session picker
+- Show renamed sessions in the session list UI
+- Preserve backward compatibility (fall back to auto-generated title when no `.meta.json` exists)
+
+## Installation
+
+Add to your project's `.claude/settings.json`:
+```json
+{
+  "plugins": ["session-rename"]
+}
+```
+
+Or install from the plugins directory in this repository.

--- a/plugins/session-rename/commands/rename.md
+++ b/plugins/session-rename/commands/rename.md
@@ -1,0 +1,66 @@
+---
+description: Rename the current session for easier identification in /resume
+argument-hint: <new session name>
+allowed-tools: Bash(ls:*), Bash(cat:*), Bash(echo:*), Bash(mkdir:*), Bash(python3:*), Bash(date:*), Read, Write
+---
+
+# Rename Current Session
+
+Rename the current Claude Code session by writing a metadata file alongside the session JSONL.
+
+## Your Task
+
+The user wants to rename this session to: `$ARGUMENTS`
+
+**If $ARGUMENTS is empty**, ask the user what they'd like to name this session using AskUserQuestion. Do not proceed until you have a name.
+
+**If $ARGUMENTS is provided**, rename the session:
+
+1. Determine the current session's storage path. The session JSONL file is located at:
+   ```
+   ~/.claude/projects/{encodedProjectPath}/{sessionId}.jsonl
+   ```
+   where `{encodedProjectPath}` is the current working directory with `/` replaced by `-` and `{sessionId}` is a UUID.
+
+   To find the correct file, run:
+   ```bash
+   ls -t ~/.claude/projects/*/  2>/dev/null | grep "\.jsonl$" | head -20
+   ```
+   Then identify the session file that corresponds to the current project path by checking which project directory matches the current working directory.
+
+   A more reliable approach: use `python3` to find the session file for the current project:
+   ```python
+   import os, glob, json
+   cwd = os.getcwd()
+   encoded = cwd.replace("/", "-")
+   project_dir = os.path.expanduser(f"~/.claude/projects/{encoded}")
+   # List .jsonl files sorted by modification time (newest first)
+   jsonl_files = sorted(
+       glob.glob(os.path.join(project_dir, "*.jsonl")),
+       key=os.path.getmtime, reverse=True
+   )
+   # The most recently modified session is likely the current one
+   if jsonl_files:
+       print(jsonl_files[0])
+   ```
+
+2. Write a `{sessionId}.meta.json` file in the same directory as the `.jsonl` file:
+   ```json
+   {
+     "title": "<user-provided name>",
+     "renamed_at": "<ISO 8601 timestamp>",
+     "auto_title": null
+   }
+   ```
+
+   If a `.meta.json` already exists, read it first and update only the `title` and `renamed_at` fields, preserving any other fields.
+
+3. Confirm the rename to the user with a brief message like:
+   ```
+   Session renamed to "<new name>".
+   Metadata saved to: ~/.claude/projects/.../{sessionId}.meta.json
+   ```
+
+**Important**: Do not modify the `.jsonl` file itself. The metadata file is a sidecar that can be read by future versions of Claude Code or by other plugins.
+
+You MUST complete this in a single message with tool calls. Do not send any other text besides the confirmation.


### PR DESCRIPTION
## Summary

- Adds a session-rename plugin that provides a /rename slash command
- Creates .meta.json sidecar files alongside session .jsonl files to store custom titles
- Does not modify existing session files — fully non-breaking
- Updates the plugins README table with the new entry

Closes #38173
Related: #17536 (IDE extension naming), #11408, #32593

## Context

This is a highly requested feature across CLI and IDE users:
- **CLI users** running multiple sessions need to distinguish them in /resume (#38173)
- **IDE users** need renamable tabs when running parallel sessions (#17536)
- **Automation users** running 10+ tmux sessions need programmatic session identification

The plugin establishes a .meta.json sidecar convention that the core CLI can adopt for:
- Displaying custom titles in /resume session picker
- Supporting --resume name for scripted session recovery
- Exposing session names to hooks and status lines

## How it works

1. User runs /rename Fix auth bug in any session
2. The command locates the current session .jsonl file in ~/.claude/projects/
3. It writes a {sessionId}.meta.json with the custom title and timestamp
4. Future /resume integration can read .meta.json to display custom names

## Meta.json format

```json
{
  "title": "Fix auth bug",
  "renamed_at": "2026-03-24T09:00:00Z",
  "auto_title": null
}
```

## Test plan

- [ ] Install plugin and run /rename My custom name
- [ ] Verify .meta.json is created alongside the session .jsonl
- [ ] Run /rename without arguments — should prompt for a name
- [ ] Run /rename again to verify it updates existing .meta.json

## Future integration path (for core CLI)

Based on community feedback in #17536:
1. /resume reads .meta.json and shows custom title when available
2. claude --session-name X flag writes .meta.json at session start
3. CLAUDE_CODE_SESSION_ID env var exposed in tool-call shell
4. IDE extension reads .meta.json for tab naming