### PR TITLE
Add multi-setup plugin for parallel development workspaces

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -145,6 +145,17 @@
       },
       "source": "./plugins/security-guidance",
       "category": "security"
+    },
+    {
+      "name": "multi-setup",
+      "description": "Create parallel development workspaces — full git clones with shared config, each opened in a new Claude Code session",
+      "version": "1.0.0",
+      "author": {
+        "name": "abhishek-git",
+        "email": "abhishekshingadiya2543@gmail.com"
+      },
+      "source": "./plugins/multi-setup",
+      "category": "development"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -151,7 +151,7 @@
       "description": "Create parallel development workspaces — full git clones with shared config, each opened in a new Claude Code session",
       "version": "1.0.0",
       "author": {
-        "name": "abhishek-git",
+        "name": "Abhishek Shingadiya",
         "email": "abhishekshingadiya2543@gmail.com"
       },
       "source": "./plugins/multi-setup",

--- a/plugins/multi-setup/.claude-plugin/plugin.json
+++ b/plugins/multi-setup/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "multi-setup",
+  "version": "1.0.0",
+  "description": "Create parallel development workspaces — full git clones with shared config, each opened in a new Claude Code session",
+  "author": {
+    "name": "abhishek-git",
+    "email": "abhishekshingadiya2543@gmail.com"
+  }
+}

--- a/plugins/multi-setup/commands/list-workspaces.md
+++ b/plugins/multi-setup/commands/list-workspaces.md
@@ -1,0 +1,19 @@
+---
+description: "List all parallel development workspaces created by /multi-setup"
+argument-hint: ""
+allowed-tools: ["Bash(cat:*)", "Bash(ls:*)"]
+---
+
+# List Workspaces
+
+Read `.claude/multi-setup-workspaces.local.md` in the current project and display a formatted table of all workspaces.
+
+```!
+if [ -f .claude/multi-setup-workspaces.local.md ]; then
+  cat .claude/multi-setup-workspaces.local.md
+else
+  echo "No workspaces found. Run /multi-setup to create one."
+fi
+```
+
+Parse and present the workspaces in a readable format: name, path, branch, config mode, and created date.

--- a/plugins/multi-setup/commands/multi-setup.md
+++ b/plugins/multi-setup/commands/multi-setup.md
@@ -1,0 +1,15 @@
+---
+description: "Create a parallel development workspace — full git clone in a new folder, opened in a new Claude Code session"
+argument-hint: "[workspace-name] [--branch BRANCH] [--config copy|symlink]"
+allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/create-workspace.sh:*)"]
+---
+
+# Multi Setup
+
+Run the workspace creation script:
+
+```!
+"${CLAUDE_PLUGIN_ROOT}/scripts/create-workspace.sh" $ARGUMENTS
+```
+
+Report the output to the user. If the script succeeded, confirm the workspace path and that a new Claude Code session was launched.

--- a/plugins/multi-setup/scripts/create-workspace.sh
+++ b/plugins/multi-setup/scripts/create-workspace.sh
@@ -1,0 +1,243 @@
+#!/bin/bash
+
+# Multi Setup - Create a parallel development workspace
+# Clones the current repo into a new folder and opens Claude Code in a new terminal window.
+
+set -euo pipefail
+
+# ── Argument parsing ────────────────────────────────────────────────────────
+
+WORKSPACE_NAME=""
+BRANCH=""
+CONFIG_MODE=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -h|--help)
+      cat <<'HELP'
+multi-setup — Create a parallel development workspace
+
+USAGE:
+  /multi-setup [workspace-name] [--branch BRANCH] [--config copy|symlink]
+
+ARGUMENTS:
+  workspace-name        Name for the new workspace folder (default: workspace-N)
+
+OPTIONS:
+  --branch <branch>     Branch to check out after cloning (default: current branch)
+  --config copy|symlink How to handle .claude/ config (prompted if omitted)
+  -h, --help            Show this help
+
+EXAMPLES:
+  /multi-setup
+  /multi-setup feature-auth --branch feature/auth
+  /multi-setup hotfix --branch main --config copy
+HELP
+      exit 0
+      ;;
+    --branch)
+      BRANCH="${2:-}"
+      [[ -z "$BRANCH" ]] && { echo "❌ --branch requires a value" >&2; exit 1; }
+      shift 2
+      ;;
+    --config)
+      CONFIG_MODE="${2:-}"
+      if [[ "$CONFIG_MODE" != "copy" && "$CONFIG_MODE" != "symlink" ]]; then
+        echo "❌ --config must be 'copy' or 'symlink', got: $CONFIG_MODE" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    -*)
+      echo "❌ Unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      WORKSPACE_NAME="$1"
+      shift
+      ;;
+  esac
+done
+
+# ── Validate git repo ────────────────────────────────────────────────────────
+
+if ! git rev-parse --is-inside-work-tree &>/dev/null; then
+  echo "❌ Not inside a git repository." >&2
+  exit 1
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+REMOTE_URL="$(git remote get-url origin 2>/dev/null || true)"
+if [[ -z "$REMOTE_URL" ]]; then
+  echo "❌ No 'origin' remote found. Cannot clone." >&2
+  exit 1
+fi
+
+REPO_NAME="$(basename "$REPO_ROOT")"
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+TARGET_BRANCH="${BRANCH:-$CURRENT_BRANCH}"
+
+# ── Determine workspace path ─────────────────────────────────────────────────
+
+BASE_DIR="$(dirname "$REPO_ROOT")/${REPO_NAME}-workspaces"
+mkdir -p "$BASE_DIR"
+
+# Auto-name if not provided
+if [[ -z "$WORKSPACE_NAME" ]]; then
+  N=1
+  while [[ -e "$BASE_DIR/workspace-$N" ]]; do
+    ((N++))
+  done
+  WORKSPACE_NAME="workspace-$N"
+fi
+
+WORKSPACE_PATH="$BASE_DIR/$WORKSPACE_NAME"
+
+if [[ -e "$WORKSPACE_PATH" ]]; then
+  echo "❌ Workspace already exists: $WORKSPACE_PATH" >&2
+  exit 1
+fi
+
+# ── Config mode prompt ────────────────────────────────────────────────────────
+
+if [[ -z "$CONFIG_MODE" ]] && [[ -d ".claude" ]]; then
+  echo ""
+  echo "How should .claude/ config be handled in the new workspace?"
+  echo "  [1] copy    — independent copy (changes won't sync)"
+  echo "  [2] symlink — shared config (changes reflect in both)"
+  echo ""
+  read -r -p "Enter choice [1/2] (default: 1): " CONFIG_CHOICE
+  case "${CONFIG_CHOICE:-1}" in
+    2|symlink) CONFIG_MODE="symlink" ;;
+    *)         CONFIG_MODE="copy" ;;
+  esac
+elif [[ -z "$CONFIG_MODE" ]]; then
+  CONFIG_MODE="copy"
+fi
+
+# ── Clone ─────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Creating workspace: $WORKSPACE_NAME"
+echo "  Clone URL : $REMOTE_URL"
+echo "  Path      : $WORKSPACE_PATH"
+echo "  Branch    : $TARGET_BRANCH"
+echo "  Config    : $CONFIG_MODE"
+echo ""
+
+echo "Cloning..."
+git clone "$REMOTE_URL" "$WORKSPACE_PATH"
+
+# Checkout target branch if different from default
+CLONED_BRANCH="$(git -C "$WORKSPACE_PATH" rev-parse --abbrev-ref HEAD)"
+if [[ "$TARGET_BRANCH" != "$CLONED_BRANCH" ]]; then
+  echo "Checking out branch: $TARGET_BRANCH"
+  git -C "$WORKSPACE_PATH" checkout "$TARGET_BRANCH" 2>/dev/null || \
+    git -C "$WORKSPACE_PATH" checkout -b "$TARGET_BRANCH"
+fi
+
+# ── Copy / symlink .claude config ─────────────────────────────────────────────
+
+if [[ -d ".claude" ]]; then
+  # Replace the cloned .claude directory so the new workspace mirrors the
+  # current repo's config choice, including any uncommitted local changes.
+  rm -rf "$WORKSPACE_PATH/.claude"
+
+  if [[ "$CONFIG_MODE" == "symlink" ]]; then
+    ln -s "$(pwd)/.claude" "$WORKSPACE_PATH/.claude"
+    echo "Symlinked .claude/ config"
+  else
+    # Copy but skip *.local.md (session-specific state files).
+    mkdir -p "$WORKSPACE_PATH/.claude"
+    (
+      cd .claude
+      tar --exclude='*.local.md' -cf - .
+    ) | (
+      cd "$WORKSPACE_PATH/.claude"
+      tar -xf -
+    )
+    echo "Copied .claude/ config (excluded *.local.md)"
+  fi
+fi
+
+# ── Record workspace in state file ───────────────────────────────────────────
+
+mkdir -p .claude
+STATE_FILE=".claude/multi-setup-workspaces.local.md"
+CREATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# Init state file if it doesn't exist
+if [[ ! -f "$STATE_FILE" ]]; then
+  cat > "$STATE_FILE" <<'EOF'
+---
+workspaces: []
+---
+EOF
+fi
+
+# Append workspace entry (simple append before closing ---)
+ENTRY="  - name: \"$WORKSPACE_NAME\"\n    path: \"$WORKSPACE_PATH\"\n    branch: \"$TARGET_BRANCH\"\n    config: \"$CONFIG_MODE\"\n    created_at: \"$CREATED_AT\""
+
+# Insert before the closing --- line
+sed -i '' "/^---$/{ N; s/---\n---/---\n${ENTRY}\n---/; }" "$STATE_FILE" 2>/dev/null || true
+
+# Fallback: just append the entry as plain markdown if sed failed
+if ! grep -q "$WORKSPACE_NAME" "$STATE_FILE" 2>/dev/null; then
+  printf "\n- name: %s\n  path: %s\n  branch: %s\n  config: %s\n  created_at: %s\n" \
+    "$WORKSPACE_NAME" "$WORKSPACE_PATH" "$TARGET_BRANCH" "$CONFIG_MODE" "$CREATED_AT" >> "$STATE_FILE"
+fi
+
+# ── Open new terminal window ──────────────────────────────────────────────────
+
+LAUNCH_STATUS="failed"
+
+if [[ "$(uname)" == "Darwin" ]]; then
+  # Try iTerm2 first, fall back to Terminal.app
+  if osascript -e 'id of app "iTerm2"' &>/dev/null 2>&1; then
+    osascript <<APPLE
+tell application "iTerm2"
+  create window with default profile command "cd '$WORKSPACE_PATH' && claude"
+end tell
+APPLE
+    LAUNCH_STATUS="iTerm2"
+  else
+    osascript <<APPLE
+tell application "Terminal"
+  do script "cd '$WORKSPACE_PATH' && claude"
+  activate
+end tell
+APPLE
+    LAUNCH_STATUS="Terminal.app"
+  fi
+else
+  # Linux fallback — print command for user to run
+  LAUNCH_STATUS="manual"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "══════════════════════════════════════════════"
+echo "  Workspace created successfully!"
+echo "══════════════════════════════════════════════"
+echo ""
+echo "  Name    : $WORKSPACE_NAME"
+echo "  Path    : $WORKSPACE_PATH"
+echo "  Branch  : $TARGET_BRANCH"
+echo "  Config  : $CONFIG_MODE"
+echo ""
+
+if [[ "$LAUNCH_STATUS" == "manual" ]]; then
+  echo "  Run the following to open Claude Code in the new workspace:"
+  echo ""
+  echo "    cd '$WORKSPACE_PATH' && claude"
+  echo ""
+else
+  echo "  Claude Code launched in: $LAUNCH_STATUS"
+  echo ""
+fi
+
+echo "  Manage workspaces: /list-workspaces"
+echo "══════════════════════════════════════════════"


### PR DESCRIPTION
## Summary

This PR introduces a **multi-setup plugin** that enables creating parallel development workspaces from the current repository.

### Key Features

* Registers the plugin in the marketplace
* Adds `/multi-setup` command to clone the repository into a new workspace
* Supports:

  * Branch selection
  * `.claude` config handling (copy or symlink)
* Adds `/list-workspaces` command to display all created workspaces
* Improves scripts to:

  * Properly handle `.claude` config in fresh clones
  * Exclude `*.local.md` files when copying configs

---

## Changes

* Added `plugins/multi-setup/.claude-plugin/plugin.json`
* Added `plugins/multi-setup/commands/multi-setup.md`
* Added `plugins/multi-setup/commands/list-workspaces.md`
* Added `plugins/multi-setup/scripts/create-workspace.sh`
* Registered plugin in `.claude-plugin/marketplace.json`
* Updated marketplace author name to **Abhishek Shingadiya**

---

## Validation

* Script syntax check:

  ```bash
  bash -n plugins/multi-setup/scripts/create-workspace.sh
  ```
* Manual end-to-end testing for:

  * `--config symlink`
  * `--config copy`
* Verified that copied config excludes `*.local.md` files
