### PR TITLE
feat: add terminal-restore plugin for kitty keyboard protocol cleanup

### DIFF
--- a/plugins/terminal-restore/.claude-plugin/plugin.json
+++ b/plugins/terminal-restore/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "terminal-restore",
+  "description": "Restores terminal state after Claude Code exits, fixing broken Ctrl-C/Ctrl-D in kitty keyboard protocol terminals (Ghostty, Kitty, WezTerm)",
+  "version": "1.0.0",
+  "author": {
+    "name": "bsene"
+  }
+}

--- a/plugins/terminal-restore/README.md
+++ b/plugins/terminal-restore/README.md
@@ -1,0 +1,31 @@
+# terminal-restore
+
+Fixes [issue #38761](https://github.com/anthropics/claude-code/issues/38761): after exiting Claude Code, terminals supporting the kitty keyboard protocol (Ghostty, Kitty, WezTerm) are left in a broken state where `Ctrl-C` and `Ctrl-D` produce raw escape sequences instead of sending SIGINT/EOF.
+
+## Root cause
+
+Claude Code enables the kitty keyboard protocol during TUI initialization (`GFH.enterAlternateScreen()`) and pushes it multiple times per session (on focus, redraw, and suspend/resume). On exit, the signal handlers (`SIGINT`, `SIGTERM`) call `process.exit()` without flushing terminal state, and `exitAlternateScreen()` omits the kitty protocol teardown — leaving ≥1 level on the stack.
+
+## What this plugin does
+
+Registers a `Stop` hook that sends two escape sequences after every session:
+
+| Sequence | Effect |
+|----------|--------|
+| `\e[=0u` | Hard-disables all kitty keyboard protocol flags (works through tmux) |
+| `\e[<99u` | Drains up to 99 stacked protocol levels |
+
+Terminals that don't support kitty protocol silently ignore both sequences — no side effects.
+
+## Workaround (without this plugin)
+
+```bash
+printf '\e[=0u'   # or: reset
+```
+
+Or add to `~/.zshrc`:
+
+```zsh
+precmd_pop_kitty_kb() { printf '\e[=0u' 2>/dev/null; }
+precmd_functions+=( precmd_pop_kitty_kb )
+```

--- a/plugins/terminal-restore/hooks/hooks.json
+++ b/plugins/terminal-restore/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "description": "Restores terminal state on exit by disabling the kitty keyboard protocol that Claude Code leaves active",
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/stop.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/terminal-restore/hooks/stop.sh
+++ b/plugins/terminal-restore/hooks/stop.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# terminal-restore: stop hook
+#
+# Root cause (issue #38761): Claude Code enables the kitty keyboard protocol
+# via the GFH class during TUI init but never sends the pop/disable sequences
+# on exit. Signal handlers (SIGINT/SIGTERM) call process.exit() without cleanup,
+# and exitAlternateScreen() omits the kitty protocol teardown.
+#
+# Fix: send both sequences — \e[=0u disables all flags (works through tmux),
+# \e[<u pops the stack. We drain up to 10 levels to handle multiple pushes.
+
+# Consume stdin (hook API requires reading it)
+read -r -d '' _INPUT < /dev/stdin 2>/dev/null || true
+
+# Only act on TTY — skip in non-interactive/piped contexts
+if [ -t 1 ]; then
+  printf '\e[=0u'   # hard-disable all kitty keyboard protocol flags
+  printf '\e[<10u'  # drain up to 10 stacked levels (safe no-op if fewer)
+fi
+
+exit 0

--- a/plugins/terminal-restore/hooks/stop.sh
+++ b/plugins/terminal-restore/hooks/stop.sh
@@ -5,17 +5,21 @@
 # via the GFH class during TUI init but never sends the pop/disable sequences
 # on exit. Signal handlers (SIGINT/SIGTERM) call process.exit() without cleanup,
 # and exitAlternateScreen() omits the kitty protocol teardown.
+# Claude Code also pushes the protocol multiple times per session (focus,
+# redraw, suspend/resume) without a matching pop count on exit.
 #
-# Fix: send both sequences — \e[=0u disables all flags (works through tmux),
-# \e[<u pops the stack. We drain up to 10 levels to handle multiple pushes.
+# Fix: \e[=0u hard-disables all flags (reliable through tmux).
+# \e[<99u drains up to 99 stacked levels — the community-validated maximum
+# (see issue #38840 and workaround at https://github.com/anthropics/claude-code/issues/38761).
+# Terminals that don't support kitty protocol silently ignore both sequences.
 
 # Consume stdin (hook API requires reading it)
-read -r -d '' _INPUT < /dev/stdin 2>/dev/null || true
+HOOK_INPUT=$(cat)
 
 # Only act on TTY — skip in non-interactive/piped contexts
 if [ -t 1 ]; then
   printf '\e[=0u'   # hard-disable all kitty keyboard protocol flags
-  printf '\e[<10u'  # drain up to 10 stacked levels (safe no-op if fewer)
+  printf '\e[<99u'  # drain full stack (safe no-op on non-kitty terminals)
 fi
 
 exit 0


### PR DESCRIPTION
Workaround for issue #38761: Claude Code leaves the kitty keyboard protocol active on exit, breaking Ctrl-C/Ctrl-D in Ghostty, Kitty, and WezTerm. Root cause is asymmetric push/pop in GFH.exitAlternateScreen() and signal handlers that call process.exit() without terminal cleanup.

The Stop hook sends \e[=0u (hard-disable flags) and \e[<10u (drain stack) after every session to restore terminal state.