### PR TITLE
docs(plugin-dev): add plugin lifecycle guidance

### DIFF
--- a/plugins/plugin-dev/README.md
+++ b/plugins/plugin-dev/README.md
@@ -101,13 +101,16 @@ Use this workflow for structured, high-quality plugin development from concept t
 - plugin.json manifest format and all fields
 - Component organization (commands, agents, skills, hooks)
 - ${CLAUDE_PLUGIN_ROOT} usage throughout
+- Plugin management workflow (`/plugin` vs `claude plugin`)
+- TTY constraints and marketplace command syntax
+- Versioning and cache invalidation during distribution
 - File naming conventions and best practices
 - Minimal, standard, and advanced plugin patterns
 
 **Resources:**
 - Core SKILL.md (1,619 words)
 - 3 example structures (minimal, standard, advanced)
-- 2 reference docs: component-patterns, manifest-reference
+- 3 reference docs: component-patterns, manifest-reference, plugin-lifecycle
 
 **Use when:** Starting a new plugin, organizing components, or configuring the plugin manifest.
 

--- a/plugins/plugin-dev/skills/plugin-structure/README.md
+++ b/plugins/plugin-dev/skills/plugin-structure/README.md
@@ -9,6 +9,9 @@ This skill provides detailed knowledge about:
 - `plugin.json` manifest configuration
 - Component organization (commands, agents, skills, hooks)
 - Auto-discovery mechanisms
+- Plugin management workflow and CLI syntax
+- TTY limitations and in-session `/plugin` usage
+- Versioning and cache invalidation during distribution
 - Portable path references with `${CLAUDE_PLUGIN_ROOT}`
 - File naming conventions
 
@@ -46,6 +49,13 @@ Detailed documentation for deep dives:
   - Script organization patterns
   - Cross-component patterns
   - Best practices for scalability
+
+- **plugin-lifecycle.md**: Plugin management and distribution workflow
+  - `claude plugin` command syntax and common mistakes
+  - When to use `/plugin` inside an active session
+  - TTY limitations for plugin-management commands
+  - Marketplace add syntax (`owner/repo`)
+  - Version bump and cache invalidation rules
 
 ### Examples
 
@@ -87,7 +97,7 @@ Claude Code activates this skill when users:
 The skill uses progressive disclosure to manage context:
 
 1. **SKILL.md** (~1600 words): Core concepts and workflows
-2. **References** (~6000 words): Detailed field references and patterns
+2. **References** (~7000 words): Detailed field references, lifecycle notes, and patterns
 3. **Examples** (~8000 words): Complete working examples
 
 Claude loads references and examples only as needed based on the task.

--- a/plugins/plugin-dev/skills/plugin-structure/SKILL.md
+++ b/plugins/plugin-dev/skills/plugin-structure/SKILL.md
@@ -14,6 +14,8 @@ Claude Code plugins follow a standardized directory structure with automatic com
 - Conventional directory layout for automatic discovery
 - Manifest-driven configuration in `.claude-plugin/plugin.json`
 - Component-based organization (commands, agents, skills, hooks)
+- Plugin management workflow: `/plugin` vs `claude plugin`, TTY limits, and marketplace syntax
+- Versioning as a distribution contract for plugin cache invalidation
 - Portable path references using `${CLAUDE_PLUGIN_ROOT}`
 - Explicit vs. auto-discovered component loading
 
@@ -354,6 +356,55 @@ Claude Code automatically discovers and loads components:
 
 **Override behavior**: Custom paths in `plugin.json` supplement (not replace) default directories
 
+## Plugin Management Workflow
+
+### In-session vs CLI operations
+
+When Claude Code is already running, prefer the `/plugin` slash command family for
+plugin management tasks. These commands are designed for the active session and do
+not require launching a nested Claude CLI process.
+
+Use the standalone CLI in a separate terminal when you are working outside Claude
+Code itself:
+
+```bash
+claude plugin list
+claude plugin install my-plugin@my-marketplace
+claude plugin marketplace add owner/repo
+```
+
+**Important**: The subcommand is `claude plugin` (singular), not `claude plugins`.
+
+### TTY limitations
+
+Do not assume `claude plugin ...` can be run successfully from arbitrary tool
+invocations or non-interactive shells. Plugin-management commands often expect a
+real TTY. If Claude is already in a session, prefer `/plugin ...` instead of
+trying to shell out to `claude plugin ...` from inside the session.
+
+### Marketplace add syntax
+
+For GitHub-hosted marketplaces, use `owner/repo` directly:
+
+```bash
+claude plugin marketplace add owner/repo
+```
+
+Do not prepend `github:` and do not pass a full GitHub URL unless the CLI
+explicitly documents a different format.
+
+### Versioning and cache invalidation
+
+Treat the plugin version as part of the distribution contract, not just release
+metadata.
+
+- Bump `.claude-plugin/plugin.json` whenever you ship a plugin change that users
+  need to receive.
+- If you publish through a marketplace registry, bump the version in both the
+  plugin manifest and the registry entry that points to it.
+- Reinstalling a plugin with changed files but the same version can leave users
+  on cached content and make it look like the update did not apply.
+
 ## Best Practices
 
 ### Organization
@@ -396,7 +447,7 @@ Claude Code automatically discovers and loads components:
 
 ### Maintenance
 
-1. **Version consistently**: Update version in plugin.json for releases
+1. **Version consistently**: Update version in plugin.json for every distributable change
 2. **Deprecate gracefully**: Mark old components clearly before removal
 3. **Document breaking changes**: Note changes affecting existing users
 4. **Test thoroughly**: Verify all components work after changes
@@ -473,4 +524,4 @@ my-plugin/
 
 ---
 
-For detailed examples and advanced patterns, see files in `references/` and `examples/` directories.
+For detailed examples and advanced patterns, see files in `references/` and `examples/` directories, especially `references/plugin-lifecycle.md` for plugin-management workflow guidance.

--- a/plugins/plugin-dev/skills/plugin-structure/references/manifest-reference.md
+++ b/plugins/plugin-dev/skills/plugin-structure/references/manifest-reference.md
@@ -51,6 +51,16 @@ Semantic versioning guidelines:
 - **MINOR**: New functionality, backward-compatible
 - **PATCH**: Bug fixes, backward-compatible
 
+**Operational note**: Claude Code plugin distribution uses the version as an
+update identity. If plugin files change without a version bump, users may keep
+seeing cached content from the older install and assume the update failed.
+
+**Distribution rule of thumb**:
+- Bump `plugin.json` on every shipped change that users should pick up
+- If a marketplace registry also stores the plugin version, update that entry in
+  lockstep with the manifest
+- Do not reuse an old version number for different plugin contents
+
 **Pre-release versions**:
 - `"1.0.0-alpha.1"` - Alpha release
 - `"1.0.0-beta.2"` - Beta release
@@ -537,7 +547,7 @@ Full configuration with all features:
 
 ### Maintenance
 
-1. **Bump version on changes**: Follow semantic versioning
+1. **Bump version on changes**: Follow semantic versioning and treat version as a cache key
 2. **Update keywords**: Reflect new functionality
 3. **Keep description current**: Match actual capabilities
 4. **Maintain changelog**: Track version history

--- a/plugins/plugin-dev/skills/plugin-structure/references/plugin-lifecycle.md
+++ b/plugins/plugin-dev/skills/plugin-structure/references/plugin-lifecycle.md
@@ -1,0 +1,109 @@
+# Plugin Lifecycle and Management
+
+Practical guidance for installing, testing, updating, and publishing Claude Code
+plugins without tripping over CLI or cache behavior.
+
+## Use the Right Interface
+
+### Inside an active Claude Code session
+
+Prefer the `/plugin` slash commands:
+
+```text
+/plugin install my-plugin@my-marketplace
+/plugin update my-plugin
+/plugin disable my-plugin
+```
+
+These are the safest option when Claude Code is already running because they
+operate within the current session and do not require nesting a second Claude
+CLI invocation.
+
+### Outside Claude Code
+
+Use the standalone CLI in a separate terminal:
+
+```bash
+claude plugin list
+claude plugin install my-plugin@my-marketplace
+claude plugin marketplace add owner/repo
+```
+
+**Important**: The correct command is `claude plugin` (singular). `claude plugins`
+is a common hallucination and will not work.
+
+## TTY Expectations
+
+Many plugin-management flows are interactive and may expect a real TTY. That
+means a command like `claude plugin install ...` is not a reliable thing to run
+from an arbitrary non-interactive shell or from Claude's own tool execution.
+
+Use this rule:
+
+- If Claude is already in a session, prefer `/plugin ...`
+- If you need the CLI, ask the user to run it in a separate terminal
+- Do not assume plugin-management commands behave well when piped, backgrounded,
+  or launched without terminal access
+
+## Marketplace Commands
+
+### Adding a marketplace from GitHub
+
+For GitHub-hosted marketplaces, pass `owner/repo` directly:
+
+```bash
+claude plugin marketplace add owner/repo
+```
+
+Avoid these incorrect variants unless the CLI explicitly documents them:
+
+```bash
+claude plugin marketplace add github:owner/repo
+claude plugin marketplace add https://github.com/owner/repo
+```
+
+## Local Development Workflow
+
+For iterative plugin development, load the plugin from disk:
+
+```bash
+cc --plugin-dir /path/to/plugin
+```
+
+This avoids unnecessary marketplace indirection while you are still changing the
+plugin structure, prompts, hooks, or scripts.
+
+Recommended loop:
+
+1. Edit plugin files locally
+2. Validate the manifest and component structure
+3. Test with `cc --plugin-dir /path/to/plugin`
+4. Bump versions before publishing or reinstall testing
+
+## Versioning Is Also Cache Invalidation
+
+The plugin version is not just release metadata. In practice it also controls
+whether Claude Code treats an install as a new artifact.
+
+### What to do
+
+- Bump `.claude-plugin/plugin.json` whenever you ship a change users need to receive
+- If you publish through a marketplace registry, update the registry version too
+- Keep version numbers monotonic across published artifacts
+
+### What goes wrong if you do not
+
+If you change plugin files but reuse the same version, existing installs may keep
+serving cached plugin contents. That can look like:
+
+- users reinstalling but not seeing your changes
+- "works on my machine" confusion between local and installed copies
+- debugging time wasted on a cache issue that is really a versioning issue
+
+## Quick Checks Before Publishing
+
+- Confirm the manifest lives at `.claude-plugin/plugin.json`
+- Confirm component paths still resolve from `${CLAUDE_PLUGIN_ROOT}`
+- Validate any marketplace entry points or registry metadata
+- Bump the plugin version before asking users to update
+- Test a fresh install path, not just your already-loaded local development copy


### PR DESCRIPTION
## Summary
- add a new `plugin-lifecycle.md` reference for plugin management and publishing workflows
- document the singular `claude plugin` CLI syntax, `/plugin` in-session guidance, and marketplace `owner/repo` syntax
- clarify version bumping as cache invalidation in the plugin structure skill and manifest reference

Closes #30792

## Validation
- docs-only change
- `git diff --check`