### PR TITLE
docs(plugin-dev): cover task lifecycle hook workflows

### DIFF
--- a/plugins/plugin-dev/README.md
+++ b/plugins/plugin-dev/README.md
@@ -60,7 +60,7 @@ Use this workflow for structured, high-quality plugin development from concept t
 **What it covers:**
 - Prompt-based hooks (recommended) with LLM decision-making
 - Command hooks for deterministic validation
-- All hook events: PreToolUse, PostToolUse, Stop, SubagentStop, SessionStart, SessionEnd, UserPromptSubmit, PreCompact, Notification
+- Common hook events: PreToolUse, PostToolUse, Stop, SubagentStop, SessionStart, SessionEnd, UserPromptSubmit, PreCompact, Notification, plus task lifecycle hooks like TaskCreated
 - Hook output formats and JSON schemas
 - Security best practices and input validation
 - ${CLAUDE_PLUGIN_ROOT} for portable paths

--- a/plugins/plugin-dev/skills/hook-development/SKILL.md
+++ b/plugins/plugin-dev/skills/hook-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Hook Development
-description: This skill should be used when the user asks to "create a hook", "add a PreToolUse/PostToolUse/Stop hook", "validate tool use", "implement prompt-based hooks", "use ${CLAUDE_PLUGIN_ROOT}", "set up event-driven automation", "block dangerous commands", or mentions hook events (PreToolUse, PostToolUse, Stop, SubagentStop, SessionStart, SessionEnd, UserPromptSubmit, PreCompact, Notification). Provides comprehensive guidance for creating and implementing Claude Code plugin hooks with focus on advanced prompt-based hooks API.
+description: This skill should be used when the user asks to "create a hook", "add a PreToolUse/PostToolUse/Stop hook", "validate tool use", "implement prompt-based hooks", "use ${CLAUDE_PLUGIN_ROOT}", "set up event-driven automation", "block dangerous commands", or mentions hook events (PreToolUse, PostToolUse, Stop, SubagentStop, SessionStart, SessionEnd, UserPromptSubmit, PreCompact, Notification, TaskCreated, TaskCompleted, TeammateIdle). Provides comprehensive guidance for creating and implementing Claude Code plugin hooks with focus on advanced prompt-based hooks API.
 version: 0.1.0
 ---
 
@@ -15,6 +15,7 @@ Hooks are event-driven automation scripts that execute in response to Claude Cod
 - React to tool results (PostToolUse)
 - Enforce completion standards (Stop, SubagentStop)
 - Load project context (SessionStart)
+- Coordinate task and teammate workflows (TaskCreated, TaskCompleted, TeammateIdle)
 - Automate workflows across the development lifecycle
 
 ## Hook Types
@@ -274,6 +275,35 @@ Execute before context compaction. Use to add critical information to preserve.
 ### Notification
 
 Execute when Claude sends notifications. Use to react to user notifications.
+
+### Task lifecycle hooks
+
+Claude Code also supports task and teammate lifecycle hooks for agent-team
+workflows:
+
+- `TaskCreated` fires when a task is created via `TaskCreate`
+- `TaskCompleted` fires when a task is marked as completed
+- `TeammateIdle` fires when an agent-team teammate is about to go idle
+
+Use `matcher: "*"` for these lifecycle events. Standard hook output fields
+(`continue`, `suppressOutput`, `systemMessage`) still apply.
+
+**Example (`TaskCreated`):**
+```json
+{
+  "TaskCreated": [
+    {
+      "matcher": "*",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/on-task-created.sh"
+        }
+      ]
+    }
+  ]
+}
+```
 
 ## Hook Output Format
 
@@ -642,6 +672,9 @@ echo "$output" | jq .
 | SessionEnd | Session ends | Cleanup, logging |
 | PreCompact | Before compact | Preserve context |
 | Notification | User notified | Logging, reactions |
+| TaskCreated | Task created | Initialize workflow state, task automation |
+| TaskCompleted | Task completed | Final validation, cleanup |
+| TeammateIdle | Teammate about to idle | Keep multi-agent workflows moving |
 
 ### Best Practices
 

--- a/plugins/plugin-dev/skills/hook-development/scripts/README.md
+++ b/plugins/plugin-dev/skills/hook-development/scripts/README.md
@@ -58,6 +58,7 @@ Tests individual hook scripts with sample input before deploying to Claude Code.
 - Validates output JSON
 - Shows exit codes and their meanings
 - Captures environment file output
+- Supports lifecycle samples such as `TaskCreated`, `TaskCompleted`, and `TeammateIdle`
 
 ## hook-linter.sh
 

--- a/plugins/plugin-dev/skills/hook-development/scripts/test-hook.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/test-hook.sh
@@ -80,20 +80,20 @@ EOF
 }
 EOF
       ;;
-    SessionStart|SessionEnd)
-      cat <<'EOF'
+    SessionStart|SessionEnd|TaskCreated|TaskCompleted|TeammateIdle)
+      cat <<EOF
 {
   "session_id": "test-session",
   "transcript_path": "/tmp/transcript.txt",
   "cwd": "/tmp/test-project",
   "permission_mode": "ask",
-  "hook_event_name": "SessionStart"
+  "hook_event_name": "$event_type"
 }
 EOF
       ;;
     *)
       echo "Unknown event type: $event_type"
-      echo "Valid types: PreToolUse, PostToolUse, Stop, SubagentStop, UserPromptSubmit, SessionStart, SessionEnd"
+      echo "Valid types: PreToolUse, PostToolUse, Stop, SubagentStop, UserPromptSubmit, SessionStart, SessionEnd, TaskCreated, TaskCompleted, TeammateIdle"
       exit 1
       ;;
   esac

--- a/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
@@ -38,7 +38,7 @@ echo "✅ Valid JSON"
 # Check 2: Root structure
 echo ""
 echo "Checking root structure..."
-VALID_EVENTS=("PreToolUse" "PostToolUse" "UserPromptSubmit" "Stop" "SubagentStop" "SessionStart" "SessionEnd" "PreCompact" "Notification")
+VALID_EVENTS=("PreToolUse" "PostToolUse" "UserPromptSubmit" "Stop" "SubagentStop" "SessionStart" "SessionEnd" "PreCompact" "Notification" "TaskCreated" "TaskCompleted" "TeammateIdle")
 
 for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
   found=false


### PR DESCRIPTION
## Summary
- add task lifecycle hook guidance to the plugin-dev hook-development skill
- document `TaskCreated`, `TaskCompleted`, and `TeammateIdle` in the quick reference
- update the hook validation and sample-generation scripts for these lifecycle events

## Validation
- git diff --check

Related to #39101