### PR TITLE
fix(plugin-dev): flag unsafe hook script commands

### DIFF
--- a/plugins/plugin-dev/skills/hook-development/SKILL.md
+++ b/plugins/plugin-dev/skills/hook-development/SKILL.md
@@ -46,7 +46,7 @@ Execute bash commands for deterministic checks:
 ```json
 {
   "type": "command",
-  "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/validate.sh",
+  "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/validate.sh\"",
   "timeout": 60
 }
 ```
@@ -90,7 +90,7 @@ Execute bash commands for deterministic checks:
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/validate.sh\""
           }
         ]
       }
@@ -248,7 +248,7 @@ Execute when Claude Code session begins. Use to load context and set environment
       "hooks": [
         {
           "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/load-context.sh"
+          "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/load-context.sh\""
         }
       ]
     }
@@ -328,12 +328,12 @@ Available in all command hooks:
 - `$CLAUDE_ENV_FILE` - SessionStart only: persist env vars here
 - `$CLAUDE_CODE_REMOTE` - Set if running in remote context
 
-**Always use ${CLAUDE_PLUGIN_ROOT} in hook commands for portability:**
+**Always use ${CLAUDE_PLUGIN_ROOT} in hook commands for portability, and wrap the expanded path in double quotes:**
 
 ```json
 {
   "type": "command",
-  "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/validate.sh"
+  "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/validate.sh\""
 }
 ```
 
@@ -371,7 +371,7 @@ In plugins, define hooks in `hooks/hooks.json`:
       "hooks": [
         {
           "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/load-context.sh",
+          "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/load-context.sh\"",
           "timeout": 10
         }
       ]
@@ -613,7 +613,7 @@ Test command hooks directly:
 
 ```bash
 echo '{"tool_name": "Write", "tool_input": {"file_path": "/test"}}' | \
-  bash ${CLAUDE_PLUGIN_ROOT}/scripts/validate.sh
+  bash "${CLAUDE_PLUGIN_ROOT}/scripts/validate.sh"
 
 echo "Exit code: $?"
 ```

--- a/plugins/plugin-dev/skills/hook-development/scripts/README.md
+++ b/plugins/plugin-dev/skills/hook-development/scripts/README.md
@@ -142,7 +142,8 @@ Checks hook scripts for common issues and best practices violations.
 Check:
 - Script has shebang (`#!/bin/bash`)
 - Script is executable (`chmod +x`)
-- Path in hooks.json is correct (use `${CLAUDE_PLUGIN_ROOT}`)
+- Path in hooks.json is correct (use `bash "${CLAUDE_PLUGIN_ROOT}/path/to/hook.sh"` for shell hooks)
+- Quote `${CLAUDE_PLUGIN_ROOT}` or `${CLAUDE_PROJECT_DIR}` expansions so paths with spaces still work
 
 ### Hook times out
 

--- a/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
@@ -14,6 +14,8 @@ if [ $# -eq 0 ]; then
   echo "  - Hook type validity"
   echo "  - Matcher patterns"
   echo "  - Timeout ranges"
+  echo "  - Portable path quoting for CLAUDE_PLUGIN_ROOT / CLAUDE_PROJECT_DIR"
+  echo "  - Explicit interpreters for shell-script commands"
   exit 1
 fi
 
@@ -23,6 +25,24 @@ if [ ! -f "$HOOKS_FILE" ]; then
   echo "❌ Error: File not found: $HOOKS_FILE"
   exit 1
 fi
+
+command_references_path_var() {
+  local command="$1"
+  local var_name="$2"
+  [[ "$command" == *"\${$var_name}"* ]]
+}
+
+command_quotes_path_var() {
+  local command="$1"
+  local var_name="$2"
+  printf '%s\n' "$command" | grep -Eq "\"[^\"]*\\$\\{$var_name\\}[^\"]*\""
+}
+
+command_uses_shell_script_without_interpreter() {
+  local command="$1"
+  printf '%s\n' "$command" | grep -Eq '\.sh([[:space:]]|$)' &&
+    ! printf '%s\n' "$command" | grep -Eq '(^|[[:space:]])(bash|sh|zsh)([[:space:]]|$)'
+}
 
 echo "🔍 Validating hooks configuration: $HOOKS_FILE"
 echo ""
@@ -110,6 +130,19 @@ for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
           # Check for hardcoded paths
           if [[ "$command" == /* ]] && [[ "$command" != *'${CLAUDE_PLUGIN_ROOT}'* ]]; then
             echo "⚠️  $event[$i].hooks[$j]: Hardcoded absolute path detected. Consider using \${CLAUDE_PLUGIN_ROOT}"
+            ((warning_count++))
+          fi
+
+          for path_var in CLAUDE_PLUGIN_ROOT CLAUDE_PROJECT_DIR; do
+            if command_references_path_var "$command" "$path_var" &&
+              ! command_quotes_path_var "$command" "$path_var"; then
+              echo "⚠️  $event[$i].hooks[$j]: Wrap \${$path_var} paths in double quotes to handle spaces safely"
+              ((warning_count++))
+            fi
+          done
+
+          if command_uses_shell_script_without_interpreter "$command"; then
+            echo "⚠️  $event[$i].hooks[$j]: Invoke .sh hooks via bash/sh instead of relying on executable permissions"
             ((warning_count++))
           fi
         fi

--- a/plugins/plugin-dev/skills/plugin-structure/SKILL.md
+++ b/plugins/plugin-dev/skills/plugin-structure/SKILL.md
@@ -219,7 +219,7 @@ hooks/
     "matcher": "Write|Edit",
     "hooks": [{
       "type": "command",
-      "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/validate.sh",
+      "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/validate.sh\"",
       "timeout": 30
     }]
   }]
@@ -261,7 +261,7 @@ Use `${CLAUDE_PLUGIN_ROOT}` environment variable for all intra-plugin path refer
 
 ```json
 {
-  "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/run.sh"
+  "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/run.sh\""
 }
 ```
 
@@ -285,7 +285,7 @@ Use `${CLAUDE_PLUGIN_ROOT}` environment variable for all intra-plugin path refer
 
 **In manifest JSON fields** (hooks, MCP servers):
 ```json
-"command": "${CLAUDE_PLUGIN_ROOT}/scripts/tool.sh"
+"command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/tool.sh\""
 ```
 
 **In component files** (commands, agents, skills):

--- a/plugins/plugin-dev/skills/plugin-structure/examples/advanced-plugin.md
+++ b/plugins/plugin-dev/skills/plugin-structure/examples/advanced-plugin.md
@@ -622,7 +622,7 @@ For copy-paste examples:
 
 For manifest validation:
 \`\`\`bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/kubernetes-ops/scripts/validate-manifest.sh deployment.yaml
+bash "${CLAUDE_PLUGIN_ROOT}/skills/kubernetes-ops/scripts/validate-manifest.sh" deployment.yaml
 \`\`\`
 ```
 
@@ -636,7 +636,7 @@ bash ${CLAUDE_PLUGIN_ROOT}/skills/kubernetes-ops/scripts/validate-manifest.sh de
       "hooks": [
         {
           "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/security/scan-secrets.sh",
+          "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/security/scan-secrets.sh\"",
           "timeout": 30
         }
       ]
@@ -658,7 +658,7 @@ bash ${CLAUDE_PLUGIN_ROOT}/skills/kubernetes-ops/scripts/validate-manifest.sh de
       "hooks": [
         {
           "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/workflow/update-status.sh",
+          "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/workflow/update-status.sh\"",
           "timeout": 15
         }
       ]
@@ -670,12 +670,12 @@ bash ${CLAUDE_PLUGIN_ROOT}/skills/kubernetes-ops/scripts/validate-manifest.sh de
       "hooks": [
         {
           "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/quality/check-config.sh",
+          "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/quality/check-config.sh\"",
           "timeout": 45
         },
         {
           "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/workflow/notify-team.sh",
+          "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/workflow/notify-team.sh\"",
           "timeout": 30
         }
       ]
@@ -687,7 +687,7 @@ bash ${CLAUDE_PLUGIN_ROOT}/skills/kubernetes-ops/scripts/validate-manifest.sh de
       "hooks": [
         {
           "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/security/validate-permissions.sh",
+          "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/security/validate-permissions.sh\"",
           "timeout": 20
         }
       ]

--- a/plugins/plugin-dev/skills/plugin-structure/examples/standard-plugin.md
+++ b/plugins/plugin-dev/skills/plugin-structure/examples/standard-plugin.md
@@ -445,7 +445,7 @@ See language-specific guides for:
       "hooks": [
         {
           "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/validate-commit.sh",
+          "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/validate-commit.sh\"",
           "timeout": 45
         }
       ]


### PR DESCRIPTION
## Summary
- teach `validate-hook-schema.sh` to warn when `${CLAUDE_PLUGIN_ROOT}` or `${CLAUDE_PROJECT_DIR}` paths are not wrapped in double quotes
- warn when `.sh` hook commands are invoked directly instead of through `bash`/`sh`
- update the main plugin-dev hook and plugin-structure examples to use the safer quoted shell-wrapper form consistently

Related: #33431, #39158

## Testing
- `bash -n plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh`
- validated that `${CLAUDE_PLUGIN_ROOT}/hooks/start.sh` now emits warnings for missing quotes and missing interpreter
- validated that `bash "${CLAUDE_PLUGIN_ROOT}/hooks/start.sh"` passes cleanly