### PR TITLE
Fix silent validation failures and improve error handling

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -1,8 +1,8 @@
 # Settings Examples
 
-Example Claude Code settings files, primarily intended for organization-wide deployments. Use these are starting points — adjust them to fit your needs.
+Example Claude Code settings files, primarily intended for organization-wide deployments. Use these as starting points — adjust them to fit your needs.
 
-These may be applied at any level of the [settings hierarchy](https://code.claude.com/docs/en/settings#settings-files), though certain properties only take effect if specified in enterprise settings (e.g. `strictKnownMarketplaces`, `allowManagedHooksOnly`, `allowManagedPermissionRulesOnly`).
+These may be applied at any level of the [settings hierarchy](https://code.claude.com/docs/en/settings#settings-files), though certain properties only take effect if specified in enterprise settings (e.g., `strictKnownMarketplaces`, `allowManagedHooksOnly`, `allowManagedPermissionRulesOnly`).
 
 
 ## Configuration Examples

--- a/scripts/edit-issue-labels.sh
+++ b/scripts/edit-issue-labels.sh
@@ -26,6 +26,8 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     *)
+      echo "Error: unknown option: $1" >&2
+      echo "Usage: ./edit-issue-labels.sh --issue 123 --add-label bug --remove-label untriaged" >&2
       exit 1
       ;;
   esac
@@ -33,14 +35,17 @@ done
 
 # Validate issue number
 if [[ -z "$ISSUE" ]]; then
+  echo "Error: --issue is required" >&2
   exit 1
 fi
 
 if ! [[ "$ISSUE" =~ ^[0-9]+$ ]]; then
+  echo "Error: --issue must be a number, got: $ISSUE" >&2
   exit 1
 fi
 
 if [[ ${#ADD_LABELS[@]} -eq 0 && ${#REMOVE_LABELS[@]} -eq 0 ]]; then
+  echo "Error: at least one --add-label or --remove-label is required" >&2
   exit 1
 fi
 

--- a/scripts/lifecycle-comment.ts
+++ b/scripts/lifecycle-comment.ts
@@ -47,7 +47,8 @@ const response = await fetch(
 
 if (!response.ok) {
   const text = await response.text();
-  throw new Error(`GitHub API ${response.status}: ${text}`);
+  const truncated = text.length > 500 ? text.substring(0, 500) + "… (truncated)" : text;
+  throw new Error(`GitHub API ${response.status}: ${truncated}`);
 }
 
 console.log(`Commented on #${issueNumber} for label "${label}"`);

--- a/scripts/sweep.ts
+++ b/scripts/sweep.ts
@@ -34,7 +34,8 @@ async function githubRequest<T>(
   if (!response.ok) {
     if (response.status === 404) return {} as T;
     const text = await response.text();
-    throw new Error(`GitHub API ${response.status}: ${text}`);
+    const truncated = text.length > 500 ? text.substring(0, 500) + "… (truncated)" : text;
+    throw new Error(`GitHub API ${response.status}: ${truncated}`);
   }
 
   return response.json();


### PR DESCRIPTION
Changes Made
1. Fix scripts/edit-issue-labels.sh — Silent validation failures
The script previously exited with code 1 on validation errors without printing any message. Users got no feedback about what went wrong. Added clear error messages to stderr for:

Unknown options: Shows the unrecognized option and usage example
Missing --issue: "Error: --issue is required"
Non-numeric --issue: "Error: --issue must be a number, got: <value>"
No labels specified: "Error: at least one --add-label or --remove-label is required"
2. Fix examples/settings/README.md — Typo
Fixed "Use these are starting points" → "Use these as starting points"
Added missing comma after "e.g." for consistent punctuation
3. Truncate API error responses in TypeScript scripts
scripts/lifecycle-comment.ts: When GitHub API returns an error, the response body could be an entire HTML error page. Now truncated to 500 characters with a "… (truncated)" indicator.
scripts/sweep.ts: Same improvement in the shared githubRequest function.
All changes are minimal, uncontroversial improvements that fix actual usability issues. The code review feedback was incorporated (added truncation indicators), and the security scan found 0 alerts.