### PR TITLE
fix: pin 7 unpinned action(s)

### DIFF
--- a/.github/workflows/auto-close-duplicates.yml
+++ b/.github/workflows/auto-close-duplicates.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 

--- a/.github/workflows/backfill-duplicate-comments.yml
+++ b/.github/workflows/backfill-duplicate-comments.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
       

--- a/.github/workflows/claude-dedupe-issues.yml
+++ b/.github/workflows/claude-dedupe-issues.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Claude Code slash command
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@3ac52d0da9f8ec9ca7b4dc23bb477e36ef9c77a9 # v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Run Claude Code for Issue Triage
         timeout-minutes: 5
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@3ac52d0da9f8ec9ca7b4dc23bb477e36ef9c77a9 # v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@3ac52d0da9f8ec9ca7b4dc23bb477e36ef9c77a9 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: "--model claude-sonnet-4-5-20250929"

--- a/.github/workflows/issue-lifecycle-comment.yml
+++ b/.github/workflows/issue-lifecycle-comment.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 


### PR DESCRIPTION
## Security: Harden GitHub Actions workflows

Hey, we found some CI/CD security issues in this repo's workflows using [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), our open-source CI/CD security scanner at [Vigilant](https://www.vigilantdefense.com). These are the same vulnerability classes being actively exploited right now in the tj-actions, Trivy, LiteLLM supply chain attack chain. We scanned the top 50K repos on GitHub and over 20,000 have this same problem. We're trying to get fixes out to as many maintainers as possible before more repos get hit.

This PR fixes what we could automatically, and flags anything else that needs a manual look. There's a real person behind this PR, we're actively checking back on comments so if you have any questions just drop them here and we'll respond.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/auto-close-duplicates.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/backfill-duplicate-comments.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/claude-dedupe-issues.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/claude-issue-triage.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/claude.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/issue-lifecycle-comment.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/sweep.yml` | Pinned 1 third-party action(s) to commit SHA |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-012 | high | `.github/workflows/claude-dedupe-issues.yml` | Secret Exfiltration via Outbound HTTP Request |
| RGS-004 | high | `.github/workflows/claude-issue-triage.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/claude-issue-triage.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/claude.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/claude.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-012 | high | `.github/workflows/log-issue-events.yml` | Secret Exfiltration via Outbound HTTP Request |
| RGS-005 | medium | `.github/workflows/claude-issue-triage.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `.github/workflows/claude.yml` | Excessive Permissions on Untrusted Trigger |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)


Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.