### PR TITLE
Add tmp-cleanup plugin to prune oversized task .output files

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -25,6 +25,7 @@ Learn more in the [official plugins documentation](https://docs.claude.com/en/do
 | [pr-review-toolkit](./pr-review-toolkit/) | Comprehensive PR review agents specializing in comments, tests, error handling, type design, code quality, and code simplification | **Command:** `/pr-review-toolkit:review-pr` - Run with optional review aspects (comments, tests, errors, types, code, simplify, all)<br>**Agents:** `comment-analyzer`, `pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer`, `code-reviewer`, `code-simplifier` |
 | [ralph-wiggum](./ralph-wiggum/) | Interactive self-referential AI loops for iterative development. Claude works on the same task repeatedly until completion | **Commands:** `/ralph-loop`, `/cancel-ralph` - Start/stop autonomous iteration loops<br>**Hook:** Stop - Intercepts exit attempts to continue iteration |
 | [security-guidance](./security-guidance/) | Security reminder hook that warns about potential security issues when editing files | **Hook:** PreToolUse - Monitors 9 security patterns including command injection, XSS, eval usage, dangerous HTML, pickle deserialization, and os.system calls |
+| [tmp-cleanup](./tmp-cleanup/) | Automatically prunes oversized task `.output` files from `/tmp` to prevent unbounded disk usage | **Hook:** SessionStart - Scans `/tmp/claude-{uid}/` on startup, resume, and compact; removes files >100 MB, >72 hours old, or when total exceeds 5 GB. All thresholds configurable via env vars. |
 
 ## Installation
 

--- a/plugins/tmp-cleanup/.claude-plugin/plugin.json
+++ b/plugins/tmp-cleanup/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "tmp-cleanup",
+  "version": "0.1.0",
+  "description": "Automatically prunes oversized task .output files from /tmp to prevent unbounded disk usage"
+}

--- a/plugins/tmp-cleanup/README.md
+++ b/plugins/tmp-cleanup/README.md
@@ -1,0 +1,64 @@
+# tmp-cleanup
+
+Automatically prunes oversized task `.output` files from `/tmp/claude-{uid}/` to prevent unbounded disk usage.
+
+## Problem
+
+When Claude Code runs background tasks or subagents, their stdout/stderr is captured in `.output` files under `/tmp/claude-{uid}/`. These files have no size cap and can grow to tens of gigabytes if a command produces infinite output (e.g., an interactive prompt in a non-interactive shell, a verbose build loop, or a runaway process).
+
+See: [#26911](https://github.com/anthropics/claude-code/issues/26911), [#15700](https://github.com/anthropics/claude-code/issues/15700), [#33789](https://github.com/anthropics/claude-code/issues/33789), [#39909](https://github.com/anthropics/claude-code/issues/39909)
+
+## How It Works
+
+A `SessionStart` hook runs on `startup`, `resume`, and `compact` events. It scans the tmp directory and removes `.output` files that are:
+
+1. **Too large** — over 100 MB per file (configurable)
+2. **Too old** — over 72 hours since last modified (configurable)
+3. **Over budget** — if total remaining size exceeds 5 GB, the largest files are pruned first (configurable)
+
+When files are cleaned up, a summary line is printed:
+
+```
+[tmp-cleanup] Pruned 3 task output files, freed 95.12 GB
+```
+
+## Configuration
+
+All thresholds are configurable via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CLAUDE_TMP_CLEANUP_MAX_FILE_MB` | `100` | Max size per `.output` file in MB |
+| `CLAUDE_TMP_CLEANUP_MAX_TOTAL_GB` | `5` | Max total `.output` size before pruning |
+| `CLAUDE_TMP_CLEANUP_MAX_AGE_HOURS` | `72` | Max age for `.output` files in hours |
+| `CLAUDE_TMP_CLEANUP_DISABLED` | - | Set to `1` to disable cleanup entirely |
+
+## Installation
+
+Install as a Claude Code plugin:
+
+```bash
+claude plugin install tmp-cleanup
+```
+
+Or add to your project's `.claude/plugins.json`:
+
+```json
+{
+  "plugins": ["tmp-cleanup"]
+}
+```
+
+## Manual Usage
+
+You can also run the cleanup script directly:
+
+```bash
+node plugins/tmp-cleanup/hooks/cleanup-tmp.mjs
+```
+
+Or add a shell alias:
+
+```bash
+alias claude-clean="rm -rf /private/tmp/claude-$(id -u)"
+```

--- a/plugins/tmp-cleanup/hooks/cleanup-tmp.mjs
+++ b/plugins/tmp-cleanup/hooks/cleanup-tmp.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+/**
+ * Claude Code Hook: Task Output Cleanup
+ *
+ * Prunes oversized .output files from /tmp/claude-{uid}/ to prevent
+ * unbounded disk usage. Background tasks and subagents can produce
+ * .output files that grow without limit (observed 46GB+ per file).
+ *
+ * Runs on SessionStart (startup, resume, compact) to keep disk usage
+ * in check without requiring manual intervention.
+ *
+ * Configuration via environment variables:
+ *   CLAUDE_TMP_CLEANUP_MAX_FILE_MB   - Max size per .output file (default: 100)
+ *   CLAUDE_TMP_CLEANUP_MAX_TOTAL_GB  - Max total size before pruning old files (default: 5)
+ *   CLAUDE_TMP_CLEANUP_MAX_AGE_HOURS - Max age for .output files (default: 72)
+ *   CLAUDE_TMP_CLEANUP_DISABLED      - Set to "1" to disable cleanup
+ */
+
+import { readdirSync, statSync, unlinkSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const MAX_FILE_BYTES =
+  (parseInt(process.env.CLAUDE_TMP_CLEANUP_MAX_FILE_MB, 10) || 100) *
+  1024 *
+  1024;
+const MAX_TOTAL_BYTES =
+  (parseInt(process.env.CLAUDE_TMP_CLEANUP_MAX_TOTAL_GB, 10) || 5) *
+  1024 *
+  1024 *
+  1024;
+const MAX_AGE_MS =
+  (parseInt(process.env.CLAUDE_TMP_CLEANUP_MAX_AGE_HOURS, 10) || 72) *
+  60 *
+  60 *
+  1000;
+
+if (process.env.CLAUDE_TMP_CLEANUP_DISABLED === "1") {
+  process.exit(0);
+}
+
+// Determine the tmp directory: /tmp/claude-{uid} on macOS/Linux
+const uid = process.getuid?.();
+const tmpBase =
+  process.platform === "darwin"
+    ? `/private/tmp/claude-${uid}`
+    : `/tmp/claude-${uid}`;
+
+if (!existsSync(tmpBase)) {
+  process.exit(0);
+}
+
+const now = Date.now();
+let deletedCount = 0;
+let freedBytes = 0;
+
+/**
+ * Recursively find all .output files under the tmp directory.
+ */
+function findOutputFiles(dir) {
+  const results = [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return results;
+  }
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...findOutputFiles(fullPath));
+    } else if (entry.name.endsWith(".output")) {
+      try {
+        const stat = statSync(fullPath);
+        results.push({ path: fullPath, size: stat.size, mtimeMs: stat.mtimeMs });
+      } catch {
+        // File may have been deleted between readdir and stat
+      }
+    }
+  }
+  return results;
+}
+
+const files = findOutputFiles(tmpBase);
+
+// Pass 1: Delete files that exceed per-file size limit
+for (const file of files) {
+  if (file.size > MAX_FILE_BYTES) {
+    try {
+      unlinkSync(file.path);
+      freedBytes += file.size;
+      deletedCount++;
+      file.deleted = true;
+    } catch {
+      // Ignore deletion errors
+    }
+  }
+}
+
+// Pass 2: Delete files older than max age
+for (const file of files) {
+  if (file.deleted) continue;
+  if (now - file.mtimeMs > MAX_AGE_MS) {
+    try {
+      unlinkSync(file.path);
+      freedBytes += file.size;
+      deletedCount++;
+      file.deleted = true;
+    } catch {
+      // Ignore deletion errors
+    }
+  }
+}
+
+// Pass 3: If total remaining size exceeds budget, delete largest files first
+const remaining = files
+  .filter((f) => !f.deleted)
+  .sort((a, b) => b.size - a.size);
+let totalRemaining = remaining.reduce((sum, f) => sum + f.size, 0);
+
+for (const file of remaining) {
+  if (totalRemaining <= MAX_TOTAL_BYTES) break;
+  try {
+    unlinkSync(file.path);
+    totalRemaining -= file.size;
+    freedBytes += file.size;
+    deletedCount++;
+  } catch {
+    // Ignore deletion errors
+  }
+}
+
+// Report only if cleanup actually happened
+if (deletedCount > 0) {
+  const freedMB = (freedBytes / (1024 * 1024)).toFixed(1);
+  const freedGB = (freedBytes / (1024 * 1024 * 1024)).toFixed(2);
+  const display = freedBytes > 1024 * 1024 * 1024 ? `${freedGB} GB` : `${freedMB} MB`;
+  process.stdout.write(
+    `[tmp-cleanup] Pruned ${deletedCount} task output file${deletedCount === 1 ? "" : "s"}, freed ${display}\n`
+  );
+}

--- a/plugins/tmp-cleanup/hooks/hooks.json
+++ b/plugins/tmp-cleanup/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/cleanup-tmp.mjs\""
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a `tmp-cleanup` plugin that automatically prunes oversized task `.output` files from `/tmp/claude-{uid}/`
- Runs as a `SessionStart` hook on `startup`, `resume`, and `compact` — no manual intervention needed
- Three-pass cleanup: oversized files (>100MB), stale files (>72h), then largest-first if total exceeds 5GB
- All thresholds configurable via environment variables
- References: #39909, #26911, #15700, #33789

## Problem

Background tasks and subagents write stdout/stderr to `.output` files with no size cap. Interactive prompts in non-interactive shells, verbose builds, and runaway processes can produce individual files of 46GB+ (95GB total observed in one session). This silently fills up user disks.

## What this PR adds

```
plugins/tmp-cleanup/
├── .claude-plugin/
│   └── plugin.json
├── hooks/
│   ├── hooks.json          # SessionStart hook config
│   └── cleanup-tmp.mjs     # Cleanup logic (Node.js, zero dependencies)
└── README.md
```

**Cleanup strategy (3 passes):**
1. Delete any `.output` file over 100 MB (`CLAUDE_TMP_CLEANUP_MAX_FILE_MB`)
2. Delete any `.output` file older than 72 hours (`CLAUDE_TMP_CLEANUP_MAX_AGE_HOURS`)
3. If remaining total exceeds 5 GB (`CLAUDE_TMP_CLEANUP_MAX_TOTAL_GB`), prune largest files first

Reports cleanup when it happens:
```
[tmp-cleanup] Pruned 3 task output files, freed 95.12 GB
```

## Test plan

- [ ] Verify script exits cleanly when no tmp directory exists
- [ ] Verify script exits cleanly when tmp directory is empty
- [ ] Verify oversized files are deleted (create a >100MB test file)
- [ ] Verify old files are deleted (touch a file with old mtime)
- [ ] Verify total budget pruning works (create multiple files exceeding 5GB total)
- [ ] Verify `CLAUDE_TMP_CLEANUP_DISABLED=1` skips all cleanup
- [ ] Verify env var overrides work for all thresholds

🤖 Generated with [Claude Code](https://claude.com/claude-code)