### PR TITLE
feat(plugin): add tmp-cleanup plugin for /tmp disk leak mitigation

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -25,6 +25,7 @@ Learn more in the [official plugins documentation](https://docs.claude.com/en/do
 | [pr-review-toolkit](./pr-review-toolkit/) | Comprehensive PR review agents specializing in comments, tests, error handling, type design, code quality, and code simplification | **Command:** `/pr-review-toolkit:review-pr` - Run with optional review aspects (comments, tests, errors, types, code, simplify, all)<br>**Agents:** `comment-analyzer`, `pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer`, `code-reviewer`, `code-simplifier` |
 | [ralph-wiggum](./ralph-wiggum/) | Interactive self-referential AI loops for iterative development. Claude works on the same task repeatedly until completion | **Commands:** `/ralph-loop`, `/cancel-ralph` - Start/stop autonomous iteration loops<br>**Hook:** Stop - Intercepts exit attempts to continue iteration |
 | [security-guidance](./security-guidance/) | Security reminder hook that warns about potential security issues when editing files | **Hook:** PreToolUse - Monitors 9 security patterns including command injection, XSS, eval usage, dangerous HTML, pickle deserialization, and os.system calls |
+| [tmp-cleanup](./tmp-cleanup/) | Automatically prunes oversized task `.output` files and stale `claude-*-cwd` tracking files from `/tmp` | **Hook:** SessionStart - Three-pass cleanup: oversized files (>100 MB), stale files (>72h), then largest-first budget enforcement (>5 GB total). Also prunes stale cwd files (>24h). All thresholds configurable via env vars. |
 
 ## Installation
 

--- a/plugins/tmp-cleanup/.claude-plugin/plugin.json
+++ b/plugins/tmp-cleanup/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "tmp-cleanup",
+  "version": "1.0.0",
+  "description": "Automatically prunes oversized task .output files and stale cwd tracking files from /tmp to prevent unbounded disk usage",
+  "author": {
+    "name": "ZVN DEV",
+    "email": "78920650+zvndev@users.noreply.github.com"
+  }
+}

--- a/plugins/tmp-cleanup/README.md
+++ b/plugins/tmp-cleanup/README.md
@@ -1,0 +1,66 @@
+# Tmp Cleanup Plugin
+
+Automatically prunes leaked temporary files from Claude Code's `/tmp` directory to prevent unbounded disk usage.
+
+## Problem
+
+Claude Code writes temporary files to `/tmp/claude-{uid}/` that can accumulate without bound:
+
+1. **Task `.output` files** — Background tasks and subagents capture stdout/stderr to `.output` files with no size cap. Interactive prompts in non-interactive shells, verbose builds, and runaway processes can produce individual files exceeding 46 GB (95 GB+ total observed in a single session). See [#26911](https://github.com/anthropics/claude-code/issues/26911), [#39909](https://github.com/anthropics/claude-code/issues/39909).
+
+2. **CWD tracking files** (`claude-*-cwd`) — Small 22-byte files that accumulate at ~174/day and are never cleaned up on crash or abnormal exit. See [#8856](https://github.com/anthropics/claude-code/issues/8856).
+
+## How It Works
+
+A `SessionStart` hook runs automatically when Claude Code starts, resumes, or compacts. It scans the tmp directory and removes files using a three-pass strategy:
+
+**Pass 1 — Task output cleanup:**
+1. Delete `.output` files exceeding the per-file size limit (default: 100 MB)
+2. Delete `.output` files older than the max age (default: 72 hours)
+3. If remaining total size exceeds the budget (default: 5 GB), prune largest files first
+
+**Pass 2 — CWD file cleanup:**
+4. Delete `claude-*-cwd` files older than 24 hours, owned by the current user
+
+When files are cleaned up, a summary is printed:
+
+```
+[tmp-cleanup] Pruned 3 task output files and 47 stale cwd files, freed 95.12 GB
+```
+
+## Safety
+
+- **Symlink-safe**: Uses `lstat` (not `stat`) and skips symlinks at every level to prevent directory traversal
+- **Path validation**: All paths are resolved and verified to be within the tmp base directory before deletion
+- **Ownership check**: CWD files are only deleted if owned by the current user (UID match)
+- **Regular files only**: Only deletes regular files, never directories or special files
+- **Graceful failures**: All filesystem errors are caught silently — the hook never blocks session start
+- **Cross-platform**: Exits cleanly on Windows where `process.getuid()` is unavailable
+
+## Configuration
+
+All thresholds are configurable via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CLAUDE_TMP_CLEANUP_MAX_FILE_MB` | `100` | Max size per `.output` file in MB |
+| `CLAUDE_TMP_CLEANUP_MAX_TOTAL_GB` | `5` | Max total `.output` size before pruning largest first |
+| `CLAUDE_TMP_CLEANUP_MAX_AGE_HOURS` | `72` | Max age for `.output` files |
+| `CLAUDE_TMP_CLEANUP_CWD_MAX_AGE_HOURS` | `24` | Max age for `claude-*-cwd` files |
+| `CLAUDE_TMP_CLEANUP_DISABLED` | — | Set to `1` to disable all cleanup |
+
+## Manual Usage
+
+Run the cleanup script directly:
+
+```bash
+node plugins/tmp-cleanup/hooks/cleanup-tmp.mjs
+```
+
+## Author
+
+ZVN DEV (78920650+zvndev@users.noreply.github.com)
+
+## Version
+
+1.0.0

--- a/plugins/tmp-cleanup/hooks/cleanup-tmp.mjs
+++ b/plugins/tmp-cleanup/hooks/cleanup-tmp.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+
+/**
+ * Claude Code SessionStart Hook: Temporary File Cleanup
+ *
+ * Prunes two categories of leaked files from the Claude Code tmp directory:
+ *
+ * 1. Task .output files — Background tasks and subagents capture stdout/stderr
+ *    to .output files with no size cap. Interactive prompts in non-interactive
+ *    shells, verbose builds, and runaway processes can produce individual files
+ *    exceeding 46 GB (95 GB+ total observed in a single session).
+ *
+ * 2. CWD tracking files (claude-*-cwd) — Small 22-byte files that accumulate
+ *    at a rate of ~174/day and are never cleaned up on crash or abnormal exit.
+ *
+ * Runs on SessionStart to catch leftovers from crashed sessions. Configurable
+ * via environment variables. All filesystem operations are symlink-safe.
+ *
+ * @see https://github.com/anthropics/claude-code/issues/26911
+ * @see https://github.com/anthropics/claude-code/issues/39909
+ * @see https://github.com/anthropics/claude-code/issues/8856
+ */
+
+import {
+  existsSync,
+  lstatSync,
+  readdirSync,
+  unlinkSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import { platform } from "node:os";
+
+// -- Configuration (all overridable via environment variables) ----------------
+
+const MAX_FILE_BYTES =
+  (parseInt(process.env.CLAUDE_TMP_CLEANUP_MAX_FILE_MB, 10) || 100) *
+  1024 *
+  1024;
+
+const MAX_TOTAL_BYTES =
+  (parseInt(process.env.CLAUDE_TMP_CLEANUP_MAX_TOTAL_GB, 10) || 5) *
+  1024 *
+  1024 *
+  1024;
+
+const MAX_AGE_MS =
+  (parseInt(process.env.CLAUDE_TMP_CLEANUP_MAX_AGE_HOURS, 10) || 72) *
+  60 *
+  60 *
+  1000;
+
+const CWD_MAX_AGE_MS =
+  (parseInt(process.env.CLAUDE_TMP_CLEANUP_CWD_MAX_AGE_HOURS, 10) || 24) *
+  60 *
+  60 *
+  1000;
+
+if (process.env.CLAUDE_TMP_CLEANUP_DISABLED === "1") {
+  process.exit(0);
+}
+
+// -- Platform detection ------------------------------------------------------
+
+// process.getuid() is only available on POSIX (macOS, Linux).
+// On Windows, Claude Code uses a different tmp path convention that this
+// plugin does not currently handle.
+const getuid = process.getuid;
+if (typeof getuid !== "function") {
+  process.exit(0);
+}
+
+const uid = getuid.call(process);
+const tmpBase =
+  platform() === "darwin"
+    ? `/private/tmp/claude-${uid}`
+    : `/tmp/claude-${uid}`;
+
+const resolvedTmpBase = resolve(tmpBase);
+
+if (!existsSync(resolvedTmpBase)) {
+  process.exit(0);
+}
+
+// -- Helpers -----------------------------------------------------------------
+
+const now = Date.now();
+let deletedCount = 0;
+let freedBytes = 0;
+let cwdDeletedCount = 0;
+
+/**
+ * Safely stat a path using lstat (does not follow symlinks).
+ * Returns null if the path cannot be accessed.
+ */
+function safeLstat(filePath) {
+  try {
+    return lstatSync(filePath);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Safely delete a file. Returns the file size if successful, 0 otherwise.
+ */
+function safeUnlink(filePath) {
+  try {
+    const stat = safeLstat(filePath);
+    if (!stat) return 0;
+
+    // Only delete regular files — never follow symlinks
+    if (!stat.isFile()) return 0;
+
+    const size = stat.size;
+    unlinkSync(filePath);
+    return size;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Verify that a resolved path is still within the tmp base directory.
+ * Prevents path traversal via symlinked directories.
+ */
+function isWithinTmpBase(filePath) {
+  return resolve(filePath).startsWith(resolvedTmpBase + "/");
+}
+
+/**
+ * Recursively find all .output files under the tmp directory.
+ * Skips symlinks at every level to prevent directory traversal attacks.
+ */
+function findOutputFiles(dir) {
+  const results = [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return results;
+  }
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+
+    // Never follow symlinks — prevents traversal outside /tmp
+    if (entry.isSymbolicLink()) continue;
+
+    if (entry.isDirectory()) {
+      results.push(...findOutputFiles(fullPath));
+    } else if (entry.name.endsWith(".output") && entry.isFile()) {
+      if (!isWithinTmpBase(fullPath)) continue;
+      const stat = safeLstat(fullPath);
+      if (stat && stat.isFile()) {
+        results.push({
+          path: fullPath,
+          size: stat.size,
+          mtimeMs: stat.mtimeMs,
+          deleted: false,
+        });
+      }
+    }
+  }
+  return results;
+}
+
+// -- Pass 1: Prune .output files ---------------------------------------------
+
+const files = findOutputFiles(resolvedTmpBase);
+
+// 1a. Delete files that exceed the per-file size limit
+for (const file of files) {
+  if (file.size > MAX_FILE_BYTES) {
+    const freed = safeUnlink(file.path);
+    if (freed > 0) {
+      freedBytes += freed;
+      deletedCount++;
+      file.deleted = true;
+    }
+  }
+}
+
+// 1b. Delete files older than the max age
+for (const file of files) {
+  if (file.deleted) continue;
+  if (now - file.mtimeMs > MAX_AGE_MS) {
+    const freed = safeUnlink(file.path);
+    if (freed > 0) {
+      freedBytes += freed;
+      deletedCount++;
+      file.deleted = true;
+    }
+  }
+}
+
+// 1c. If total remaining size exceeds budget, delete largest files first
+const remaining = files
+  .filter((f) => !f.deleted)
+  .sort((a, b) => b.size - a.size);
+let totalRemaining = remaining.reduce((sum, f) => sum + f.size, 0);
+
+for (const file of remaining) {
+  if (totalRemaining <= MAX_TOTAL_BYTES) break;
+  const freed = safeUnlink(file.path);
+  if (freed > 0) {
+    totalRemaining -= freed;
+    freedBytes += freed;
+    deletedCount++;
+  }
+}
+
+// -- Pass 2: Clean stale cwd tracking files ----------------------------------
+
+// CWD files match the pattern: claude-XXXX-cwd (4 hex chars)
+const cwdPattern = /^claude-[0-9a-f]{4}-cwd$/;
+
+try {
+  const tmpParent = resolve(resolvedTmpBase, "..");
+  const tmpEntries = readdirSync(tmpParent, { withFileTypes: true });
+
+  for (const entry of tmpEntries) {
+    if (!cwdPattern.test(entry.name)) continue;
+    if (entry.isSymbolicLink()) continue;
+    if (!entry.isFile()) continue;
+
+    const fullPath = join(tmpParent, entry.name);
+    const stat = safeLstat(fullPath);
+    if (!stat || !stat.isFile()) continue;
+
+    // Only delete stale cwd files (older than threshold)
+    if (now - stat.mtimeMs > CWD_MAX_AGE_MS) {
+      // Verify ownership — only delete files owned by the current user
+      if (stat.uid !== uid) continue;
+
+      const freed = safeUnlink(fullPath);
+      if (freed > 0) {
+        freedBytes += freed;
+        cwdDeletedCount++;
+      }
+    }
+  }
+} catch {
+  // Parent directory not readable — skip cwd cleanup
+}
+
+// -- Report ------------------------------------------------------------------
+
+const totalDeleted = deletedCount + cwdDeletedCount;
+
+if (totalDeleted > 0) {
+  const parts = [];
+  if (deletedCount > 0) {
+    parts.push(`${deletedCount} task output file${deletedCount === 1 ? "" : "s"}`);
+  }
+  if (cwdDeletedCount > 0) {
+    parts.push(`${cwdDeletedCount} stale cwd file${cwdDeletedCount === 1 ? "" : "s"}`);
+  }
+
+  const freedMB = (freedBytes / (1024 * 1024)).toFixed(1);
+  const freedGB = (freedBytes / (1024 * 1024 * 1024)).toFixed(2);
+  const display =
+    freedBytes >= 1024 * 1024 * 1024 ? `${freedGB} GB` : `${freedMB} MB`;
+
+  process.stdout.write(
+    `[tmp-cleanup] Pruned ${parts.join(" and ")}, freed ${display}\n`
+  );
+}

--- a/plugins/tmp-cleanup/hooks/hooks.json
+++ b/plugins/tmp-cleanup/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Prunes oversized task .output files and stale cwd tracking files from /tmp on session start",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/cleanup-tmp.mjs\"",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `tmp-cleanup` plugin that automatically prunes two categories of leaked files from Claude Code's `/tmp` directory:

- **Task `.output` files** — the primary disk killer. Background tasks and subagents produce `.output` files with no size cap. Users have reported **46 GB+ per file**, **95 GB+ per session**, and **up to 740 GB** total consumption.
- **CWD tracking files** (`claude-*-cwd`) — small 22-byte files that accumulate at ~174/day without cleanup on crash.

### Why a plugin?

The root cause is in the compiled runtime (no size cap on output capture, no cleanup on session end). Until that's fixed upstream, this plugin provides immediate relief via the existing hook system — no binary patches, no external dependencies, runs on every session start.

## Approach

A `SessionStart` hook with a three-pass cleanup strategy:

| Pass | Target | Condition | Default |
|------|--------|-----------|---------|
| 1a | `.output` files | Size exceeds per-file limit | 100 MB |
| 1b | `.output` files | Age exceeds max age | 72 hours |
| 1c | `.output` files | Total remaining exceeds budget (largest first) | 5 GB |
| 2 | `claude-*-cwd` files | Age exceeds max age + UID ownership check | 24 hours |

All thresholds configurable via `CLAUDE_TMP_CLEANUP_*` environment variables. Set `CLAUDE_TMP_CLEANUP_DISABLED=1` to opt out entirely.

## Safety

| Concern | Mitigation |
|---------|-----------|
| Symlink traversal | `lstat` (not `stat`) + `isSymbolicLink()` check at every directory and file level |
| Path traversal | All paths `resolve()`d and verified to start with the tmp base directory |
| Cross-user deletion | CWD files checked for UID ownership before deletion |
| Non-regular files | Only `isFile()` entries are deleted — never directories or special files |
| Windows | Exits cleanly when `process.getuid()` is unavailable |
| Session blocking | All filesystem errors caught silently — hook never blocks session start |
| Timeout | 15-second timeout configured in hooks.json |

## Comparison with existing PRs

| | This PR | #33015 | #30721 | #34545 |
|---|---|---|---|---|
| Targets `.output` files (the 740 GB problem) | Yes | No | No | Yes (cli.js patch) |
| Targets `cwd` files | Yes | Yes | Yes | No |
| Plugin-based (no binary patches) | Yes | Yes | Yes | No |
| Language | Node.js (zero deps) | Python | Python | JS (patches minified cli.js) |
| Hook event | SessionStart | PostToolUse + Stop | Stop | N/A |
| Catches crash leftovers | Yes (runs on next start) | Partial (Stop doesn't fire on crash) | No (Stop only) | N/A |
| Symlink protection | Yes | Yes | No | N/A |
| Configurable thresholds | Yes (5 env vars) | No | No | No |
| Cross-platform safe | Yes (Windows exit) | Yes (tempfile.gettempdir) | No | No |

## Files

```
plugins/tmp-cleanup/
├── .claude-plugin/
│   └── plugin.json           # Plugin metadata (v1.0.0)
├── hooks/
│   ├── hooks.json            # SessionStart hook with 15s timeout
│   └── cleanup-tmp.mjs       # Cleanup logic (Node.js, zero dependencies)
└── README.md                 # Documentation with safety details and config
```

## Closes

- Closes #26911 — Task `.output` files in `/tmp` grow unbounded (537 GB+)
- Closes #39909 — Task `.output` files grow unbounded (95 GB+)
- Closes #8856 — `/tmp/claude-*-cwd` files never deleted

## Test plan

- [x] Script exits cleanly when no tmp directory exists
- [x] Script exits cleanly when tmp directory is empty
- [x] Script exits cleanly on platforms without `process.getuid()` (Windows)
- [x] Syntax validation passes (`node -c`)
- [ ] Oversized `.output` files are deleted (create >100 MB test file)
- [ ] Old `.output` files are deleted (touch file with old mtime)
- [ ] Total budget pruning removes largest files first
- [ ] Symlinks in tmp directory are not followed
- [ ] CWD files matching `claude-XXXX-cwd` pattern are cleaned
- [ ] CWD files owned by other users are not deleted
- [ ] `CLAUDE_TMP_CLEANUP_DISABLED=1` skips all cleanup
- [ ] Environment variable overrides work for all thresholds

🤖 Generated with [Claude Code](https://claude.com/claude-code)