### PR TITLE
fix: pin 7 actions to commit SHA

### DIFF
--- a/.github/workflows/auto-close-duplicates.yml
+++ b/.github/workflows/auto-close-duplicates.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 

--- a/.github/workflows/backfill-duplicate-comments.yml
+++ b/.github/workflows/backfill-duplicate-comments.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
       

--- a/.github/workflows/claude-dedupe-issues.yml
+++ b/.github/workflows/claude-dedupe-issues.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Claude Code slash command
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@3ac52d0da9f8ec9ca7b4dc23bb477e36ef9c77a9 # v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Run Claude Code for Issue Triage
         timeout-minutes: 5
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@3ac52d0da9f8ec9ca7b4dc23bb477e36ef9c77a9 # v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@3ac52d0da9f8ec9ca7b4dc23bb477e36ef9c77a9 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: "--model claude-sonnet-4-5-20250929"

--- a/.github/workflows/issue-lifecycle-comment.yml
+++ b/.github/workflows/issue-lifecycle-comment.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 


### PR DESCRIPTION
Re-submission of #39515. Had a problem with my fork and had to delete it, which closed the original PR. Apologies for the noise.

## Summary

This PR pins unpinned third-party GitHub Actions to immutable commit SHAs instead of mutable version tags.

- Pin 7 unpinned actions to full 40-character SHAs
- Add version comments for readability (e.g., `@abc123 # v2`)

This is a general hardening measure. Mutable tags can be force-pushed to point at different code if an upstream action repo is compromised. Pinning to SHA makes the reference immutable. The practical risk here is low given the actions involved, but it's a best practice that removes the possibility.

## Changes by file

| File | Changes |
|------|---------|
| auto-close-duplicates.yml | Pinned actions to SHA |
| backfill-duplicate-comments.yml | Pinned actions to SHA |
| claude-dedupe-issues.yml | Pinned actions to SHA |
| claude-issue-triage.yml | Pinned actions to SHA |
| claude.yml | Pinned actions to SHA |
| issue-lifecycle-comment.yml | Pinned actions to SHA |
| sweep.yml | Pinned actions to SHA |

## How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@v2` becomes `action@abc123 # v2` — original version preserved as comment
- No workflow logic, triggers, or permissions are modified

If you have any questions, reach out. I'll be monitoring comms.

\- Chris Nyhuis (dagecko)