### PR TITLE
FIXED feat(devcontainer): enhance firewall with hybrid static/dynamic IP management

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -86,6 +86,6 @@ RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
 COPY init-firewall.sh /usr/local/bin/
 USER root
 RUN chmod +x /usr/local/bin/init-firewall.sh && \
-  echo "node ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh" > /etc/sudoers.d/node-firewall && \
+  echo "node ALL=(root) NOPASSWD:SETENV: /usr/local/bin/init-firewall.sh" > /etc/sudoers.d/node-firewall && \
   chmod 0440 /etc/sudoers.d/node-firewall
 USER node

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -49,10 +49,10 @@
     "NODE_OPTIONS": "--max-old-space-size=4096",
     "CLAUDE_CONFIG_DIR": "/home/node/.claude",
     "POWERLEVEL9K_DISABLE_GITSTATUS": "true",
-    "WHITELIST_DOMAINS": "${localEnv:WHITELIST_DOMAINS:}"
+    "EXTRA_DOMAINS": "${localEnv:EXTRA_DOMAINS:}"
   },
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",
-  "postStartCommand": "sudo WHITELIST_DOMAINS=\"$WHITELIST_DOMAINS\" /usr/local/bin/init-firewall.sh",
+  "postStartCommand": "sudo EXTRA_DOMAINS=\"$EXTRA_DOMAINS\" /usr/local/bin/init-firewall.sh",
   "waitFor": "postStartCommand"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -48,7 +48,8 @@
   "containerEnv": {
     "NODE_OPTIONS": "--max-old-space-size=4096",
     "CLAUDE_CONFIG_DIR": "/home/node/.claude",
-    "POWERLEVEL9K_DISABLE_GITSTATUS": "true"
+    "POWERLEVEL9K_DISABLE_GITSTATUS": "true",
+    "WHITELIST_DOMAINS": "${localEnv:WHITELIST_DOMAINS:}"
   },
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -53,6 +53,6 @@
   },
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",
-  "postStartCommand": "sudo /usr/local/bin/init-firewall.sh",
+  "postStartCommand": "sudo WHITELIST_DOMAINS=\"$WHITELIST_DOMAINS\" /usr/local/bin/init-firewall.sh",
   "waitFor": "postStartCommand"
 }

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -14,9 +14,9 @@ declare -a DYNAMIC_DOMAINS=(
     "update.code.visualstudio.com"
 )
 
-# Merge user-specified domains from WHITELIST_DOMAINS env var (space-separated)
-if [ -n "${WHITELIST_DOMAINS:-}" ]; then
-    IFS=' ' read -ra USER_DOMAINS <<< "$WHITELIST_DOMAINS"
+# Merge user-specified domains from EXTRA_DOMAINS env var (space-separated)
+if [ -n "${EXTRA_DOMAINS:-}" ]; then
+    IFS=' ' read -ra USER_DOMAINS <<< "$EXTRA_DOMAINS"
     DYNAMIC_DOMAINS+=("${USER_DOMAINS[@]}")
 fi
 

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -23,7 +23,12 @@ fi
 # IPSet configuration
 IPSET_STATIC="allowed-static"    # For GitHub and other static IPs
 IPSET_DYNAMIC="allowed-dynamic"  # For dynamically resolved domains
-DNS_TTL=600                      # DNS cache timeout in seconds
+# TTL must be > refresh interval so IPs are re-added before they expire.
+# CDN-backed domains (Google, Fastly, CloudFront) rotate IPs frequently.
+# The background refresh loop re-resolves all dynamic domains every
+# DNS_REFRESH seconds to track ongoing DNS rotation.
+: "${DNS_TTL:=600}"              # Seconds before dynamic IPs expire from ipset
+: "${DNS_REFRESH:=300}"          # Seconds between DNS refresh cycles
 
 # 1. Extract Docker DNS info BEFORE any flushing
 DOCKER_DNS_RULES=$(iptables-save -t nat | grep "127\.0\.0\.11" || true)
@@ -88,7 +93,9 @@ while read -r cidr; do
     ipset add "$IPSET_STATIC" "$cidr"
 done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q 2>/dev/null || echo "$gh_ranges" | jq -r '(.web + .api + .git)[]')
 
-# Resolve and add other allowed domains with TTL
+# Resolve and add other allowed domains with TTL.
+# This initial resolution fails loudly on misconfigured domains (exit 1).
+# The background refresh script below tolerates transient DNS failures silently.
 for domain in "${DYNAMIC_DOMAINS[@]}"; do
     echo "Resolving $domain..."
     ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}')
@@ -133,14 +140,17 @@ iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 iptables -A OUTPUT -m set --match-set "$IPSET_STATIC" dst -j ACCEPT
 iptables -A OUTPUT -m set --match-set "$IPSET_DYNAMIC" dst -j ACCEPT
 
-# Create DNS refresh script
+# Create DNS refresh script.
+# Unlike the initial resolution above, this tolerates transient DNS failures
+# silently (2>/dev/null) since it runs in a background loop where temporary
+# errors should not interrupt the container.
 cat > /usr/local/bin/refresh-dynamic-domains.sh << EOF
 #!/bin/bash
 IPSET_DYNAMIC="$IPSET_DYNAMIC"
 DNS_TTL=$DNS_TTL
 
 # Domain list passed as arguments
-for domain in $@; do
+for domain in "\$@"; do
     ips=\$(dig +short A "\$domain" 2>/dev/null | grep -E '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\$')
     if [ -n "\$ips" ]; then
         while IFS= read -r ip; do
@@ -152,14 +162,11 @@ EOF
 
 chmod +x /usr/local/bin/refresh-dynamic-domains.sh 2>/dev/null || true
 
-# Setup cron job for automatic refresh
-if command -v crontab &> /dev/null; then
-    DOMAIN_ARGS="${DYNAMIC_DOMAINS[@]}"
-    (crontab -l 2>/dev/null || true; echo "*/5 * * * * /usr/local/bin/refresh-dynamic-domains.sh $DOMAIN_ARGS") | \
-        grep -v refresh-dynamic-domains | \
-        (cat; echo "*/5 * * * * /usr/local/bin/refresh-dynamic-domains.sh $DOMAIN_ARGS") | \
-        crontab - 2>/dev/null || true
-fi
+# Start background DNS refresh loop.
+(while true; do
+    sleep "$DNS_REFRESH"
+    /usr/local/bin/refresh-dynamic-domains.sh "${DYNAMIC_DOMAINS[@]}"
+done) &
 
 # Explicitly REJECT all other outbound traffic for immediate feedback
 iptables -A OUTPUT -j REJECT --reject-with icmp-admin-prohibited

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -2,6 +2,23 @@
 set -euo pipefail  # Exit on error, undefined vars, and pipeline failures
 IFS=$'\n\t'       # Stricter word splitting
 
+# Configuration - Domain list as shell array for easy maintenance
+declare -a DYNAMIC_DOMAINS=(
+    "registry.npmjs.org"
+    "api.anthropic.com"
+    "sentry.io"
+    "statsig.anthropic.com"
+    "statsig.com"
+    "marketplace.visualstudio.com"
+    "vscode.blob.core.windows.net"
+    "update.code.visualstudio.com"
+)
+
+# IPSet configuration
+IPSET_STATIC="allowed-static"    # For GitHub and other static IPs
+IPSET_DYNAMIC="allowed-dynamic"  # For dynamically resolved domains
+DNS_TTL=600                      # DNS cache timeout in seconds
+
 # 1. Extract Docker DNS info BEFORE any flushing
 DOCKER_DNS_RULES=$(iptables-save -t nat | grep "127\.0\.0\.11" || true)
 
@@ -12,6 +29,8 @@ iptables -t nat -F
 iptables -t nat -X
 iptables -t mangle -F
 iptables -t mangle -X
+ipset destroy "$IPSET_STATIC" 2>/dev/null || true
+ipset destroy "$IPSET_DYNAMIC" 2>/dev/null || true
 ipset destroy allowed-domains 2>/dev/null || true
 
 # 2. Selectively restore ONLY internal Docker DNS resolution
@@ -37,8 +56,9 @@ iptables -A INPUT -p tcp --sport 22 -m state --state ESTABLISHED -j ACCEPT
 iptables -A INPUT -i lo -j ACCEPT
 iptables -A OUTPUT -o lo -j ACCEPT
 
-# Create ipset with CIDR support
-ipset create allowed-domains hash:net
+# Create ipsets
+ipset create "$IPSET_STATIC" hash:net
+ipset create "$IPSET_DYNAMIC" hash:ip timeout "$DNS_TTL"
 
 # Fetch GitHub meta information and aggregate + add their IP ranges
 echo "Fetching GitHub IP ranges..."
@@ -59,20 +79,11 @@ while read -r cidr; do
         echo "ERROR: Invalid CIDR range from GitHub meta: $cidr"
         exit 1
     fi
-    echo "Adding GitHub range $cidr"
-    ipset add allowed-domains "$cidr"
-done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
+    ipset add "$IPSET_STATIC" "$cidr"
+done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q 2>/dev/null || echo "$gh_ranges" | jq -r '(.web + .api + .git)[]')
 
-# Resolve and add other allowed domains
-for domain in \
-    "registry.npmjs.org" \
-    "api.anthropic.com" \
-    "sentry.io" \
-    "statsig.anthropic.com" \
-    "statsig.com" \
-    "marketplace.visualstudio.com" \
-    "vscode.blob.core.windows.net" \
-    "update.code.visualstudio.com"; do
+# Resolve and add other allowed domains with TTL
+for domain in "${DYNAMIC_DOMAINS[@]}"; do
     echo "Resolving $domain..."
     ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}')
     if [ -z "$ips" ]; then
@@ -85,8 +96,7 @@ for domain in \
             echo "ERROR: Invalid IP from DNS for $domain: $ip"
             exit 1
         fi
-        echo "Adding $ip for $domain"
-        ipset add allowed-domains "$ip"
+        ipset add "$IPSET_DYNAMIC" "$ip" timeout "$DNS_TTL" -exist
     done < <(echo "$ips")
 done
 
@@ -114,7 +124,36 @@ iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 
 # Then allow only specific outbound traffic to allowed domains
-iptables -A OUTPUT -m set --match-set allowed-domains dst -j ACCEPT
+iptables -A OUTPUT -m set --match-set "$IPSET_STATIC" dst -j ACCEPT
+iptables -A OUTPUT -m set --match-set "$IPSET_DYNAMIC" dst -j ACCEPT
+
+# Create DNS refresh script
+cat > /usr/local/bin/refresh-dynamic-domains.sh << EOF
+#!/bin/bash
+IPSET_DYNAMIC="$IPSET_DYNAMIC"
+DNS_TTL=$DNS_TTL
+
+# Domain list passed as arguments
+for domain in $@; do
+    ips=\$(dig +short A "\$domain" 2>/dev/null | grep -E '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\$')
+    if [ -n "\$ips" ]; then
+        while IFS= read -r ip; do
+            ipset add "\$IPSET_DYNAMIC" "\$ip" timeout "\$DNS_TTL" -exist 2>/dev/null
+        done <<< "\$ips"
+    fi
+done
+EOF
+
+chmod +x /usr/local/bin/refresh-dynamic-domains.sh 2>/dev/null || true
+
+# Setup cron job for automatic refresh
+if command -v crontab &> /dev/null; then
+    DOMAIN_ARGS="${DYNAMIC_DOMAINS[@]}"
+    (crontab -l 2>/dev/null || true; echo "*/5 * * * * /usr/local/bin/refresh-dynamic-domains.sh $DOMAIN_ARGS") | \
+        grep -v refresh-dynamic-domains | \
+        (cat; echo "*/5 * * * * /usr/local/bin/refresh-dynamic-domains.sh $DOMAIN_ARGS") | \
+        crontab - 2>/dev/null || true
+fi
 
 # Explicitly REJECT all other outbound traffic for immediate feedback
 iptables -A OUTPUT -j REJECT --reject-with icmp-admin-prohibited

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -97,13 +97,20 @@ done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q 2>/de
 # This initial resolution fails loudly on misconfigured domains (exit 1).
 # The background refresh script below tolerates transient DNS failures silently.
 for domain in "${DYNAMIC_DOMAINS[@]}"; do
+    # Raw IPs: add directly, skip DNS resolution
+    if [[ "$domain" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+        echo "Adding IP $domain directly..."
+        ipset add "$IPSET_DYNAMIC" "$domain" timeout "$DNS_TTL" -exist
+        continue
+    fi
+
     echo "Resolving $domain..."
     ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}')
     if [ -z "$ips" ]; then
         echo "ERROR: Failed to resolve $domain"
         exit 1
     fi
-    
+
     while read -r ip; do
         if [[ ! "$ip" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
             echo "ERROR: Invalid IP from DNS for $domain: $ip"
@@ -151,6 +158,11 @@ DNS_TTL=$DNS_TTL
 
 # Domain list passed as arguments
 for domain in "\$@"; do
+    # Raw IPs: re-add directly, skip DNS
+    if [[ "\$domain" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\$ ]]; then
+        ipset add "\$IPSET_DYNAMIC" "\$domain" timeout "\$DNS_TTL" -exist 2>/dev/null
+        continue
+    fi
     ips=\$(dig +short A "\$domain" 2>/dev/null | grep -E '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\$')
     if [ -n "\$ips" ]; then
         while IFS= read -r ip; do

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -14,6 +14,12 @@ declare -a DYNAMIC_DOMAINS=(
     "update.code.visualstudio.com"
 )
 
+# Merge user-specified domains from WHITELIST_DOMAINS env var (space-separated)
+if [ -n "${WHITELIST_DOMAINS:-}" ]; then
+    IFS=' ' read -ra USER_DOMAINS <<< "$WHITELIST_DOMAINS"
+    DYNAMIC_DOMAINS+=("${USER_DOMAINS[@]}")
+fi
+
 # IPSet configuration
 IPSET_STATIC="allowed-static"    # For GitHub and other static IPs
 IPSET_DYNAMIC="allowed-dynamic"  # For dynamically resolved domains


### PR DESCRIPTION
Supersedes #5609 by @sakumoto-shota (same approach, with fixes for: sudo stripping env vars, crontab not available in the container, and broken heredoc in the refresh script). I also changed `WHITELIST_DOMAINS` to `EXTRA_DOMAINS` (inclusive language and clarifying semantics - these are additional domains on top of the script's built-in list) CC @MarkS-AL

@sakumoto-shota, I included your commits. If you prefer to cherry-pick my commit into yours, that would work too. Note that your PR did not work when 1. not running as root, or 2. cron was not installed in the devcontainer (it it not in the default container). I also cherry-picked your commits because it is too far behind main to rebase cleanly.

## Summary

The devcontainer firewall resolves domain IPs once at startup. CDN-backed domains (Google, Fastly, CloudFront) rotate IPs, causing tools like `go get`, `pip install`, and `cargo install` to fail with "no route to host" after startup.

This PR adds:

- **Hybrid ipset**: static for GitHub CIDRs (stable), dynamic with TTL for everything else
- **Background DNS refresh**: re-resolves dynamic domains every 5 minutes (configurable)
- **`EXTRA_DOMAINS` env var**: add custom domains to the firewall allowlist

## Configuration

Users can add custom domains via the `EXTRA_DOMAINS` environment variable (space-separated). `DNS_TTL` and `DNS_REFRESH` are also configurable.