### PR TITLE
fix: preserve existing labels when auto-closing duplicate issues

### DIFF
--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -70,6 +70,16 @@ async function closeIssueAsDuplicate(
   duplicateOfNumber: number,
   token: string
 ): Promise<void> {
+  // Fetch existing labels so we can preserve them when adding "duplicate"
+  const issue: { labels: Array<{ name: string }> } = await githubRequest(
+    `/repos/${owner}/${repo}/issues/${issueNumber}`,
+    token
+  );
+  const existingLabels = issue.labels.map(l => l.name);
+  if (!existingLabels.includes('duplicate')) {
+    existingLabels.push('duplicate');
+  }
+
   await githubRequest(
     `/repos/${owner}/${repo}/issues/${issueNumber}`,
     token,
@@ -77,7 +87,7 @@ async function closeIssueAsDuplicate(
     {
       state: 'closed',
       state_reason: 'duplicate',
-      labels: ['duplicate']
+      labels: existingLabels
     }
   );
 


### PR DESCRIPTION
## Summary

- The `closeIssueAsDuplicate` function in `scripts/auto-close-duplicates.ts` was passing `labels: ["duplicate"]` to the GitHub Issues PATCH endpoint, which **replaces the entire label set** rather than adding to it
- This means when an issue is auto-closed as a duplicate, all existing labels (e.g. `bug`, `has repro`, `platform:macos`, `area:tui`) are silently removed and replaced with just `duplicate`
- Fix: fetch the issue's existing labels first, append `duplicate` if not already present, then pass the full label list to the PATCH call

## Test plan

- [ ] Verify auto-close workflow still adds the `duplicate` label
- [ ] Verify existing labels on the issue are preserved after auto-close
- [ ] Edge case: issue already has `duplicate` label — no duplicate entry added