### PR TITLE
Add SessionStart and PostToolUse hook examples

### DIFF
--- a/examples/hooks/post_edit_auto_format_example.py
+++ b/examples/hooks/post_edit_auto_format_example.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+Claude Code Hook: Post-Edit Auto Formatter
+============================================
+This hook runs as a PostToolUse hook for file-editing tools (Edit, Write, MultiEdit).
+After Claude edits or creates a file, it automatically runs the appropriate code
+formatter based on the file extension.
+
+For example, editing a .py file runs "black", editing a .js file runs "prettier".
+If the formatter is not installed, the hook silently skips — it never blocks Claude.
+
+You can customize the FORMATTERS dictionary below to add or change formatters.
+
+Read more about hooks here: https://docs.anthropic.com/en/docs/claude-code/hooks
+
+Make sure to change your path to your actual script.
+
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /path/to/claude-code/examples/hooks/post_edit_auto_format_example.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+# Map file extensions to their formatter commands.
+# Each value is a list of command-line arguments.
+# The file path is appended automatically.
+_FORMATTERS = {
+    ".py": ["black", "--quiet"],
+    ".js": ["prettier", "--write"],
+    ".ts": ["prettier", "--write"],
+    ".jsx": ["prettier", "--write"],
+    ".tsx": ["prettier", "--write"],
+    ".css": ["prettier", "--write"],
+    ".json": ["prettier", "--write"],
+    ".go": ["gofmt", "-w"],
+    ".rs": ["rustfmt"],
+}
+
+
+def main():
+    try:
+        input_data = json.load(sys.stdin)
+    except json.JSONDecodeError as e:
+        print(f"Error: Invalid JSON input: {e}", file=sys.stderr)
+        # Exit code 1 shows stderr to the user but not to Claude
+        sys.exit(1)
+
+    tool_name = input_data.get("tool_name", "")
+    if tool_name not in ("Edit", "Write", "MultiEdit"):
+        sys.exit(0)
+
+    tool_input = input_data.get("tool_input", {})
+    file_path = tool_input.get("file_path", "")
+
+    if not file_path or not os.path.isfile(file_path):
+        sys.exit(0)
+
+    _, ext = os.path.splitext(file_path)
+    formatter = _FORMATTERS.get(ext)
+
+    if not formatter:
+        sys.exit(0)
+
+    try:
+        result = subprocess.run(
+            [*formatter, file_path],
+            capture_output=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            print(
+                f"Auto-formatted {os.path.basename(file_path)} with {formatter[0]}",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"Formatter {formatter[0]} exited with code {result.returncode} on {os.path.basename(file_path)}",
+                file=sys.stderr,
+            )
+    except (FileNotFoundError, OSError):
+        # Formatter is not installed or not executable — skip silently
+        pass
+    except subprocess.TimeoutExpired:
+        print(
+            f"Formatter {formatter[0]} timed out on {os.path.basename(file_path)}",
+            file=sys.stderr,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hooks/session_start_context_loader_example.sh
+++ b/examples/hooks/session_start_context_loader_example.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Claude Code Hook: Session Start Context Loader
+# ================================================
+# This hook runs as a SessionStart hook that loads project-specific context
+# from a file and feeds it to Claude at the beginning of every session.
+#
+# This is useful for giving Claude persistent instructions like coding
+# conventions, project rules, or architecture notes — without repeating
+# yourself every time you start a session.
+#
+# The hook looks for a context file at .claude/project-context.md in your
+# project directory. If the file exists, its contents are passed to Claude
+# as additional context. If it doesn't exist, the hook exits silently.
+#
+# Requires: jq (https://jqlang.github.io/jq/)
+#
+# Read more about hooks here: https://docs.anthropic.com/en/docs/claude-code/hooks
+#
+# Make sure to change your path to your actual script.
+#
+# {
+#   "hooks": {
+#     "SessionStart": [
+#       {
+#         "hooks": [
+#           {
+#             "type": "command",
+#             "command": "bash /path/to/claude-code/examples/hooks/session_start_context_loader_example.sh"
+#           }
+#         ]
+#       }
+#     ]
+#   }
+# }
+#
+
+CONTEXT_FILE="${CLAUDE_PROJECT_DIR:-.}/.claude/project-context.md"
+
+if [ ! -f "$CONTEXT_FILE" ]; then
+    exit 0
+fi
+
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq is required but not installed" >&2
+    # Exit code 1 shows stderr to the user but not to Claude
+    exit 1
+fi
+
+CONTENT=$(cat "$CONTEXT_FILE")
+
+# Use jq to safely encode the file content as a JSON string.
+# This handles all special characters (newlines, quotes, backslashes,
+# control characters, Unicode) correctly.
+jq -n --arg ctx "$CONTENT" '{
+  hookSpecificOutput: {
+    hookEventName: "SessionStart",
+    additionalContext: $ctx
+  }
+}'
+
+exit 0


### PR DESCRIPTION
The `examples/hooks/` directory only had one example (a PreToolUse bash command validator). Added two more examples covering different hook types and languages to help users get started with hooks.

- `session_start_context_loader_example.sh`: Loads project context from `.claude/project-context.md` at session start (shell/jq)
- `post_edit_auto_format_example.py`: Runs code formatters (black, prettier, gofmt, rustfmt) after file edits (Python)