### PR TITLE
feat: Add support for global Hookify rules

### DIFF
--- a/plugins/hookify/commands/list.md
+++ b/plugins/hookify/commands/list.md
@@ -7,11 +7,18 @@ allowed-tools: ["Glob", "Read", "Skill"]
 
 **Load hookify:writing-rules skill first** to understand rule format.
 
-Show all configured hookify rules in the project.
+Show all configured hookify rules from both the global (`~/.claude/`) and project (`.claude/`) directories.
 
 ## Steps
 
-1. Use Glob tool to find all hookify rule files:
+1. Search for rules in both locations:
+
+   **Global rules** (apply to all projects):
+   ```
+   pattern: "~/.claude/hookify.*.md"
+   ```
+
+   **Project rules** (apply to this project only):
    ```
    pattern: ".claude/hookify.*.local.md"
    ```
@@ -20,35 +27,47 @@ Show all configured hookify rules in the project.
    - Use Read tool to read the file
    - Extract frontmatter fields: name, enabled, event, pattern
    - Extract message preview (first 100 chars)
+   - Note whether it came from `~/.claude/` (global) or `.claude/` (project)
 
-3. Present results in a table:
+3. Determine overrides: if a global rule and a project rule share the same `name`, the project rule wins. Mark the global rule as `(overridden)` in the output.
+
+4. Present results in a table with a Scope column:
 
 ```
 ## Configured Hookify Rules
 
-| Name | Enabled | Event | Pattern | File |
-|------|---------|-------|---------|------|
-| warn-dangerous-rm | ✅ Yes | bash | rm\s+-rf | hookify.dangerous-rm.local.md |
-| warn-console-log | ✅ Yes | file | console\.log\( | hookify.console-log.local.md |
-| check-tests | ❌ No | stop | .* | hookify.require-tests.local.md |
+| Name | Scope | Enabled | Event | Pattern | File |
+|------|-------|---------|-------|---------|------|
+| warn-dangerous-rm | [global] | ✅ Yes | bash | rm\s+-rf | hookify.dangerous-rm.local.md |
+| warn-console-log | [project] | ✅ Yes | file | console\.log\( | hookify.console-log.local.md |
+| check-tests | [project] | ❌ No | stop | .* | hookify.require-tests.local.md |
 
-**Total**: 3 rules (2 enabled, 1 disabled)
+**Total**: 3 rules (1 global, 2 project; 2 active, 1 disabled)
 ```
 
-4. For each rule, show a brief preview:
+   If a global rule is overridden by a project rule of the same name, show it as:
+   ```
+   | warn-dangerous-rm | [global] (overridden) | — | bash | rm\s+-rf | hookify.dangerous-rm.local.md |
+   ```
+
+5. For each active (non-overridden) rule, show a brief preview:
 ```
-### warn-dangerous-rm
+### warn-dangerous-rm [global]
 **Event**: bash
 **Pattern**: `rm\s+-rf`
 **Message**: "⚠️ **Dangerous rm command detected!** This command could delete..."
 
 **Status**: ✅ Active
-**File**: .claude/hookify.dangerous-rm.local.md
+**File**: ~/.claude/hookify.dangerous-rm.md
 ```
 
-5. Add helpful footer:
+6. Add helpful footer:
 ```
 ---
+
+**Global rules** (~/.claude/hookify.*.md) apply across all projects.
+**Project rules** (.claude/hookify.*.local.md) apply to this project only.
+A project rule with the same name as a global rule overrides it (project wins).
 
 To modify a rule: Edit the .local.md file directly
 To disable a rule: Set `enabled: false` in frontmatter
@@ -61,16 +80,20 @@ To create a rule: Use `/hookify` command
 
 ## If No Rules Found
 
-If no hookify rules exist:
+If no hookify rules exist in either `~/.claude/` or `.claude/`:
 
 ```
 ## No Hookify Rules Configured
 
 You haven't created any hookify rules yet.
 
+Rules can be placed in:
+- `~/.claude/hookify.*.md` — global rules (all projects)
+- `.claude/hookify.*.local.md` — project rules (this project only)
+
 To get started:
 1. Use `/hookify` to analyze conversation and create rules
-2. Or manually create `.claude/hookify.my-rule.local.md` files
+2. Or manually create rule files in either location
 3. See `/hookify:help` for documentation
 
 Example:

--- a/plugins/hookify/core/config_loader.py
+++ b/plugins/hookify/core/config_loader.py
@@ -4,98 +4,101 @@
 Loads and parses .claude/hookify.*.local.md files.
 """
 
+import glob
 import os
 import sys
-import glob
-import re
-from typing import List, Optional, Dict, Any
 from dataclasses import dataclass, field
+from typing import Any
 
 
 @dataclass
 class Condition:
     """A single condition for matching."""
+
     field: str  # "command", "new_text", "old_text", "file_path", etc.
     operator: str  # "regex_match", "contains", "equals", etc.
     pattern: str  # Pattern to match
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'Condition':
+    def from_dict(cls, data: dict[str, Any]) -> "Condition":
         """Create Condition from dict."""
         return cls(
-            field=data.get('field', ''),
-            operator=data.get('operator', 'regex_match'),
-            pattern=data.get('pattern', '')
+            field=data.get("field", ""),
+            operator=data.get("operator", "regex_match"),
+            pattern=data.get("pattern", ""),
         )
 
 
 @dataclass
 class Rule:
     """A hookify rule."""
+
     name: str
     enabled: bool
     event: str  # "bash", "file", "stop", "all", etc.
-    pattern: Optional[str] = None  # Simple pattern (legacy)
-    conditions: List[Condition] = field(default_factory=list)
+    pattern: str | None = None  # Simple pattern (legacy)
+    conditions: list[Condition] = field(default_factory=list)
     action: str = "warn"  # "warn" or "block" (future)
-    tool_matcher: Optional[str] = None  # Override tool matching
+    tool_matcher: str | None = None  # Override tool matching
     message: str = ""  # Message body from markdown
 
     @classmethod
-    def from_dict(cls, frontmatter: Dict[str, Any], message: str) -> 'Rule':
+    def from_dict(cls, frontmatter: dict[str, Any], message: str) -> "Rule":
         """Create Rule from frontmatter dict and message body."""
         # Handle both simple pattern and complex conditions
         conditions = []
 
         # New style: explicit conditions list
-        if 'conditions' in frontmatter:
-            cond_list = frontmatter['conditions']
+        if "conditions" in frontmatter:
+            cond_list = frontmatter["conditions"]
             if isinstance(cond_list, list):
                 conditions = [Condition.from_dict(c) for c in cond_list]
 
         # Legacy style: simple pattern field
-        simple_pattern = frontmatter.get('pattern')
+        simple_pattern = frontmatter.get("pattern")
         if simple_pattern and not conditions:
             # Convert simple pattern to condition
             # Infer field from event
-            event = frontmatter.get('event', 'all')
-            if event == 'bash':
-                field = 'command'
-            elif event == 'file':
-                field = 'new_text'
+            event = frontmatter.get("event", "all")
+            if event == "bash":
+                field = "command"
+            elif event == "file":
+                field = "new_text"
             else:
-                field = 'content'
+                field = "content"
 
-            conditions = [Condition(
-                field=field,
-                operator='regex_match',
-                pattern=simple_pattern
-            )]
+            conditions = [
+                Condition(
+                    field=field,
+                    operator="regex_match",
+                    pattern=simple_pattern,
+                ),
+            ]
 
         return cls(
-            name=frontmatter.get('name', 'unnamed'),
-            enabled=frontmatter.get('enabled', True),
-            event=frontmatter.get('event', 'all'),
+            name=frontmatter.get("name", "unnamed"),
+            enabled=frontmatter.get("enabled", True),
+            event=frontmatter.get("event", "all"),
             pattern=simple_pattern,
             conditions=conditions,
-            action=frontmatter.get('action', 'warn'),
-            tool_matcher=frontmatter.get('tool_matcher'),
-            message=message.strip()
+            action=frontmatter.get("action", "warn"),
+            tool_matcher=frontmatter.get("tool_matcher"),
+            message=message.strip(),
         )
 
 
-def extract_frontmatter(content: str) -> tuple[Dict[str, Any], str]:
+def extract_frontmatter(content: str) -> tuple[dict[str, Any], str]:
     """Extract YAML frontmatter and message body from markdown.
 
     Returns (frontmatter_dict, message_body).
 
     Supports multi-line dictionary items in lists by preserving indentation.
     """
-    if not content.startswith('---'):
+    if not content.startswith("---"):
         return {}, content
 
     # Split on --- markers
-    parts = content.split('---', 2)
+    parts = content.split("---", 2)
     if len(parts) < 3:
         return {}, content
 
@@ -104,7 +107,7 @@ def extract_frontmatter(content: str) -> tuple[Dict[str, Any], str]:
 
     # Simple YAML parser that handles indented list items
     frontmatter = {}
-    lines = frontmatter_text.split('\n')
+    lines = frontmatter_text.split("\n")
 
     current_key = None
     current_list = []
@@ -115,14 +118,14 @@ def extract_frontmatter(content: str) -> tuple[Dict[str, Any], str]:
     for line in lines:
         # Skip empty lines and comments
         stripped = line.strip()
-        if not stripped or stripped.startswith('#'):
+        if not stripped or stripped.startswith("#"):
             continue
 
         # Check indentation level
         indent = len(line) - len(line.lstrip())
 
         # Top-level key (no indentation or minimal)
-        if indent == 0 and ':' in line and not line.strip().startswith('-'):
+        if indent == 0 and ":" in line and not line.strip().startswith("-"):
             # Save previous list/dict if any
             if in_list and current_key:
                 if in_dict_item and current_dict:
@@ -133,7 +136,7 @@ def extract_frontmatter(content: str) -> tuple[Dict[str, Any], str]:
                 in_dict_item = False
                 current_list = []
 
-            key, value = line.split(':', 1)
+            key, value = line.split(":", 1)
             key = key.strip()
             value = value.strip()
 
@@ -145,14 +148,14 @@ def extract_frontmatter(content: str) -> tuple[Dict[str, Any], str]:
             else:
                 # Simple key-value pair
                 value = value.strip('"').strip("'")
-                if value.lower() == 'true':
+                if value.lower() == "true":
                     value = True
-                elif value.lower() == 'false':
+                elif value.lower() == "false":
                     value = False
                 frontmatter[key] = value
 
         # List item (starts with -)
-        elif stripped.startswith('-') and in_list:
+        elif stripped.startswith("-") and in_list:
             # Save previous dict item if any
             if in_dict_item and current_dict:
                 current_list.append(current_dict)
@@ -161,19 +164,19 @@ def extract_frontmatter(content: str) -> tuple[Dict[str, Any], str]:
             item_text = stripped[1:].strip()
 
             # Check if this is an inline dict (key: value on same line)
-            if ':' in item_text and ',' in item_text:
+            if ":" in item_text and "," in item_text:
                 # Inline comma-separated dict: "- field: command, operator: regex_match"
                 item_dict = {}
-                for part in item_text.split(','):
-                    if ':' in part:
-                        k, v = part.split(':', 1)
+                for part in item_text.split(","):
+                    if ":" in part:
+                        k, v = part.split(":", 1)
                         item_dict[k.strip()] = v.strip().strip('"').strip("'")
                 current_list.append(item_dict)
                 in_dict_item = False
-            elif ':' in item_text:
+            elif ":" in item_text:
                 # Start of multi-line dict item: "- field: command"
                 in_dict_item = True
-                k, v = item_text.split(':', 1)
+                k, v = item_text.split(":", 1)
                 current_dict = {k.strip(): v.strip().strip('"').strip("'")}
             else:
                 # Simple list item
@@ -181,9 +184,9 @@ def extract_frontmatter(content: str) -> tuple[Dict[str, Any], str]:
                 in_dict_item = False
 
         # Continuation of dict item (indented under list item)
-        elif indent > 2 and in_dict_item and ':' in line:
+        elif indent > 2 and in_dict_item and ":" in line:
             # This is a field of the current dict item
-            k, v = stripped.split(':', 1)
+            k, v = stripped.split(":", 1)
             current_dict[k.strip()] = v.strip().strip('"').strip("'")
 
     # Save final list/dict if any
@@ -217,16 +220,14 @@ def load_rules(event: Optional[str] = None) -> List[Rule]:
                 continue
 
             # Filter by event if specified
-            if event:
-                if rule.event != 'all' and rule.event != event:
-                    continue
+            if event and rule.event != "all" and rule.event != event:
+                continue
 
             # Only include enabled rules
             if rule.enabled:
                 rules.append(rule)
 
-        except (IOError, OSError, PermissionError) as e:
-            # File I/O errors - log and continue
+        except (OSError, PermissionError) as e:
             print(f"Warning: Failed to read {file_path}: {e}", file=sys.stderr)
             continue
         except (ValueError, KeyError, AttributeError, TypeError) as e:
@@ -246,21 +247,25 @@ def load_rule_file(file_path: str) -> Optional[Rule]:
 
     Returns:
         Rule object or None if file is invalid.
+
     """
     try:
-        with open(file_path, 'r') as f:
+        with open(file_path) as f:
             content = f.read()
 
         frontmatter, message = extract_frontmatter(content)
 
         if not frontmatter:
-            print(f"Warning: {file_path} missing YAML frontmatter (must start with ---)", file=sys.stderr)
+            print(
+                f"Warning: {file_path} missing YAML frontmatter (must start with ---)",
+                file=sys.stderr,
+            )
             return None
 
         rule = Rule.from_dict(frontmatter, message)
         return rule
 
-    except (IOError, OSError, PermissionError) as e:
+    except (OSError, PermissionError) as e:
         print(f"Error: Cannot read {file_path}: {e}", file=sys.stderr)
         return None
     except (ValueError, KeyError, AttributeError, TypeError) as e:
@@ -270,12 +275,15 @@ def load_rule_file(file_path: str) -> Optional[Rule]:
         print(f"Error: Invalid encoding in {file_path}: {e}", file=sys.stderr)
         return None
     except Exception as e:
-        print(f"Error: Unexpected error parsing {file_path} ({type(e).__name__}): {e}", file=sys.stderr)
+        print(
+            f"Error: Unexpected error parsing {file_path} ({type(e).__name__}): {e}",
+            file=sys.stderr,
+        )
         return None
 
 
 # For testing
-if __name__ == '__main__':
+if __name__ == "__main__":
     import sys
 
     # Test frontmatter parsing

--- a/plugins/hookify/core/config_loader.py
+++ b/plugins/hookify/core/config_loader.py
@@ -4,10 +4,9 @@
 Loads and parses .claude/hookify.*.local.md files.
 """
 
-import glob
-import os
 import sys
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 
@@ -41,6 +40,7 @@ class Rule:
     action: str = "warn"  # "warn" or "block" (future)
     tool_matcher: str | None = None  # Override tool matching
     message: str = ""  # Message body from markdown
+    scope: str = "project"  # "project" or "global"
 
     @classmethod
     def from_dict(cls, frontmatter: dict[str, Any], message: str) -> "Rule":
@@ -198,52 +198,83 @@ def extract_frontmatter(content: str) -> tuple[dict[str, Any], str]:
     return frontmatter, message
 
 
-def load_rules(event: Optional[str] = None) -> List[Rule]:
-    """Load all hookify rules from .claude directory.
+def _load_rules_from_dir(
+    directory: Path,
+    scope: str,
+    event: str | None,
+    merged: dict,
+) -> None:
+    """Load rules from a directory into a merged dict (name → Rule).
+
+    Rules with the same name overwrite earlier entries, so call global first
+    and project second to let project rules win.
+
+    Args:
+        directory: Directory path to scan for hookify.*.local.md files.
+        scope: "global" or "project" — set on each loaded Rule.
+        event: Optional event filter; rules not matching are skipped.
+        merged: Dict to update in-place.
+
+    """
+    files = directory.glob("hookify.*.md")
+
+    for file_path in files:
+        try:
+            rule = load_rule_file(file_path, scope=scope)
+            if not rule:
+                continue
+
+            # Filter by event if specified
+            if event and rule.event not in ("all", event):
+                continue
+
+            merged[rule.name] = rule
+
+        except (OSError, PermissionError) as e:
+            print(f"Warning: Failed to read {file_path}: {e}", file=sys.stderr)
+        except (ValueError, KeyError, AttributeError, TypeError) as e:
+            print(f"Warning: Failed to parse {file_path}: {e}", file=sys.stderr)
+        except Exception as e:
+            print(
+                f"Warning: Unexpected error loading {file_path} ({type(e).__name__}): {e}",
+                file=sys.stderr,
+            )
+
+
+def load_rules(event: str | None = None) -> list[Rule]:
+    """Load all hookify rules from global (~/.claude) and project (.claude) directories.
+
+    Global rules are loaded first; project rules overlay them by name so that
+    a project rule with the same name as a global rule takes precedence.
+    A project rule with enabled=false suppresses the global rule of the same name.
 
     Args:
         event: Optional event filter ("bash", "file", "stop", etc.)
 
     Returns:
         List of enabled Rule objects matching the event.
+
     """
-    rules = []
+    merged: dict[str, Rule] = {}
 
-    # Find all hookify.*.local.md files
-    pattern = os.path.join('.claude', 'hookify.*.local.md')
-    files = glob.glob(pattern)
+    # Load global rules first (from ~/.claude/)
+    global_dir = Path.home() / ".claude"
+    _load_rules_from_dir(global_dir, scope="global", event=event, merged=merged)
 
-    for file_path in files:
-        try:
-            rule = load_rule_file(file_path)
-            if not rule:
-                continue
+    # Load project rules second (from .claude/ relative to CWD); they overwrite globals by name
+    project_dir = Path(".claude")
+    _load_rules_from_dir(project_dir, scope="project", event=event, merged=merged)
 
-            # Filter by event if specified
-            if event and rule.event != "all" and rule.event != event:
-                continue
-
-            # Only include enabled rules
-            if rule.enabled:
-                rules.append(rule)
-
-        except (OSError, PermissionError) as e:
-            print(f"Warning: Failed to read {file_path}: {e}", file=sys.stderr)
-            continue
-        except (ValueError, KeyError, AttributeError, TypeError) as e:
-            # Parsing errors - log and continue
-            print(f"Warning: Failed to parse {file_path}: {e}", file=sys.stderr)
-            continue
-        except Exception as e:
-            # Unexpected errors - log with type details
-            print(f"Warning: Unexpected error loading {file_path} ({type(e).__name__}): {e}", file=sys.stderr)
-            continue
-
-    return rules
+    # Return only enabled rules
+    return [rule for rule in merged.values() if rule.enabled]
 
 
-def load_rule_file(file_path: str) -> Optional[Rule]:
+def load_rule_file(file_path: str, scope: str = "project") -> Rule | None:
     """Load a single rule file.
+
+    Args:
+        file_path: Path to the .local.md rule file.
+        scope: "project" or "global" — recorded on the returned Rule.
 
     Returns:
         Rule object or None if file is invalid.
@@ -263,6 +294,7 @@ def load_rule_file(file_path: str) -> Optional[Rule]:
             return None
 
         rule = Rule.from_dict(frontmatter, message)
+        rule.scope = scope
         return rule
 
     except (OSError, PermissionError) as e:

--- a/plugins/hookify/hooks/posttooluse.py
+++ b/plugins/hookify/hooks/posttooluse.py
@@ -8,11 +8,12 @@ It reads .claude/hookify.*.local.md files and evaluates rules.
 import os
 import sys
 import json
+from pathlib import Path
 
 # CRITICAL: Add plugin root to Python path for imports
 PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
 if PLUGIN_ROOT:
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
+    parent_dir = str(Path(PLUGIN_ROOT).parent)
     if parent_dir not in sys.path:
         sys.path.insert(0, parent_dir)
     if PLUGIN_ROOT not in sys.path:

--- a/plugins/hookify/hooks/pretooluse.py
+++ b/plugins/hookify/hooks/pretooluse.py
@@ -8,13 +8,14 @@ It reads .claude/hookify.*.local.md files and evaluates rules.
 import os
 import sys
 import json
+from pathlib import Path
 
 # CRITICAL: Add plugin root to Python path for imports
 # We need to add the parent of the plugin directory so Python can find "hookify" package
 PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
 if PLUGIN_ROOT:
     # Add the parent directory of the plugin
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
+    parent_dir = str(Path(PLUGIN_ROOT).parent)
     if parent_dir not in sys.path:
         sys.path.insert(0, parent_dir)
 

--- a/plugins/hookify/hooks/stop.py
+++ b/plugins/hookify/hooks/stop.py
@@ -8,11 +8,12 @@ It reads .claude/hookify.*.local.md files and evaluates stop rules.
 import os
 import sys
 import json
+from pathlib import Path
 
 # CRITICAL: Add plugin root to Python path for imports
 PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
 if PLUGIN_ROOT:
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
+    parent_dir = str(Path(PLUGIN_ROOT).parent)
     if parent_dir not in sys.path:
         sys.path.insert(0, parent_dir)
     if PLUGIN_ROOT not in sys.path:

--- a/plugins/hookify/hooks/userpromptsubmit.py
+++ b/plugins/hookify/hooks/userpromptsubmit.py
@@ -8,11 +8,12 @@ It reads .claude/hookify.*.local.md files and evaluates rules.
 import os
 import sys
 import json
+from pathlib import Path
 
 # CRITICAL: Add plugin root to Python path for imports
 PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
 if PLUGIN_ROOT:
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
+    parent_dir = str(Path(PLUGIN_ROOT).parent)
     if parent_dir not in sys.path:
         sys.path.insert(0, parent_dir)
     if PLUGIN_ROOT not in sys.path:


### PR DESCRIPTION
## Summary
This pull request introduces support for loading Hookify rules from a global directory (`~/.claude/`) alongside project-specific rules (`.claude/`). This allows users to configure rules that apply across all projects.

## Changes
- **Global Rules Support:** Modified `config_loader.py` to scan for and load `hookify.*.md` files from `~/.claude/`.
- **Rule Overrides:** Implemented a merging strategy where project-specific rules take precedence over global rules with the same name.
- **Pathlib Migration:** Refactored various hooks and the config loader to utilize modern `pathlib` instead of `os.path` for file path resolution.
- **Documentation Updates:** Updated `list.md` to accurately display rule scopes (global vs. project) and indicate when a global rule has been overridden.