### PR TITLE
feat: add session-manager plugin to list sessions for current workdir

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -25,6 +25,7 @@ Learn more in the [official plugins documentation](https://docs.claude.com/en/do
 | [pr-review-toolkit](./pr-review-toolkit/) | Comprehensive PR review agents specializing in comments, tests, error handling, type design, code quality, and code simplification | **Command:** `/pr-review-toolkit:review-pr` - Run with optional review aspects (comments, tests, errors, types, code, simplify, all)<br>**Agents:** `comment-analyzer`, `pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer`, `code-reviewer`, `code-simplifier` |
 | [ralph-wiggum](./ralph-wiggum/) | Interactive self-referential AI loops for iterative development. Claude works on the same task repeatedly until completion | **Commands:** `/ralph-loop`, `/cancel-ralph` - Start/stop autonomous iteration loops<br>**Hook:** Stop - Intercepts exit attempts to continue iteration |
 | [security-guidance](./security-guidance/) | Security reminder hook that warns about potential security issues when editing files | **Hook:** PreToolUse - Monitors 9 security patterns including command injection, XSS, eval usage, dangerous HTML, pickle deserialization, and os.system calls |
+| [session-manager](./session-manager/) | List and resume Claude Code sessions for the current working directory | **Command:** `/sessions` - Displays all saved sessions for the current project with timestamps and resume instructions |
 
 ## Installation
 

--- a/plugins/session-manager/.claude-plugin/plugin.json
+++ b/plugins/session-manager/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "session-manager",
+  "description": "List and resume Claude Code sessions for the current working directory",
+  "version": "1.0.0",
+  "author": {
+    "name": "Abdul Sahil",
+    "email": "abdulsaheel81@gmail.com"
+  }
+}

--- a/plugins/session-manager/README.md
+++ b/plugins/session-manager/README.md
@@ -1,0 +1,57 @@
+# Session Manager Plugin
+
+List and resume Claude Code sessions for the current working directory.
+
+## Overview
+
+Claude Code saves conversation sessions per project directory under `~/.claude/projects/`. This plugin provides a simple `/sessions` command to discover and display all saved sessions for your current working directory, making it easy to pick up where you left off.
+
+## Commands
+
+### `/sessions`
+
+Lists all available Claude Code sessions for the current working directory.
+
+**What it does:**
+1. Resolves the current working directory to its Claude project path
+2. Lists all saved session files (`.jsonl`) for that directory
+3. Displays each session ID with its last-modified timestamp
+4. Shows the command to resume any session
+
+**Usage:**
+```bash
+/sessions
+```
+
+**Example output:**
+```
+Available Claude Code sessions for /Users/you/my-project:
+
+  56d1e406-31c0-4589-b7ae-a35965d9692b  (last modified: 2026-03-29 14:22)
+  f86b6356-c5bf-467c-b05f-5cb34c48e354  (last modified: 2026-03-28 09:11)
+
+To resume a session, run:
+  claude --resume <session-id>
+```
+
+**Features:**
+- Scoped to the current working directory — only shows sessions relevant to your project
+- Displays last-modified timestamps so you can identify the most recent session
+- Works on macOS and Linux
+
+## Installation
+
+This plugin is included in the Claude Code repository. To use it in your own project, install it via the `/plugin` command or configure it in `.claude/settings.json`.
+
+## Requirements
+
+- Claude Code installed
+- Sessions are stored at `~/.claude/projects/<encoded-path>/`
+
+## Author
+
+Abdul Sahil (abdulsaheel81@gmail.com)
+
+## Version
+
+1.0.0

--- a/plugins/session-manager/commands/sessions.md
+++ b/plugins/session-manager/commands/sessions.md
@@ -1,26 +1,24 @@
 ---
-allowed-tools: Bash(ls:*), Bash(stat:*)
+allowed-tools: Bash(pwd:*), Bash(ls:*), Bash(stat:*)
 description: List available Claude Code sessions for the current working directory
 ---
 
-## Context
-
-- Current working directory: !`pwd`
-- Available sessions: !`bash -c 'dir=$(pwd | sed "s|/|-|g" | sed "s|^-||"); session_dir="$HOME/.claude/projects/$dir"; if [ -d "$session_dir" ]; then ls "$session_dir"/*.jsonl 2>/dev/null | while read f; do id=$(basename "$f" .jsonl); modified=$(stat -f "%Sm" -t "%Y-%m-%d %H:%M" "$f" 2>/dev/null || stat --format="%y" "$f" 2>/dev/null | cut -d. -f1); echo "  $id  (last modified: $modified)"; done; else echo "No sessions found for this directory."; fi'`
-
 ## Your task
 
-Display the list of available Claude Code sessions for the current working directory shown above.
+1. Run `pwd` to get the current working directory
+2. Convert the path to the Claude project directory format by replacing all `/` with `-` and removing the leading `-` (e.g. `/Users/foo/myproject` → `Users-foo-myproject`)
+3. Run `ls $HOME/.claude/projects/<encoded-path>/*.jsonl 2>/dev/null` to list session files
+4. For each `.jsonl` file found, run `stat -f "%Sm" -t "%Y-%m-%d %H:%M" <file>` (macOS) to get the last modified time
+5. Display the results in this format:
 
-For each session, show:
-1. The session ID
-2. The last modified time
-
-Then inform the user they can resume any session with:
 ```
-claude --resume <session-id>
+Available Claude Code sessions for <cwd>:
+
+  <session-id>  (last modified: <timestamp>)
+  ...
+
+To resume a session, run:
+  claude --resume <session-id>
 ```
 
-If no sessions are found, let the user know there are no saved sessions for this directory.
-
-Do not use any other tools or do anything beyond displaying this information.
+If no session files are found, tell the user there are no saved sessions for this directory.

--- a/plugins/session-manager/commands/sessions.md
+++ b/plugins/session-manager/commands/sessions.md
@@ -1,0 +1,26 @@
+---
+allowed-tools: Bash(ls:*), Bash(stat:*)
+description: List available Claude Code sessions for the current working directory
+---
+
+## Context
+
+- Current working directory: !`pwd`
+- Available sessions: !`bash -c 'dir=$(pwd | sed "s|/|-|g" | sed "s|^-||"); session_dir="$HOME/.claude/projects/$dir"; if [ -d "$session_dir" ]; then ls "$session_dir"/*.jsonl 2>/dev/null | while read f; do id=$(basename "$f" .jsonl); modified=$(stat -f "%Sm" -t "%Y-%m-%d %H:%M" "$f" 2>/dev/null || stat --format="%y" "$f" 2>/dev/null | cut -d. -f1); echo "  $id  (last modified: $modified)"; done; else echo "No sessions found for this directory."; fi'`
+
+## Your task
+
+Display the list of available Claude Code sessions for the current working directory shown above.
+
+For each session, show:
+1. The session ID
+2. The last modified time
+
+Then inform the user they can resume any session with:
+```
+claude --resume <session-id>
+```
+
+If no sessions are found, let the user know there are no saved sessions for this directory.
+
+Do not use any other tools or do anything beyond displaying this information.


### PR DESCRIPTION
## Summary

- Adds a new `session-manager` plugin with a `/sessions` command
- Lists all saved Claude Code sessions for the current working directory
- Displays each session ID with its last-modified timestamp and instructions to resume via `claude --resume <session-id>`

## Motivation

There's currently no easy way to discover existing sessions for a project directory. Users have to manually navigate `~/.claude/projects/` to find session IDs. This plugin surfaces that information directly inside Claude Code.

## Changes

- `plugins/session-manager/.claude-plugin/plugin.json` — plugin metadata
- `plugins/session-manager/commands/sessions.md` — `/sessions` slash command
- `plugins/session-manager/README.md` — documentation
- `plugins/README.md` — added entry to the plugin index table

## Test plan

- [ ] Run `/sessions` in a project directory that has existing sessions — verify session IDs and timestamps are displayed
- [ ] Run `/sessions` in a fresh directory with no sessions — verify "No sessions found" message
- [ ] Confirm `claude --resume <id>` works with a listed session ID