### PR TITLE
feat(security-guidance): add hardcoded secret detection patterns

### DIFF
--- a/plugins/security-guidance/.claude-plugin/plugin.json
+++ b/plugins/security-guidance/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "security-guidance",
   "version": "1.0.0",
-  "description": "Security reminder hook that warns about potential security issues when editing files, including command injection, XSS, and unsafe code patterns",
+  "description": "Security reminder hook that warns about potential security issues when editing files, including command injection, XSS, unsafe code patterns, and hardcoded secrets",
   "author": {
     "name": "David Dworken",
     "email": "dworken@anthropic.com"

--- a/plugins/security-guidance/hooks/security_reminder_hook.py
+++ b/plugins/security-guidance/hooks/security_reminder_hook.py
@@ -123,6 +123,42 @@ Only use exec() if you absolutely need shell features and the input is guarantee
         "substrings": ["os.system", "from os import system"],
         "reminder": "⚠️ Security Warning: This code appears to use os.system. This should only be used with static arguments and never with arguments that could be user-controlled.",
     },
+    {
+        "ruleName": "hardcoded_github_token",
+        "substrings": ["ghp_", "github_pat_", "gho_"],
+        "reminder": "⚠️ Security Warning: This content appears to contain a GitHub token. Never hardcode tokens in source files. Use environment variables or a secrets manager instead.",
+    },
+    {
+        "ruleName": "hardcoded_aws_key",
+        "substrings": ["AKIA"],
+        "reminder": "⚠️ Security Warning: This content appears to contain an AWS access key ID (starts with AKIA). Never hardcode AWS credentials in source files. Use environment variables, IAM roles, or AWS credentials files instead.",
+    },
+    {
+        "ruleName": "hardcoded_anthropic_key",
+        "substrings": ["sk-ant-"],
+        "reminder": "⚠️ Security Warning: This content appears to contain an Anthropic API key. Never hardcode API keys in source files. Use environment variables or a secrets manager instead.",
+    },
+    {
+        "ruleName": "hardcoded_openai_key",
+        "substrings": ["sk-proj-"],
+        "reminder": "⚠️ Security Warning: This content appears to contain an OpenAI API key. Never hardcode API keys in source files. Use environment variables or a secrets manager instead.",
+    },
+    {
+        "ruleName": "hardcoded_private_key",
+        "substrings": [
+            "-----BEGIN RSA PRIVATE KEY-----",
+            "-----BEGIN OPENSSH PRIVATE KEY-----",
+            "-----BEGIN EC PRIVATE KEY-----",
+            "-----BEGIN DSA PRIVATE KEY-----",
+            "-----BEGIN PRIVATE KEY-----",
+        ],
+        "reminder": "⚠️ Security Warning: This content appears to contain a private key. Never commit private keys to source files. Use a secrets manager or mount them at runtime instead.",
+    },
+    {
+        "ruleName": "hardcoded_generic_secret",
+        "substrings": ["sk-live_", "rk-live_", "whsec_", "pypi-AgEIcHlwaS5vcmc"],
+        "reminder": "⚠️ Security Warning: This content appears to contain a hardcoded secret or API key. Never commit secrets to source files. Use environment variables or a secrets manager instead.",
+    },
 ]
 
 


### PR DESCRIPTION
## Summary

- Adds 6 new security patterns to the `security-guidance` plugin to detect hardcoded credentials being written to files via `Edit`, `Write`, or `MultiEdit` tools
- Covers GitHub tokens (`ghp_`, `github_pat_`, `gho_`), AWS access keys (`AKIA`), Anthropic API keys (`sk-ant-`), OpenAI API keys (`sk-proj-`), private keys (RSA/OPENSSH/EC/DSA/PKCS8 PEM formats), and generic secrets (Stripe live keys, webhook secrets, PyPI tokens)
- Updates plugin description to reflect the new capability

Addresses #40724 where the model wrote a GitHub PAT into a config file with no warning from the security-guidance plugin.

## How we tested

Test harness that pipes simulated JSON payloads to the hook and asserts the exit code (`2` = blocked, `0` = allowed).

[Test script gist](https://gist.github.com/tiennguyen-onehouse/5ed99d156e63e36f337837c1251dd039) — run it yourself:

```bash
cd claude-code/
curl -sL https://gist.github.com/tiennguyen-onehouse/5ed99d156e63e36f337837c1251dd039/raw/test_security_reminder_hook.py | python3
```

```
--- New secret detection patterns (should block) ---
  PASS  GitHub token (ghp_)
  PASS  GitHub PAT (github_pat_)
  PASS  AWS access key (AKIA)
  PASS  Anthropic API key (sk-ant-)
  PASS  OpenAI API key (sk-proj-)
  PASS  RSA private key
  PASS  OpenSSH private key
  PASS  Stripe live key (sk-live_)
  PASS  Webhook secret (whsec_)

--- Existing patterns - regression check (should block) ---
  PASS  innerHTML (existing pattern)

--- Safe content (should allow) ---
  PASS  Normal Python code
  PASS  Env var reference (no literal secret)

--- Session dedup (same file+rule should only block once) ---
  PASS  First call blocks (exit 2)
  PASS  Second call allowed (exit 0)

--- Non-file tool (should be ignored) ---
  PASS  Bash tool with secret in args (ignored)

========================================
Results: 15/15 passed
```