### PR TITLE
feat(examples): add security rules to bash command validator hook

### DIFF
--- a/examples/hooks/bash_command_validator_example.py
+++ b/examples/hooks/bash_command_validator_example.py
@@ -4,7 +4,12 @@ Claude Code Hook: Bash Command Validator
 =========================================
 This hook runs as a PreToolUse hook for the Bash tool.
 It validates bash commands against a set of rules before execution.
-In this case it changes grep calls to using rg.
+
+There are two categories of rules:
+  - Tool preference rules: suggest better alternatives (e.g. rg over grep)
+  - Security rules: block dangerous commands as a defense-in-depth layer
+    that catches patterns the settings.json deny list may miss
+    (see https://github.com/anthropics/claude-code/issues/40730)
 
 Read more about hooks here: https://docs.anthropic.com/en/docs/claude-code/hooks
 
@@ -32,8 +37,9 @@ import json
 import re
 import sys
 
-# Define validation rules as a list of (regex pattern, message) tuples
-_VALIDATION_RULES = [
+# ── Tool preference rules ─────────────────────────────────────────────
+# Suggest better alternatives for common commands.
+_TOOL_PREFERENCE_RULES = [
     (
         r"^grep\b(?!.*\|)",
         "Use 'rg' (ripgrep) instead of 'grep' for better performance and features",
@@ -44,13 +50,78 @@ _VALIDATION_RULES = [
     ),
 ]
 
+# ── Security rules ────────────────────────────────────────────────────
+# Block dangerous shell patterns. Exit code 2 prevents the command from
+# running and shows the message to Claude so it can self-correct.
+_SECURITY_RULES = [
+    # Sensitive file access via shell builtins (#40730)
+    (
+        r"(?:^|\s|;|&&|\|\|)\.\s+.*\.env\b",
+        "Blocked: sourcing .env files can leak secrets into the shell environment",
+    ),
+    (
+        r"(?:^|\s|;|&&|\|\|)source\s+.*\.env\b",
+        "Blocked: sourcing .env files can leak secrets into the shell environment",
+    ),
+    # Destructive filesystem operations
+    (
+        r"(?:^|\s|;|&&|\|\|)rm\s+.*-[a-zA-Z]*r[a-zA-Z]*f[a-zA-Z]*\s+/(?:\s|$)",
+        "Blocked: 'rm -rf /' is catastrophically destructive",
+    ),
+    (
+        r"(?:^|\s|;|&&|\|\|)rm\s+.*-[a-zA-Z]*f[a-zA-Z]*r[a-zA-Z]*\s+/(?:\s|$)",
+        "Blocked: 'rm -fr /' is catastrophically destructive",
+    ),
+    (
+        r"(?:^|\s|;|&&|\|\|)chmod\s+777\s",
+        "Blocked: 'chmod 777' sets world-writable permissions; use a more restrictive mode",
+    ),
+    # Remote code execution via pipe-to-shell
+    (
+        r"curl\s.*\|\s*(?:bash|sh|zsh)\b",
+        "Blocked: piping curl output to a shell executes unreviewed remote code",
+    ),
+    (
+        r"wget\s.*\|\s*(?:bash|sh|zsh)\b",
+        "Blocked: piping wget output to a shell executes unreviewed remote code",
+    ),
+    # Git force-push to protected branches
+    (
+        r"git\s+push\s+.*--force(?:-with-lease)?\s.*\b(?:main|master)\b",
+        "Blocked: force-pushing to main/master can destroy shared history",
+    ),
+    (
+        r"git\s+push\s+.*\b(?:main|master)\b.*--force",
+        "Blocked: force-pushing to main/master can destroy shared history",
+    ),
+    # Git destructive operations
+    (
+        r"(?:^|\s|;|&&|\|\|)git\s+reset\s+--hard\b",
+        "Blocked: 'git reset --hard' discards uncommitted changes; use 'git stash' instead",
+    ),
+    (
+        r"(?:^|\s|;|&&|\|\|)git\s+clean\s+.*-[a-zA-Z]*f",
+        "Blocked: 'git clean -f' permanently deletes untracked files",
+    ),
+    # Sensitive credential file access
+    (
+        r"(?:^|\s|;|&&|\|\|)(?:cat|head|tail|less|more)\s+.*(?:\.ssh/|\.gnupg/|\.aws/credentials)",
+        "Blocked: reading sensitive credential files",
+    ),
+]
 
-def _validate_command(command: str) -> list[str]:
-    issues = []
-    for pattern, message in _VALIDATION_RULES:
+
+def _validate_command(command: str) -> tuple[list[str], list[str]]:
+    """Returns (blocking_issues, warning_issues)."""
+    blocking = []
+    warnings = []
+    for pattern, message in _SECURITY_RULES:
         if re.search(pattern, command):
-            issues.append(message)
-    return issues
+            blocking.append(message)
+    for pattern, message in _TOOL_PREFERENCE_RULES:
+        if re.search(pattern, command):
+            warnings.append(message)
+    return blocking, warnings
 
 
 def main():
@@ -58,7 +129,6 @@ def main():
         input_data = json.load(sys.stdin)
     except json.JSONDecodeError as e:
         print(f"Error: Invalid JSON input: {e}", file=sys.stderr)
-        # Exit code 1 shows stderr to the user but not to Claude
         sys.exit(1)
 
     tool_name = input_data.get("tool_name", "")
@@ -71,11 +141,16 @@ def main():
     if not command:
         sys.exit(0)
 
-    issues = _validate_command(command)
-    if issues:
-        for message in issues:
+    blocking, warnings = _validate_command(command)
+
+    if blocking:
+        for message in blocking:
+            print(f"BLOCKED: {message}", file=sys.stderr)
+        sys.exit(2)
+
+    if warnings:
+        for message in warnings:
             print(f"• {message}", file=sys.stderr)
-        # Exit code 2 blocks tool call and shows stderr to Claude
         sys.exit(2)
 
 


### PR DESCRIPTION
## Summary

- Expands the bash command validator example hook with security rules that block dangerous shell patterns
- Acts as a defense-in-depth layer that catches commands the `settings.json` deny list may miss (see #40730 where shell builtins bypass deny patterns)
- Separates rules into "tool preference" (existing grep/find suggestions) and "security" (new blocking rules)

New security rules detect:
- `source .env` / `. .env` — shell builtins that bypass deny patterns (#40730)
- `rm -rf /` / `rm -fr /` — catastrophic filesystem deletion
- `chmod 777` — world-writable permissions
- `curl ... | bash` / `wget ... | sh` — remote code execution via pipe-to-shell
- `git push --force main/master` — destroying shared branch history
- `git reset --hard` / `git clean -f` — discarding uncommitted work
- `cat ~/.ssh/*` / `cat ~/.aws/credentials` — credential file exfiltration

Addresses #40730.

## How we tested

[Test script gist](https://gist.github.com/tiennguyen-onehouse/107f91f91aa1413b558cb2e74b1e947e) — run it yourself:

```bash
cd claude-code/
curl -sL https://gist.github.com/tiennguyen-onehouse/107f91f91aa1413b558cb2e74b1e947e/raw/test_bash_validator.py | python3
```

```
--- Security rules (should block) ---
  PASS  source .env (exit 2)
  PASS  . .env (exit 2)
  PASS  rm -rf / (exit 2)
  PASS  rm -fr / (exit 2)
  PASS  chmod 777 (exit 2)
  PASS  curl | bash (exit 2)
  PASS  wget | sh (exit 2)
  PASS  git push --force main (exit 2)
  PASS  git push main --force (reversed) (exit 2)
  PASS  git reset --hard (exit 2)
  PASS  git reset --hard HEAD~3 (exit 2)
  PASS  git clean -fd (exit 2)
  PASS  cat ~/.ssh/id_rsa (exit 2)
  PASS  cat ~/.aws/credentials (exit 2)
  PASS  tail ~/.gnupg/secring.gpg (exit 2)

--- Existing tool-preference rules (should block) ---
  PASS  grep (suggests rg) (exit 2)
  PASS  find -name (suggests rg --files) (exit 2)

--- Safe commands (should allow) ---
  PASS  git status (exit 0)
  PASS  git diff HEAD (exit 0)
  PASS  ls -la (exit 0)
  PASS  echo hello (exit 0)
  PASS  python3 test.py (exit 0)
  PASS  npm install (exit 0)
  PASS  rm -f single file (no -r) (exit 0)
  PASS  chmod 755 (not 777) (exit 0)
  PASS  git push feature branch (no --force) (exit 0)
  PASS  git push --force feature (not main) (exit 0)
  PASS  source .bashrc (not .env) (exit 0)

--- Non-Bash tool (should pass through) ---
  PASS  Read tool ignored (exit 0)

========================================
Results: 29/29 passed
```