### PR TITLE
fix(commit-commands): prevent session URLs from leaking into commits

### DIFF
--- a/plugins/commit-commands/commands/commit-push-pr.md
+++ b/plugins/commit-commands/commands/commit-push-pr.md
@@ -14,7 +14,7 @@ description: Commit, push, and open a PR
 Based on the above changes:
 
 1. Create a new branch if on main
-2. Create a single commit with an appropriate message
+2. Create a single commit with an appropriate message. Do NOT include any Claude session URLs, session IDs, or links to claude.ai in commit messages or PR descriptions.
 3. Push the branch to origin
 4. Create a pull request using `gh pr create`
 5. You have the capability to call multiple tools in a single response. You MUST do all of the above in a single message. Do not use any other tools or do anything else. Do not send any other text or messages besides these tool calls.

--- a/plugins/commit-commands/commands/commit.md
+++ b/plugins/commit-commands/commands/commit.md
@@ -14,4 +14,6 @@ description: Create a git commit
 
 Based on the above changes, create a single git commit.
 
+Do NOT include any Claude session URLs, session IDs, or links to claude.ai in the commit message. The commit message should only describe the code changes.
+
 You have the capability to call multiple tools in a single response. Stage and create the commit using a single message. Do not use any other tools or do anything else. Do not send any other text or messages besides these tool calls.


### PR DESCRIPTION
## Summary

- Adds explicit instruction to both `/commit` and `/commit-push-pr` commands to not include Claude session URLs, session IDs, or links to claude.ai in commit messages or PR descriptions
- Prevents privacy/information leakage in public repos when using Claude Code Web

Addresses #40733.

## How we tested

[Test script gist](https://gist.github.com/tiennguyen-onehouse/2a6c71c5afde3774f28b97175fe69a48) — run it yourself:

```bash
cd claude-code/
curl -sL https://gist.github.com/tiennguyen-onehouse/2a6c71c5afde3774f28b97175fe69a48/raw/test_commit_commands.py | python3
```

```
--- commit.md content checks ---
  PASS  Has session URL prohibition
  PASS  Mentions session IDs
  PASS  Mentions claude.ai links
  PASS  Says only describe code changes
  PASS  Still has git context section
  PASS  Still has allowed-tools frontmatter
  PASS  Still has original task instruction

--- commit-push-pr.md content checks ---
  PASS  Has session URL prohibition
  PASS  Mentions session IDs
  PASS  Mentions claude.ai links
  PASS  Still has gh pr create step
  PASS  Still has allowed-tools frontmatter
  PASS  Still has push step

--- Negative checks (should NOT contain) ---
  PASS  commit.md has no claude.ai URL
  PASS  commit-push-pr.md has no claude.ai URL

========================================
Results: 15/15 passed
```