### PR TITLE
fix(devcontainer): allow googleapis.com through sandbox firewall

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -72,7 +72,9 @@ for domain in \
     "statsig.com" \
     "marketplace.visualstudio.com" \
     "vscode.blob.core.windows.net" \
-    "update.code.visualstudio.com"; do
+    "update.code.visualstudio.com" \
+    "googleapis.com" \
+    "oauth2.googleapis.com"; do
     echo "Resolving $domain..."
     ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}')
     if [ -z "$ips" ]; then


### PR DESCRIPTION
## Summary

- Adds `googleapis.com` and `oauth2.googleapis.com` to the devcontainer firewall allowlist in `init-firewall.sh`
- Allows tools using Google Cloud APIs (GCS, BigQuery, Vertex AI, etc.) and Google OAuth to function inside the devcontainer sandbox

Partially addresses #40769 for devcontainer sandbox users. The reporter's `anthropic_cloud` environment uses a separate TLS-intercepting proxy not controlled by this file — that requires a separate fix on the cloud platform side.

## How we tested

[Test script gist](https://gist.github.com/tiennguyen-onehouse/3c1ad4cf8f190ba36987a5aa52bb3bdb) — run it yourself:

```bash
cd claude-code/
curl -sL https://gist.github.com/tiennguyen-onehouse/3c1ad4cf8f190ba36987a5aa52bb3bdb/raw/test_devcontainer_firewall.py | python3
```

```
--- New domains added ---
  PASS  Contains googleapis.com
  PASS  Contains oauth2.googleapis.com

--- Regression: existing domains still present ---
  PASS  registry.npmjs.org
  PASS  api.anthropic.com
  PASS  sentry.io
  PASS  statsig.anthropic.com
  PASS  statsig.com
  PASS  marketplace.visualstudio.com
  PASS  vscode.blob.core.windows.net
  PASS  update.code.visualstudio.com

--- Script structure checks ---
  PASS  Has shebang
  PASS  Has set -euo pipefail
  PASS  Has ipset create
  PASS  Has GitHub IP fetch
  PASS  Has default DROP policy
  PASS  Has firewall verification
  PASS  Has example.com block test
  PASS  Has GitHub API verify
  PASS  bash -n syntax check (exit 0)

========================================
Results: 19/19 passed
```