### PR TITLE
docs(vscode): add "Not responding" status bar guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,20 @@ For more installation options, uninstall steps, and troubleshooting, see the [se
 
 This repository includes several Claude Code plugins that extend functionality with custom commands and agents. See the [plugins directory](./plugins/README.md) for detailed documentation on available plugins.
 
+## VS Code extension
+
+For detailed VS Code setup and usage, see the [VS Code documentation](https://code.claude.com/docs/en/vs-code).
+
+### Status bar states
+
+When Claude runs long-running commands in VS Code, the extension shows progress in the status bar. The status bar can display the following states:
+
+- **Normal progress** — A spinner indicates Claude is actively working. This is expected during long-running operations such as large file edits or complex commands.
+- **"Not responding"** — The spinner turns red with a "Not responding" label when the extension has not received a response from the backend for approximately 60 seconds. This is **not** the expected state during normal long-running operations. If you see this indicator:
+  1. Check your internet connection.
+  2. Start a new conversation to see if the issue persists.
+  3. Try running `claude` from the terminal for more detailed error output.
+
 ## Reporting Bugs
 
 We welcome your feedback. Use the `/bug` command to report issues directly within Claude Code, or file a [GitHub issue](https://github.com/anthropics/claude-code/issues).


### PR DESCRIPTION
## Summary

- Added a "VS Code extension" section to README.md with a "Status bar states" subsection
- Documents the normal spinner progress state vs. the "Not responding" warning state
- Clarifies that "Not responding" means no backend response for ~60 seconds and is not expected during normal long-running operations
- Includes recovery steps when the indicator appears

## Issue

Fixes #40122

## Context

The VS Code extension's "Not responding" status bar indicator was added in v2.1.81 and refined in v2.1.86 but was never documented. Users seeing the red spinner during long-running operations had no guidance on whether this was expected behavior or a problem requiring action.

The official docs at `code.claude.com/docs/en/vs-code` may also need a corresponding update for the "Monitor background processes" and "Claude Code never responds" sections referenced in the issue.

## Testing

- Visual review of markdown rendering
- Content verified against CHANGELOG entries for v2.1.81 and v2.1.86