### PR TITLE
fix: use jq for JSON construction in Statsig logging workflow

### DIFF
--- a/.github/workflows/log-issue-events.yml
+++ b/.github/workflows/log-issue-events.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       issues: read
     steps:
-      - name: Log issue creation to Statsig
+      - name: Log issue event to Statsig
         env:
           STATSIG_API_KEY: ${{ secrets.STATSIG_API_KEY }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
@@ -18,23 +18,33 @@ jobs:
           ISSUE_TITLE: ${{ github.event.issue.title }}
           AUTHOR: ${{ github.event.issue.user.login }}
           CREATED_AT: ${{ github.event.issue.created_at }}
+          EVENT_ACTION: ${{ github.event.action }}
         run: |
-          # All values are now safely passed via environment variables
-          # No direct templating in the shell script to prevent injection attacks
-          
-          curl -X POST "https://events.statsigapi.net/v1/log_event" \
+          EVENT_NAME="github_issue_${EVENT_ACTION}"
+
+          PAYLOAD=$(jq -n \
+            --arg event_name "$EVENT_NAME" \
+            --arg issue_number "$ISSUE_NUMBER" \
+            --arg repository "$REPO" \
+            --arg title "$ISSUE_TITLE" \
+            --arg author "$AUTHOR" \
+            --arg created_at "$CREATED_AT" \
+            --argjson time "$(date +%s)000" \
+            '{
+              events: [{
+                eventName: $event_name,
+                metadata: {
+                  issue_number: $issue_number,
+                  repository: $repository,
+                  title: $title,
+                  author: $author,
+                  created_at: $created_at
+                },
+                time: $time
+              }]
+            }')
+
+          curl -s -X POST "https://events.statsigapi.net/v1/log_event" \
             -H "Content-Type: application/json" \
             -H "statsig-api-key: $STATSIG_API_KEY" \
-            -d '{
-              "events": [{
-                "eventName": "github_issue_created",
-                "metadata": {
-                  "issue_number": "'"$ISSUE_NUMBER"'",
-                  "repository": "'"$REPO"'",
-                  "title": "'"$(echo "$ISSUE_TITLE" | sed "s/\"/\\\\\"/g")"'",
-                  "author": "'"$AUTHOR"'",
-                  "created_at": "'"$CREATED_AT"'"
-                },
-                "time": '"$(date +%s)000"'
-              }]
-            }'
+            -d "$PAYLOAD"


### PR DESCRIPTION
## Problem

`log-issue-events.yml` builds the Statsig JSON payload via shell string concatenation with sed escaping. The sed only handles double quotes — issue titles containing backslashes, newlines, or single quotes produce malformed JSON that silently fails the curl request.

```bash
# Current: breaks on \, ', newlines
"title": "'"$(echo "$ISSUE_TITLE" | sed "s/\"/\\\\\"/g")"'"
```

Separately, the event name is hardcoded to `github_issue_created` even when the workflow triggers on `issues.closed`.

## Fix

Replace shell string concatenation with `jq --arg`, which handles all JSON special characters correctly. `jq` is pre-installed on `ubuntu-latest` runners.

Derive the event name from `github.event.action` so opened/closed events log distinctly.

## Verified

```bash
$ export ISSUE_TITLE='[BUG] "quotes" and \backslash and '"'"'single quote'"'"''
$ jq -n --arg title "$ISSUE_TITLE" '{title: $title}'
{
  "title": "[BUG] \"quotes\" and \\backslash and 'single quote'"
}
```

Valid JSON for all tested edge cases: double quotes, backslashes, single quotes, dollar signs, unicode.