### PR TITLE
fix: remove all lifecycle labels on human activity, not just autoclose

### DIFF
--- a/.github/workflows/remove-autoclose-label.yml
+++ b/.github/workflows/remove-autoclose-label.yml
@@ -1,4 +1,4 @@
-name: "Remove Autoclose Label on Activity"
+name: "Remove Lifecycle Labels on Activity"
 
 on:
   issue_comment:
@@ -8,35 +8,43 @@ permissions:
   issues: write
 
 jobs:
-  remove-autoclose:
-    # Only run if the issue has the autoclose label
-    if: |
+  remove-lifecycle-labels:
+    if: >-
       github.event.issue.state == 'open' &&
-      contains(github.event.issue.labels.*.name, 'autoclose') &&
-      github.event.comment.user.login != 'github-actions[bot]'
+      github.event.comment.user.login != 'github-actions[bot]' &&
+      (
+        contains(github.event.issue.labels.*.name, 'autoclose') ||
+        contains(github.event.issue.labels.*.name, 'stale') ||
+        contains(github.event.issue.labels.*.name, 'needs-info') ||
+        contains(github.event.issue.labels.*.name, 'needs-repro') ||
+        contains(github.event.issue.labels.*.name, 'invalid')
+      )
     runs-on: ubuntu-latest
     steps:
-      - name: Remove autoclose label
+      - name: Remove lifecycle labels on human activity
         uses: actions/github-script@v7
         with:
           script: |
-            console.log(`Removing autoclose label from issue #${context.issue.number} due to new comment from ${context.payload.comment.user.login}`);
-            
-            try {
-              // Remove the autoclose label
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                name: 'autoclose'
-              });
-              
-              console.log(`Successfully removed autoclose label from issue #${context.issue.number}`);
-            } catch (error) {
-              // If the label was already removed or doesn't exist, that's fine
-              if (error.status === 404) {
-                console.log(`Autoclose label was already removed from issue #${context.issue.number}`);
-              } else {
-                throw error;
+            // All lifecycle labels from scripts/issue-lifecycle.ts
+            const lifecycleLabels = ['autoclose', 'stale', 'needs-info', 'needs-repro', 'invalid'];
+
+            const issueLabels = context.payload.issue.labels.map(l => l.name);
+            const toRemove = lifecycleLabels.filter(l => issueLabels.includes(l));
+
+            if (toRemove.length === 0) return;
+
+            console.log(`Removing lifecycle labels [${toRemove.join(', ')}] from issue #${context.issue.number} due to new comment from ${context.payload.comment.user.login}`);
+
+            for (const label of toRemove) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name: label
+                });
+                console.log(`Removed '${label}' from issue #${context.issue.number}`);
+              } catch (error) {
+                if (error.status !== 404) throw error;
               }
             }


### PR DESCRIPTION
## Problem

`remove-autoclose-label.yml` only removes the `autoclose` label when a human comments. The other 4 lifecycle labels (`stale`, `needs-info`, `needs-repro`, `invalid`) persist — even after the author responds with the requested information.

`sweep.ts` has a safety check (lines 124-138) that prevents closing issues with human comments post-label, so no issues are incorrectly closed. But the label stays, which is confusing for authors who responded and still see `needs-info` on their issue.

## Fix

Extend the workflow to remove all lifecycle labels (matching the set in `scripts/issue-lifecycle.ts`) when a non-bot user comments. The job-level `if` condition checks for any lifecycle label, so GitHub still skips the job entirely for issues without them.

## What changed

- Workflow name: "Remove Autoclose Label on Activity" → "Remove Lifecycle Labels on Activity"
- Job `if`: checks for any of the 5 lifecycle labels (was: only `autoclose`)
- Script: iterates over all lifecycle labels present on the issue, removes each one

## Why this is safe

1. `sweep.ts` already skips issues with human comments after label (lines 124-138) — this is defense-in-depth, not removing a safety net
2. The `if` condition only runs when at least one lifecycle label is present — no extra job starts for normal issues
3. 404 on `removeLabel` is caught (label already removed) — matches original behavior
4. Label list matches `scripts/issue-lifecycle.ts` exactly: `autoclose`, `stale`, `needs-info`, `needs-repro`, `invalid`