### PR TITLE
fix: skip lifecycle comment job for non-lifecycle labels

### DIFF
--- a/.github/workflows/issue-lifecycle-comment.yml
+++ b/.github/workflows/issue-lifecycle-comment.yml
@@ -9,6 +9,14 @@ permissions:
 
 jobs:
   comment:
+    # Only run for lifecycle labels — skip bug, enhancement, platform:*, area:*, etc.
+    # Label set matches scripts/issue-lifecycle.ts
+    if: >-
+      github.event.label.name == 'autoclose' ||
+      github.event.label.name == 'stale' ||
+      github.event.label.name == 'needs-info' ||
+      github.event.label.name == 'needs-repro' ||
+      github.event.label.name == 'invalid'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Problem

`issue-lifecycle-comment.yml` triggers on every `issues.labeled` event. For non-lifecycle labels (`bug`, `enhancement`, `platform:macos`, `area:core`, `has repro`, etc.) the workflow starts a runner, checks out the repo, installs Bun, and runs the script — which immediately exits with "No lifecycle entry, skipping."

With the volume of label activity on this repo, that's unnecessary runner time on every triage action.

## Fix

Add a job-level `if` condition that matches the 5 lifecycle labels defined in `scripts/issue-lifecycle.ts`:

```yaml
if: >-
  github.event.label.name == 'autoclose' ||
  github.event.label.name == 'stale' ||
  github.event.label.name == 'needs-info' ||
  github.event.label.name == 'needs-repro' ||
  github.event.label.name == 'invalid'
```

GitHub evaluates this before provisioning a runner, so non-lifecycle labels skip the job entirely.

## Why this is safe

The script (`lifecycle-comment.ts` line 19-23) already has the same guard — it looks up the label in the lifecycle config and exits if not found. This just moves the filter earlier in the pipeline to avoid the checkout+install overhead.