### PR TITLE
feat(plugins): add setup-reviewer plugin

### DIFF
--- a/plugins/setup-reviewer/.claude-plugin/plugin.json
+++ b/plugins/setup-reviewer/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "setup-reviewer",
+  "description": "Comprehensive audit of your Claude Code setup — dispatches 10 parallel agents to review skills, commands, rules, plugins, MCP servers, settings, hooks, terminal config, and CLAUDE.md files, then synthesizes findings into a scored health report",
+  "version": "1.0.0",
+  "author": {
+    "name": "Patrick Freyer",
+    "url": "https://github.com/patrickfreyer"
+  }
+}

--- a/plugins/setup-reviewer/README.md
+++ b/plugins/setup-reviewer/README.md
@@ -1,0 +1,68 @@
+# Setup Reviewer
+
+Comprehensive audit of your Claude Code configuration. Dispatches **10 parallel review agents**, each specialized in one area of your setup, then synthesizes all findings into a single report with a health score, maturity rating, and prioritized action items.
+
+## What it reviews
+
+| # | Agent | What it checks |
+|---|-------|---------------|
+| 1 | Skills Auditor | SKILL.md files, allowed-tools scoping, script references, overlaps |
+| 2 | Commands Auditor | Slash command quality, MCP references, skill overlap |
+| 3 | Rules Auditor | Contradictions, staleness, duplicates, secrets, context window cost |
+| 4 | Plugins Auditor | Registry health, blocklist, orphaned plugins, marketplace freshness |
+| 5 | MCP Servers Auditor | Connectivity, env vars, ghost servers, security |
+| 6 | Settings Auditor | Permission scoping, hook wiring, env var security, JSON validity |
+| 7 | CLAUDE.md Auditor | Global + project files, content placement, bloat detection |
+| 8 | Terminal Auditor | Shell aliases, env vars, API key security, tool versions |
+| 9 | Hooks Auditor | Wiring, orphaned scripts, automation opportunities |
+| 10 | Best Practices Researcher | Web research from Anthropic docs and community guides |
+
+A final **Synthesis Agent** cross-references all findings, benchmarks against best practices, and assigns a maturity rating.
+
+## How it works
+
+The skill auto-triggers when the user asks to review or audit their Claude Code setup.
+
+1. **Phase 1**: Dispatches agents 1-10 in parallel. Each reads its own instruction file (`agents/XX_name.md`) and works autonomously.
+2. **Phase 2**: Synthesis agent receives all findings and produces the final report.
+3. **Phase 3**: Report is presented with quick-fix offers and follow-up recommendations.
+
+## Report output
+
+- **Health Score** (X/10)
+- **Maturity Rating** (Beginner / Intermediate / Advanced / Power User / Elite)
+- **Findings by area** with severity (Critical / Improvement / Info)
+- **Best Practices Scorecard** comparing setup against official recommendations
+- **Prioritized actions** grouped by effort (quick fix / moderate / strategic)
+
+## Architecture
+
+```
+skills/review-setup/SKILL.md (orchestrator)
+  |
+  |-- dispatches in parallel -->
+  |     agents/01_skills.md
+  |     agents/02_commands.md
+  |     agents/03_rules.md
+  |     agents/04_plugins.md
+  |     agents/05_mcp.md
+  |     agents/06_settings.md
+  |     agents/07_claudemd.md
+  |     agents/08_terminal.md
+  |     agents/09_hooks.md
+  |     agents/10_best_practices.md
+  |
+  |-- then synthesizes -->
+        agents/11_synthesis.md
+```
+
+## Customization
+
+- **Add a review dimension**: Create `agents/12_your_area.md` following the existing pattern
+- **Adjust scoring**: Edit `agents/11_synthesis.md` to change maturity criteria or severity thresholds
+- **Scope the review**: Remove agent dispatches from the orchestrator to skip areas
+
+## Contents
+
+- **Skill:** `review-setup` — auto-invoked orchestrator that dispatches parallel audit agents
+- **Agents:** 11 specialized audit agents (10 parallel reviewers + 1 synthesis)

--- a/plugins/setup-reviewer/agents/01_skills.md
+++ b/plugins/setup-reviewer/agents/01_skills.md
@@ -1,0 +1,54 @@
+# Skills Auditor
+
+You are auditing a Claude Code user's skills configuration. Your job is to review every skill in `~/.claude/skills/` and produce a findings report.
+
+## What to do
+
+1. **Discover all skills:** `Glob("**/SKILL.md", path="~/.claude/skills/")`
+2. **Read each SKILL.md** and extract: name, description, allowed-tools, referenced scripts/files
+3. **Run the following checks on each skill:**
+
+### Structural checks
+- Does the SKILL.md have valid frontmatter with `name` and `description`?
+- Is the `description` specific enough to trigger correctly? (A vague description like "general helper" is a problem)
+- Are `allowed-tools` listed? If so, are they appropriately scoped?
+  - Flag overly broad: listing every tool when only Read/Bash are needed
+  - Flag too narrow: skill instructions reference tools not in allowed-tools
+- Does the skill reference any scripts, files, or paths? Verify each exists with `Bash("test -f <path> && echo EXISTS || echo MISSING")`
+
+### Quality checks
+- Is the instruction text clear, actionable, and well-structured?
+- Does the skill tell the agent what to do AND how to present results?
+- Are there hardcoded paths that should be parameterized?
+- Are there magic strings or values that should be configurable?
+
+### Ecosystem checks
+- List all skills side by side — are there overlaps? (Two skills that do similar things)
+- Are there skills that seem abandoned or outdated? (Check creation dates, relevance of content)
+- Based on the overall setup, are there obvious missing skills? (Common workflows with no skill)
+
+## Output format
+
+Return your findings as structured markdown:
+
+```markdown
+## Skills Audit
+
+### Inventory
+| # | Skill Name | Description | Tools | Scripts | Status |
+|---|-----------|-------------|-------|---------|--------|
+
+### Findings
+
+#### Critical
+- [skill-name]: [issue] → [suggested fix]
+
+#### Improvements
+- [skill-name]: [observation] → [suggestion]
+
+#### Good Practices
+- [what's working well]
+
+### Missing Skills (suggestions)
+- [workflow that could benefit from a skill]
+```

--- a/plugins/setup-reviewer/agents/02_commands.md
+++ b/plugins/setup-reviewer/agents/02_commands.md
@@ -1,0 +1,54 @@
+# Commands Auditor
+
+You are auditing a Claude Code user's custom commands (slash commands). Review every file in `~/.claude/commands/` and produce a findings report.
+
+## What to do
+
+1. **Discover all commands:** `Glob("*.md", path="~/.claude/commands/")`
+2. **Read each command file** — these are markdown files containing instructions that execute when the user types `/<filename>`
+3. **Also read the skills directory:** `Glob("**/SKILL.md", path="~/.claude/skills/")` — you need this to detect overlaps
+
+### Structural checks
+- Is each command file well-structured with clear steps?
+- Does the command reference specific MCP tools or APIs? Verify they exist by checking MCP config in `~/.claude/mcp.json` and `~/.claude/settings.json`
+- Are there hardcoded values (dates, names, paths) that should be dynamic?
+- Does the command handle edge cases (e.g., "no unread messages found")?
+
+### Quality checks
+- Is the instruction unambiguous? Could Claude misinterpret the intent?
+- Does the command specify how to present results to the user?
+- Is the command an appropriate length? (Too short = vague, too long = should be a skill with sub-files)
+- Are there commands that try to do too many things at once? (Should be split)
+
+### Ecosystem checks
+- **Overlap with skills:** For each command, check if a skill exists that does the same thing. Flag duplicates.
+  - Commands are lightweight (single markdown file, no frontmatter)
+  - Skills are richer (frontmatter with allowed-tools, can reference scripts)
+  - If both exist, recommend which to keep based on complexity
+- **Naming consistency:** Do command filenames follow a consistent pattern?
+- **Missing commands:** Based on the user's skills and rules, are there obvious command gaps?
+
+## Output format
+
+```markdown
+## Commands Audit
+
+### Inventory
+| # | Command | Purpose | References MCP? | Overlaps Skill? |
+|---|---------|---------|-----------------|-----------------|
+
+### Findings
+
+#### Critical
+- [command]: [issue] → [fix]
+
+#### Improvements
+- [command]: [observation] → [suggestion]
+
+#### Good Practices
+- [what's working well]
+
+### Overlap Analysis
+| Command | Overlapping Skill | Recommendation |
+|---------|------------------|----------------|
+```

--- a/plugins/setup-reviewer/agents/03_rules.md
+++ b/plugins/setup-reviewer/agents/03_rules.md
@@ -1,0 +1,62 @@
+# Rules Auditor
+
+You are auditing a Claude Code user's rules files. Rules are persistent instructions loaded into every conversation. Review all files in `~/.claude/rules/` and produce a findings report.
+
+## What to do
+
+1. **Discover all rules:** `Glob("**/*.md", path="~/.claude/rules/")`
+2. **Read every rule file** — these are markdown files with behavioral instructions, preferences, reference data, and context
+
+### Structural checks
+- Is each file focused on a single topic? Flag files that are catch-alls covering too many unrelated things
+- Is the file well-organized with clear headers and bullet points?
+- Are files at a reasonable length? Very long files (>200 lines) waste context window on every conversation
+- Is `notes.md` getting unwieldy? (This file tends to grow unbounded — check its line count and whether entries are still relevant)
+
+### Content checks
+- **Contradictions:** Read all rules and flag any cases where two files give conflicting instructions
+  - Example: one file says "always reply-all" and another says "use direct reply"
+- **Duplicates:** Flag information repeated across multiple files (each fact should live in one canonical place)
+- **Staleness:** Flag entries that reference:
+  - Dates that have passed (e.g., "OOO Mar 20-Apr 6" — is it still accurate?)
+  - People who may have left or changed roles
+  - Tools, URLs, or services that may no longer exist
+  - Temporary instructions that should have been removed
+- **Sensitivity:** Flag any rules containing secrets, tokens, or credentials that shouldn't be in plain text
+- **Misplaced content:** Is there content that belongs in CLAUDE.md instead of rules (or vice versa)?
+
+### Ecosystem checks
+- Are there topics with no rule coverage that should have one? Consider:
+  - Does the user have preferences about code style, testing, deployment?
+  - Are there communication channels not covered (e.g., rules for email and Slack but not Teams)?
+  - Are there tools the user uses frequently with no documented conventions?
+- Is the `projects/` subdirectory being used effectively for project-specific rules?
+
+## Output format
+
+```markdown
+## Rules Audit
+
+### Inventory
+| # | File | Topic | Lines | Last Modified | Status |
+|---|------|-------|-------|--------------|--------|
+
+### Findings
+
+#### Critical
+- [file]: [issue] → [fix]
+
+#### Improvements
+- [file]: [observation] → [suggestion]
+
+#### Staleness Check
+| File | Stale Entry | Why It May Be Stale |
+|------|-------------|---------------------|
+
+#### Contradiction Check
+| File A | File B | Conflicting Instructions |
+|--------|--------|------------------------|
+
+#### Good Practices
+- [what's working well]
+```

--- a/plugins/setup-reviewer/agents/04_plugins.md
+++ b/plugins/setup-reviewer/agents/04_plugins.md
@@ -1,0 +1,54 @@
+# Plugins Auditor
+
+You are auditing a Claude Code user's plugin configuration. Plugins extend Claude Code with additional skills, agents, and capabilities from marketplaces or local repos.
+
+## What to do
+
+1. **Read the plugin registry:** `~/.claude/plugins/installed_plugins.json`
+2. **Read the blocklist:** `~/.claude/plugins/blocklist.json`
+3. **Read plugin config:** `~/.claude/plugins/config.json`
+4. **Read marketplace config:** `~/.claude/plugins/known_marketplaces.json`
+5. **Read enabled plugins from settings:** `~/.claude/settings.json` — look for the `enabledPlugins` or similar field
+6. **List plugin repos:** `ls ~/.claude/plugins/repos/` and `ls ~/.claude/plugins/marketplaces/`
+
+### Registry checks
+- Compare installed_plugins.json against the enabled list in settings.json
+- Flag plugins that are installed but not enabled (why install and not use?)
+- Flag plugins that are enabled but not in the installed registry (broken reference?)
+- Check if any plugins are on the blocklist — is the block intentional or accidental?
+
+### Health checks
+- For each plugin with a local repo path, verify the path exists
+- Check for plugins with very old install dates that may be abandoned
+- Look for plugins that provide overlapping functionality with custom skills or MCP servers
+- Check if marketplace URLs in known_marketplaces.json are still valid (don't fetch, just note them)
+
+### Quality checks
+- Are there too many plugins? (Plugin bloat slows down skill resolution)
+- Are there plugins the user seems to never use? (Check if any skill/command references them)
+- Are there useful official plugins not yet installed? (e.g., database-design, frontend-design)
+
+## Output format
+
+```markdown
+## Plugins Audit
+
+### Installed Plugins
+| # | Plugin | Source | Enabled? | Blocked? | Notes |
+|---|--------|--------|----------|----------|-------|
+
+### Findings
+
+#### Critical
+- [plugin]: [issue] → [fix]
+
+#### Improvements
+- [observation] → [suggestion]
+
+#### Good Practices
+- [what's working well]
+
+### Marketplace Health
+| Marketplace | URL | Status |
+|-------------|-----|--------|
+```

--- a/plugins/setup-reviewer/agents/05_mcp.md
+++ b/plugins/setup-reviewer/agents/05_mcp.md
@@ -1,0 +1,59 @@
+# MCP Servers Auditor
+
+You are auditing a Claude Code user's MCP (Model Context Protocol) server configuration. MCP servers extend Claude with tools for interacting with external services.
+
+## What to do
+
+1. **Read MCP config:** `~/.claude/mcp.json` — this defines MCP servers at user scope
+2. **Check settings.json** for any additional MCP server definitions in `~/.claude/settings.json`
+3. **Check for project-level MCP configs:** Look for `.mcp.json` or `.claude/mcp.json` in any active project directories
+
+### Connectivity checks
+For each MCP server:
+- **Command path:** Does the binary/script referenced in `command` exist? Verify with `which <command>` or `test -f <path>`
+- **Args:** Are arguments valid? (e.g., file paths that exist, port numbers that make sense)
+- **Environment variables:** If the config references env vars, check they're set: `echo $VAR_NAME`
+- **Startup test:** Try running `timeout 5 <command> <args>` to see if the server starts without immediate errors (capture stderr). Don't leave processes running — kill after test.
+
+### Configuration checks
+- Are there MCP servers with duplicate capabilities? (e.g., two different browser automation servers)
+- Are there servers that seem unused? Grep for the server name across skills, commands, and rules to see if anything references it
+- Are server names descriptive and consistent?
+- Are there common MCP servers the user might benefit from but hasn't installed? Consider:
+  - File system tools (if not covered)
+  - Database connectors
+  - Calendar/email integration
+  - Version control tools
+
+### Security checks
+- Are any API keys or tokens hardcoded in the MCP config? (Should use env vars instead)
+- Are there servers running with excessive permissions?
+- Do any servers expose network ports unnecessarily?
+
+## Output format
+
+```markdown
+## MCP Servers Audit
+
+### Server Inventory
+| # | Server Name | Command | Status | Used By |
+|---|-------------|---------|--------|---------|
+
+### Connectivity Tests
+| Server | Command Exists? | Starts OK? | Env Vars Set? | Notes |
+|--------|----------------|------------|---------------|-------|
+
+### Findings
+
+#### Critical
+- [server]: [issue] → [fix]
+
+#### Improvements
+- [observation] → [suggestion]
+
+#### Good Practices
+- [what's working well]
+
+### Missing Integrations (suggestions)
+- [MCP server that could add value based on the user's workflow]
+```

--- a/plugins/setup-reviewer/agents/06_settings.md
+++ b/plugins/setup-reviewer/agents/06_settings.md
@@ -1,0 +1,68 @@
+# Settings & Permissions Auditor
+
+You are auditing a Claude Code user's settings and permission configuration. These files control what Claude can do automatically vs. what requires user approval.
+
+## What to do
+
+1. **Read main settings:** `~/.claude/settings.json`
+2. **Read local overrides:** `~/.claude/settings.local.json`
+3. **Read keybindings:** `~/.claude/keybindings.json` (if exists)
+4. **Read policy limits:** `~/.claude/policy-limits.json` (if exists)
+
+### Permission checks
+- List all permission rules (allow/deny patterns for tools)
+- Flag overly permissive patterns:
+  - Blanket `Bash(*)` allows (should scope to specific commands or patterns)
+  - `Edit(*)` or `Write(*)` with no path restrictions
+  - Any pattern that effectively bypasses all safety checks
+- Flag overly restrictive patterns that might frustrate the user (blocking tools their skills need)
+- Check if permission rules are consistent between settings.json and settings.local.json
+
+### Environment variable checks
+- List all env vars defined in settings
+- Check for sensitive values (API keys, tokens) — flag if they appear to be real credentials vs. env var references
+- Verify env vars are actually used by checking if MCP servers or hooks reference them
+
+### Hook configuration checks
+- List all hooks defined in settings (SessionStart, PostToolUse, PreToolUse, etc.)
+- For each hook:
+  - Does the referenced script/command exist?
+  - Is the script executable? (`test -x <path>`)
+  - Is the timeout reasonable?
+  - Does the hook match the right event type?
+- Are there event types with no hooks that could benefit from automation?
+
+### Structural checks
+- Is the JSON valid and well-formatted?
+- Are there deprecated or unknown keys?
+- Is there unnecessary duplication between settings.json and settings.local.json?
+- Are there any team/org settings that might conflict with personal settings?
+
+## Output format
+
+```markdown
+## Settings & Permissions Audit
+
+### Permission Rules
+| # | Type | Pattern | Scope | Concern? |
+|---|------|---------|-------|----------|
+
+### Environment Variables
+| Var | Set In | Used By | Sensitive? |
+|-----|--------|---------|------------|
+
+### Hook Configuration
+| Event | Script/Command | Exists? | Executable? | Notes |
+|-------|---------------|---------|-------------|-------|
+
+### Findings
+
+#### Critical
+- [setting]: [issue] → [fix]
+
+#### Improvements
+- [observation] → [suggestion]
+
+#### Good Practices
+- [what's working well]
+```

--- a/plugins/setup-reviewer/agents/07_claudemd.md
+++ b/plugins/setup-reviewer/agents/07_claudemd.md
@@ -1,0 +1,74 @@
+# CLAUDE.md Auditor
+
+You are auditing all CLAUDE.md files in a user's Claude Code environment. CLAUDE.md files provide context instructions that Claude reads at the start of every conversation in that scope.
+
+## What to do
+
+1. **Read global CLAUDE.md:** `~/.claude/CLAUDE.md`
+2. **Find project-level CLAUDE.md files:** Search common project paths:
+   ```
+   Glob("**/CLAUDE.md", path="~/Library/Mobile Documents/com~apple~CloudDocs/Documents/Projects/")
+   Glob("**/CLAUDE.md", path="~/Documents/")
+   Glob("**/CLAUDE.md", path="~/Library/CloudStorage/")
+   ```
+3. **Read each file found**
+
+### Content checks — Global CLAUDE.md
+- Is it concise? The global CLAUDE.md is loaded in EVERY conversation — every line costs context window. It should be <50 lines of high-signal content.
+- Does it contain information that belongs in rules instead? (Rules are also always loaded but are better organized by topic)
+- Does it contain project-specific information that should be in a project CLAUDE.md instead?
+- Are the instructions clear and unambiguous?
+- Does it reference the rules directory so Claude knows to look there?
+
+### Content checks — Project CLAUDE.md files
+- Does each project CLAUDE.md have:
+  - A clear project purpose/description?
+  - A document map (what files are where)?
+  - Key context that isn't derivable from the code itself?
+  - Build/test/run commands if applicable?
+- Are there outdated references? (Files that no longer exist, deprecated features, old team members)
+- Is there content that contradicts the global CLAUDE.md or rules?
+- Is the file appropriately sized for the project? (Small project = short CLAUDE.md, large project = more detail)
+
+### Ecosystem checks
+- Is there content in CLAUDE.md that duplicates rules files? (The same instruction in both places)
+- Are there projects that should have a CLAUDE.md but don't?
+- Is there a clear separation of concerns between global CLAUDE.md, project CLAUDE.md, and rules?
+
+### Best practices comparison
+- CLAUDE.md should focus on: project context, file structure, build commands, key decisions
+- CLAUDE.md should NOT contain: personal preferences (→ rules), people info (→ rules), tool conventions (→ rules)
+- The global CLAUDE.md should be a brief "who am I working with and what are the ground rules" — everything else goes to rules/
+
+## Output format
+
+```markdown
+## CLAUDE.md Audit
+
+### Files Found
+| # | Path | Scope | Lines | Purpose |
+|---|------|-------|-------|---------|
+
+### Global CLAUDE.md Review
+- **Size:** X lines (target: <50)
+- **Signal-to-noise:** [assessment]
+- **Content that should move to rules:** [list]
+- **Missing content:** [list]
+
+### Project CLAUDE.md Reviews
+For each:
+- **Project:** [name]
+- **Quality:** [assessment]
+- **Issues:** [list]
+
+### Findings
+
+#### Critical
+- [file]: [issue] → [fix]
+
+#### Improvements
+- [observation] → [suggestion]
+
+#### Good Practices
+- [what's working well]
+```

--- a/plugins/setup-reviewer/agents/08_terminal.md
+++ b/plugins/setup-reviewer/agents/08_terminal.md
@@ -1,0 +1,82 @@
+# Terminal & Shell Config Auditor
+
+You are auditing a Claude Code user's terminal and shell configuration for optimal Claude Code usage.
+
+## What to do
+
+1. **Read shell config files:**
+   - `~/.zshrc` (primary — macOS default shell is zsh)
+   - `~/.zprofile` (if exists)
+   - `~/.zshenv` (if exists)
+   - `~/.bash_profile` and `~/.bashrc` (if exists, for fallback)
+2. **Check terminal app:** `echo $TERM_PROGRAM` and `echo $TERM`
+3. **Check Claude installation:** `which claude && claude --version`
+4. **Check shell integrations:** Look for any Claude-related sourced files or integrations
+
+### Alias & shortcut checks
+- List all Claude-related aliases (grep for `claude` in shell configs)
+- Are there useful aliases missing? Common power-user aliases:
+  - Quick launch: `c` → `claude`
+  - Skip permissions: `cdanger` → `claude --dangerously-skip-permissions`
+  - Open config: edit CLAUDE.md or settings
+  - Session management aliases
+- Are existing aliases well-named and documented?
+
+### Environment variable checks
+- List all env vars related to Claude or AI tools (ANTHROPIC_*, OPENAI_*, CLAUDE_*, NODE_*)
+- Check for PATH entries that include Claude-related tools
+- **Security audit:** Flag any API keys, tokens, or secrets stored directly in shell config files
+  - These should use a secrets manager, keychain, or at minimum be in a separate sourced file with restricted permissions
+- Check for env vars that MCP servers or hooks expect but aren't set in the shell
+
+### Terminal app checks
+- What terminal app is being used? (iTerm2, Terminal.app, Warp, Alacritty, etc.)
+- Is the terminal configured for optimal Claude Code usage?
+  - Font that supports unicode and box-drawing characters
+  - Adequate scrollback buffer
+  - Color scheme that works with Claude's output
+- Are there terminal-specific integrations (e.g., iTerm2 shell integration, status line)?
+
+### PATH and tool checks
+- Is `claude` in PATH? What version?
+- Are there other AI CLI tools installed? (gh copilot, aider, cursor, etc.)
+- Are Node.js and npm/npx available? (Required for many MCP servers)
+- Is Python available? (Required for some scripts and venvs)
+- Are common dev tools available? (git, gh, jq, etc.)
+
+## Output format
+
+```markdown
+## Terminal & Shell Config Audit
+
+### Shell Environment
+| Property | Value |
+|----------|-------|
+| Shell | zsh/bash |
+| Terminal | iTerm2/Terminal.app/etc |
+| Claude Version | X.Y.Z |
+| Node.js | X.Y.Z |
+| Python | X.Y.Z |
+
+### Aliases
+| Alias | Command | Notes |
+|-------|---------|-------|
+
+### Environment Variables (Claude-related)
+| Variable | Set? | Source | Sensitive? |
+|----------|------|--------|------------|
+
+### Findings
+
+#### Critical
+- [issue] → [fix]
+
+#### Improvements
+- [observation] → [suggestion]
+
+#### Good Practices
+- [what's working well]
+
+### Missing Tools / Aliases (suggestions)
+- [tool or alias that could improve the workflow]
+```

--- a/plugins/setup-reviewer/agents/09_hooks.md
+++ b/plugins/setup-reviewer/agents/09_hooks.md
@@ -1,0 +1,71 @@
+# Hooks Auditor
+
+You are auditing a Claude Code user's hooks configuration. Hooks are scripts that run automatically in response to Claude Code events (session start, before/after tool use, etc.).
+
+## What to do
+
+1. **Read hook config from settings:** `~/.claude/settings.json` — look for hook definitions under event types like `SessionStart`, `PreToolUse`, `PostToolUse`, `Notification`, etc.
+2. **List hook scripts:** `ls -la ~/.claude/hooks/`
+3. **Read each hook script** to understand what it does
+
+### Wiring checks
+- For each hook defined in settings.json:
+  - Does the referenced script/command exist? (`test -f <path>`)
+  - Is the script executable? (`test -x <path>`)
+  - Is the script syntax-valid? (For Python: `python3 -m py_compile <path>`, for bash: `bash -n <path>`)
+- For each script in `~/.claude/hooks/`:
+  - Is it wired up in settings.json? Flag orphaned scripts (exist but aren't triggered)
+  - What event does it respond to?
+
+### Behavior checks
+- **SessionStart hooks:** What runs on every session start?
+  - Are there hooks that slow down startup? (network calls, heavy git operations)
+  - Are there hooks that could fail and block the session? (Consider timeout settings)
+  - Do they add value on every session, or should they be conditional?
+- **PostToolUse hooks:** What runs after tool invocations?
+  - Are they scoped to specific tools or do they run on every tool call? (Running on every call is expensive)
+  - Do they have appropriate timeouts?
+- **PreToolUse hooks:** Any pre-execution validation?
+  - Are there safety checks that should be here but aren't? (e.g., confirming destructive operations)
+
+### Coverage checks
+- Are there automation opportunities the user is missing? Common useful hooks:
+  - **SessionStart:** Auto-pull repos, check for updates, display dashboard
+  - **PostToolUse (Bash):** Auto-format code after edits, run linters
+  - **Notification:** Custom notification routing (Slack, email, etc.)
+  - **PreToolUse:** Safety gates for destructive operations
+- Are there manual processes the user could automate with hooks?
+
+### Quality checks
+- Do hooks have proper error handling? (A crashing hook shouldn't break the session)
+- Are hook scripts well-documented with comments?
+- Are there hooks that should log their output for debugging?
+- Are timeouts configured appropriately? (Too short = hook killed mid-work, too long = blocks Claude)
+
+## Output format
+
+```markdown
+## Hooks Audit
+
+### Hook Scripts
+| # | Script | Event | Wired? | Executable? | Syntax Valid? | Purpose |
+|---|--------|-------|--------|-------------|---------------|---------|
+
+### Hook Configuration (from settings.json)
+| Event | Command | Timeout | Script Exists? | Notes |
+|-------|---------|---------|----------------|-------|
+
+### Findings
+
+#### Critical
+- [hook]: [issue] → [fix]
+
+#### Improvements
+- [observation] → [suggestion]
+
+#### Good Practices
+- [what's working well]
+
+### Automation Opportunities
+- [event type]: [what could be automated] — [effort estimate]
+```

--- a/plugins/setup-reviewer/agents/10_best_practices.md
+++ b/plugins/setup-reviewer/agents/10_best_practices.md
@@ -1,0 +1,95 @@
+# Best Practices Researcher
+
+You are a web research agent tasked with gathering the latest Claude Code best practices from official and community sources. Your findings will be used to benchmark a user's setup.
+
+## What to do
+
+Use WebSearch and WebFetch to research Claude Code configuration best practices from these sources:
+
+### Official Sources (prioritize these)
+1. **Anthropic Claude Code docs:** Search for and fetch pages from `docs.anthropic.com` related to:
+   - Claude Code overview and setup
+   - CLAUDE.md best practices and structure
+   - MCP server configuration
+   - Hooks and automation
+   - Settings and permissions
+   - Skills and commands
+   - Memory and context management
+
+2. **Claude Code GitHub:** Fetch from `github.com/anthropics/claude-code`:
+   - README.md for setup recommendations
+   - Any docs/ directory content
+   - Issues/discussions with popular configuration tips
+
+3. **Anthropic blog:** Search `anthropic.com/engineering` or `anthropic.com/blog` for posts about Claude Code best practices
+
+### Community Sources
+4. **GitHub search:** Search for repos with high-quality Claude Code configurations:
+   - Search: `"CLAUDE.md" best practices` or `claude code setup guide`
+   - Look for repos that share `.claude/` configurations or CLAUDE.md templates
+
+5. **Blog posts & guides:** Search for:
+   - "Claude Code power user tips"
+   - "Claude Code advanced configuration"
+   - "Claude Code MCP setup guide"
+   - "CLAUDE.md examples"
+
+### What to extract
+
+Compile a **best practices checklist** organized by area:
+
+```markdown
+## Best Practices Baseline
+
+### CLAUDE.md
+- [ ] Keep global CLAUDE.md under 50 lines
+- [ ] Include project purpose, file structure, build commands
+- [ ] Don't duplicate rules content
+- [ ] etc.
+
+### Settings & Permissions
+- [ ] Scope permissions narrowly
+- [ ] Use env vars for secrets, not hardcoded values
+- [ ] etc.
+
+### MCP Servers
+- [ ] Verify server health on session start
+- [ ] Use env vars for credentials
+- [ ] etc.
+
+### Skills & Commands
+- [ ] Include clear descriptions for trigger matching
+- [ ] Scope allowed-tools appropriately
+- [ ] etc.
+
+### Rules
+- [ ] Keep individual files focused on one topic
+- [ ] Avoid files over 200 lines
+- [ ] etc.
+
+### Hooks
+- [ ] Use SessionStart for environment validation
+- [ ] Set appropriate timeouts
+- [ ] etc.
+
+### Terminal & Shell
+- [ ] Use aliases for common Claude commands
+- [ ] Secure API keys via keychain or env files
+- [ ] etc.
+
+### Security
+- [ ] Never hardcode API keys in config files
+- [ ] Scope file access permissions
+- [ ] etc.
+
+### Performance
+- [ ] Minimize rules file sizes (context window cost)
+- [ ] Avoid heavy operations in SessionStart hooks
+- [ ] etc.
+```
+
+For each checklist item, note the source (official docs, community guide, blog post) so the synthesis agent can weight official recommendations higher.
+
+## Output format
+
+Return the compiled checklist with source citations. Be thorough — this is the baseline the entire review will be benchmarked against.

--- a/plugins/setup-reviewer/agents/11_synthesis.md
+++ b/plugins/setup-reviewer/agents/11_synthesis.md
@@ -1,0 +1,148 @@
+# Synthesis Agent — Cross-Cutting Analysis & Final Report
+
+You are the synthesis agent for a Claude Code setup review. You receive findings from 10 parallel audit agents and produce the final report.
+
+## Input
+
+You will receive the findings from these agents:
+1. Skills Auditor
+2. Commands Auditor
+3. Rules Auditor
+4. Plugins Auditor
+5. MCP Servers Auditor
+6. Settings & Permissions Auditor
+7. CLAUDE.md Auditor
+8. Terminal & Shell Auditor
+9. Hooks Auditor
+10. Best Practices Researcher
+
+## What to do
+
+### 1. Cross-cutting analysis
+
+Look for patterns that span multiple areas:
+
+- **Redundancies:** Same capability provided by a skill AND a command AND an MCP server. Pick the best home and recommend consolidating.
+- **Integration gaps:** MCP server exists but no skill/command uses it. Plugin installed but no workflow references it.
+- **Consistency issues:** Naming conventions, file organization patterns, documentation style differences across areas.
+- **Security posture:** Aggregate all security findings. API keys in shell config + overly permissive settings + unscoped MCP servers = compound risk.
+- **Performance:** Total context window cost of all rules + CLAUDE.md files. Hook overhead on session start. Plugin count impact.
+- **Missing capabilities:** Based on the user's workflow (inferred from skills, commands, MCP servers), what common automation patterns are they NOT using?
+
+### 2. Best practices benchmark
+
+Compare the user's actual setup against the best practices checklist from Agent 10:
+- For each best practice: does the user follow it? (Yes/Partial/No)
+- Highlight areas where the user EXCEEDS best practices (doing things the community hasn't caught up to)
+- Highlight the biggest gaps between their setup and recommended practices
+
+### 3. Maturity rating
+
+Rate the overall setup on this scale:
+
+| Level | Description |
+|-------|-------------|
+| **Beginner** | Basic Claude Code install, minimal customization |
+| **Intermediate** | Some skills/commands, basic rules, 1-2 MCP servers |
+| **Advanced** | Comprehensive rules, multiple skills, MCP ecosystem, some hooks |
+| **Power User** | Full automation pipeline, parallel agents, custom plugins, web research integration |
+| **Elite** | Self-improving setup (meta-skills like review-setup), cross-tool integration, security-hardened, context-optimized |
+
+Justify the rating with specific evidence from the audit.
+
+### 4. Compile the final report
+
+```markdown
+# Claude Code Setup Review
+
+**Date:** [today]
+**Maturity Level:** [rating] — [one-line justification]
+
+## Executive Summary
+- **Health Score:** X/10
+- **Total findings:** N across all areas
+  - Critical: X (broken functionality, security risks)
+  - Improvement: Y (working but suboptimal)
+  - Info: Z (observations, nice-to-haves)
+- **Top 3 quick wins:** [highest impact, lowest effort actions]
+
+## Setup Statistics
+| Metric | Count |
+|--------|-------|
+| Skills | X |
+| Commands | X |
+| Rule files | X (Y total lines) |
+| Plugins | X |
+| MCP Servers | X |
+| Hooks | X |
+| CLAUDE.md files | X |
+
+## Findings by Area
+
+### 1. Skills
+[Summarize agent 1 findings — keep critical items, condense info items]
+
+### 2. Commands
+[Summarize agent 2 findings]
+
+### 3. Rules
+[Summarize agent 3 findings]
+
+### 4. Plugins
+[Summarize agent 4 findings]
+
+### 5. MCP Servers
+[Summarize agent 5 findings]
+
+### 6. Settings & Permissions
+[Summarize agent 6 findings]
+
+### 7. CLAUDE.md Files
+[Summarize agent 7 findings]
+
+### 8. Terminal & Shell
+[Summarize agent 8 findings]
+
+### 9. Hooks
+[Summarize agent 9 findings]
+
+## Cross-Cutting Insights
+- [Pattern 1 spanning multiple areas]
+- [Pattern 2]
+- [Pattern 3]
+
+## Best Practices Scorecard
+| Category | Score | Key Gaps |
+|----------|-------|----------|
+| CLAUDE.md | X/10 | [gaps] |
+| Settings | X/10 | [gaps] |
+| MCP | X/10 | [gaps] |
+| Skills/Commands | X/10 | [gaps] |
+| Rules | X/10 | [gaps] |
+| Hooks | X/10 | [gaps] |
+| Terminal | X/10 | [gaps] |
+| Security | X/10 | [gaps] |
+
+## Recommended Actions
+
+### Quick Fixes (< 5 min each)
+1. [action] — [why] — [which area]
+2. [action] — [why] — [which area]
+
+### Moderate Improvements (30 min - 2 hours)
+1. [action] — [why] — [which area]
+
+### Strategic Improvements (half day+)
+1. [action] — [why] — [which area]
+
+## Where the User Exceeds Best Practices
+- [thing they do that's better than standard recommendations]
+```
+
+### 5. Important guidelines
+
+- **Be specific:** "Fix the broken script reference in fill-timesheet" not "some scripts are broken"
+- **Be actionable:** Every finding should have a clear next step
+- **Be honest:** If the setup is excellent, say so. Don't manufacture problems.
+- **Prioritize:** The user's time is valuable. Lead with what matters most.
+- **Acknowledge strengths:** A good review highlights what's working well, not just problems.

--- a/plugins/setup-reviewer/skills/review-setup/SKILL.md
+++ b/plugins/setup-reviewer/skills/review-setup/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: review-setup
+description: Comprehensive review and audit of a user's Claude Code setup — skills, commands, rules, plugins, MCP servers, settings, hooks, terminal config, and CLAUDE.md files. Identifies gaps, redundancies, errors, and improvement opportunities.
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - Grep
+  - Agent
+  - TaskCreate
+  - TaskUpdate
+  - WebFetch
+  - WebSearch
+---
+
+# Claude Code Setup Reviewer
+
+Comprehensive audit of a Claude Code installation. Dispatches 10 parallel review agents, each with detailed instructions in `agents/`, then synthesizes findings into a scored report.
+
+## Execution Flow
+
+### Phase 1 — Parallel Audit (agents 1-10)
+
+Dispatch ALL of the following agents simultaneously using the Agent tool. Each agent's full instructions are in the corresponding file under `${CLAUDE_PLUGIN_ROOT}/agents/`. Read the file and pass its contents as the agent prompt.
+
+| # | Agent | Instruction File | What It Reviews |
+|---|-------|-----------------|-----------------|
+| 1 | Skills Auditor | `agents/01_skills.md` | Skills directory, SKILL.md files, referenced scripts |
+| 2 | Commands Auditor | `agents/02_commands.md` | Command files, overlap with skills |
+| 3 | Rules Auditor | `agents/03_rules.md` | Rule files, contradictions, staleness |
+| 4 | Plugins Auditor | `agents/04_plugins.md` | Plugin registry, blocklist, marketplace config |
+| 5 | MCP Servers Auditor | `agents/05_mcp.md` | MCP config, connectivity, env vars |
+| 6 | Settings Auditor | `agents/06_settings.md` | Permissions, hooks config, env vars, JSON validity |
+| 7 | CLAUDE.md Auditor | `agents/07_claudemd.md` | Global + project CLAUDE.md files |
+| 8 | Terminal Auditor | `agents/08_terminal.md` | Shell config, aliases, env vars, security |
+| 9 | Hooks Auditor | `agents/09_hooks.md` | Hook scripts, wiring, coverage gaps |
+| 10 | Best Practices Researcher | `agents/10_best_practices.md` | Web research: Anthropic docs, community guides |
+
+**Launch pattern:**
+
+For each agent, send a prompt like:
+
+> Read your instruction file at `${CLAUDE_PLUGIN_ROOT}/agents/XX_name.md` and follow it exactly. That file is your guidebook — it tells you what to inspect, what checks to run, and how to format your findings. Return your findings report when done.
+
+Do NOT read the agent files yourself. Each agent reads its own guidebook and works autonomously.
+
+Launch all 10 in a single message for maximum parallelism.
+
+### Phase 2 — Synthesis
+
+Once all 10 agents have returned, launch one final agent with this prompt:
+
+> Read your instruction file at `${CLAUDE_PLUGIN_ROOT}/agents/11_synthesis.md` and follow it exactly. Below are the findings from 10 parallel audit agents. Synthesize them into the final report format described in your guidebook.
+>
+> [paste all 10 agents' findings here]
+
+This agent produces the final report.
+
+### Phase 3 — Present & Act
+
+1. Present the synthesized report to the user
+2. Offer to apply quick fixes immediately
+3. For larger improvements, suggest the user create reminders or tasks for follow-up
+4. If the user has an `/update-rules` skill, suggest running it to persist any learnings
+
+## Finding Severity Levels
+
+Agents should categorize every finding as one of:
+- **Critical:** Broken functionality, security risk, or missing essential config
+- **Improvement:** Working but suboptimal — clear benefit to fixing
+- **Info:** Observation, nice-to-have, or cosmetic


### PR DESCRIPTION
## Summary

- Adds a **setup-reviewer** plugin that performs a comprehensive audit of a Claude Code installation
- Dispatches **10 parallel review agents**, each specialized in one area (skills, commands, rules, plugins, MCP servers, settings, CLAUDE.md, terminal config, hooks, + best practices web research)
- A **synthesis agent** cross-references all findings into a scored health report

## What it reviews

| Agent | Area |
|-------|------|
| Skills Auditor | SKILL.md files, allowed-tools scoping, script references, overlaps |
| Commands Auditor | Slash command quality, MCP references, skill overlap |
| Rules Auditor | Contradictions, staleness, duplicates, secrets, context window cost |
| Plugins Auditor | Registry health, blocklist, orphaned plugins |
| MCP Servers Auditor | Connectivity, env vars, ghost servers, security |
| Settings Auditor | Permission scoping, hook wiring, env var security |
| CLAUDE.md Auditor | Global + project files, content placement, bloat |
| Terminal Auditor | Shell aliases, env vars, API key security |
| Hooks Auditor | Wiring, orphaned scripts, automation opportunities |
| Best Practices Researcher | Anthropic docs, community guides |

## Report output

- Health Score (X/10)
- Maturity Rating (Beginner → Elite)
- Findings by area with severity levels
- Best Practices Scorecard
- Prioritized actions by effort

## Plugin structure

```
setup-reviewer/
├── .claude-plugin/plugin.json
├── README.md
├── skills/review-setup/SKILL.md    # Orchestrator
└── agents/                          # 11 agent instruction files
    ├── 01_skills.md ... 10_best_practices.md
    └── 11_synthesis.md
```

## Test plan

- [ ] Install plugin and run review-setup
- [ ] Verify all 10 agents dispatch in parallel
- [ ] Verify synthesis agent produces scored report
- [ ] Verify no personal information in any files
- [ ] Test on a fresh Claude Code installation (minimal config)
- [ ] Test on a heavily customized installation

Standalone repo with demo screenshot: https://github.com/patrickfreyer/claude-code-setup-reviewer

Generated with Claude Code