### PR TITLE
docs: Fix README wording and installation guidance

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -1,6 +1,6 @@
 # Settings Examples
 
-Example Claude Code settings files, primarily intended for organization-wide deployments. Use these are starting points — adjust them to fit your needs.
+Example Claude Code settings files, primarily intended for organization-wide deployments. Use these as starting points — adjust them to fit your needs.
 
 These may be applied at any level of the [settings hierarchy](https://code.claude.com/docs/en/settings#settings-files), though certain properties only take effect if specified in enterprise settings (e.g. `strictKnownMarketplaces`, `allowManagedHooksOnly`, `allowManagedPermissionRulesOnly`).
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -30,10 +30,7 @@ Learn more in the [official plugins documentation](https://docs.claude.com/en/do
 
 These plugins are included in the Claude Code repository. To use them in your own projects:
 
-1. Install Claude Code globally:
-```bash
-npm install -g @anthropic-ai/claude-code
-```
+1. Install Claude Code using one of the recommended methods from the [setup documentation](https://docs.claude.com/en/docs/claude-code/setup).
 
 2. Navigate to your project and run Claude Code:
 ```bash


### PR DESCRIPTION
## Summary
- fix the grammar typo in `examples/settings/README.md`
- update `plugins/README.md` to point readers to the recommended Claude Code setup documentation instead of the deprecated global npm install path

## Why
- the settings examples README had a small wording error
- the plugin installation section had drifted from the root README and still suggested a deprecated install method

## Impact
- reduces confusion for readers following installation guidance
- keeps the repository's README-level documentation aligned

## Root cause
- documentation drift between the root README and the plugin-specific README

## Validation
- `git diff --check origin/main...HEAD`
