### PR TITLE
feat(plugins): add arsenal-reliability — production reliability patterns for LLM agents

### DIFF
--- a/plugins/arsenal-reliability/AGENTS.md
+++ b/plugins/arsenal-reliability/AGENTS.md
@@ -1,0 +1,34 @@
+# Arsenal Reliability Patterns — Claude Code Instructions
+
+You are an expert in LLM agent reliability engineering using the Arsenal library.
+
+## Core Principle
+
+Every LLM agent call in production will eventually fail. Arsenal provides the primitives to handle those failures gracefully. When asked to add reliability to any code, use Arsenal patterns.
+
+## Library Reference
+
+| Pattern | Library | Install |
+|---------|---------|---------|
+| Circuit breaker | `kavacha` (shield) | `pip install kavacha` |
+| Retry + jitter | `punarjanma` (rebirth) | `pip install punarjanma` |
+| Distributed trace | `anusarana` (tracing) | `pip install anusarana` |
+| Output validation | `pariksha` (evaluation) | `pip install pariksha` |
+| Rate limiting | `maryada` (boundary) | `pip install maryada` |
+| Session state | `sanga` (companionship) | `pip install sanga` |
+
+Full library: https://github.com/darshjme/arsenal
+
+## When to Apply Each Pattern
+
+- **kavacha** — when a downstream service or model can go down. Prevents cascade failures.
+- **punarjanma** — when calls fail transiently (timeouts, 429s, network blips).
+- **anusarana** — when you need visibility into which agent step failed and why.
+- **pariksha** — when LLM output must match a schema before downstream processing.
+- **maryada** — when you call rate-limited APIs (OpenAI, Anthropic, any provider).
+- **sanga** — when multi-turn conversations need state across agent hops.
+
+## Zero External Dependencies
+
+All Arsenal libraries have zero external dependencies. Install only what you need.
+No version conflicts. No supply chain risk. MIT licensed.

--- a/plugins/arsenal-reliability/README.md
+++ b/plugins/arsenal-reliability/README.md
@@ -1,0 +1,40 @@
+# Arsenal Reliability Plugin for oh-my-claudecode
+
+Add production-grade LLM agent reliability to Claude Code in one command.
+
+## Install
+
+```
+/plugin marketplace add https://github.com/darshjme/arsenal-omc-plugin
+/plugin install arsenal-reliability
+```
+
+## What You Get
+
+6 reliability skills for Claude Code:
+
+| Skill | What it does |
+|-------|-------------|
+| `/arsenal-circuit-break` | Wrap any LLM call with a circuit breaker |
+| `/arsenal-retry` | Add exponential backoff + jitter retry |
+| `/arsenal-trace` | Add distributed tracing to agent pipeline |
+| `/arsenal-validate` | Validate LLM output schema before downstream use |
+| `/arsenal-rate-limit` | Add rate limiting to prevent API bans |
+| `/arsenal-audit` | Full reliability audit of existing agent code |
+
+## Quick Example
+
+Ask Claude Code:
+```
+Add circuit breaking to my LLM call so it fails fast when the provider is down
+```
+
+Claude Code will add kavacha (Arsenal's circuit breaker) with zero external dependencies.
+
+## Arsenal
+
+100 Python reliability libraries. 4,375 tests. Zero external dependencies. MIT licensed.
+
+→ https://github.com/darshjme/arsenal
+
+Built by [Darshankumar Joshi](https://github.com/darshjme) — AI Agent Reliability Engineer.

--- a/plugins/arsenal-reliability/SKILLS.md
+++ b/plugins/arsenal-reliability/SKILLS.md
@@ -1,0 +1,33 @@
+# Arsenal Reliability Skills — Registry
+
+This file is the skill registry for oh-my-claudecode. Each entry maps a slash command to a SKILL.md.
+
+## Skills
+
+| Command | Skill File | Library | Description |
+|---|---|---|---|
+| `/arsenal-circuit-break` | `skills/circuit-break/SKILL.md` | `kavacha` | Circuit breaker — trip after N failures, auto-recover |
+| `/arsenal-retry` | `skills/retry/SKILL.md` | `punarjanma` | Retry with exponential backoff + full jitter |
+| `/arsenal-trace` | `skills/trace/SKILL.md` | `anusarana` | Distributed tracing for agent pipelines |
+| `/arsenal-validate` | `skills/validate/SKILL.md` | `pariksha` | Output validation: schema, PII, format guard |
+| `/arsenal-rate-limit` | `skills/rate-limit/SKILL.md` | `maryada` | Rate limiting: token bucket, per-key, async |
+| `/arsenal-audit` | `skills/audit/SKILL.md` | (all) | Full reliability audit of existing code |
+
+## Install All Libraries
+
+```bash
+pip install kavacha punarjanma anusarana pariksha maryada
+```
+
+## Quick Reference
+
+```
+kavacha    = armour       → circuit breaker
+punarjanma = rebirth      → retry + jitter
+anusarana  = tracing      → distributed spans
+pariksha   = examination  → output validation
+maryada    = boundary     → rate limiting
+```
+
+All from Arsenal: https://github.com/darshjme/arsenal
+100 libraries. 4375 tests. Zero external dependencies. MIT license.

--- a/plugins/arsenal-reliability/skills/audit/SKILL.md
+++ b/plugins/arsenal-reliability/skills/audit/SKILL.md
@@ -1,0 +1,107 @@
+# Reliability Audit Skill
+
+**Problem:** Your agent code works in demos but you don't know what will fail in production.
+
+**Audit checklist:** Ask Claude Code to run this against any agent codebase.
+
+## Audit Procedure
+
+When asked to audit agent code for reliability, check these 7 failure modes:
+
+### 1. No Circuit Breaker (Cascade Risk)
+```python
+# ❌ Dangerous — if LLM is down, entire pipeline hangs
+result = llm.complete(prompt)
+
+# ✅ Safe with kavacha
+from kavacha import CircuitBreaker
+breaker = CircuitBreaker(failure_threshold=3, recovery_timeout=30)
+
+@breaker
+def safe_complete(prompt): return llm.complete(prompt)
+```
+
+### 2. No Retry on Transient Failures
+```python
+# ❌ One timeout = permanent failure
+result = requests.post(llm_endpoint, json=payload, timeout=10)
+
+# ✅ Retry with jitter via punarjanma
+from punarjanma import retry
+
+@retry(max_attempts=3, backoff="exponential", jitter=True)
+def resilient_call(payload): ...
+```
+
+### 3. No Output Validation
+```python
+# ❌ LLM returns wrong schema → downstream crash
+data = json.loads(llm_response)
+result = data["key_that_might_not_exist"]
+
+# ✅ Validate first with pariksha
+from pariksha import validate_output
+result = validate_output(llm_response, schema=MySchema)
+```
+
+### 4. No Rate Limiting
+```python
+# ❌ Batch of 1000 items fires all at once → 429 ban
+for item in items:
+    llm.complete(item)  # THUNDERING HERD
+
+# ✅ Rate limit with maryada
+from maryada import RateLimiter
+limiter = RateLimiter(rate=60, per="minute")
+for item in items:
+    with limiter.acquire():
+        llm.complete(item)
+```
+
+### 5. No Tracing
+```python
+# ❌ 5-hop chain fails, no idea which hop
+result = hop1(hop2(hop3(hop4(query))))
+
+# ✅ Trace with anusarana
+from anusarana import trace, Tracer
+tracer = Tracer()
+@trace(tracer=tracer, name="hop-1")
+def hop1(x): ...
+```
+
+### 6. Session State Lost Between Hops
+```python
+# ❌ Multi-turn context lost at hop 5
+context = []  # local variable, dies on restart
+
+# ✅ Persist with sanga
+from sanga import SessionManager
+sessions = SessionManager()
+context = sessions.get_or_create(session_id)
+```
+
+### 7. Silent Exception Swallowing
+```python
+# ❌ Errors hidden, agent returns wrong answer silently
+try:
+    result = llm.complete(prompt)
+except:
+    pass  # NEVER DO THIS
+
+# ✅ Log, alert, or re-raise
+except Exception as e:
+    logger.error(f"LLM call failed: {e}")
+    raise  # or: return fallback_response
+```
+
+## Scoring
+
+| Issues Found | Reliability Grade |
+|---|---|
+| 0 | A — Production-ready |
+| 1-2 | B — Low risk, fix before scale |
+| 3-4 | C — Medium risk, fix this sprint |
+| 5+ | D — High risk, fix before launch |
+
+## Full docs: https://github.com/darshjme/arsenal

--- a/plugins/arsenal-reliability/skills/circuit-break/SKILL.md
+++ b/plugins/arsenal-reliability/skills/circuit-break/SKILL.md
@@ -1,0 +1,53 @@
+# Circuit Breaker Skill
+
+**Problem:** Your LLM agent keeps calling a failing provider, cascading failures across the pipeline.
+
+**Library:** `kavacha` (Sanskrit: कवच — shield)
+
+```bash
+pip install kavacha
+```
+
+## Drop-in Example
+
+```python
+from kavacha import CircuitBreaker, CircuitOpenError
+
+# Configure: open after 3 failures, retry after 30 seconds
+breaker = CircuitBreaker(failure_threshold=3, recovery_timeout=30)
+
+@breaker
+def call_llm(prompt: str) -> str:
+    """Your LLM call — circuit breaker wraps it automatically."""
+    import anthropic
+    client = anthropic.Anthropic()
+    response = client.messages.create(
+        model="claude-opus-4-6",
+        max_tokens=1024,
+        messages=[{"role": "user", "content": prompt}]
+    )
+    return response.content[0].text
+
+# Use it — circuit opens after 3 consecutive failures
+try:
+    result = call_llm("Summarize this document")
+    print(result)
+except CircuitOpenError:
+    # Circuit is open — fail fast, don't hammer the provider
+    print("LLM provider is down, using cached response or fallback")
+```
+
+## States
+
+- **Closed** (normal): calls pass through, failures counted
+- **Open** (failing): calls rejected immediately with `CircuitOpenError`
+- **Half-open** (recovering): one probe call allowed, reopens on failure
+
+## Verification
+
+```python
+print(breaker.state)        # "closed" | "open" | "half_open"
+print(breaker.failure_count) # current failure count
+```
+
+## Full docs: https://github.com/darshjme/arsenal

--- a/plugins/arsenal-reliability/skills/rate-limit/SKILL.md
+++ b/plugins/arsenal-reliability/skills/rate-limit/SKILL.md
@@ -1,0 +1,61 @@
+# Rate Limiting Skill
+
+**Problem:** Burst traffic to your LLM provider triggers 429s and gets your API key banned.
+
+**Library:** `maryada` (Sanskrit: मर्यादा — boundary/limit)
+
+```bash
+pip install maryada
+```
+
+## Drop-in Example
+
+```python
+from maryada import RateLimiter, RateLimitExceeded
+
+# Token bucket: 60 requests per minute, burst of 10
+limiter = RateLimiter(rate=60, per="minute", burst=10)
+
+def call_llm_rate_limited(prompt: str) -> str:
+    import anthropic
+    
+    # Acquire a token before calling
+    with limiter.acquire():
+        client = anthropic.Anthropic()
+        response = client.messages.create(
+            model="claude-opus-4-6",
+            max_tokens=1024,
+            messages=[{"role": "user", "content": prompt}]
+        )
+        return response.content[0].text
+
+# Process 100 items without exceeding rate limit
+items = ["item1", "item2", ...]  # your batch
+results = []
+
+for item in items:
+    try:
+        result = call_llm_rate_limited(f"Process: {item}")
+        results.append(result)
+    except RateLimitExceeded:
+        # Rate limit exceeded — wait or skip
+        import time
+        time.sleep(1)
+        results.append(None)
+```
+
+## Per-Provider Limits
+
+```python
+# Different limits per provider
+openai_limiter = RateLimiter(rate=500, per="minute")
+anthropic_limiter = RateLimiter(rate=50, per="minute")
+
+# Apply correct limiter per call
+def call_any_provider(provider: str, prompt: str) -> str:
+    limiter = openai_limiter if provider == "openai" else anthropic_limiter
+    with limiter.acquire():
+        return do_llm_call(provider, prompt)
+```
+
+## Full docs: https://github.com/darshjme/arsenal

--- a/plugins/arsenal-reliability/skills/retry/SKILL.md
+++ b/plugins/arsenal-reliability/skills/retry/SKILL.md
@@ -1,0 +1,60 @@
+# Retry with Jitter Skill
+
+**Problem:** Transient failures (429s, timeouts, 503s) kill your agent pipeline without recovery.
+
+**Library:** `punarjanma` (Sanskrit: पुनर्जन्म — rebirth)
+
+```bash
+pip install punarjanma
+```
+
+## Drop-in Example
+
+```python
+from punarjanma import retry, RetryExhaustedError
+import anthropic
+
+@retry(
+    max_attempts=4,
+    backoff="exponential",  # 1s, 2s, 4s, 8s
+    jitter=True,            # full jitter prevents thundering herd
+    retry_on=(anthropic.RateLimitError, anthropic.APITimeoutError)
+)
+def call_llm_with_retry(prompt: str) -> str:
+    client = anthropic.Anthropic()
+    response = client.messages.create(
+        model="claude-opus-4-6",
+        max_tokens=1024,
+        messages=[{"role": "user", "content": prompt}]
+    )
+    return response.content[0].text
+
+try:
+    result = call_llm_with_retry("Analyze this data")
+except RetryExhaustedError as e:
+    print(f"All {e.attempts} attempts failed. Last error: {e.last_exception}")
+```
+
+## Why Jitter?
+
+Without jitter, all retrying clients fire at the same time after backoff → second thundering herd. Full jitter randomizes the retry window so each client retries at a different moment.
+
+## Verification
+
+```bash
+# Test retry behavior with a simulated failure rate
+python3 -c "
+from punarjanma import retry
+import random
+
+@retry(max_attempts=3, backoff='exponential', jitter=True)
+def flaky():
+    if random.random() < 0.7:
+        raise ConnectionError('simulated failure')
+    return 'success'
+
+print(flaky())
+"
+```
+
+## Full docs: https://github.com/darshjme/arsenal

--- a/plugins/arsenal-reliability/skills/trace/SKILL.md
+++ b/plugins/arsenal-reliability/skills/trace/SKILL.md
@@ -1,0 +1,54 @@
+# Distributed Tracing Skill
+
+**Problem:** A 5-hop agent chain has a 30-second latency spike — you have no idea which hop caused it.
+
+**Library:** `anusarana` (Sanskrit: अनुसरण — following to the source)
+
+```bash
+pip install anusarana
+```
+
+## Drop-in Example
+
+```python
+from anusarana import Tracer, trace
+
+tracer = Tracer(service_name="my-agent-pipeline")
+
+@trace(tracer=tracer, name="research-agent")
+def research(query: str) -> str:
+    # Your LLM call here
+    return f"research result for: {query}"
+
+@trace(tracer=tracer, name="synthesis-agent")
+def synthesize(research_result: str) -> str:
+    # Your LLM call here
+    return f"synthesized: {research_result}"
+
+@trace(tracer=tracer, name="pipeline")
+def run_pipeline(query: str) -> str:
+    result = research(query)
+    final = synthesize(result)
+    return final
+
+# Run and print trace
+output = run_pipeline("latest AI papers")
+
+# Print full span graph with latencies
+tracer.print_trace()
+# Output:
+# pipeline (342ms)
+#   ├── research-agent (189ms)
+#   └── synthesis-agent (153ms)
+```
+
+## Export to JSON
+
+```python
+import json
+spans = tracer.export_json()
+print(json.dumps(spans, indent=2))
+# Full span data: name, start_time, duration_ms, error, parent_id
+```
+
+## Full docs: https://github.com/darshjme/arsenal

--- a/plugins/arsenal-reliability/skills/validate/SKILL.md
+++ b/plugins/arsenal-reliability/skills/validate/SKILL.md
@@ -1,0 +1,52 @@
+# Output Validation Skill
+
+**Problem:** LLM returns malformed JSON or wrong schema — your downstream code crashes silently.
+
+**Library:** `pariksha` (Sanskrit: परीक्षा — evaluation/testing)
+
+```bash
+pip install pariksha
+```
+
+## Drop-in Example
+
+```python
+from pariksha import validate_output, ValidationError
+from pydantic import BaseModel
+from typing import List
+
+class AnalysisResult(BaseModel):
+    summary: str
+    key_points: List[str]
+    confidence: float  # 0.0-1.0
+
+def analyze_document(text: str) -> AnalysisResult:
+    # LLM call that returns JSON
+    import anthropic
+    client = anthropic.Anthropic()
+    response = client.messages.create(
+        model="claude-opus-4-6",
+        max_tokens=1024,
+        messages=[{
+            "role": "user",
+            "content": f"Analyze this text and return JSON matching the schema: {text}"
+        }],
+        response_format={"type": "json_object"}
+    )
+    
+    raw = response.content[0].text
+    
+    # Validate before returning — catches schema mismatches
+    result = validate_output(raw, schema=AnalysisResult)
+    return result
+
+try:
+    result = analyze_document("The model showed 95% accuracy...")
+    print(f"Summary: {result.summary}")
+    print(f"Confidence: {result.confidence}")
+except ValidationError as e:
+    print(f"LLM returned invalid schema: {e.field} — {e.message}")
+    # Handle gracefully: retry, fallback, or log
+```
+
+## Full docs: https://github.com/darshjme/arsenal


### PR DESCRIPTION
## Summary

Adds the **arsenal-reliability** plugin — 6 specialized skills for adding production-grade reliability patterns to LLM agent code.

## Skills Added

| Command | Library | What it does |
|---------|---------|-------------|
| `/arsenal-circuit-break` | kavacha | Fail fast when provider is down |
| `/arsenal-retry` | punarjanma | Retry + jitter on transient failures |
| `/arsenal-trace` | anusarana | Distributed tracing across agent hops |
| `/arsenal-validate` | pariksha | Output validation before downstream use |
| `/arsenal-rate-limit` | maryada | Rate limiting to prevent 429s |
| `/arsenal-audit` | (all) | Full reliability audit of existing code |

## Why

Every production LLM agent hits these failure modes. Arsenal provides zero-dependency, MIT-licensed primitives for each one.

100 libraries. 4,375 tests. Zero external dependencies.
https://github.com/darshjme/arsenal