### PR TITLE
Added dev-proxy.sh, dev-start.sh

### DIFF
--- a/dev-proxy.mjs
+++ b/dev-proxy.mjs
@@ -1,0 +1,48 @@
+import http from 'node:http';
+
+// The remote server where your API and Database actually live
+const GATEWAY_HOST = process.env.GATEWAY_HOST || '192.168.1.50'; // Change to your remote IP
+const GATEWAY_PORT = 8080; 
+
+const server = http.createServer((req, res) => {
+  // 1. Manually handle CORS to allow your local Vite dev server (port 5173)
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+
+  // Handle preflight requests
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  // 2. Configure the proxy request to the remote backend
+  const options = {
+    hostname: GATEWAY_HOST,
+    port: GATEWAY_PORT,
+    path: req.url,
+    method: req.method,
+    headers: req.headers,
+    // CRITICAL: Force IPv4 to avoid the Node.js 24 + Vite 7 DNS resolution bug
+    family: 4 
+  };
+
+  const proxyReq = http.request(options, (proxyRes) => {
+    res.writeHead(proxyRes.statusCode, proxyRes.headers);
+    proxyRes.pipe(res);
+  });
+
+  proxyReq.on('error', (err) => {
+    console.error('Proxy Error:', err.message);
+    res.writeHead(502);
+    res.end('Bad Gateway');
+  });
+
+  req.pipe(proxyReq);
+});
+
+// The proxy sits on 5174, listening for Vite's requests
+server.listen(5174, '127.0.0.1', () => {
+  console.log(`🚀 Proxy bridging Local (5174) -> Remote (${GATEWAY_HOST}:${GATEWAY_PORT})`);
+});

--- a/dev-start.sh
+++ b/dev-start.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+# --- Configuration ---
+# Change this to your remote server's IP address
+export GATEWAY_HOST=${GATEWAY_HOST:-"192.168.1.50"} 
+PROXY_PORT=5174
+VITE_PORT=5173
+
+# Get the directory where this script is located
+DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$DIR"
+
+# Cleanup function to kill background processes on exit
+cleanup() {
+  echo ""
+  echo "🛑 Shutting down dev services..."
+  kill $PROXY_PID $VITE_PID 2>/dev/null || true
+  exit 0
+}
+
+# Trap interruption signals (Ctrl+C, termination, etc.)
+trap cleanup EXIT INT TERM
+
+echo "Starting Remote Backend Bridge..."
+echo "🔗 Gateway: $GATEWAY_HOST"
+
+# 1. Start the Proxy (Background)
+# Explicitly using node to run the proxy script
+node dev-proxy.mjs &
+PROXY_PID=$!
+
+# 2. Start Vite (Background)
+# We point Vite's API base to our local proxy port
+echo "🚀 Starting Vite on port $VITE_PORT..."
+VITE_API_BASE=http://localhost:$PROXY_PORT npx vite --host 0.0.0.0 --port $VITE_PORT &
+VITE_PID=$!
+
+# Wait for processes to finish (POSIX compliant for macOS/Linux)
+wait $PROXY_PID $VITE_PID


### PR DESCRIPTION
---

## PR Title
`docs: add remote backend proxy pattern for hybrid dev environments`

## Description
This PR addresses **#41406** by introducing a standard pattern for developing frontends locally while connecting to a remote backend (API/DB). 

The current Preview MCP documentation assumes a unified local stack. However, developers often face resource constraints (RAM/CPU) or utilize shared development servers, necessitating a bridge between the local Vite dev server and a remote gateway.

### Changes
- Added `dev-proxy.mjs`: A lightweight, zero-dependency Node.js reverse proxy using `node:http`.
- Added `dev-start.sh`: A cross-platform shell wrapper to orchestrate the lifecycle of both the proxy and Vite.
- Includes specific fixes for:
    - **Node.js 24 IPv6 resolution**: Forces `family: 4` to prevent connection hangs.
    - **macOS Compatibility**: Uses POSIX-compliant `wait` instead of `wait -n` (which requires Bash 4+).
    - **CORS handling**: Manually injects headers to allow local development against remote origins.

### Architecture
The pattern implements the following flow:
`Browser` → `Vite (5173)` → `dev-proxy (5174)` → `Remote Gateway (8080)`

---

## Technical Implementation Details

### The Proxy (`dev-proxy.mjs`)
- **Port:** 5174
- **Feature:** Explicitly handles `OPTIONS` preflight requests and adds `Access-Control-Allow-Origin` headers.
- **Reliability:** Uses the `family: 4` option in `http.request` to bypass known DNS resolution issues in Vite 7/Node 24 environments.

### The Orchestrator (`dev-start.sh`)
- Uses a `trap` mechanism to ensure that stopping the script (Ctrl+C) kills both the proxy and Vite processes simultaneously, preventing "ghost" processes from occupying ports.
- Configurable via `GATEWAY_HOST` environment variable.

## How to Test
1. Place `dev-proxy.mjs` and `dev-start.sh` in the `scripts/` directory.
2. Set your remote IP: `export GATEWAY_HOST="your.remote.ip"`.
3. Run `./scripts/dev-start.sh`.
4. Verify that API calls from the frontend are successfully routed to the remote backend through the proxy.

## Checklist
- [x] Tested on macOS (Bash 3.2 compatibility)
- [x] Tested on Linux
- [x] Verified Node.js 24 compatibility
- [x] No new dependencies added (uses native `node:http`)

---