### PR TITLE
fix(hookify): use relative imports so plugin works when installed via plugin cache

### DIFF
--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -7,7 +7,7 @@ from functools import lru_cache
 from typing import List, Dict, Any, Optional
 
 # Import from local module
-from hookify.core.config_loader import Rule, Condition
+from core.config_loader import Rule, Condition
 
 
 # Cache compiled regexes (max 128 patterns)
@@ -275,7 +275,7 @@ class RuleEngine:
 
 # For testing
 if __name__ == '__main__':
-    from hookify.core.config_loader import Condition, Rule
+    from core.config_loader import Condition, Rule
 
     # Test rule evaluation
     rule = Rule(

--- a/plugins/hookify/hooks/posttooluse.py
+++ b/plugins/hookify/hooks/posttooluse.py
@@ -19,8 +19,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)

--- a/plugins/hookify/hooks/pretooluse.py
+++ b/plugins/hookify/hooks/pretooluse.py
@@ -23,8 +23,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     # If imports fail, allow operation and log error
     error_msg = {"systemMessage": f"Hookify import error: {e}"}

--- a/plugins/hookify/hooks/stop.py
+++ b/plugins/hookify/hooks/stop.py
@@ -19,8 +19,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)

--- a/plugins/hookify/hooks/userpromptsubmit.py
+++ b/plugins/hookify/hooks/userpromptsubmit.py
@@ -19,8 +19,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)


### PR DESCRIPTION
## Problem

When the hookify plugin is installed via Claude Code's plugin system, files are placed at a path like:

```
~/.claude/plugins/cache/claude-code-plugins/hookify/0.1.0/
```

In this layout, `core/` is a **direct child** of the plugin root directory — there is no `hookify/` package subdirectory wrapping it. Python therefore cannot resolve `from hookify.core.` imports, and every hook script fails immediately with an `ImportError`.

The hook scripts do add `PLUGIN_ROOT` and its parent to `sys.path`, but since there is no `hookify/` directory at either of those locations, the `hookify.core` package simply does not exist at runtime.

## Fix

Change all `from hookify.core.<module> import ...` statements to `from core.<module> import ...` across the five affected files:

- `plugins/hookify/core/rule_engine.py` (2 occurrences)
- `plugins/hookify/hooks/stop.py`
- `plugins/hookify/hooks/posttooluse.py`
- `plugins/hookify/hooks/pretooluse.py`
- `plugins/hookify/hooks/userpromptsubmit.py`

With `PLUGIN_ROOT` already on `sys.path`, `from core.` resolves correctly to the `core/` directory sitting directly inside the plugin installation.

## Test plan

- Install the hookify plugin via the Claude Code plugin system
- Trigger a PreToolUse, PostToolUse, Stop, or UserPromptSubmit hook
- Confirm hooks execute without an `ImportError` in the output