### PR TITLE
fix(hookify): normalize tool matcher parsing

### DIFF
--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -134,12 +134,14 @@ class RuleEngine:
         Returns:
             True if matches
         """
+        matcher = matcher.strip()
         if matcher == '*':
             return True
 
-        # Split on | for OR matching
-        patterns = matcher.split('|')
-        return tool_name in patterns
+        # Split on | for OR matching and normalize whitespace/case.
+        # Example: "Edit | Write" should match tool_name "Write".
+        patterns = [p.strip().lower() for p in matcher.split('|') if p.strip()]
+        return tool_name.lower() in patterns
 
     def _check_condition(self, condition: Condition, tool_name: str,
                         tool_input: Dict[str, Any], input_data: Dict[str, Any] = None) -> bool:


### PR DESCRIPTION
Summary
Fixes Hookify tool matcher parsing so matcher strings with spaces around separators match correctly.

Problem
Matchers like Edit space-or Write could fail because values were split but not trimmed before comparison.

Changes
- Trim matcher before evaluation
- Normalize each OR segment with whitespace trimming
- Compare in case-insensitive mode

File Changed
- plugins/hookify/core/rule_engine.py

Validation
- Verified no editor diagnostics errors in updated file
