### PR TITLE
Add EvalView plugin — regression testing for AI agents

### DIFF
--- a/plugins/evalview/.claude-plugin/plugin.json
+++ b/plugins/evalview/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "evalview",
+  "version": "0.6.1",
+  "description": "Regression testing for AI agents — catch behavioral changes, tool call diffs, and quality drops before they ship",
+  "author": {
+    "name": "Hidai Bar-Mor",
+    "url": "https://github.com/hidai25"
+  },
+  "repository": "https://github.com/hidai25/eval-view",
+  "license": "Apache-2.0",
+  "keywords": ["testing", "evaluation", "agents", "regression", "mcp", "ai-agents", "quality"]
+}

--- a/plugins/evalview/.mcp.json
+++ b/plugins/evalview/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "evalview": {
+      "command": "evalview",
+      "args": ["mcp", "serve"],
+      "env": {}
+    }
+  }
+}

--- a/plugins/evalview/README.md
+++ b/plugins/evalview/README.md
@@ -1,0 +1,36 @@
+# EvalView Plugin for Claude Code
+
+Regression testing for AI agents — catch behavioral changes before they ship.
+
+## What it does
+
+EvalView detects when your AI agent's behavior changes by comparing tool calls, parameters, and outputs against golden baselines. Unlike score-based evaluation, EvalView shows you exactly *what* changed — which tool was skipped, which parameter shifted, which output diverged.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/evalview:eval-init` | Set up regression testing for your project |
+| `/evalview:eval-check` | Quick regression check against baselines |
+| `/evalview:eval-run` | Full evaluation suite with detailed analysis |
+
+## MCP Tools
+
+When connected, the EvalView MCP server provides these tools:
+
+- `run_check` — Execute regression tests
+- `run_snapshot` — Capture golden baselines
+- `create_test` — Create new test cases
+- `generate_visual_report` — Generate HTML diff reports
+
+## Prerequisites
+
+```bash
+pip install evalview
+```
+
+## Links
+
+- [GitHub](https://github.com/hidai25/eval-view)
+- [Documentation](https://github.com/hidai25/eval-view/tree/main/docs)
+- [PyPI](https://pypi.org/project/evalview/)

--- a/plugins/evalview/commands/eval-check.md
+++ b/plugins/evalview/commands/eval-check.md
@@ -1,0 +1,12 @@
+---
+description: Run a quick regression check against golden baselines
+allowed-tools: mcp__evalview__run_check, mcp__evalview__generate_visual_report, Bash, Read
+---
+
+Run EvalView regression checks on the current project.
+
+1. Look for existing test configurations in the project (`.evalview/`, `tests/eval/`, or `evalview.yaml`)
+2. If found, use the `run_check` MCP tool to execute regression tests against golden baselines
+3. If no config exists, suggest running `/evalview:eval-init` first
+4. Report results clearly: which tests passed, which regressed, and what specifically changed
+5. If there are regressions, explain the behavioral diff (tool calls changed, parameters shifted, output diverged)

--- a/plugins/evalview/commands/eval-init.md
+++ b/plugins/evalview/commands/eval-init.md
@@ -1,0 +1,12 @@
+---
+description: Initialize EvalView regression testing for this project
+allowed-tools: Bash, Read, Write
+---
+
+Set up EvalView regression testing for the current project.
+
+1. Check if `evalview` is installed (`pip show evalview`). If not, install it: `pip install evalview`
+2. Run `evalview init` to create the default configuration
+3. Help the user create their first test case based on their agent setup
+4. Run `evalview snapshot` to capture the initial golden baseline
+5. Explain the workflow: make changes → run `evalview check` → review diffs → update baselines

--- a/plugins/evalview/commands/eval-run.md
+++ b/plugins/evalview/commands/eval-run.md
@@ -1,0 +1,15 @@
+---
+description: Run full evaluation suite with detailed analysis
+allowed-tools: mcp__evalview__run_check, mcp__evalview__run_snapshot, mcp__evalview__generate_visual_report, mcp__evalview__create_test, Bash, Read
+---
+
+Run a comprehensive EvalView evaluation workflow.
+
+1. Run all regression tests using `run_check`
+2. Generate a visual HTML report using `generate_visual_report`
+3. Analyze results and provide a summary:
+   - Total tests, passed, failed, regressions
+   - For each regression: what changed at the behavioral level (tool calls, parameters, output)
+   - Cost and latency comparison if available
+4. If tests pass, suggest updating snapshots if the user made intentional changes
+5. If tests fail, help diagnose the root cause and suggest fixes

--- a/plugins/evalview/skills/eval-regression/SKILL.md
+++ b/plugins/evalview/skills/eval-regression/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: eval-regression
+description: Detect and analyze agent regressions using EvalView — structural diffing of tool calls, parameters, and output against golden baselines
+---
+
+# Agent Regression Detection
+
+You are an expert at detecting and analyzing AI agent regressions using EvalView.
+
+## When to activate
+
+- User asks "did my change break anything?"
+- User mentions regression testing, eval, or baseline comparison
+- User wants to verify agent behavior after code changes
+- User asks about tool call diffs or behavioral changes
+
+## What you do
+
+1. **Check for regressions**: Run `evalview check` or use the `run_check` MCP tool to compare current agent behavior against golden baselines
+2. **Analyze diffs**: EvalView provides structural diffs — not just score changes, but actual tool call sequence changes, parameter modifications, and output divergence
+3. **Explain clearly**: Tell the user exactly what changed and whether it's intentional or a regression
+4. **Suggest actions**: Update baselines for intentional changes, fix code for unintentional regressions
+
+## Key concepts
+
+- **Golden baseline**: A snapshot of expected agent behavior (tool calls, outputs, costs)
+- **Structural diff**: Comparing the actual sequence of tool calls and parameters, not just output scores
+- **Four statuses**: PASSED (identical), OUTPUT_CHANGED (same tools, different output), TOOLS_CHANGED (different tool calls), REGRESSION (quality drop)
+
+## Installation
+
+```bash
+pip install evalview
+```


### PR DESCRIPTION
## Summary

Adds EvalView as a Claude Code plugin for AI agent regression testing.

EvalView detects behavioral changes in AI agents by structurally diffing tool calls, parameters, and outputs against golden baselines. Unlike score-based evaluation, it shows exactly what changed — which tool was skipped, which parameter shifted, which output diverged.

### What's included

- 3 slash commands: `/evalview:eval-init`, `/evalview:eval-check`, `/evalview:eval-run`
- 1 skill: `eval-regression` (triggers on regression testing questions)
- MCP server integration for `run_check`, `run_snapshot`, `create_test`, `generate_visual_report`
- README with setup instructions

### Why this plugin

There's currently no eval or testing plugin in the ecosystem. EvalView fills this gap by bringing regression testing directly into the Claude Code workflow — developers can check for agent regressions without leaving their terminal.

## Test plan

- [ ] Install plugin with `/plugin install ./plugins/evalview`
- [ ] Run `/evalview:eval-init` on a project with an AI agent
- [ ] Run `/evalview:eval-check` after making changes
- [ ] Verify MCP tools are accessible when server is running
- [ ] Verify skill triggers on "did my change break anything?"