### PR TITLE
fix(commit-commands): use valid git flag -b instead of --branch

### DIFF
--- a/.claude/commands/commit-push-pr.md
+++ b/.claude/commands/commit-push-pr.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*)
+allowed-tools: Bash(git checkout -b:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*)
 description: Commit, push, and open a PR
 ---
 

--- a/plugins/commit-commands/commands/commit-push-pr.md
+++ b/plugins/commit-commands/commands/commit-push-pr.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*)
+allowed-tools: Bash(git checkout -b:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*)
 description: Commit, push, and open a PR
 ---
 


### PR DESCRIPTION
## Summary

- `git checkout --branch` is not a valid git command — git errors with `unknown option 'branch'`
- The correct flag for creating a new branch is `-b` (there is no long-form `--branch`)
- This prevented `/commit-push-pr` step 1 ("Create a new branch if on main") from working, as `git checkout -b <name>` would never match the `Bash(git checkout --branch:*)` allowed-tools pattern

Fixed in both locations:
- `.claude/commands/commit-push-pr.md`
- `plugins/commit-commands/commands/commit-push-pr.md`

## Reproduction

```
$ git checkout --branch test
error: unknown option `branch'
usage: git checkout [<options>] <branch>
   ...
    -b <branch>           create and checkout a new branch
```

## Test plan

- [x] Verified `git checkout --branch` fails with "unknown option" error
- [x] Verified `git checkout -b` is the correct flag (confirmed via `git checkout --help`)
- [x] Updated both command file locations

🤖 Generated with [Claude Code](https://claude.ai/claude-code)