### PR TITLE
fix init-firewall.sh crash from ipset when a domain resolves to repeated IPs

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -60,7 +60,7 @@ while read -r cidr; do
         exit 1
     fi
     echo "Adding GitHub range $cidr"
-    ipset add allowed-domains "$cidr"
+    ipset add allowed-domains "$cidr" -exist
 done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
 
 # Resolve and add other allowed domains
@@ -86,7 +86,7 @@ for domain in \
             exit 1
         fi
         echo "Adding $ip for $domain"
-        ipset add allowed-domains "$ip"
+        ipset add allowed-domains "$ip" -exist
     done < <(echo "$ips")
 done
 


### PR DESCRIPTION
Launching the devcontainer failed when I tried it, because marketplace.visualstudio.com resolved to multiple IP addresses of which one was repeated.
ipset then returned a non-zero exit code, because this address had already been added.
Adding the `-exist` switch to `ipset` solves this problem.

See a copy of a log from launching the container below to see what was happening:

```
Resolving sentry.io...
Adding 35.186.247.156 for sentry.io
Resolving statsig.anthropic.com...
Adding 34.36.57.103 for statsig.anthropic.com
Resolving statsig.com...
Adding 34.128.128.0 for statsig.com
Resolving marketplace.visualstudio.com...
Adding 150.171.74.16 for marketplace.visualstudio.com
Adding 150.171.73.16 for marketplace.visualstudio.com
Adding 150.171.73.16 for marketplace.visualstudio.com
ipset v7.17: Element cannot be added to the set: it's already added
[16069 ms] postStartCommand from devcontainer.json failed with exit code 1. Skipping any further user-provided commands.
[16073 ms] Error: Command failed: /bin/sh -c sudo /usr/local/bin/init-firewall.sh
[16073 ms]     at Q (c:\Users\MichaelKonecny\.vscode\extensions\ms-vscode-remote.remote-containers-0.447.0\dist\spec-node\devContainersSpecCLI.js:235:157)
[16073 ms]     at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
[16074 ms]     at async Promise.allSettled (index 0)
[16074 ms]     at async _q (c:\Users\MichaelKonecny\.vscode\extensions\ms-vscode-remote.remote-containers-0.447.0\dist\spec-node\devContainersSpecCLI.js:237:119)
[16074 ms]     at async qp (c:\Users\MichaelKonecny\.vscode\extensions\ms-vscode-remote.remote-containers-0.447.0\dist\spec-node\devContainersSpecCLI.js:226:4668)
[16074 ms]     at async Tq (c:\Users\MichaelKonecny\.vscode\extensions\ms-vscode-remote.remote-containers-0.447.0\dist\spec-node\devContainersSpecCLI.js:226:4185)
[16074 ms]     at async _p (c:\Users\MichaelKonecny\.vscode\extensions\ms-vscode-remote.remote-containers-0.447.0\dist\spec-node\devContainersSpecCLI.js:226:3377)
[16074 ms]     at async q5 (c:\Users\MichaelKonecny\.vscode\extensions\ms-vscode-remote.remote-containers-0.447.0\dist\spec-node\devContainersSpecCLI.js:669:2832)
[16074 ms]     at async _5 (c:\Users\MichaelKonecny\.vscode\extensions\ms-vscode-remote.remote-containers-0.447.0\dist\spec-node\devContainersSpecCLI.js:668:8904)
[16074 ms]     at async c:\Users\MichaelKonecny\.vscode\extensions\ms-vscode-remote.remote-containers-0.447.0\dist\spec-node\devContainersSpecCLI.js:485:1188
[16097 ms] Exit code 1
[16103 ms] Command failed: C:\Users\MichaelKonecny\AppData\Local\Programs\Microsoft VS Code\Code.exe c:\Users\MichaelKonecny\.vscode\extensions\ms-vscode-remote.remote-containers-0.447.0\dist\spec-node\devContainersSpecCLI.js run-user-commands --user-data-folder c:\Users\MichaelKonecny\AppData\Roaming\Code\User\globalStorage\ms-vscode-remote.remote-containers\data --container-session-data-folder /tmp/devcontainers-8699ff5a-600e-4955-b193-39b154a1c5351775151235881 --workspace-folder c:\code\claude-code --id-label devcontainer.local_folder=c:\code\claude-code --id-label devcontainer.config_file=c:\code\claude-code\.devcontainer\devcontainer.json --container-id 03521c3691871be79461576441842bcda6d62d45e48d66732db978c826cebcb1 --log-level debug --log-format json --config c:\code\claude-code\.devcontainer\devcontainer.json --default-user-env-probe loginInteractiveShell --skip-non-blocking-commands true --prebuild false --stop-for-personalization false --remote-env REMOTE_CONTAINERS_IPC=/tmp/vscode-remote-containers-ipc-ca93f602-a11b-4b5a-99e7-5bc9fc17573a.sock --remote-env DISPLAY=:0 --remote-env REMOTE_CONTAINERS_DISPLAY_SOCK=/tmp/.X11-unix/X0 --remote-env REMOTE_CONTAINERS=true --mount-workspace-git-root --dotfiles-target-path ~/dotfiles
[16103 ms] Exit code 1
``` 