### PR TITLE
fix(hookify): support phase-qualified events, absolute paths, and NotebookEdit

### DIFF
--- a/plugins/hookify/core/config_loader.py
+++ b/plugins/hookify/core/config_loader.py
@@ -195,11 +195,15 @@ def extract_frontmatter(content: str) -> tuple[Dict[str, Any], str]:
     return frontmatter, message
 
 
-def load_rules(event: Optional[str] = None) -> List[Rule]:
+def load_rules(event: Optional[str] = None, phase: Optional[str] = None) -> List[Rule]:
     """Load all hookify rules from .claude directory.
 
     Args:
         event: Optional event filter ("bash", "file", "stop", etc.)
+        phase: Optional phase filter ("pre" or "post"). When set, rules with
+               phase-qualified events (e.g. "pre-file", "post-bash") are matched
+               only to the correct phase. Unqualified events (e.g. "file") match
+               both phases for backwards compatibility.
 
     Returns:
         List of enabled Rule objects matching the event.
@@ -207,7 +211,10 @@ def load_rules(event: Optional[str] = None) -> List[Rule]:
     rules = []
 
     # Find all hookify.*.local.md files
-    pattern = os.path.join('.claude', 'hookify.*.local.md')
+    # Use CLAUDE_PROJECT_DIR for absolute path — relative paths break
+    # when hooks run from a different working directory.
+    project_dir = os.environ.get('CLAUDE_PROJECT_DIR', '.')
+    pattern = os.path.join(project_dir, '.claude', 'hookify.*.local.md')
     files = glob.glob(pattern)
 
     for file_path in files:
@@ -218,8 +225,19 @@ def load_rules(event: Optional[str] = None) -> List[Rule]:
 
             # Filter by event if specified
             if event:
-                if rule.event != 'all' and rule.event != event:
-                    continue
+                if rule.event == 'all':
+                    pass  # 'all' always matches
+                elif '-' in rule.event:
+                    # Phase-qualified event (e.g. "pre-file", "post-bash")
+                    rule_phase, rule_event = rule.event.split('-', 1)
+                    if rule_event != event:
+                        continue  # wrong event type
+                    if phase and rule_phase != phase:
+                        continue  # wrong phase
+                else:
+                    # Unqualified event (e.g. "file", "bash") — matches both phases
+                    if rule.event != event:
+                        continue
 
             # Only include enabled rules
             if rule.enabled:

--- a/plugins/hookify/hooks/posttooluse.py
+++ b/plugins/hookify/hooks/posttooluse.py
@@ -9,18 +9,14 @@ import os
 import sys
 import json
 
-# CRITICAL: Add plugin root to Python path for imports
+# Add plugin root to Python path for imports
 PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+if PLUGIN_ROOT and PLUGIN_ROOT not in sys.path:
+    sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)
@@ -38,11 +34,11 @@ def main():
         event = None
         if tool_name == 'Bash':
             event = 'bash'
-        elif tool_name in ['Edit', 'Write', 'MultiEdit']:
+        elif tool_name in ['Edit', 'Write', 'MultiEdit', 'NotebookEdit']:
             event = 'file'
 
-        # Load rules
-        rules = load_rules(event=event)
+        # Load rules (phase='post' enables post-file/post-bash filtering)
+        rules = load_rules(event=event, phase='post')
 
         # Evaluate rules
         engine = RuleEngine()

--- a/plugins/hookify/hooks/pretooluse.py
+++ b/plugins/hookify/hooks/pretooluse.py
@@ -9,22 +9,14 @@ import os
 import sys
 import json
 
-# CRITICAL: Add plugin root to Python path for imports
-# We need to add the parent of the plugin directory so Python can find "hookify" package
+# Add plugin root to Python path for imports
 PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    # Add the parent directory of the plugin
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-
-    # Also add PLUGIN_ROOT itself in case we have other scripts
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+if PLUGIN_ROOT and PLUGIN_ROOT not in sys.path:
+    sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     # If imports fail, allow operation and log error
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
@@ -45,11 +37,11 @@ def main():
         event = None
         if tool_name == 'Bash':
             event = 'bash'
-        elif tool_name in ['Edit', 'Write', 'MultiEdit']:
+        elif tool_name in ['Edit', 'Write', 'MultiEdit', 'NotebookEdit']:
             event = 'file'
 
-        # Load rules
-        rules = load_rules(event=event)
+        # Load rules (phase='pre' enables pre-file/pre-bash filtering)
+        rules = load_rules(event=event, phase='pre')
 
         # Evaluate rules
         engine = RuleEngine()


### PR DESCRIPTION
## Summary
- Fix phase-qualified events (`pre-file`, `post-file`, `pre-bash`, `post-bash`) being silently dropped due to exact string matching in `config_loader.py`
- Use `CLAUDE_PROJECT_DIR` env var for rule file discovery instead of relative paths (fixes breakage in worktrees and subagents)
- Add `NotebookEdit` to file event tool matching in `pretooluse.py` and `posttooluse.py`

## Problem
Rules with `event: post-file` never fire because `config_loader.py:221` compares `'post-file' != 'file'` and filters them out. Users get no error — rules are silently ignored. This affects any hookify user who uses phase-qualified events.

Similarly, `load_rules()` uses `os.path.join('.claude', 'hookify.*.local.md')` which fails when the hook runs from a non-project-root working directory (common in worktrees and subagent contexts).

## Changes
- `config_loader.py`: Added `phase` parameter to `load_rules()`, parse phase prefix from event strings, use `CLAUDE_PROJECT_DIR` for absolute paths
- `pretooluse.py`: Pass `phase='pre'`, add `NotebookEdit` to file event tools, fix import path
- `posttooluse.py`: Pass `phase='post'`, add `NotebookEdit` to file event tools, fix import path

## Test
Create `.claude/hookify.test.local.md`:
```yaml
---
name: test-post-edit
enabled: true
event: post-file
action: warn
tool_matcher: 'Edit|Write'
conditions:
  - field: file_path
    operator: regex_match
    pattern: \.tsx?$
---
Post-edit reminder showing.
```
Edit any `.ts` file — the message should appear after the edit completes.