### PR TITLE
feat: Agent message interrupts — subagents should receive messages mid-tool-batch

### DIFF
--- a/proposals/agent-message-interrupts/RFC.md
+++ b/proposals/agent-message-interrupts/RFC.md
@@ -1,0 +1,83 @@
+# RFC: Agent Message Interrupts
+
+**Status:** Proposal  
+**Author:** Community contribution  
+**Target:** `src/services/tools/toolOrchestration.ts`, `src/tasks/LocalAgentTask/LocalAgentTask.tsx`, `src/tools/SendMessageTool/SendMessageTool.ts`, `src/query.ts`, `src/utils/messages.ts`
+
+## Problem
+
+When a subagent is executing a batch of tool calls, messages sent via `SendMessage` are queued in `pendingMessages[]` and only drained **after ALL tools in the batch complete**, during the attachment phase. This creates a frustrating delay:
+
+```
+API response -> [tool_use_1, tool_use_2, tool_use_3, tool_use_4, tool_use_5]
+                    |            |            |            |            |
+                 execute      execute      execute      execute      execute
+                                  ^
+                                  |
+                        SendMessage("stop, wrong approach")
+                        -> queued, invisible until tool_use_5 finishes
+```
+
+For serial tool batches (writes, edits, bash commands), each tool can take seconds to minutes. An agent given 5 serial file edits cannot be redirected until all 5 complete, even if the coordinator sends a correction after the first one.
+
+This is the single most operationally painful gap in the coordinator/agent architecture. The coordinator can see the agent is wrong, sends a message, and then watches it continue being wrong for 4 more tool calls.
+
+## Solution
+
+Three layers of interrupt, from lightweight to aggressive:
+
+### Layer 1: Cooperative check between serial tool calls
+
+In `runToolsSerially()`, after each tool completes and before the next begins, peek at `pendingMessages`. If non-empty, cancel remaining tools with `is_error` results and return early. The normal attachment phase then drains and delivers the messages on the very next API turn.
+
+**Cost:** One `getAppState()` call per serial tool boundary. Zero cost for agents with no pending messages (the common case). Zero cost for the main thread (guarded by `agentId` check).
+
+### Layer 2: Cooperative check between batch boundaries
+
+Same check in the outer `runTools()` loop between partitioned batches. Catches messages that arrive during a concurrent read-only batch, before an expensive serial batch begins.
+
+### Layer 3: Urgent abort for long-running individual tools
+
+New `urgent: boolean` field on `SendMessage`. When set, after queueing the message, fires `abortController.abort('message_interrupt')` on the target agent. The query loop recognizes this as a special abort reason: skips the generic interruption message, resets the abort controller, and falls through to the attachment phase. The agent continues running with a fresh controller.
+
+## What the agent sees
+
+```
+tool_result (tool 1): { actual result }
+tool_result (tool 2): { actual result }
+tool_result (tool 3): [is_error] "Tool execution interrupted: a message was received
+                       from the coordinator. Remaining tool calls in this batch were
+                       skipped. The message will be delivered as an attachment."
+tool_result (tool 4): [is_error] (same)
+attachment: "Stop working on X, pivot to Y instead"
+```
+
+The agent can re-issue cancelled tools if still relevant, or pivot to the new directive.
+
+## Design Decisions
+
+**Why not inject messages mid-tool-result sequence?**  
+The API requires all `tool_result` blocks for every `tool_use` in an assistant message. We can't insert a user message between them. The only option is to provide error results for skipped tools and deliver the message as an attachment after the results.
+
+**Why peek instead of drain?**  
+`hasPendingMessages()` is non-draining. The actual drain happens at the normal attachment phase in `getAgentPendingMessageAttachments()`. This preserves the single-drain-point invariant and avoids duplicating drain logic.
+
+**Why reset the abort controller instead of creating a child?**  
+The `message_interrupt` abort is cooperative, not terminal. The agent should continue running. A fresh `AbortController` is the simplest way to achieve this without introducing a new signal type. The child abort controller hierarchy (parent abort -> children abort) is preserved because the parent's controller is unaffected.
+
+**Why only check between serial tools (not mid-concurrent)?**  
+Concurrent batches are read-only operations that typically complete fast. Interrupting them mid-flight would require cancelling in-progress promises and is high complexity for low value. The batch boundary check covers the transition from concurrent-to-serial, which is the common case.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `tasks/LocalAgentTask/LocalAgentTask.tsx` | +`hasPendingMessages()` non-draining peek function |
+| `utils/messages.ts` | +`PENDING_MESSAGE_INTERRUPT` constant, +`createToolResultInterruptMessage()` |
+| `services/tools/toolOrchestration.ts` | Interrupt checks at batch boundaries and between serial tools |
+| `tools/SendMessageTool/SendMessageTool.ts` | +`urgent` field in input schema, abort on urgent |
+| `query.ts` | `message_interrupt` abort reason handling: reset + continue |
+
+## Patches
+
+See the `patches/` directory for file-level diffs against the internal source tree.

--- a/proposals/agent-message-interrupts/patches/01-LocalAgentTask.patch
+++ b/proposals/agent-message-interrupts/patches/01-LocalAgentTask.patch
@@ -1,0 +1,19 @@
+--- a/src/tasks/LocalAgentTask/LocalAgentTask.tsx
++++ b/src/tasks/LocalAgentTask/LocalAgentTask.tsx
+@@ -161,6 +161,17 @@ export function queuePendingMessage(taskId: string, msg: string, setAppState: (f
+   }));
+ }
+
++/**
++ * Non-draining peek: returns true if the agent has pending messages waiting.
++ * Used by tool orchestration to check between serial tool calls without
++ * consuming the messages (the normal attachment phase handles that).
++ */
++export function hasPendingMessages(taskId: string, getAppState: () => AppState): boolean {
++  const task = getAppState().tasks[taskId];
++  return isLocalAgentTask(task) && task.pendingMessages.length > 0;
++}
++
+ export function drainPendingMessages(taskId: string, getAppState: () => AppState, setAppState: (f: (prev: AppState) => AppState) => void): string[] {
+   const task = getAppState().tasks[taskId];
+   if (!isLocalAgentTask(task) || task.pendingMessages.length === 0) {

--- a/proposals/agent-message-interrupts/patches/02-messages.patch
+++ b/proposals/agent-message-interrupts/patches/02-messages.patch
@@ -1,0 +1,30 @@
+--- a/src/utils/messages.ts
++++ b/src/utils/messages.ts
+@@ -208,6 +208,8 @@ export const INTERRUPT_MESSAGE = '[Request interrupted by user]'
+ export const INTERRUPT_MESSAGE_FOR_TOOL_USE =
+   '[Request interrupted by user for tool use]'
++export const PENDING_MESSAGE_INTERRUPT =
++  'Tool execution interrupted: a message was received from the coordinator. Remaining tool calls in this batch were skipped. The message will be delivered as an attachment — read and respond to it before continuing.'
+ export const CANCEL_MESSAGE =
+   "The user doesn't want to take this action right now. STOP what you are doing and wait for the user to tell you how to proceed."
+
+@@ -631,6 +633,19 @@ export function createToolResultStopMessage(
+   }
+ }
+
++/**
++ * Creates a tool_result for a tool that was skipped because a pending
++ * message interrupt arrived between serial tool executions.
++ */
++export function createToolResultInterruptMessage(
++  toolUseID: string,
++): ToolResultBlockParam {
++  return {
++    type: 'tool_result',
++    content: PENDING_MESSAGE_INTERRUPT,
++    is_error: true,
++    tool_use_id: toolUseID,
++  }
++}
++
+ export function extractTag(html: string, tagName: string): string | null {

--- a/proposals/agent-message-interrupts/patches/03-toolOrchestration.patch
+++ b/proposals/agent-message-interrupts/patches/03-toolOrchestration.patch
@@ -1,0 +1,86 @@
+--- a/src/services/tools/toolOrchestration.ts
++++ b/src/services/tools/toolOrchestration.ts
+@@ -1,7 +1,14 @@
+ import type { ToolUseBlock } from '@anthropic-ai/sdk/resources/index.mjs'
+ import type { CanUseToolFn } from '../../hooks/useCanUseTool.js'
++import { hasPendingMessages } from '../../tasks/LocalAgentTask/LocalAgentTask.js'
+ import { findToolByName, type ToolUseContext } from '../../Tool.js'
+ import type { AssistantMessage, Message } from '../../types/message.js'
+ import { all } from '../../utils/generators.js'
++import {
++  createToolResultInterruptMessage,
++  createUserMessage,
++  PENDING_MESSAGE_INTERRUPT,
++} from '../../utils/messages.js'
+ import { type MessageUpdateLazy, runToolUse } from './toolExecution.js'
+
+@@ -24,9 +31,33 @@ export async function* runTools(
+ ): AsyncGenerator<MessageUpdate, void> {
+   let currentContext = toolUseContext
+-  for (const { isConcurrencySafe, blocks } of partitionToolCalls(
+-    toolUseMessages,
+-    currentContext,
+-  )) {
++  const batches = partitionToolCalls(toolUseMessages, currentContext)
++  for (let batchIdx = 0; batchIdx < batches.length; batchIdx++) {
++    const { isConcurrencySafe, blocks } = batches[batchIdx]!
++
++    // Between batches, check for pending messages addressed to this agent.
++    // If found, cancel all remaining tool calls across remaining batches
++    // so the message surfaces on the next API turn.
++    if (
++      batchIdx > 0 &&
++      currentContext.agentId &&
++      hasPendingMessages(currentContext.agentId, currentContext.getAppState)
++    ) {
++      for (let k = batchIdx; k < batches.length; k++) {
++        for (const skipped of batches[k]!.blocks) {
++          yield {
++            message: createUserMessage({
++              content: [createToolResultInterruptMessage(skipped.id)],
++              toolUseResult: PENDING_MESSAGE_INTERRUPT,
++            }),
++            newContext: currentContext,
++          }
++          markToolUseAsComplete(currentContext, skipped.id)
++        }
++      }
++      return
++    }
++
+     if (isConcurrencySafe) {
+
+@@ -118,8 +149,32 @@ async function* runToolsSerially(
+ ): AsyncGenerator<MessageUpdate, void> {
+   let currentContext = toolUseContext
+
+-  for (const toolUse of toolUseMessages) {
+-    toolUseContext.setInProgressToolUseIDs(prev =>
++  for (let i = 0; i < toolUseMessages.length; i++) {
++    const toolUse = toolUseMessages[i]!
++
++    // Between serial tool calls, check if the agent has pending messages.
++    // If so, cancel remaining tools so the message is delivered on the very
++    // next API turn instead of waiting for the entire batch to finish.
++    if (
++      i > 0 &&
++      currentContext.agentId &&
++      hasPendingMessages(currentContext.agentId, currentContext.getAppState)
++    ) {
++      for (let j = i; j < toolUseMessages.length; j++) {
++        const skipped = toolUseMessages[j]!
++        yield {
++          message: createUserMessage({
++            content: [createToolResultInterruptMessage(skipped.id)],
++            toolUseResult: PENDING_MESSAGE_INTERRUPT,
++          }),
++          newContext: currentContext,
++        }
++        markToolUseAsComplete(toolUseContext, skipped.id)
++      }
++      return
++    }
++
++    toolUseContext.setInProgressToolUseIDs(prev =>
+       new Set(prev).add(toolUse.id),
+     )

--- a/proposals/agent-message-interrupts/patches/04-SendMessageTool.patch
+++ b/proposals/agent-message-interrupts/patches/04-SendMessageTool.patch
@@ -1,0 +1,40 @@
+--- a/src/tools/SendMessageTool/SendMessageTool.ts
++++ b/src/tools/SendMessageTool/SendMessageTool.ts
+@@ -82,6 +82,12 @@ const inputSchema = lazySchema(() =>
+     message: z.union([
+       z.string().describe('Plain text message content'),
+       StructuredMessage(),
+     ]),
++    urgent: z
++      .boolean()
++      .optional()
++      .describe(
++        'When true, interrupts the target agent mid-tool-batch so it processes this message immediately instead of waiting for all queued tool calls to finish. Use for corrections, cancellations, or priority redirects.',
++      ),
+   }),
+ )
+
+@@ -809,12 +815,22 @@ export function createSendMessageTool(
+           if (task.status === 'running') {
+               queuePendingMessage(
+                 agentId,
+                 input.message,
+                 context.setAppStateForTasks ?? context.setAppState,
+               )
++              // When urgent, abort the agent's current operation so it
++              // processes the message immediately instead of finishing
++              // the entire tool batch first. The 'message_interrupt'
++              // reason distinguishes this from user Ctrl+C aborts.
++              if (input.urgent && task.abortController) {
++                task.abortController.abort('message_interrupt')
++              }
+               return {
+                 data: {
+                   success: true,
+-                  message: `Message queued for delivery to ${input.to} at its next tool round.`,
++                  message: input.urgent
++                    ? `Urgent message delivered to ${input.to} — agent interrupted mid-execution.`
++                    : `Message queued for delivery to ${input.to} at its next tool round.`,
+                 },
+               }
+             }

--- a/proposals/agent-message-interrupts/patches/05-query.patch
+++ b/proposals/agent-message-interrupts/patches/05-query.patch
@@ -1,0 +1,46 @@
+--- a/src/query.ts
++++ b/src/query.ts
+@@ -1499,11 +1499,27 @@ export async function* query(
+       // Skip the interruption message for submit-interrupts — the queued
+       // user message that follows provides sufficient context.
+-      if (toolUseContext.abortController.signal.reason !== 'interrupt') {
++      // Also skip for message_interrupt — the pending message attachment
++      // from SendMessage(urgent=true) provides the context instead.
++      if (
++        toolUseContext.abortController.signal.reason !== 'interrupt' &&
++        toolUseContext.abortController.signal.reason !== 'message_interrupt'
++      ) {
+         yield createUserInterruptionMessage({
+           toolUse: true,
+         })
+       }
+-      // Check maxTurns before returning when aborted
+-      const nextTurnCountOnAbort = turnCount + 1
+-      if (maxTurns && nextTurnCountOnAbort > maxTurns) {
+-        yield createAttachmentMessage({
+-          type: 'max_turns_reached',
+-          maxTurns,
+-          turnCount: nextTurnCountOnAbort,
+-        })
++
++      // For message_interrupt (urgent SendMessage), don't exit the query
++      // loop — fall through to the attachment phase so the pending message
++      // is drained and delivered, then continue the agent's conversation.
++      if (toolUseContext.abortController.signal.reason === 'message_interrupt') {
++        // Reset the abort controller so the agent can continue running.
++        // The child controller was one-shot; create a fresh one.
++        toolUseContext.abortController = new AbortController()
++      } else {
++        // Check maxTurns before returning when aborted
++        const nextTurnCountOnAbort = turnCount + 1
++        if (maxTurns && nextTurnCountOnAbort > maxTurns) {
++          yield createAttachmentMessage({
++            type: 'max_turns_reached',
++            maxTurns,
++            turnCount: nextTurnCountOnAbort,
++          })
++        }
++        return { reason: 'aborted_tools' }
+       }
+-      return { reason: 'aborted_tools' }
+     }


### PR DESCRIPTION
## Summary

Subagents currently **cannot see `SendMessage` messages until ALL queued tool calls in a batch finish**. If the API returns 5 serial tool calls and the coordinator sends a correction after tool #1, the agent blindly executes tools #2–#5 before seeing the message. This is the single most operationally painful gap in the coordinator/agent architecture.

This PR proposes three layers of interrupt to fix it:

```
                                         ┌─ Layer 1: peek between serial tools
                                         │  ┌─ Layer 2: peek between batches
API response ─► [read, read, read] ─► [edit] ─► [edit] ─► [edit] ─► [bash]
                 concurrent batch     serial ──────────────────────── serial
                                         │              │
                                    check here     check here
                                         │
                         ┌─ Layer 3: SendMessage(urgent=true)
                         │  aborts long-running individual tools
```

- **Layer 1** — `hasPendingMessages()` peek between serial tool calls in `runToolsSerially()`. Cancel remaining tools if messages waiting.
- **Layer 2** — Same check at batch boundaries in `runTools()`.  
- **Layer 3** — New `urgent` boolean on `SendMessage`. Fires `abortController.abort('message_interrupt')` on the target. `query.ts` handles this by resetting the controller and falling through to the attachment phase instead of exiting.

### What the agent sees after interrupt:
```
tool_result (tool 1): { actual result }
tool_result (tool 2): { actual result }  
tool_result (tool 3): [is_error] "Tool execution interrupted: message received..."
tool_result (tool 4): [is_error] "Tool execution interrupted: message received..."
attachment: "Stop working on X, pivot to Y instead"
```

## Files

Since the source tree is internal, this PR includes an **RFC document** and **5 patch files** against the internal paths:

| Patch | Target | Change |
|-------|--------|--------|
| `01-LocalAgentTask.patch` | `src/tasks/LocalAgentTask/LocalAgentTask.tsx` | `hasPendingMessages()` non-draining peek |
| `02-messages.patch` | `src/utils/messages.ts` | `PENDING_MESSAGE_INTERRUPT` + `createToolResultInterruptMessage()` |
| `03-toolOrchestration.patch` | `src/services/tools/toolOrchestration.ts` | Interrupt checks at batch + serial boundaries |
| `04-SendMessageTool.patch` | `src/tools/SendMessageTool/SendMessageTool.ts` | `urgent` field + abort on urgent |
| `05-query.patch` | `src/query.ts` | `message_interrupt` abort handling |

## Cost

- One `getAppState()` call per serial tool boundary, only for subagents (`agentId` guard). Zero overhead for the main thread. Zero overhead when no messages pending.

## Test plan

- [ ] Spawn agent with 5+ serial tool calls, send it a message after tool #1 — verify it sees the message after tool #1 instead of after tool #5
- [ ] Same test with concurrent read-only batch followed by serial batch — verify interrupt at batch boundary
- [ ] `SendMessage(urgent=true)` during a long-running Bash command — verify agent is interrupted and receives message
- [ ] Verify normal (non-urgent) `SendMessage` still queues as before when no interrupt check fires
- [ ] Verify main thread is unaffected (no `agentId`, checks are skipped)
- [ ] Verify `message_interrupt` abort resets controller and agent continues (doesn't exit query loop)

``

🤖 Generated with [Claude Code](https://claude.com/claude-code)