### PR TITLE
Add /list-slash-commands for workspace command discovery

### DIFF
--- a/.claude/commands/list-slash-commands.md
+++ b/.claude/commands/list-slash-commands.md
@@ -1,0 +1,6 @@
+---
+description: List slash commands detected in this workspace
+allowed-tools: Bash(./scripts/list-slash-commands.sh:*)
+---
+
+Run `./scripts/list-slash-commands.sh` and return the output as-is.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ For more installation options, uninstall steps, and troubleshooting, see the [se
 
 This repository includes several Claude Code plugins that extend functionality with custom commands and agents. See the [plugins directory](./plugins/README.md) for detailed documentation on available plugins.
 
+## Local slash command discovery
+
+This repository includes a local slash command: `/list-slash-commands`.
+
+It reports **detected slash commands in the current workspace** from:
+- project commands in `.claude/commands`
+- bundled plugin commands in `plugins/*/commands`
+
+It does **not** guarantee a complete runtime list of all Claude Code commands. In particular, this local command does not introspect built-in runtime commands or MCP-backed prompts/commands that are only available through the Claude Code runtime.
+
 ## Reporting Bugs
 
 We welcome your feedback. Use the `/bug` command to report issues directly within Claude Code, or file a [GitHub issue](https://github.com/anthropics/claude-code/issues).

--- a/scripts/list-slash-commands.sh
+++ b/scripts/list-slash-commands.sh
@@ -78,17 +78,29 @@ extract_frontmatter_field() {
 
 extract_plugin_name() {
   local manifest="$1"
-  local plugin_name=""
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$manifest" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as f:
+    data = json.load(f)
+
+name = data.get("name", "")
+if isinstance(name, str):
+    print(name)
+else:
+    print("")
+PY
+    return
+  fi
 
   if command -v jq >/dev/null 2>&1; then
-    plugin_name="$(jq -r 'if .name == null then empty else .name end' "$manifest" 2>/dev/null || true)"
+    jq -er '.name // empty' "$manifest" 2>/dev/null
+    return
   fi
-
-  if [[ -z "$plugin_name" ]]; then
-    plugin_name="$(awk -F'"' '/"name"[[:space:]]*:[[:space:]]*"/ { print $4; exit }' "$manifest" 2>/dev/null || true)"
-  fi
-
-  printf '%s' "$plugin_name"
+  return 2
 }
 
 command_name_from_relative_markdown() {
@@ -174,9 +186,15 @@ collect_plugin_commands() {
 
     if [[ -f "$manifest" && -r "$manifest" ]]; then
       local parsed_name
-      parsed_name="$(extract_plugin_name "$manifest")"
-      if [[ -n "$parsed_name" ]]; then
-        plugin_name="$parsed_name"
+      if parsed_name="$(extract_plugin_name "$manifest" 2>/dev/null)"; then
+        if [[ -n "$parsed_name" ]]; then
+          plugin_name="$parsed_name"
+        fi
+      else
+        local extract_status="$?"
+        if [[ "$extract_status" -eq 1 ]]; then
+          WARNINGS=1
+        fi
       fi
     elif [[ -e "$manifest" && ! -r "$manifest" ]]; then
       WARNINGS=1
@@ -217,12 +235,18 @@ print_section() {
 
   while IFS= read -r row; do
     local _category name source description usage origin
-    _category="$(printf '%s\n' "$row" | awk -F'\t' '{ print $1 }')"
-    name="$(printf '%s\n' "$row" | awk -F'\t' '{ print $2 }')"
-    source="$(printf '%s\n' "$row" | awk -F'\t' '{ print $3 }')"
-    description="$(printf '%s\n' "$row" | awk -F'\t' '{ print $4 }')"
-    usage="$(printf '%s\n' "$row" | awk -F'\t' '{ print $5 }')"
-    origin="$(printf '%s\n' "$row" | awk -F'\t' '{ print $6 }')"
+    local remainder
+    _category="${row%%$'\t'*}"
+    remainder="${row#*$'\t'}"
+    name="${remainder%%$'\t'*}"
+    remainder="${remainder#*$'\t'}"
+    source="${remainder%%$'\t'*}"
+    remainder="${remainder#*$'\t'}"
+    description="${remainder%%$'\t'*}"
+    remainder="${remainder#*$'\t'}"
+    usage="${remainder%%$'\t'*}"
+    remainder="${remainder#*$'\t'}"
+    origin="$remainder"
 
     if [[ -z "$description" ]]; then
       description="-"

--- a/scripts/list-slash-commands.sh
+++ b/scripts/list-slash-commands.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+set -u
+set -o pipefail
+
+WORKSPACE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workspace)
+      if [[ $# -lt 2 ]]; then
+        echo "Error: --workspace requires a value" >&2
+        exit 1
+      fi
+      WORKSPACE="$2"
+      shift 2
+      ;;
+    *)
+      echo "Error: unknown argument: $1" >&2
+      echo "Usage: $0 [--workspace PATH]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$WORKSPACE" ]]; then
+  WORKSPACE="$(pwd)"
+fi
+
+if [[ ! -d "$WORKSPACE" ]]; then
+  echo "Error: workspace is not a directory: $WORKSPACE" >&2
+  exit 1
+fi
+
+WORKSPACE="$(cd "$WORKSPACE" && pwd)"
+WARNINGS=0
+
+RECORDS_FILE="$(mktemp)"
+cleanup() {
+  rm -f "$RECORDS_FILE"
+}
+trap cleanup EXIT
+
+sanitize_field() {
+  local value="${1:-}"
+  value="${value//$'\t'/ }"
+  value="${value//$'\n'/ }"
+  printf '%s' "$value"
+}
+
+extract_frontmatter_field() {
+  local file="$1"
+  local field="$2"
+
+  awk -v key="$field" '
+    NR == 1 {
+      if ($0 != "---") {
+        exit
+      }
+      next
+    }
+    $0 == "---" {
+      exit
+    }
+    {
+      line = $0
+      if (match(line, "^[[:space:]]*" key ":[[:space:]]*")) {
+        sub("^[[:space:]]*" key ":[[:space:]]*", "", line)
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+        if (line ~ /^".*"$/) {
+          line = substr(line, 2, length(line) - 2)
+        }
+        print line
+        exit
+      }
+    }
+  ' "$file" 2>/dev/null
+}
+
+extract_plugin_name() {
+  local manifest="$1"
+  local plugin_name=""
+
+  if command -v jq >/dev/null 2>&1; then
+    plugin_name="$(jq -r 'if .name == null then empty else .name end' "$manifest" 2>/dev/null || true)"
+  fi
+
+  if [[ -z "$plugin_name" ]]; then
+    plugin_name="$(awk -F'"' '/"name"[[:space:]]*:[[:space:]]*"/ { print $4; exit }' "$manifest" 2>/dev/null || true)"
+  fi
+
+  printf '%s' "$plugin_name"
+}
+
+command_name_from_relative_markdown() {
+  local rel_path="$1"
+  rel_path="${rel_path%.md}"
+  rel_path="${rel_path#/}"
+  rel_path="${rel_path//\//:}"
+  printf '/%s' "$rel_path"
+}
+
+relative_to_workspace() {
+  local path="$1"
+  if [[ "$path" == "$WORKSPACE/"* ]]; then
+    printf '%s' "${path#$WORKSPACE/}"
+  else
+    printf '%s' "$path"
+  fi
+}
+
+append_record() {
+  local category="$1"
+  local name="$2"
+  local source="$3"
+  local description="$4"
+  local usage="$5"
+  local origin="$6"
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$category" \
+    "$(sanitize_field "$name")" \
+    "$(sanitize_field "$source")" \
+    "$(sanitize_field "$description")" \
+    "$(sanitize_field "$usage")" \
+    "$(sanitize_field "$origin")" \
+    >> "$RECORDS_FILE"
+}
+
+collect_project_commands() {
+  local commands_dir="$WORKSPACE/.claude/commands"
+  local file=""
+
+  if [[ ! -e "$commands_dir" ]]; then
+    return
+  fi
+
+  if [[ ! -d "$commands_dir" || ! -r "$commands_dir" ]]; then
+    WARNINGS=1
+    return
+  fi
+
+  while IFS= read -r file; do
+    local rel_path command_name description usage origin
+    rel_path="${file#$commands_dir/}"
+    command_name="$(command_name_from_relative_markdown "$rel_path")"
+    description="$(extract_frontmatter_field "$file" "description")"
+    usage="$(extract_frontmatter_field "$file" "argument-hint")"
+    origin="$(relative_to_workspace "$file")"
+    append_record "project" "$command_name" "project" "$description" "$usage" "$origin"
+  done < <(LC_ALL=C find "$commands_dir" -type f -name '*.md' 2>/dev/null | LC_ALL=C sort)
+}
+
+collect_plugin_commands() {
+  local plugins_dir="$WORKSPACE/plugins"
+  local file=""
+
+  if [[ ! -e "$plugins_dir" ]]; then
+    return
+  fi
+
+  if [[ ! -d "$plugins_dir" || ! -r "$plugins_dir" ]]; then
+    WARNINGS=1
+    return
+  fi
+
+  while IFS= read -r file; do
+    local rest plugin_dir_name plugin_dir manifest plugin_name after_commands
+    local command_name description usage origin
+
+    rest="${file#$plugins_dir/}"
+    plugin_dir_name="${rest%%/*}"
+    plugin_dir="$plugins_dir/$plugin_dir_name"
+    manifest="$plugin_dir/.claude-plugin/plugin.json"
+    plugin_name="$plugin_dir_name"
+
+    if [[ -f "$manifest" && -r "$manifest" ]]; then
+      local parsed_name
+      parsed_name="$(extract_plugin_name "$manifest")"
+      if [[ -n "$parsed_name" ]]; then
+        plugin_name="$parsed_name"
+      fi
+    elif [[ -e "$manifest" && ! -r "$manifest" ]]; then
+      WARNINGS=1
+    fi
+
+    after_commands="${rest#*/commands/}"
+    if [[ "$after_commands" == "$rest" ]]; then
+      WARNINGS=1
+      continue
+    fi
+
+    command_name="$(command_name_from_relative_markdown "$after_commands")"
+    description="$(extract_frontmatter_field "$file" "description")"
+    usage="$(extract_frontmatter_field "$file" "argument-hint")"
+    origin="$(relative_to_workspace "$file")"
+    append_record "plugin" "$command_name" "plugin:$plugin_name" "$description" "$usage" "$origin"
+  done < <(LC_ALL=C find "$plugins_dir" -type f -name '*.md' -path '*/commands/*' 2>/dev/null | LC_ALL=C sort)
+}
+
+print_section() {
+  local header="$1"
+  local category="$2"
+  local rows row
+  local tab
+
+  tab="$(printf '\t')"
+  rows="$(
+    awk -F'\t' -v c="$category" '$1 == c { print }' "$RECORDS_FILE" \
+      | LC_ALL=C sort -t "$tab" -k2,2 -k3,3 -k6,6
+  )"
+
+  echo "$header"
+  if [[ -z "$rows" ]]; then
+    echo "  (none detected)"
+    echo
+    return
+  fi
+
+  while IFS= read -r row; do
+    local _category name source description usage origin
+    _category="$(printf '%s\n' "$row" | awk -F'\t' '{ print $1 }')"
+    name="$(printf '%s\n' "$row" | awk -F'\t' '{ print $2 }')"
+    source="$(printf '%s\n' "$row" | awk -F'\t' '{ print $3 }')"
+    description="$(printf '%s\n' "$row" | awk -F'\t' '{ print $4 }')"
+    usage="$(printf '%s\n' "$row" | awk -F'\t' '{ print $5 }')"
+    origin="$(printf '%s\n' "$row" | awk -F'\t' '{ print $6 }')"
+
+    if [[ -z "$description" ]]; then
+      description="-"
+    fi
+    if [[ -z "$usage" ]]; then
+      usage="-"
+    fi
+
+    echo "  $name"
+    echo "    source: $source"
+    echo "    description: $description"
+    echo "    usage: $usage"
+    echo "    origin: $origin"
+  done <<< "$rows"
+
+  echo
+}
+
+collect_project_commands
+collect_plugin_commands
+
+echo "Detected slash commands in current workspace:"
+echo
+
+print_section "Project" "project"
+print_section "Plugins" "plugin"
+
+if [[ "$WARNINGS" -eq 1 ]]; then
+  echo "Note: Some command sources could not be introspected."
+fi

--- a/scripts/test-list-slash-commands.sh
+++ b/scripts/test-list-slash-commands.sh
@@ -155,9 +155,34 @@ test_unavailable_sources_do_not_crash() {
   assert_contains "$output" "Note: Some command sources could not be introspected." "unavailable sources should produce warning"
 }
 
+test_invalid_plugin_manifest_falls_back_and_warns() {
+  local ws="$TMP_ROOT/invalid-manifest"
+  local output
+
+  mkdir -p "$ws/plugins/broken/commands"
+  mkdir -p "$ws/plugins/broken/.claude-plugin"
+
+  cat > "$ws/plugins/broken/.claude-plugin/plugin.json" <<'EOF'
+{ "name":
+EOF
+  cat > "$ws/plugins/broken/commands/run.md" <<'EOF'
+---
+description: Run broken plugin command
+---
+run body
+EOF
+
+  output="$("$COLLECTOR" --workspace "$ws")"
+
+  assert_contains "$output" "  /run" "command should still be listed when manifest is invalid"
+  assert_contains "$output" "source: plugin:broken" "invalid manifest should fallback to plugin directory name"
+  assert_contains "$output" "Note: Some command sources could not be introspected." "invalid manifest should emit introspection warning"
+}
+
 test_no_results
 test_project_detection_and_sorting
 test_plugin_detection
 test_unavailable_sources_do_not_crash
+test_invalid_plugin_manifest_falls_back_and_warns
 
 echo "PASS: list-slash-commands collector tests"

--- a/scripts/test-list-slash-commands.sh
+++ b/scripts/test-list-slash-commands.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COLLECTOR="$SCRIPT_DIR/list-slash-commands.sh"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local message="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    fail "$message (missing: $needle)"
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local message="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    fail "$message (unexpected: $needle)"
+  fi
+}
+
+line_number_of() {
+  local haystack="$1"
+  local needle="$2"
+  printf '%s\n' "$haystack" | grep -nF "$needle" | head -n 1 | cut -d: -f1
+}
+
+TMP_ROOT="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+test_no_results() {
+  local ws="$TMP_ROOT/no-results"
+  local output
+  mkdir -p "$ws"
+  output="$("$COLLECTOR" --workspace "$ws")"
+
+  assert_contains "$output" "Detected slash commands in current workspace:" "header should be present"
+  assert_contains "$output" "Project" "project section should be present"
+  assert_contains "$output" "Plugins" "plugins section should be present"
+  assert_contains "$output" "  (none detected)" "empty workspace should show no detections"
+  assert_not_contains "$output" "Some command sources could not be introspected" "missing dirs should not produce source warning"
+}
+
+test_project_detection_and_sorting() {
+  local ws="$TMP_ROOT/project"
+  local output
+  local alpha_line zeta_line nested_line
+
+  mkdir -p "$ws/.claude/commands/nested"
+  cat > "$ws/.claude/commands/zeta.md" <<'EOF'
+---
+description: Zeta command
+---
+zeta body
+EOF
+  cat > "$ws/.claude/commands/alpha.md" <<'EOF'
+---
+description: Alpha command
+argument-hint: [issue-number]
+---
+alpha body
+EOF
+  cat > "$ws/.claude/commands/nested/build.md" <<'EOF'
+---
+description: Build nested command
+---
+nested body
+EOF
+
+  output="$("$COLLECTOR" --workspace "$ws")"
+
+  assert_contains "$output" "  /alpha" "project command /alpha should be listed"
+  assert_contains "$output" "description: Alpha command" "description should be extracted"
+  assert_contains "$output" "usage: [issue-number]" "argument-hint should appear as usage"
+  assert_contains "$output" "origin: .claude/commands/alpha.md" "project origin should be relative"
+  assert_contains "$output" "  /zeta" "project command /zeta should be listed"
+  assert_contains "$output" "usage: -" "missing argument-hint should render as '-'"
+  assert_contains "$output" "origin: .claude/commands/zeta.md" "origin should still render when usage is missing"
+  assert_contains "$output" "  /nested:build" "nested project command should be namespaced"
+
+  alpha_line="$(line_number_of "$output" "  /alpha")"
+  nested_line="$(line_number_of "$output" "  /nested:build")"
+  zeta_line="$(line_number_of "$output" "  /zeta")"
+  if [[ -z "$alpha_line" || -z "$nested_line" || -z "$zeta_line" ]]; then
+    fail "expected line numbers for project sort assertions"
+  fi
+  if (( alpha_line >= nested_line || nested_line >= zeta_line )); then
+    fail "project commands should be sorted by name"
+  fi
+}
+
+test_plugin_detection() {
+  local ws="$TMP_ROOT/plugins"
+  local output
+
+  mkdir -p "$ws/plugins/acme/commands/review"
+  mkdir -p "$ws/plugins/acme/.claude-plugin"
+  mkdir -p "$ws/plugins/fallback/commands"
+
+  cat > "$ws/plugins/acme/.claude-plugin/plugin.json" <<'EOF'
+{
+  "name": "acme-tools"
+}
+EOF
+  cat > "$ws/plugins/acme/commands/review/security.md" <<'EOF'
+---
+description: Security review command
+argument-hint: [pr]
+---
+review body
+EOF
+  cat > "$ws/plugins/fallback/commands/lint.md" <<'EOF'
+---
+description: Lint command
+---
+lint body
+EOF
+
+  output="$("$COLLECTOR" --workspace "$ws")"
+
+  assert_contains "$output" "  /review:security" "nested plugin command should be namespaced"
+  assert_contains "$output" "source: plugin:acme-tools" "plugin source should use manifest name"
+  assert_contains "$output" "origin: plugins/acme/commands/review/security.md" "plugin origin should be relative"
+  assert_contains "$output" "  /lint" "fallback plugin command should be listed"
+  assert_contains "$output" "source: plugin:fallback" "plugin source should fallback to dir name"
+}
+
+test_unavailable_sources_do_not_crash() {
+  local ws="$TMP_ROOT/unavailable"
+  local output status
+
+  mkdir -p "$ws"
+  printf 'not-a-directory' > "$ws/.claude"
+  printf 'not-a-directory' > "$ws/plugins"
+
+  set +e
+  output="$("$COLLECTOR" --workspace "$ws")"
+  status=$?
+  set -e
+
+  if [[ "$status" -ne 0 ]]; then
+    fail "collector should not fail when command sources are unavailable"
+  fi
+  assert_contains "$output" "Note: Some command sources could not be introspected." "unavailable sources should produce warning"
+}
+
+test_no_results
+test_project_detection_and_sorting
+test_plugin_detection
+test_unavailable_sources_do_not_crash
+
+echo "PASS: list-slash-commands collector tests"


### PR DESCRIPTION
## Context
Users currently need to know slash command names in advance. This change adds an explicit discovery command for commands that are actually introspectable from this repository/workspace.

## Problem
There was no dedicated command to list currently detectable slash commands in the active workspace. This hurts discoverability, especially for project and plugin commands.

## Solution
- Add local slash command `/list-slash-commands`.
- Add `scripts/list-slash-commands.sh` as a single collection/normalization point.
- Detect and display commands from:
  - `.claude/commands` (Project)
  - `plugins/*/commands` (Plugins)
- Output is stable and sorted:
  - grouped by source (`Project`, then `Plugins`)
  - sorted by command name within each group
  - includes `name`, `source`, `description`, `usage` (from `argument-hint`), and `origin`
- Robustness behavior:
  - command does not fail if some sources are unavailable
  - emits note: `Some command sources could not be introspected.`
- Hardening included:
  - robust plugin manifest parsing (`python3` with `jq` fallback)
  - fallback to plugin directory name when manifest is invalid/unavailable

## Scope and honesty
This command reports **detected slash commands in current workspace**. It does **not** claim to list all runtime Claude Code commands (for example built-ins or non-introspectable MCP-backed runtime commands).

## Tests
Added `scripts/test-list-slash-commands.sh` covering:
- empty result set
- project command detection
- plugin command detection
- stable output/sorting
- unavailable source tolerance (no crash)
- invalid plugin manifest fallback + warning

Run:
```bash
bash scripts/test-list-slash-commands.sh
```

## Documentation
Updated README with a short `Local slash command discovery` section documenting both supported sources and explicit non-guarantees.
