### PR TITLE
docs: fix plugin-dev reference links

### DIFF
--- a/plugins/plugin-dev/skills/command-development/references/documentation-patterns.md
+++ b/plugins/plugin-dev/skills/command-development/references/documentation-patterns.md
@@ -673,11 +673,11 @@ enable_feature: true
 
 ## Contributing
 
-Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md).
+Contributions welcome! Open an issue or pull request in the [claude-code repository](https://github.com/anthropics/claude-code).
 
 ## License
 
-MIT License - See [LICENSE](LICENSE).
+MIT License - See [LICENSE](../../../../../LICENSE.md).
 
 ## Support
 


### PR DESCRIPTION
## Summary
- replace a broken `CONTRIBUTING.md` link in `documentation-patterns.md` with the actual claude-code repository entry point
- fix the `LICENSE` link so it resolves to the repo-root `LICENSE.md` from this nested reference file
- keep the change scoped to the plugin-dev command-development reference docs

## Testing
- verified the new repository link target exists
- verified `../../../../../LICENSE.md` resolves to the existing repo-root `LICENSE.md`

## Notes
- this is a fresh resubmission of the same broken-link shape that previously appeared in #16215 and was self-closed as stale without landing