### PR TITLE
docs: update plugin install instructions and fix settings README typo

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -1,6 +1,6 @@
 # Settings Examples
 
-Example Claude Code settings files, primarily intended for organization-wide deployments. Use these are starting points — adjust them to fit your needs.
+Example Claude Code settings files, primarily intended for organization-wide deployments. Use these as starting points — adjust them to fit your needs.
 
 These may be applied at any level of the [settings hierarchy](https://code.claude.com/docs/en/settings#settings-files), though certain properties only take effect if specified in enterprise settings (e.g. `strictKnownMarketplaces`, `allowManagedHooksOnly`, `allowManagedPermissionRulesOnly`).
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -30,10 +30,11 @@ Learn more in the [official plugins documentation](https://docs.claude.com/en/do
 
 These plugins are included in the Claude Code repository. To use them in your own projects:
 
-1. Install Claude Code globally:
-```bash
-npm install -g @anthropic-ai/claude-code
-```
+1. Install Claude Code using one of the recommended methods from the main setup guide:
+   - macOS/Linux: `curl -fsSL https://claude.ai/install.sh | bash`
+   - Windows: `irm https://claude.ai/install.ps1 | iex`
+   - WinGet: `winget install Anthropic.ClaudeCode`
+   - Homebrew: `brew install --cask claude-code`
 
 2. Navigate to your project and run Claude Code:
 ```bash


### PR DESCRIPTION
## Summary
- update plugin install instructions to use recommended install methods instead of deprecated npm guidance
- fix a typo in the settings README

## Why
These docs were slightly inconsistent with the main setup instructions and could confuse new users.