### PR TITLE
fix: normalize Windows paths in security guidance hook

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -1,6 +1,6 @@
 # Settings Examples
 
-Example Claude Code settings files, primarily intended for organization-wide deployments. Use these are starting points — adjust them to fit your needs.
+Example Claude Code settings files, primarily intended for organization-wide deployments. Use these as starting points — adjust them to fit your needs.
 
 These may be applied at any level of the [settings hierarchy](https://code.claude.com/docs/en/settings#settings-files), though certain properties only take effect if specified in enterprise settings (e.g. `strictKnownMarketplaces`, `allowManagedHooksOnly`, `allowManagedPermissionRulesOnly`).
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -30,10 +30,11 @@ Learn more in the [official plugins documentation](https://docs.claude.com/en/do
 
 These plugins are included in the Claude Code repository. To use them in your own projects:
 
-1. Install Claude Code globally:
-```bash
-npm install -g @anthropic-ai/claude-code
-```
+1. Install Claude Code using one of the recommended methods from the main setup guide:
+   - macOS/Linux: `curl -fsSL https://claude.ai/install.sh | bash`
+   - Windows: `irm https://claude.ai/install.ps1 | iex`
+   - WinGet: `winget install Anthropic.ClaudeCode`
+   - Homebrew: `brew install --cask claude-code`
 
 2. Navigate to your project and run Claude Code:
 ```bash

--- a/plugins/security-guidance/hooks/security_reminder_hook.py
+++ b/plugins/security-guidance/hooks/security_reminder_hook.py
@@ -182,8 +182,8 @@ def save_state(session_id, shown_warnings):
 
 def check_patterns(file_path, content):
     """Check if file path or content matches any security patterns."""
-    # Normalize path by removing leading slashes
-    normalized_path = file_path.lstrip("/")
+    # Normalize separators so path-based checks work across Windows and Unix paths.
+    normalized_path = file_path.replace("\\", "/").lstrip("/")
 
     for pattern in SECURITY_PATTERNS:
         # Check path-based patterns


### PR DESCRIPTION
## Summary
- normalize backslashes to forward slashes before running path-based security checks

## Why
The security guidance hook checks whether a file is under `.github/workflows/`, but Windows paths commonly use backslashes. Without normalization, workflow edits on Windows can miss the GitHub Actions security warning entirely.