### PR TITLE
docs: capitalize 'Get Started' heading in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Claude Code is an agentic coding tool that lives in your terminal, understands y
 
 <img src="./demo.gif" />
 
-## Get started
+## Get Started
 > [!NOTE]
 > Installation via npm is deprecated. Use one of the recommended methods below.
 


### PR DESCRIPTION
## Summary
Fix heading case inconsistency — capitalize "Get started" to "Get Started" to match the title case convention used by other section headings in the README.

## Issue
Fixes #44041

## Changes
- Changed `## Get started` to `## Get Started` in README.md

## Testing
- Visual inspection of README rendering