### PR TITLE
fix(plugin-dev): add missing plugin manifest

### DIFF
--- a/plugins/plugin-dev/.claude-plugin/plugin.json
+++ b/plugins/plugin-dev/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "plugin-dev",
+  "version": "0.1.0",
+  "description": "Comprehensive toolkit for developing Claude Code plugins. Includes skills, agents, and commands for plugin creation and validation.",
+  "author": {
+    "name": "Daisy Hollman",
+    "email": "daisy@anthropic.com"
+  }
+}


### PR DESCRIPTION
## Summary
- add the missing `plugins/plugin-dev/.claude-plugin/plugin.json`
- align `plugin-dev` metadata with the marketplace entry
- make `plugin-dev` consistent with the other bundled plugins

## Why
`plugin-dev` is listed in the bundled marketplace, but it was missing its local plugin manifest. The repo documentation also says each plugin should include `.claude-plugin/plugin.json`.

Adding the manifest makes the plugin packaging more consistent and reduces confusion for contributors and users exploring the bundled plugins.

## Testing
- verified the manifest file was added in the expected plugin location
- no runtime tests were needed because this is a metadata-only change
