### PR TITLE
docs: expand CLAUDE_CODE_ACCESSIBILITY docs with screen reader guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,30 @@ For more installation options, uninstall steps, and troubleshooting, see the [se
 
 2. Navigate to your project directory and run `claude`.
 
+## Accessibility
+
+Claude Code supports assistive technologies via the `CLAUDE_CODE_ACCESSIBILITY` environment variable. Set it to `1` to enable accessibility mode:
+
+```bash
+export CLAUDE_CODE_ACCESSIBILITY=1
+```
+
+When accessibility mode is enabled:
+
+- **Native terminal cursor stays visible** instead of being replaced by an inverted-text cursor indicator. This allows screen magnifiers (such as macOS Zoom) and screen readers to track cursor position.
+- **Dialog tab focus is tracked by the native cursor.** When you navigate between tabs in permission dialogs and menus using `Left`/`Right` arrows or `Tab`/`Shift+Tab`, the native terminal cursor moves to the selected tab so assistive technologies can follow the selection.
+
+These behaviors ensure that screen readers and screen magnifiers can reliably follow both text input and dialog navigation within Claude Code.
+
+### Dialog tab navigation
+
+| Action | Keys |
+|--------|------|
+| Next tab | `Tab` or `Right` |
+| Previous tab | `Shift+Tab` or `Left` |
+
+> **Tip:** If you use a screen reader or screen magnifier with Claude Code, set `CLAUDE_CODE_ACCESSIBILITY=1` so the native terminal cursor tracks the selected tab during dialog navigation. See the [environment variables documentation](https://code.claude.com/docs/en/env-vars) and [keybindings reference](https://code.claude.com/docs/en/keybindings) for full details.
+
 ## Plugins
 
 This repository includes several Claude Code plugins that extend functionality with custom commands and agents. See the [plugins directory](./plugins/README.md) for detailed documentation on available plugins.


### PR DESCRIPTION
## Summary

- Add an **Accessibility** section to the README documenting `CLAUDE_CODE_ACCESSIBILITY=1` behavior
- Clarify that accessibility mode keeps the native terminal cursor synchronized with both text input **and** dialog tab focus, enabling screen readers and screen magnifiers to track navigation
- Include a dialog tab navigation shortcut table (`Tab`/`Shift+Tab`, `Left`/`Right`)
- Add cross-references to the env-vars and keybindings docs pages so users can discover the setting from either direction

Fixes #44906

## Context

The current documentation mentions `CLAUDE_CODE_ACCESSIBILITY` only in the context of screen magnifiers tracking cursor position. It omits that the cursor also follows the selected tab in dialogs/menus (confirmed in changelog v2.1.94), and does not mention screen reader support at all. The tab navigation docs also lack any pointer back to the accessibility setting.

## Test plan

- [ ] Verify the README renders correctly on GitHub
- [ ] Confirm cross-reference links resolve to the correct docs pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)