### PR TITLE
feat: add bash-workdir-guard plugin

### DIFF
--- a/plugins/bash-workdir-guard/.claude-plugin/plugin.json
+++ b/plugins/bash-workdir-guard/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "bash-workdir-guard",
+  "description": "Warns when Bash commands navigate outside the project workspace boundary, suggesting safer alternatives like `git -C` or `make -C`.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Rush"
+  },
+  "license": "MIT"
+}

--- a/plugins/bash-workdir-guard/README.md
+++ b/plugins/bash-workdir-guard/README.md
@@ -1,0 +1,72 @@
+# bash-workdir-guard
+
+A Claude Code plugin that warns when Bash commands navigate outside the project workspace boundary, suggesting safer alternatives.
+
+## Problem
+
+Claude Code's Bash tool states that "working directory persists between commands," but in practice, navigating outside the approved workspace triggers a silent auto-reset back to the project directory. This causes confusion when agents use `cd /external && command` patterns, leading to:
+
+- Commands running in unexpected directories after auto-reset
+- Unnecessary git permission prompts
+- Wasted iterations debugging directory state
+
+See [anthropics/claude-code#45478](https://github.com/anthropics/claude-code/issues/45478) for details.
+
+## Solution
+
+This plugin adds a `PreToolUse` hook on the `Bash` tool that:
+
+1. Parses the command for `cd` or `pushd` targets
+2. Checks if the target resolves to a path outside the project workspace
+3. If outside: **blocks the command** with an advisory message suggesting safer alternatives
+4. If inside: allows the command to proceed normally
+
+## Safer Alternatives Suggested
+
+When a command tries to navigate outside the workspace, the plugin suggests:
+
+- **Absolute paths**: `ls /tmp` instead of `cd /tmp && ls`
+- **Tool flags**: `git -C /other/repo status`, `make -C /other/dir build`
+- **Subshells**: `(cd /tmp && command)` to avoid cwd side effects
+
+## Installation
+
+```bash
+# From the plugin directory
+claude --plugin-dir /path/to/bash-workdir-guard
+
+# Or install from the marketplace (once published)
+/plugin install bash-workdir-guard
+```
+
+## How It Works
+
+- **Hook type**: `PreToolUse` (command-based)
+- **Matcher**: `Bash` (only intercepts Bash tool calls)
+- **Detection**: Extracts `cd`/`pushd` targets, resolves paths, checks against `$CLAUDE_PROJECT_DIR`
+- **Behavior**: Exit 2 (block + warn) for outside paths, Exit 0 (allow) for inside paths
+
+## Known Limitations
+
+- **Quoted paths**: `cd "/path with spaces"` may not be parsed correctly
+- **Variable paths**: `cd "$DIR"` or `cd ${HOME}` are not resolved
+- **Command substitution**: `cd $(pwd)` is not evaluated
+- Only detects `cd` and `pushd` — other directory-changing commands are not covered
+
+These are acceptable trade-offs for a lightweight, zero-dependency hook. Complex path resolution would require a full shell parser.
+
+## Requirements
+
+- Claude Code v2.1.32 or later
+- `jq` available in PATH (for JSON parsing)
+- `bash` shell
+
+## Development
+
+```bash
+# Test locally
+claude --plugin-dir ./bash-workdir-guard
+
+# Reload after changes
+/reload-plugins
+```

--- a/plugins/bash-workdir-guard/hooks/hooks.json
+++ b/plugins/bash-workdir-guard/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "Warns when Bash commands navigate outside the project workspace boundary",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/workdir_guard.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/bash-workdir-guard/hooks/workdir_guard.sh
+++ b/plugins/bash-workdir-guard/hooks/workdir_guard.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# bash-workdir-guard: PreToolUse hook for Claude Code
+#
+# Detects Bash commands that navigate outside the project workspace boundary
+# and blocks with an advisory suggesting safer alternatives.
+#
+# Input (stdin): JSON with tool_input.command and cwd
+# Output: exit 0 = allow, exit 2 + stderr message = block with advisory
+
+set -euo pipefail
+
+# Read the hook input from stdin
+INPUT=$(cat)
+
+# Extract the command being run
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# Get project directory from environment (set by Claude Code)
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-}"
+
+if [ -z "$PROJECT_DIR" ]; then
+  exit 0
+fi
+
+# Normalize project dir (resolve symlinks, remove trailing slash)
+PROJECT_DIR=$(cd "$PROJECT_DIR" 2>/dev/null && pwd -P) || exit 0
+
+# Extract cd targets from the command
+# Matches: cd /path, cd ~/path, cd ../, cd /tmp, pushd /path
+# Does NOT match: cd subdir (relative within project)
+CD_TARGETS=$(echo "$COMMAND" | grep -oE '(cd|pushd)[[:space:]]+[^[:space:];&|]+' | awk '{print $2}' || true)
+
+if [ -z "$CD_TARGETS" ]; then
+  exit 0
+fi
+
+for TARGET in $CD_TARGETS; do
+  # Skip relative paths that stay within project (no leading / or ~ or ..)
+  case "$TARGET" in
+    /*|~/*|../*|..)
+      # This could go outside the project — check it
+      ;;
+    *)
+      # Relative path, likely stays in project
+      continue
+      ;;
+  esac
+
+  # Resolve the target path
+  RESOLVED=""
+  case "$TARGET" in
+    /*)  RESOLVED="$TARGET" ;;
+    '~'/*) RESOLVED="${HOME}/${TARGET#'~'/}" ;;
+    '~')   RESOLVED="${HOME}" ;;
+    *)
+      # Resolve relative to current cwd from the hook input
+      CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+      if [ -n "$CWD" ]; then
+        RESOLVED=$(cd "$CWD" 2>/dev/null && cd "$TARGET" 2>/dev/null && pwd -P) || continue
+      else
+        continue
+      fi
+      ;;
+  esac
+
+  # Canonicalize if the path exists
+  if [ -d "$RESOLVED" ]; then
+    RESOLVED=$(cd "$RESOLVED" 2>/dev/null && pwd -P) || continue
+  fi
+
+  # Check if resolved path is outside project
+  case "$RESOLVED" in
+    "$PROJECT_DIR"|"$PROJECT_DIR"/*)
+      # Inside project — no warning needed
+      continue
+      ;;
+    *)
+      # Outside project — block with advisory
+      SAFE_TARGET=$(printf '%s' "$TARGET")
+      cat >&2 <<GUARD_EOF
+[bash-workdir-guard] Blocked: command navigates to '${SAFE_TARGET}' which is outside the project workspace.
+
+Claude Code auto-resets cwd to the workspace after external navigation. Use these alternatives instead:
+  - Absolute paths: ls ${SAFE_TARGET} (no cd needed)
+  - Tool flags: git -C ${SAFE_TARGET} status, make -C ${SAFE_TARGET} build
+  - Subshells: (cd ${SAFE_TARGET} && command)
+
+Ref: https://github.com/anthropics/claude-code/issues/45478
+GUARD_EOF
+      exit 2
+      ;;
+  esac
+done
+
+# All cd targets are within project, allow
+exit 0


### PR DESCRIPTION
## Summary

- Adds a new `bash-workdir-guard` plugin with a `PreToolUse` hook on the `Bash` tool
- Detects when commands use `cd` or `pushd` to navigate outside the project workspace boundary
- Blocks with an advisory suggesting safer alternatives: absolute paths, tool flags (`git -C`, `make -C`), or subshells

## Motivation

Relates to #45478 — the Bash tool's "working directory persists between commands" behavior has a workspace boundary auto-reset that silently resets `cwd` when navigating outside approved directories. This causes agents to waste iterations debugging unexpected directory state.

This plugin proactively prevents the issue by intercepting external `cd` commands before they run.

## How it works

1. Hook parses the Bash command for `cd`/`pushd` targets
2. Resolves the target path (absolute, `~`-relative, or `..`-relative)
3. Checks if the resolved path is inside `$CLAUDE_PROJECT_DIR`
4. If outside: exits with code 2 (block) + stderr advisory with alternatives
5. If inside: exits with code 0 (allow)

## Test plan

- [x] `cd /tmp` → blocked (outside project)
- [x] `cd directives` → allowed (relative path inside project)
- [x] `ls -la` → allowed (no cd)
- [x] `cd /absolute/path/inside/project` → allowed
- [x] `cd ..` → blocked (parent = outside project)
- [x] `pushd /var/log` → blocked (outside project)
- [x] Empty command → allowed