### PR TITLE
fix(security-guidance): move debug log out of /tmp and accept standard boolean env values

### DIFF
--- a/plugins/security-guidance/hooks/security_reminder_hook.py
+++ b/plugins/security-guidance/hooks/security_reminder_hook.py
@@ -10,8 +10,8 @@ import random
 import sys
 from datetime import datetime
 
-# Debug log file
-DEBUG_LOG_FILE = "/tmp/security-warnings-log.txt"
+# Debug log file — use ~/.claude/ to avoid world-readable /tmp
+DEBUG_LOG_FILE = os.path.join(os.path.expanduser("~"), ".claude", "security-warnings-log.txt")
 
 
 def debug_log(message):
@@ -220,7 +220,7 @@ def main():
     security_reminder_enabled = os.environ.get("ENABLE_SECURITY_REMINDER", "1")
 
     # Only run if security reminders are enabled
-    if security_reminder_enabled == "0":
+    if security_reminder_enabled.lower() in ("0", "false", "no", "off"):
         sys.exit(0)
 
     # Periodically clean up old state files (10% chance per run)


### PR DESCRIPTION
## Summary

Two small fixes to the security-guidance plugin:

- **Move debug log out of `/tmp`**: `/tmp/security-warnings-log.txt` is world-readable on multi-user systems. Moved to `~/.claude/security-warnings-log.txt` which is user-scoped.

- **Accept standard boolean values for `ENABLE_SECURITY_REMINDER`**: Previously only `"0"` disabled the hook. Now also accepts `"false"`, `"no"`, `"off"` (case-insensitive), which is the standard convention for boolean environment variables.

## Changes

`plugins/security-guidance/hooks/security_reminder_hook.py`:
- Line 14: `DEBUG_LOG_FILE` changed from `/tmp/...` to `~/.claude/...`
- Line 223: `== "0"` changed to `.lower() in ("0", "false", "no", "off")`

## Test plan

- [x] Log path resolves to `~/.claude/security-warnings-log.txt`
- [x] `"0"`, `"false"`, `"False"`, `"no"`, `"NO"`, `"off"`, `"OFF"` all disable the hook
- [x] `"1"`, `"true"`, `"yes"`, `"on"`, `""` all keep the hook enabled
- [x] Backward compatible: existing `ENABLE_SECURITY_REMINDER=0` still works