### PR TITLE
feat: add commit-guard plugin

### DIFF
--- a/plugins/commit-guard/.claude-plugin/plugin.json
+++ b/plugins/commit-guard/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "commit-guard",
+  "description": "Blocks git add/commit of sensitive files (.env, credentials, private keys) before they enter version control",
+  "version": "1.0.0",
+  "author": {
+    "name": "Rush"
+  },
+  "license": "MIT"
+}

--- a/plugins/commit-guard/README.md
+++ b/plugins/commit-guard/README.md
@@ -1,0 +1,45 @@
+# commit-guard
+
+A Claude Code plugin that blocks `git add` and `git commit` of sensitive files before they enter version control.
+
+## Problem
+
+Claude Code's security-guidance plugin checks for code injection patterns during file edits, and hookify provides configurable edit-time warnings. But neither intercepts the **commit stage** — the last line of defense before secrets enter git history.
+
+Once a `.env` file or private key is committed, removing it from git history requires `git filter-branch` or BFG Repo-Cleaner, and the secret must be rotated.
+
+## What it catches
+
+| Pattern | Examples |
+|---------|----------|
+| Environment files | `.env`, `.env.local`, `.env.production` |
+| Credential files | `credentials.json`, `credentials.yml` |
+| Service accounts | `service-account.json`, `service_account_key.json` |
+| Private keys | `*.pem`, `*.key`, `*.p12`, `*.pfx` |
+| SSH keys | `id_rsa`, `id_ed25519`, `id_ecdsa` |
+| Auth tokens | `token.json`, `*.secret` |
+| Keystores | `*.keystore`, `*.jks` |
+| System files | `htpasswd`, `shadow` |
+
+## How it works
+
+`PreToolUse` hook on the `Bash` tool:
+
+1. Detects `git add` or `git commit -a/--all` commands
+2. For specific files: checks each filename against sensitive patterns
+3. For broad adds (`git add .`, `git add -A`): scans the working tree for sensitive files
+4. If found: blocks with exit 2 and suggests safer alternatives
+
+## Installation
+
+```bash
+/plugin install commit-guard
+# or
+claude --plugin-dir /path/to/commit-guard
+```
+
+## Known limitations
+
+- Only detects sensitive files by filename pattern, not by content
+- `find` scans to maxdepth 3 to keep the hook fast
+- Does not check files already in git history

--- a/plugins/commit-guard/hooks/commit_guard.sh
+++ b/plugins/commit-guard/hooks/commit_guard.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# commit-guard: PreToolUse hook for Claude Code
+#
+# Blocks git add/commit when the command targets sensitive files
+# (.env, credentials, private keys, tokens, etc.)
+#
+# Input (stdin): JSON with tool_input.command
+# Output: exit 0 = allow, exit 2 + stderr = block with advisory
+
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# Only check git add and git commit commands
+# Match: git add, git commit -a, git commit --all
+IS_GIT_ADD=false
+IS_GIT_COMMIT_ALL=false
+
+if echo "$COMMAND" | grep -qE '(^|&&|;|[|])\s*git\s+add\b'; then
+  IS_GIT_ADD=true
+fi
+
+if echo "$COMMAND" | grep -qE '(^|&&|;|[|])\s*git\s+commit\s+.*(-a|--all)\b'; then
+  IS_GIT_COMMIT_ALL=true
+fi
+
+if [ "$IS_GIT_ADD" = false ] && [ "$IS_GIT_COMMIT_ALL" = false ]; then
+  exit 0
+fi
+
+# Sensitive file patterns
+SENSITIVE_PATTERNS=(
+  '\.env$'
+  '\.env\.'
+  'credentials\.json'
+  'credentials\.yml'
+  'credentials\.yaml'
+  'service[_-]account.*\.json'
+  '\.pem$'
+  '\.key$'
+  '\.p12$'
+  '\.pfx$'
+  'id_rsa'
+  'id_ed25519'
+  'id_ecdsa'
+  '\.secret'
+  'token\.json'
+  '\.keystore'
+  '\.jks$'
+  'htpasswd'
+  'shadow$'
+)
+
+# Build a single regex from all patterns
+COMBINED_PATTERN=$(IFS='|'; echo "${SENSITIVE_PATTERNS[*]}")
+
+# For git add: check the files being added
+if [ "$IS_GIT_ADD" = true ]; then
+  # Extract file arguments after 'git add'
+  # Handle: git add .env, git add -A, git add ., git add file1 file2
+  ADD_ARGS=$(echo "$COMMAND" | grep -oE '(^|&&|;|[|])\s*git\s+add\s+(.+)' | sed 's/.*git\s\+add\s\+//')
+
+  # Check for broad adds that would include everything
+  if echo "$ADD_ARGS" | grep -qE '^\s*(-A|--all|\.|--update|-u)\s*$'; then
+    # Broad add — check if any sensitive files exist in the working tree
+    PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+    FOUND_FILES=""
+    for PATTERN in "${SENSITIVE_PATTERNS[@]}"; do
+      MATCHES=$(find "$PROJECT_DIR" -maxdepth 3 -regex ".*${PATTERN}" -not -path '*/.git/*' -not -path '*/node_modules/*' 2>/dev/null | head -5)
+      if [ -n "$MATCHES" ]; then
+        FOUND_FILES="${FOUND_FILES}${MATCHES}\n"
+      fi
+    done
+
+    if [ -n "$FOUND_FILES" ]; then
+      cat >&2 <<GUARD_EOF
+[commit-guard] Blocked: 'git add' with broad scope would include sensitive files:
+
+$(echo -e "$FOUND_FILES" | head -10)
+
+Add files individually instead of using 'git add -A' or 'git add .',
+or add these files to .gitignore first:
+
+  echo '.env' >> .gitignore
+  git add specific-file.ts
+GUARD_EOF
+      exit 2
+    fi
+    exit 0
+  fi
+
+  # Specific files — check each one
+  for FILE in $ADD_ARGS; do
+    # Skip flags
+    case "$FILE" in
+      -*) continue ;;
+    esac
+    if echo "$FILE" | grep -qE "$COMBINED_PATTERN"; then
+      cat >&2 <<GUARD_EOF
+[commit-guard] Blocked: '$FILE' matches a sensitive file pattern.
+
+This file may contain secrets, credentials, or private keys.
+If this is intentional, add it to .gitignore first or use:
+
+  COMMIT_GUARD_ALLOW='$FILE' git add $FILE
+GUARD_EOF
+      exit 2
+    fi
+  done
+fi
+
+# For git commit -a/--all: check staged + unstaged sensitive files
+if [ "$IS_GIT_COMMIT_ALL" = true ]; then
+  PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+  FOUND_FILES=""
+  for PATTERN in "${SENSITIVE_PATTERNS[@]}"; do
+    MATCHES=$(find "$PROJECT_DIR" -maxdepth 3 -regex ".*${PATTERN}" -not -path '*/.git/*' -not -path '*/node_modules/*' 2>/dev/null | head -5)
+    if [ -n "$MATCHES" ]; then
+      FOUND_FILES="${FOUND_FILES}${MATCHES}\n"
+    fi
+  done
+
+  if [ -n "$FOUND_FILES" ]; then
+    cat >&2 <<GUARD_EOF
+[commit-guard] Blocked: 'git commit -a' would include sensitive files:
+
+$(echo -e "$FOUND_FILES" | head -10)
+
+Stage files individually instead:
+
+  git add specific-file.ts
+  git commit -m "your message"
+GUARD_EOF
+    exit 2
+  fi
+fi
+
+exit 0

--- a/plugins/commit-guard/hooks/hooks.json
+++ b/plugins/commit-guard/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "Blocks git add/commit of sensitive files before they enter version control",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/commit_guard.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- New plugin that blocks `git add`/`git commit -a` of sensitive files before they enter version control
- Catches: `.env`, `credentials.json`, `*.pem`, `*.key`, SSH keys, `token.json`, keystores, etc.
- Complements existing security layers: `security-guidance` (code injection at edit time) and `hookify` (configurable edit-time warnings) by guarding the **commit stage**

## Motivation

Once a `.env` or private key is committed, removing it from git history requires `git filter-branch` or BFG Repo-Cleaner, and the secret must be rotated. This plugin provides a last line of defense.

The existing `hookify` example `sensitive-files-warning` warns at edit time, but does not intercept `git add`/`git commit`. This plugin fills that gap.

## How it works

PreToolUse hook on the Bash tool:

1. Detects `git add` or `git commit -a/--all` in the command
2. For specific files: checks each filename against 18 sensitive patterns
3. For broad adds (`git add .`, `git add -A`): scans working tree (maxdepth 3) for matches
4. If found: blocks with exit 2 and suggests safer alternatives

## Test plan

- [x] `git add .env` → blocked
- [x] `git add src/index.ts` → allowed
- [x] `git add credentials.json` → blocked
- [x] `git add id_rsa` → blocked
- [x] `git add server.key` → blocked
- [x] `git commit -m "msg"` (no -a) → allowed
- [x] `ls -la` (not git) → allowed
- [x] Empty command → allowed
- [x] `git add .env.production` → blocked
- [x] `git add token.json` → blocked
- [x] 10/10 tests passed