### PR TITLE
fix: use jq for JSON construction in log-issue-events workflow

### DIFF
--- a/.github/workflows/log-issue-events.yml
+++ b/.github/workflows/log-issue-events.yml
@@ -19,22 +19,30 @@ jobs:
           AUTHOR: ${{ github.event.issue.user.login }}
           CREATED_AT: ${{ github.event.issue.created_at }}
         run: |
-          # All values are now safely passed via environment variables
-          # No direct templating in the shell script to prevent injection attacks
-          
+          # Build JSON payload with jq to safely handle special characters
+          # in issue titles (newlines, quotes, backslashes, control chars).
+          # The previous sed-based approach only escaped double quotes.
+          PAYLOAD=$(jq -n \
+            --arg num "$ISSUE_NUMBER" \
+            --arg repo "$REPO" \
+            --arg title "$ISSUE_TITLE" \
+            --arg author "$AUTHOR" \
+            --arg created "$CREATED_AT" \
+            '{
+              events: [{
+                eventName: "github_issue_created",
+                metadata: {
+                  issue_number: $num,
+                  repository: $repo,
+                  title: $title,
+                  author: $author,
+                  created_at: $created
+                },
+                time: (now | floor * 1000)
+              }]
+            }')
+
           curl -X POST "https://events.statsigapi.net/v1/log_event" \
             -H "Content-Type: application/json" \
             -H "statsig-api-key: $STATSIG_API_KEY" \
-            -d '{
-              "events": [{
-                "eventName": "github_issue_created",
-                "metadata": {
-                  "issue_number": "'"$ISSUE_NUMBER"'",
-                  "repository": "'"$REPO"'",
-                  "title": "'"$(echo "$ISSUE_TITLE" | sed "s/\"/\\\\\"/g")"'",
-                  "author": "'"$AUTHOR"'",
-                  "created_at": "'"$CREATED_AT"'"
-                },
-                "time": '"$(date +%s)000"'
-              }]
-            }'
+            -d "$PAYLOAD"


### PR DESCRIPTION
## Summary

Replace manual `sed`-based JSON string escaping with `jq --arg` in the Statsig logging workflow.

## Problem

The current implementation (line 34) only escapes double quotes:

```bash
"title": "'"$(echo "$ISSUE_TITLE" | sed "s/\"/\\\\\"/g")"'"
```

Issue titles containing newlines, backslashes, tabs, or other control characters produce invalid JSON, causing the Statsig API call to silently fail.

## Fix

Use `jq -n --arg` to construct the entire JSON payload. `jq` correctly escapes all special characters:

| Character | Before (sed) | After (jq) |
|-----------|-------------|------------|
| `"` | ✓ escaped | ✓ escaped |
| newline | **breaks JSON** | `\n` |
| `\` | **breaks JSON** | `\\` |
| tab | **breaks JSON** | `\t` |
| control chars | **breaks JSON** | `\uXXXX` |

## Test plan

- [x] Title with double quotes: `Fix the "broken" parser` → `"Fix the \"broken\" parser"`
- [x] Title with newline: `Line one\nLine two` → `"Line one\nLine two"`
- [x] Title with backslash: `path\to\file` → `"path\\to\\file"`
- [x] Combined special chars → valid JSON confirmed with `python3 -m json.tool`