### PR TITLE
fix(auto-close): preserve existing labels when closing duplicate issues

### DIFF
--- a/scripts/auto-close-duplicates.test.ts
+++ b/scripts/auto-close-duplicates.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'bun:test';
+import { extractDuplicateIssueNumber, mergeLabels } from './auto-close-duplicates';
+
+describe('extractDuplicateIssueNumber', () => {
+  it('extracts issue number from inline #N format', () => {
+    expect(extractDuplicateIssueNumber('This is a duplicate of #123')).toBe(123);
+  });
+
+  it('extracts issue number from a GitHub issue URL', () => {
+    const body =
+      'Found 1 possible duplicate issues:\n\n' +
+      '1. https://github.com/anthropics/claude-code/issues/456\n\n' +
+      'This issue will be automatically closed as a duplicate in 3 days.';
+    expect(extractDuplicateIssueNumber(body)).toBe(456);
+  });
+
+  it('returns the first URL when multiple duplicates are listed', () => {
+    const body =
+      'Found 2 possible duplicate issues:\n\n' +
+      '1. https://github.com/anthropics/claude-code/issues/100\n' +
+      '2. https://github.com/anthropics/claude-code/issues/200\n\n' +
+      'This issue will be automatically closed as a duplicate in 3 days.';
+    expect(extractDuplicateIssueNumber(body)).toBe(100);
+  });
+
+  it('returns null when the comment contains no issue reference', () => {
+    expect(extractDuplicateIssueNumber('No issue reference here at all.')).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(extractDuplicateIssueNumber('')).toBeNull();
+  });
+});
+
+describe('mergeLabels', () => {
+  it('adds the label to an empty list', () => {
+    expect(mergeLabels([], 'duplicate')).toEqual(['duplicate']);
+  });
+
+  it('preserves existing triage labels when adding duplicate', () => {
+    const result = mergeLabels(['bug', 'has repro', 'platform:macos', 'area:sandbox'], 'duplicate');
+    expect(result).toContain('bug');
+    expect(result).toContain('has repro');
+    expect(result).toContain('platform:macos');
+    expect(result).toContain('area:sandbox');
+    expect(result).toContain('duplicate');
+  });
+
+  it('does not add the label a second time when already present', () => {
+    const result = mergeLabels(['bug', 'duplicate'], 'duplicate');
+    expect(result.filter((l) => l === 'duplicate')).toHaveLength(1);
+  });
+
+  it('returns the original array unchanged when label is already present', () => {
+    const existing = ['bug', 'duplicate'];
+    expect(mergeLabels(existing, 'duplicate')).toEqual(['bug', 'duplicate']);
+  });
+
+  it('does not mutate the original array', () => {
+    const original = ['bug', 'has repro'];
+    const result = mergeLabels(original, 'duplicate');
+    expect(original).toEqual(['bug', 'has repro']); // unchanged
+    expect(result).toHaveLength(3);
+  });
+});

--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -46,22 +46,42 @@ async function githubRequest<T>(endpoint: string, token: string, method: string 
   return response.json();
 }
 
-function extractDuplicateIssueNumber(commentBody: string): number | null {
+export function extractDuplicateIssueNumber(commentBody: string): number | null {
   // Try to match #123 format first
   let match = commentBody.match(/#(\d+)/);
   if (match) {
     return parseInt(match[1], 10);
   }
-  
+
   // Try to match GitHub issue URL format: https://github.com/owner/repo/issues/123
   match = commentBody.match(/github\.com\/[^\/]+\/[^\/]+\/issues\/(\d+)/);
   if (match) {
     return parseInt(match[1], 10);
   }
-  
+
   return null;
 }
 
+// Merges a label into an existing label list without duplicating it.
+export function mergeLabels(existing: string[], label: string): string[] {
+  if (existing.includes(label)) {
+    return existing;
+  }
+  return [...existing, label];
+}
+
+async function getIssueLabels(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  token: string
+): Promise<string[]> {
+  const issue = await githubRequest<{ labels: Array<{ name: string }> }>(
+    `/repos/${owner}/${repo}/issues/${issueNumber}`,
+    token
+  );
+  return issue.labels.map((l) => l.name);
+}
 
 async function closeIssueAsDuplicate(
   owner: string,
@@ -70,6 +90,11 @@ async function closeIssueAsDuplicate(
   duplicateOfNumber: number,
   token: string
 ): Promise<void> {
+  // Fetch existing labels so that the PATCH call (which replaces the full
+  // label list) preserves triage metadata like bug/has-repro/platform/area.
+  const existingLabels = await getIssueLabels(owner, repo, issueNumber, token);
+  const labels = mergeLabels(existingLabels, 'duplicate');
+
   await githubRequest(
     `/repos/${owner}/${repo}/issues/${issueNumber}`,
     token,
@@ -77,7 +102,7 @@ async function closeIssueAsDuplicate(
     {
       state: 'closed',
       state_reason: 'duplicate',
-      labels: ['duplicate']
+      labels,
     }
   );
 
@@ -271,7 +296,7 @@ async function autoCloseDuplicates(): Promise<void> {
   );
 }
 
-autoCloseDuplicates().catch(console.error);
-
-// Make it a module
-export {};
+// Only run when invoked directly, not when imported by tests.
+if (import.meta.main) {
+  autoCloseDuplicates().catch(console.error);
+}


### PR DESCRIPTION
## Summary

Fixes a label-stripping bug in `scripts/auto-close-duplicates.ts`.

- The GitHub Issues `PATCH` endpoint **replaces** the entire label list when `labels` is supplied. The previous code sent `labels: ['duplicate']`, silently dropping all triage metadata (`bug`, `has repro`, `platform:macos`, `area:sandbox`, etc.) from every auto-closed issue.
- Fix: call `GET /issues/{n}` first to read existing labels, merge `'duplicate'` in with the new `mergeLabels()` helper, then `PATCH` with the full merged list.
- Add `import.meta.main` guard so the script can be imported cleanly by tests without triggering the live GitHub API call.

## Verification

- [x] Baseline tests: 0 (no test suite existed)
- [x] Post-fix tests: 10 pass, 0 fail, 0 regressions
- [x] New tests: 10 added — 5 for `extractDuplicateIssueNumber`, 5 for `mergeLabels` — all pass

## Files changed

| File | Change |
|------|--------|
| `scripts/auto-close-duplicates.ts` | Add `mergeLabels` + `getIssueLabels` helpers; fix `closeIssueAsDuplicate`; export pure functions; add `import.meta.main` guard |
| `scripts/auto-close-duplicates.test.ts` | New — 10 unit tests using `bun:test` |

Generated by Claude Code
Vibe coded by ousamabenyounes