### PR TITLE
Add MDM deployment example templates

### DIFF
--- a/examples/mdm/README.md
+++ b/examples/mdm/README.md
@@ -1,0 +1,28 @@
+# MDM Deployment Examples
+
+Example templates for deploying Claude Code [managed settings](https://code.claude.com/docs/en/settings#settings-files) through Jamf, Iru (Kandji), Intune, or Group Policy. Use these as starting points — adjust them to fit your needs.
+
+All templates encode the same minimal example (`permissions.disableBypassPermissionsMode`). See the [settings reference](https://code.claude.com/docs/en/settings#available-settings) for the full list of keys, and [`../settings`](../settings) for more complete example configurations.
+
+
+## Templates
+
+> [!WARNING]
+> These examples are community-maintained templates which may be unsupported or incorrect. You are responsible for the correctness of your own deployment configuration.
+
+| File | Use with |
+| :--- | :--- |
+| [`managed-settings.json`](./managed-settings.json) | Any platform. Deploy to the [system config directory](https://code.claude.com/docs/en/settings#settings-files). |
+| [`macos/com.anthropic.claudecode.plist`](./macos/com.anthropic.claudecode.plist) | Jamf or Iru (Kandji) **Custom Settings** payload. Preference domain: `com.anthropic.claudecode`. |
+| [`macos/com.anthropic.claudecode.mobileconfig`](./macos/com.anthropic.claudecode.mobileconfig) | Full configuration profile for local testing or MDMs that take a complete profile. |
+| [`windows/Set-ClaudeCodePolicy.ps1`](./windows/Set-ClaudeCodePolicy.ps1) | Intune **Platform scripts**. Writes `managed-settings.json` to `C:\Program Files\ClaudeCode\`. |
+| [`windows/ClaudeCode.admx`](./windows/ClaudeCode.admx) + [`en-US/ClaudeCode.adml`](./windows/en-US/ClaudeCode.adml) | Group Policy or Intune **Import ADMX**. Writes `HKLM\SOFTWARE\Policies\ClaudeCode\Settings` (REG_SZ, single-line JSON). |
+
+## Tips
+- Replace the placeholder `PayloadUUID` and `PayloadOrganization` values in the `.mobileconfig` with your own (`uuidgen`)
+- Before deploying to your fleet, test on a single machine and confirm `/status` lists the source under **Setting sources** — e.g. `Enterprise managed settings (plist)` on macOS or `Enterprise managed settings (HKLM)` on Windows
+- Settings deployed this way sit at the top of the precedence order and cannot be overridden by users
+
+## Full Documentation
+
+See https://code.claude.com/docs/en/settings#settings-files for complete documentation on managed settings and settings precedence.

--- a/examples/mdm/macos/com.anthropic.claudecode.mobileconfig
+++ b/examples/mdm/macos/com.anthropic.claudecode.mobileconfig
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadDisplayName</key>
+	<string>Claude Code Managed Settings</string>
+	<key>PayloadDescription</key>
+	<string>Configures managed settings for Claude Code.</string>
+	<key>PayloadIdentifier</key>
+	<string>com.anthropic.claudecode.profile</string>
+	<key>PayloadOrganization</key>
+	<string>Example Organization</string>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>DC3CBC17-3330-4CDE-94AC-D2342E9C88A3</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>Claude Code</string>
+			<key>PayloadIdentifier</key>
+			<string>com.anthropic.claudecode.profile.BEFD5F54-71FC-4012-82B2-94399A1E220B</string>
+			<key>PayloadType</key>
+			<string>com.apple.ManagedClient.preferences</string>
+			<key>PayloadUUID</key>
+			<string>BEFD5F54-71FC-4012-82B2-94399A1E220B</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadContent</key>
+			<dict>
+				<key>com.anthropic.claudecode</key>
+				<dict>
+					<key>Forced</key>
+					<array>
+						<dict>
+							<key>mcx_preference_settings</key>
+							<dict>
+								<key>permissions</key>
+								<dict>
+									<key>disableBypassPermissionsMode</key>
+									<string>disable</string>
+								</dict>
+							</dict>
+						</dict>
+					</array>
+				</dict>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/examples/mdm/macos/com.anthropic.claudecode.plist
+++ b/examples/mdm/macos/com.anthropic.claudecode.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>permissions</key>
+	<dict>
+		<key>disableBypassPermissionsMode</key>
+		<string>disable</string>
+	</dict>
+</dict>
+</plist>

--- a/examples/mdm/managed-settings.json
+++ b/examples/mdm/managed-settings.json
@@ -1,0 +1,5 @@
+{
+  "permissions": {
+    "disableBypassPermissionsMode": "disable"
+  }
+}

--- a/examples/mdm/windows/ClaudeCode.admx
+++ b/examples/mdm/windows/ClaudeCode.admx
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions"
+                   revision="1.0" schemaVersion="1.0">
+  <policyNamespaces>
+    <target prefix="claudecode" namespace="Anthropic.Policies.ClaudeCode" />
+    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+  </policyNamespaces>
+  <resources minRequiredRevision="1.0" />
+  <categories>
+    <category name="Cat_ClaudeCode" displayName="$(string.Cat_ClaudeCode)" />
+  </categories>
+  <policies>
+    <policy name="ManagedSettings"
+            class="Machine"
+            displayName="$(string.ManagedSettings)"
+            explainText="$(string.ManagedSettings_Explain)"
+            presentation="$(presentation.ManagedSettings)"
+            key="SOFTWARE\Policies\ClaudeCode">
+      <parentCategory ref="Cat_ClaudeCode" />
+      <supportedOn ref="windows:SUPPORTED_Windows_10_0" />
+      <elements>
+        <text id="SettingsJson" valueName="Settings" maxLength="1000000" required="true" />
+      </elements>
+    </policy>
+  </policies>
+</policyDefinitions>

--- a/examples/mdm/windows/Set-ClaudeCodePolicy.ps1
+++ b/examples/mdm/windows/Set-ClaudeCodePolicy.ps1
@@ -1,0 +1,28 @@
+<#
+Deploys Claude Code managed settings as a JSON file.
+
+Intune: Devices > Scripts and remediations > Platform scripts > Add (Windows 10 and later).
+  Run this script using the logged on credentials: No
+  Run script in 64 bit PowerShell Host: Yes
+
+Claude Code reads C:\Program Files\ClaudeCode\managed-settings.json at startup
+and treats it as a managed policy source. Edit the JSON below to change the
+deployed settings; see https://code.claude.com/docs/en/settings for available keys.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$dir = Join-Path $env:ProgramFiles 'ClaudeCode'
+New-Item -ItemType Directory -Path $dir -Force | Out-Null
+
+$json = @'
+{
+  "permissions": {
+    "disableBypassPermissionsMode": "disable"
+  }
+}
+'@
+
+$path = Join-Path $dir 'managed-settings.json'
+[System.IO.File]::WriteAllText($path, $json, (New-Object System.Text.UTF8Encoding($false)))
+Write-Output "Wrote $path"

--- a/examples/mdm/windows/en-US/ClaudeCode.adml
+++ b/examples/mdm/windows/en-US/ClaudeCode.adml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                            xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions"
+                            revision="1.0" schemaVersion="1.0">
+  <displayName>Claude Code</displayName>
+  <description>Claude Code policy settings</description>
+  <resources>
+    <stringTable>
+      <string id="Cat_ClaudeCode">Claude Code</string>
+      <string id="ManagedSettings">Managed settings (JSON)</string>
+      <string id="ManagedSettings_Explain">Configures managed settings for Claude Code.
+
+Enter the full settings configuration as a single line of JSON. The value is stored as a REG_SZ string at HKLM\SOFTWARE\Policies\ClaudeCode\Settings and is applied at the highest precedence; users cannot override these settings.
+
+Example:
+{"permissions":{"disableBypassPermissionsMode":"disable"}}
+
+For the list of available settings keys, see https://code.claude.com/docs/en/settings.
+
+If your configuration is large or you prefer to manage a JSON file directly, deploy C:\Program Files\ClaudeCode\managed-settings.json instead (see Set-ClaudeCodePolicy.ps1).</string>
+    </stringTable>
+    <presentationTable>
+      <presentation id="ManagedSettings">
+        <textBox refId="SettingsJson">
+          <label>Settings JSON:</label>
+        </textBox>
+      </presentation>
+    </presentationTable>
+  </resources>
+</policyDefinitionResources>

--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -1,6 +1,6 @@
 # Settings Examples
 
-Example Claude Code settings files, primarily intended for organization-wide deployments. Use these are starting points — adjust them to fit your needs.
+Example Claude Code settings files, primarily intended for organization-wide deployments. Use these as starting points — adjust them to fit your needs.
 
 These may be applied at any level of the [settings hierarchy](https://code.claude.com/docs/en/settings#settings-files), though certain properties only take effect if specified in enterprise settings (e.g. `strictKnownMarketplaces`, `allowManagedHooksOnly`, `allowManagedPermissionRulesOnly`).
 
@@ -25,6 +25,10 @@ These may be applied at any level of the [settings hierarchy](https://code.claud
 - Settings files must be valid JSON
 - Before deploying configuration files to your organization, test them locally by applying to `managed-settings.json`, `settings.json` or `settings.local.json`
 - The `sandbox` property only applies to the `Bash` tool; it does not apply to other tools (like Read, Write, WebSearch, WebFetch, MCPs), hooks, or internal commands
+
+## Deploying via MDM
+
+To distribute these settings as enterprise-managed policy through Jamf, Iru (Kandji), Intune, or Group Policy, see the deployment templates in [`../mdm`](../mdm).
 
 ## Full Documentation
 


### PR DESCRIPTION
Adds `examples/mdm/` with starter templates for deploying Claude Code managed settings via common MDM platforms:

- `managed-settings.json` — bare JSON for any platform
- **macOS:** `.plist` (Jamf / Iru Custom Settings payload) and `.mobileconfig` (full configuration profile)
- **Windows:** PowerShell script (Intune Platform scripts) and ADMX/ADML (Group Policy / Intune Import ADMX)

All templates encode the same minimal `permissions.disableBypassPermissionsMode` example.

Also:
- Cross-links `examples/settings/README.md` ↔ `examples/mdm/`
- Fixes a typo in `examples/settings/README.md`