### PR TITLE
Add research-loop plugin

### DIFF
--- a/plugins/research-loop/.claude-plugin/plugin.json
+++ b/plugins/research-loop/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "research-loop",
+  "version": "0.1.0",
+  "description": "Compatibility plugin for 10000 Mentors Research Workflow: a source-gated autonomous research loop for GitHub research repositories.",
+  "author": {
+    "name": "Da Wei",
+    "email": "wd041216-bit@users.noreply.github.com"
+  }
+}

--- a/plugins/research-loop/README.md
+++ b/plugins/research-loop/README.md
@@ -1,0 +1,30 @@
+# Research Loop
+
+Compatibility plugin for [10000 Mentors Research Workflow](https://github.com/wd041216-bit/10000-mentors-research-workflow), a source-gated autonomous research loop for GitHub research repositories.
+
+## What It Provides
+
+- A `research-loop` skill for running one bounded research micro-step per cycle.
+- Evidence-first rules: current repo HEAD and current literature outrank memory or expert profiles.
+- Submission Advisor completion gate: stop only when readiness reaches `100` and `submission_ready`.
+- No Ollama API key requirement in the default workflow.
+
+## Expected Companion Project
+
+This plugin is a compatibility wrapper. The full workflow lives in the companion repository:
+
+```bash
+git clone https://github.com/wd041216-bit/10000-mentors-research-workflow.git
+cd 10000-mentors-research-workflow
+python3 -m pip install -e ".[dev]"
+```
+
+Then use the skill on a research repo:
+
+```text
+Use $research-loop on https://github.com/<owner>/<research-repo> until the Submission Advisor marks it submission_ready.
+```
+
+## Safety Boundary
+
+This plugin does not claim empirical progress unless the executor writes runnable artifacts and an `executor_manifest.json`.

--- a/plugins/research-loop/skills/research-loop/SKILL.md
+++ b/plugins/research-loop/skills/research-loop/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: research-loop
+description: Claude Code compatibility mirror for the Codex-native 10000 Mentors Research Workflow. Use only when running from Claude Code and the user wants the same source-gated research loop contract.
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
+  - WebSearch
+model: inherit
+argument-hint: "<repo-url> [--max-cycles N] [--target-journal NAME] [--no-push]"
+---
+
+# Research Loop Compatibility Skill
+
+This is the Claude Code compatibility mirror. The primary skill lives at:
+
+```text
+.codex/skills/research-loop/
+```
+
+Use this mirror only when the runtime is Claude Code. Keep the same safety contract:
+
+1. Treat the current target repo HEAD as primary truth.
+2. Treat MemPalace, prior handoffs, and expert memory as secondary context.
+3. Use native web search only for short, attributed fresh context when needed.
+4. Do not require Ollama API keys or Ollama native web search.
+5. Run one bounded micro-step per cycle.
+6. Write source changes into the workflow run's `source_changes/` repo-root mirror.
+7. Write the executor manifest with `python3 -m autonomous_research_workflow.cli write-executor-manifest`.
+8. Do not mark empirical progress unless runnable code or checkable result artifacts were produced.
+9. Stop only when Submission Advisor reports `score >= 100` and `level = submission_ready`, executor completed, and delivery completed.
+
+## Phase Order
+
+Run the 15-phase loop described in [phases](references/phases.md):
+
+1. `source_intake`
+2. `mempalace_context`
+3. `council_knowledge`
+4. `expert_forum_coverage`
+5. `literature_refresh`
+6. `knowledge_publish`
+7. `advisor_design`
+8. `execution_packet`
+9. `executor_run`
+10. `advisor_reflection`
+11. `openspace_retrospective`
+12. `next_cycle_handoff`
+13. `star_office_status`
+14. `overwatcher_check`
+15. `github_publish`
+
+## Native Executor
+
+Phase 9 remains the key agent-native phase:
+
+- Read the execution packet.
+- Read the source clone.
+- Generate the smallest useful runnable research asset.
+- Write only to `source_changes/`.
+- Run lightweight checks when possible.
+- Write `executor_manifest.json`.
+
+Use [executor-template](references/executor-template.md) as the output contract.
+
+## Completion Gate
+
+Only stop when all are true:
+
+- Submission Advisor score is at least `100`.
+- Submission Advisor level is `submission_ready`.
+- Executor manifest status is `completed`.
+- Delivery status is `published` or explicitly `local_only` for dry runs.

--- a/plugins/research-loop/skills/research-loop/references/advisor-rubric.md
+++ b/plugins/research-loop/skills/research-loop/references/advisor-rubric.md
@@ -1,0 +1,21 @@
+# Submission Advisor Rubric
+
+Score from `0` to `100` with `100` reserved for a repo that is ready to deliver as a submission package.
+
+Axes:
+
+- Problem definition and novelty
+- Methodological rigor
+- Result quality and analysis
+- Manuscript or package completeness
+- Reproducibility and asset hygiene
+- Venue fit
+
+The advisor must use current repo files and current literature as primary evidence. Prior memory and expert profiles can pressure-test conclusions but cannot support a claim alone.
+
+Completion requires:
+
+- `overall_readiness.score >= 100`
+- `overall_readiness.level == "submission_ready"`
+- A completed executor manifest
+- Published or explicitly local-only delivery

--- a/plugins/research-loop/skills/research-loop/references/executor-template.md
+++ b/plugins/research-loop/skills/research-loop/references/executor-template.md
@@ -1,0 +1,44 @@
+# Agent-Native Executor Output Template
+
+The executor must produce a bounded, runnable micro-step.
+
+## Required Files
+
+- At least one runnable Python file unless the micro-step is explicitly a config/test-only edit.
+- `requirements.txt` only when new dependencies are required.
+- Optional `docs/agentic_research/<cycle_id>/...` notes for protocol context.
+- `executor_manifest.json` written via the CLI helper.
+
+## Manifest Shape
+
+```json
+{
+  "cycle_id": "20260411_120451",
+  "generated_at": "2026-04-11T12:04:51Z",
+  "status": "completed",
+  "mode": "agent_native_executor",
+  "source": "agent_native_exec",
+  "selected_micro_step": {"title": "..."},
+  "summary": "What changed and why this is the next smallest useful step.",
+  "limitations": ["What this step still does not prove."],
+  "next_probe": "The next smallest follow-up probe.",
+  "generated_files": [
+    {
+      "destination": "source_repo",
+      "repo_path": "scripts/run_pilot.py",
+      "local_path": "/absolute/path/under/source_changes/scripts/run_pilot.py",
+      "purpose": "Minimal executable experiment script"
+    }
+  ],
+  "claim_rule": "No empirical claim is supported unless tied to generated runnable evidence."
+}
+```
+
+## Rules
+
+1. Keep one micro-step per cycle.
+2. Read the target repo before writing.
+3. Write into the `source_changes/` repo-root mirror, not directly into the source clone.
+4. Prefer deterministic offline checks over secret-dependent API calls.
+5. Do not require `OLLAMA_API_KEY`.
+6. If a model call is optional, make it explicit and document the fallback.

--- a/plugins/research-loop/skills/research-loop/references/phases.md
+++ b/plugins/research-loop/skills/research-loop/references/phases.md
@@ -1,0 +1,23 @@
+# Research Loop Phases
+
+All phases are small and inspectable. Python helper phases write deterministic artifacts; agent-native phases perform judgment and code generation.
+
+| Phase | Owner | Output |
+| --- | --- | --- |
+| `source_intake` | Python + agent | source snapshot and inventory |
+| `mempalace_context` | Python | current-head memory pack |
+| `council_knowledge` | Python | expert council route |
+| `expert_forum_coverage` | Python | coverage score and expansion queue |
+| `literature_refresh` | OpenAlex + native web search | papers and web evidence |
+| `knowledge_publish` | Python | cycle knowledge base |
+| `advisor_design` | agent | advisor manifest and action backlog |
+| `execution_packet` | Python | one selected micro-step |
+| `executor_run` | agent | runnable source changes and executor manifest |
+| `advisor_reflection` | Python | post-execution constraints |
+| `openspace_retrospective` | Python | loop improvement notes |
+| `next_cycle_handoff` | Python | next-cycle handoff |
+| `star_office_status` | Python | local dashboard status |
+| `overwatcher_check` | Python | observe-only workflow health report |
+| `github_publish` | Python | target repo delivery |
+
+Do not rely on Ollama native web search. If fresh web evidence is needed inside an agent-native phase, use native web search and pass short, attributed snippets into the relevant helper stage.

--- a/plugins/research-loop/skills/research-loop/references/state-schema.md
+++ b/plugins/research-loop/skills/research-loop/references/state-schema.md
@@ -1,0 +1,26 @@
+# State Schema
+
+Each run writes a durable local state tree and publishes sanitized artifacts to the target repo under `.autonomous-research-workflow/`.
+
+Important paths:
+
+```text
+<run-dir>/
+  events.jsonl
+  manifest.json
+  payload/.autonomous-research-workflow/
+    cycles/<cycle_id>/cycle_manifest.json
+    execution/<cycle_id>/execution_packet.json
+    execution/<cycle_id>/executor_manifest.json
+    knowledge/<cycle_id>/knowledge_base.json
+    memory/<cycle_id>/mempalace_context.json
+    reflections/<cycle_id>/advisor_reflection.json
+    retrospectives/<cycle_id>/openspace_retrospective.json
+    handoffs/<cycle_id>/next_cycle_handoff.json
+    office_status/<cycle_id>/star_office_status.json
+    overwatcher/<cycle_id>/overwatcher_status.json
+  source/<cycle_id>/<repo>/
+  source_changes/
+```
+
+`source_changes/` mirrors the target repository root and is copied into the source clone during publish.


### PR DESCRIPTION
## Summary

Adds a `research-loop` plugin as a community compatibility wrapper for [10000 Mentors Research Workflow](https://github.com/wd041216-bit/10000-mentors-research-workflow).

The plugin provides a skill for source-gated autonomous research loops over GitHub research repositories:

- current repo HEAD and current literature stay primary evidence
- memory and expert council context stay secondary
- each cycle runs one bounded research micro-step
- completion requires Submission Advisor `score >= 100` and `level = submission_ready`
- fallback scaffolds are explicitly not empirical evidence

## Notes

This is intentionally a small plugin wrapper rather than a change to Claude Code core behavior. The full workflow implementation remains in the companion project.
