### PR TITLE
feat(examples): add session auto-title UserPromptSubmit hook

### DIFF
--- a/examples/hooks/README.md
+++ b/examples/hooks/README.md
@@ -1,0 +1,57 @@
+# Hook Examples
+
+Example hooks for [Claude Code's hook system](https://docs.anthropic.com/en/docs/claude-code/hooks).
+
+Hooks let you run shell commands at specific points in the Claude Code lifecycle —
+before or after tool use, when the session ends, or when the user submits a prompt.
+
+## Available Examples
+
+### `bash_command_validator_example.py`
+
+**Event:** `PreToolUse` (matcher: `Bash`)
+
+Validates Bash commands before they run. Blocks dangerous patterns such as
+`rm -rf /` or `sudo` usage, and injects a safety reminder for commands it
+allows through.
+
+### `session_auto_title_example.py` / `session_auto_title_example.js`
+
+**Event:** `UserPromptSubmit`
+
+Automatically sets a descriptive session title on the first message of each new
+session. Works by injecting an `additionalContext` instruction that tells Claude
+to call the `mcp__happy__change_title` MCP tool (if available) or the `/rename`
+slash command.
+
+Why a hook rather than relying on the system prompt alone? MCP tool schemas are
+loaded lazily in Claude Code. Injecting the instruction at the first user-message
+turn is more reliable than putting it only in the system prompt.
+
+Use the Python version (`session_auto_title_example.py`) or the JavaScript
+version (`session_auto_title_example.js`) — both behave identically.
+
+## Quick Setup
+
+Copy a hook script to a convenient location, then reference it in
+`~/.claude/settings.json` (global) or `.claude/settings.json` (project-local):
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /path/to/session_auto_title_example.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+See the [hooks documentation](https://docs.anthropic.com/en/docs/claude-code/hooks)
+for all supported events, matcher syntax, and output formats.

--- a/examples/hooks/session_auto_title_example.js
+++ b/examples/hooks/session_auto_title_example.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Claude Code Hook: Session Auto-Title (JavaScript)
+ * ==================================================
+ * This hook runs as a UserPromptSubmit hook.
+ * On the FIRST message of each new session it injects an additionalContext
+ * instruction that tells Claude to set a meaningful session title (via whatever
+ * title-setting mechanism is available — e.g. /rename or an MCP tool such as
+ * mcp__happy__change_title from the Happy app).
+ *
+ * Without this hook, title-setting relies solely on the system prompt, which is
+ * less reliable because MCP tool schemas are loaded lazily (deferred). Injecting
+ * the instruction directly into the first user-message turn — the same technique
+ * used for Codex / Gemini integrations — makes auto-titling deterministic.
+ *
+ * Read more about hooks here: https://docs.anthropic.com/en/docs/claude-code/hooks
+ *
+ * HOW IT WORKS
+ * ------------
+ * * Uses CLAUDE_SESSION_ID to create a tiny per-session flag file in the OS temp
+ *   directory (/tmp on Linux/macOS, %TEMP% on Windows).
+ * * First call  → writes flag, outputs additionalContext JSON → Claude sets title.
+ * * Later calls → flag exists, hook exits 0 silently (no overhead).
+ * * Flag files are cleaned up automatically by the OS on reboot.
+ *
+ * SETUP
+ * -----
+ * Add to ~/.claude/settings.json (global) or .claude/settings.json (project):
+ *
+ * {
+ *   "hooks": {
+ *     "UserPromptSubmit": [
+ *       {
+ *         "hooks": [
+ *           {
+ *             "type": "command",
+ *             "command": "node /path/to/claude-code/examples/hooks/session_auto_title_example.js"
+ *           }
+ *         ]
+ *       }
+ *     ]
+ *   }
+ * }
+ *
+ * UserPromptSubmit hooks have no "matcher" field (they always run).
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Instruction injected into the model context on the first turn.
+// Tells Claude to set a concise title that represents the session topic.
+// If no title-setting tool is available, Claude is instructed to skip gracefully.
+const TITLE_INSTRUCTION = [
+  'IMPORTANT — this is the first message of a new session.',
+  'Please set a short, descriptive session title (≤60 chars) that captures',
+  'what this conversation is about.',
+  '• If the mcp__happy__change_title tool is available:',
+  '  call ToolSearch with query "select:mcp__happy__change_title",',
+  '  then call mcp__happy__change_title with the title.',
+  '• Otherwise, use the /rename slash command.',
+  'Do this alongside your first response — not after.',
+].join('\n');
+
+/**
+ * Return a per-session flag file path in the OS temp directory.
+ * @param {string} sessionId
+ * @returns {string}
+ */
+function flagPath(sessionId) {
+  return path.join(os.tmpdir(), `cc-autotitle-${sessionId}.done`);
+}
+
+function main() {
+  const sessionId = process.env.CLAUDE_SESSION_ID;
+
+  if (!sessionId) {
+    // No session ID — nothing to do.
+    process.exit(0);
+  }
+
+  const flag = flagPath(sessionId);
+
+  if (fs.existsSync(flag)) {
+    // Not the first message — skip silently.
+    process.exit(0);
+  }
+
+  // Mark this session so subsequent messages don't inject the instruction.
+  try {
+    // 'wx' flag = exclusive create; fails if the file already exists (race-safe).
+    fs.writeFileSync(flag, '1', { flag: 'wx' });
+  } catch (err) {
+    if (err.code === 'EEXIST') {
+      // Another process beat us to it — treat as "not first message".
+      process.exit(0);
+    }
+    // On other errors, still proceed — worst case we inject the instruction
+    // twice in a race, which is harmless.
+  }
+
+  // Output additionalContext to inject into the model's context window.
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'UserPromptSubmit',
+      additionalContext: TITLE_INSTRUCTION,
+    },
+  };
+
+  process.stdout.write(JSON.stringify(output));
+}
+
+main();

--- a/examples/hooks/session_auto_title_example.py
+++ b/examples/hooks/session_auto_title_example.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""
+Claude Code Hook: Session Auto-Title
+=====================================
+This hook runs as a UserPromptSubmit hook.
+On the FIRST message of each new session it injects an additionalContext
+instruction that tells Claude to set a meaningful session title (via whatever
+title-setting mechanism is available — e.g. /rename or an MCP tool such as
+mcp__happy__change_title from the Happy app).
+
+Without this hook, title-setting relies solely on the system prompt, which is
+less reliable because MCP tool schemas are loaded lazily (deferred). Injecting
+the instruction directly into the first user-message turn — the same technique
+used for Codex / Gemini integrations — makes auto-titling deterministic.
+
+Read more about hooks here: https://docs.anthropic.com/en/docs/claude-code/hooks
+
+HOW IT WORKS
+------------
+* Uses CLAUDE_SESSION_ID to create a tiny per-session flag file in the OS temp
+  directory (/tmp on Linux/macOS, %TEMP% on Windows).
+* First call  → writes flag, outputs additionalContext JSON → Claude sets title.
+* Later calls → flag exists, hook exits 0 silently (no overhead).
+* Flag files are cleaned up automatically by the OS on reboot.
+
+SETUP
+-----
+Add to ~/.claude/settings.json (global) or .claude/settings.json (project):
+
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /path/to/claude-code/examples/hooks/session_auto_title_example.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+
+UserPromptSubmit hooks have no "matcher" field (they always run).
+"""
+
+import json
+import os
+import sys
+import tempfile
+
+# Instruction injected into the model context on the first turn.
+# Tells Claude to set a concise title that represents the session topic.
+# If no title-setting tool is available, Claude is instructed to skip gracefully.
+_TITLE_INSTRUCTION = (
+    "IMPORTANT — this is the first message of a new session.\n"
+    "Please set a short, descriptive session title (≤60 chars) that captures "
+    "what this conversation is about.\n"
+    "• If the mcp__happy__change_title tool is available: "
+    "call ToolSearch with query 'select:mcp__happy__change_title', "
+    "then call mcp__happy__change_title with the title.\n"
+    "• Otherwise, use the /rename slash command.\n"
+    "Do this alongside your first response — not after."
+)
+
+
+def _flag_path(session_id: str) -> str:
+    """Return a per-session flag file path in the OS temp directory."""
+    return os.path.join(tempfile.gettempdir(), f"cc-autotitle-{session_id}.done")
+
+
+def main() -> None:
+    session_id = os.environ.get("CLAUDE_SESSION_ID", "")
+    if not session_id:
+        # No session ID — nothing to do.
+        sys.exit(0)
+
+    flag = _flag_path(session_id)
+
+    if os.path.exists(flag):
+        # Not the first message — skip silently.
+        sys.exit(0)
+
+    # Mark this session so subsequent messages don't inject the instruction.
+    try:
+        # 'x' flag = exclusive create; fails if the file already exists (race-safe).
+        with open(flag, "x") as fh:
+            fh.write("1")
+    except FileExistsError:
+        # Another process beat us to it — treat as "not first message".
+        sys.exit(0)
+
+    # Output additionalContext to inject into the model's context window.
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": _TITLE_INSTRUCTION,
+        }
+    }
+    print(json.dumps(output))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds `examples/hooks/session_auto_title_example.py` — a `UserPromptSubmit` hook that automatically injects a title-setting instruction into the model context on the **first message** of each new Claude Code session.

Related issue: #47176

## Problem

Session titling currently relies entirely on system-prompt injection (e.g. from the [Happy app](https://happy.engineering)), which is fragile:

- MCP tools like `mcp__happy__change_title` are **deferred** in Claude Code — their schemas are not pre-loaded
- Setting a title requires a two-step `ToolSearch → tool-call` sequence
- The LLM executes this inconsistently, leading to sessions with missing or stale titles that don't appear in `/resume`

## Solution

Inject the title instruction via `additionalContext` on the **first user-message turn** — the same technique already used by Happy for Codex and Gemini:

```python
output = {
    "hookSpecificOutput": {
        "hookEventName": "UserPromptSubmit",
        "additionalContext": _TITLE_INSTRUCTION,
    }
}
```

A per-session flag file in the OS temp directory (`/tmp/cc-autotitle-<session_id>.done`) ensures the instruction is injected exactly once, with zero overhead on subsequent messages.

## How it works

```
Session start (first message)
  → hook writes flag file
  → hook outputs additionalContext
  → model sets title (via mcp__happy__change_title or /rename)

All subsequent messages
  → flag file exists → hook exits 0 silently
```

## Usage

```json
{
  "hooks": {
    "UserPromptSubmit": [
      {
        "hooks": [
          {
            "type": "command",
            "command": "python3 /path/to/examples/hooks/session_auto_title_example.py"
          }
        ]
      }
    ]
  }
}
```

## Testing

```bash
# First call → outputs JSON with additionalContext
CLAUDE_SESSION_ID="test-123" python3 examples/hooks/session_auto_title_example.py
# → {"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": "..."}}

# Second call → silent (flag exists)
CLAUDE_SESSION_ID="test-123" python3 examples/hooks/session_auto_title_example.py
# → (no output, exit 0)
```

## Checklist

- [x] Follows the same style as `bash_command_validator_example.py`
- [x] Pure stdlib — no dependencies
- [x] Cross-platform (Linux / macOS / Windows via `tempfile.gettempdir()`)
- [x] Race-safe flag file creation (`open(..., 'x')`)
- [x] Degrades gracefully when `CLAUDE_SESSION_ID` is absent