### PR TITLE
feat(hookify): add ask action support

### DIFF
--- a/plugins/hookify/README.md
+++ b/plugins/hookify/README.md
@@ -92,6 +92,7 @@ This command could delete important files. Please:
 
 **Action field:**
 - `warn`: Shows warning but allows operation (default)
+- `ask`: Prompts for approval before the tool runs (PreToolUse only; `confirm` also works)
 - `block`: Prevents operation from executing (PreToolUse) or stops session (Stop events)
 
 ### Advanced Rule (Multiple Conditions)

--- a/plugins/hookify/commands/help.md
+++ b/plugins/hookify/commands/help.md
@@ -133,7 +133,7 @@ Use Python regex syntax:
 
 **No Restart Needed**: Hookify rules (`.local.md` files) take effect immediately on the next tool use. The hookify hooks are already loaded and read your rules dynamically.
 
-**Block or Warn**: Rules can either `block` operations (prevent execution) or `warn` (show message but allow). Set `action: block` or `action: warn` in the rule's frontmatter.
+**Warn, Ask, or Block**: Rules can `warn` (show message but allow), `ask` (show a native approval prompt before the tool runs), or `block` (prevent execution). Set `action: warn`, `action: ask`/`action: confirm`, or `action: block` in the rule's frontmatter.
 
 **Rule Files**: Keep rules in `.claude/hookify.*.local.md` - they should be git-ignored (add to .gitignore if needed).
 

--- a/plugins/hookify/commands/hookify.md
+++ b/plugins/hookify/commands/hookify.md
@@ -69,9 +69,10 @@ After gathering behaviors (from arguments or agent), present to user using AskUs
   - Description: Why it's problematic
 
 **Question 2: For each selected behavior, ask about action:**
-- "Should this block the operation or just warn?"
+- "Should this warn, ask for approval, or block the operation?"
 - Options:
   - "Just warn" (action: warn - shows message but allows)
+  - "Ask first" (action: ask - shows a native approval prompt before running)
   - "Block operation" (action: block - prevents execution)
 
 **Question 3: Ask for example patterns:**
@@ -95,7 +96,7 @@ name: {rule-name}
 enabled: true
 event: {bash|file|stop|prompt|all}
 pattern: {regex pattern}
-action: {warn|block}
+action: {warn|ask|block}
 ---
 
 {Message to show Claude when rule triggers}
@@ -103,6 +104,7 @@ action: {warn|block}
 
 **Action values:**
 - `warn`: Show message but allow operation (default)
+- `ask`: Prompt for approval before the tool runs (PreToolUse only; `confirm` also works)
 - `block`: Prevent operation or stop session
 
 **For more complex rules (multiple conditions):**

--- a/plugins/hookify/core/config_loader.py
+++ b/plugins/hookify/core/config_loader.py
@@ -12,6 +12,19 @@ from typing import List, Optional, Dict, Any
 from dataclasses import dataclass, field
 
 
+def normalize_action(action: Any) -> str:
+    """Normalize user-facing action aliases."""
+    if not isinstance(action, str):
+        return "warn"
+
+    normalized = action.strip().lower()
+    if normalized == "confirm":
+        return "ask"
+    if normalized in {"warn", "ask", "block"}:
+        return normalized
+    return "warn"
+
+
 @dataclass
 class Condition:
     """A single condition for matching."""
@@ -37,7 +50,7 @@ class Rule:
     event: str  # "bash", "file", "stop", "all", etc.
     pattern: Optional[str] = None  # Simple pattern (legacy)
     conditions: List[Condition] = field(default_factory=list)
-    action: str = "warn"  # "warn" or "block" (future)
+    action: str = "warn"  # "warn", "ask", or "block"
     tool_matcher: Optional[str] = None  # Override tool matching
     message: str = ""  # Message body from markdown
 
@@ -78,7 +91,7 @@ class Rule:
             event=frontmatter.get('event', 'all'),
             pattern=simple_pattern,
             conditions=conditions,
-            action=frontmatter.get('action', 'warn'),
+            action=normalize_action(frontmatter.get('action', 'warn')),
             tool_matcher=frontmatter.get('tool_matcher'),
             message=message.strip()
         )

--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -36,7 +36,8 @@ class RuleEngine:
         """Evaluate all rules and return combined results.
 
         Checks all rules and accumulates matches. Blocking rules take priority
-        over warning rules. All matching rule messages are combined.
+        over ask rules, which take priority over warning rules. All matching
+        rule messages are combined within the winning action bucket.
 
         Args:
             rules: List of Rule objects to evaluate
@@ -48,12 +49,15 @@ class RuleEngine:
         """
         hook_event = input_data.get('hook_event_name', '')
         blocking_rules = []
+        ask_rules = []
         warning_rules = []
 
         for rule in rules:
             if self._rule_matches(rule, input_data):
                 if rule.action == 'block':
                     blocking_rules.append(rule)
+                elif rule.action == 'ask' and hook_event == 'PreToolUse':
+                    ask_rules.append(rule)
                 else:
                     warning_rules.append(rule)
 
@@ -82,6 +86,17 @@ class RuleEngine:
                 return {
                     "systemMessage": combined_message
                 }
+
+        if ask_rules:
+            messages = [f"**[{r.name}]**\n{r.message}" for r in ask_rules]
+            combined_message = "\n\n".join(messages)
+            return {
+                "hookSpecificOutput": {
+                    "hookEventName": hook_event,
+                    "permissionDecision": "ask"
+                },
+                "systemMessage": combined_message
+            }
 
         # If only warnings, show them but allow operation
         if warning_rules:

--- a/plugins/hookify/skills/writing-rules/SKILL.md
+++ b/plugins/hookify/skills/writing-rules/SKILL.md
@@ -47,6 +47,7 @@ Can include markdown formatting, warnings, suggestions, etc.
 
 **action** (optional): What to do when rule matches
 - `warn`: Show message but allow operation (default)
+- `ask`: Prompt for approval before the tool runs (PreToolUse only; `confirm` also works)
 - `block`: Prevent operation (PreToolUse) or stop session (Stop events)
 - If omitted, defaults to `warn`
 

--- a/plugins/hookify/tests/test_rule_engine.py
+++ b/plugins/hookify/tests/test_rule_engine.py
@@ -1,0 +1,95 @@
+import sys
+import unittest
+from pathlib import Path
+
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+PLUGIN_PARENT = PLUGIN_ROOT.parent
+if str(PLUGIN_PARENT) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_PARENT))
+
+from hookify.core.config_loader import Condition, Rule, normalize_action
+from hookify.core.rule_engine import RuleEngine
+
+
+def make_rule(*, name: str, action: str, pattern: str = r"systemctl\s+restart") -> Rule:
+    return Rule(
+        name=name,
+        enabled=True,
+        event="bash",
+        conditions=[
+            Condition(
+                field="command",
+                operator="regex_match",
+                pattern=pattern,
+            )
+        ],
+        action=action,
+        message=f"{name} triggered",
+    )
+
+
+class RuleEngineAskActionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.engine = RuleEngine()
+        self.input_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "systemctl restart nginx"},
+        }
+
+    def test_pretooluse_ask_returns_permission_prompt(self) -> None:
+        result = self.engine.evaluate_rules([make_rule(name="confirm-systemctl", action="ask")], self.input_data)
+
+        self.assertEqual(
+            result,
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "ask",
+                },
+                "systemMessage": "**[confirm-systemctl]**\nconfirm-systemctl triggered",
+            },
+        )
+
+    def test_block_still_overrides_ask(self) -> None:
+        result = self.engine.evaluate_rules(
+            [
+                make_rule(name="confirm-systemctl", action="ask"),
+                make_rule(name="block-systemctl", action="block"),
+            ],
+            self.input_data,
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                },
+                "systemMessage": "**[block-systemctl]**\nblock-systemctl triggered",
+            },
+        )
+
+    def test_ask_falls_back_to_warning_for_non_pretool_events(self) -> None:
+        result = self.engine.evaluate_rules(
+            [make_rule(name="confirm-systemctl", action="ask")],
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"command": "systemctl restart nginx"},
+            },
+        )
+
+        self.assertEqual(
+            result,
+            {"systemMessage": "**[confirm-systemctl]**\nconfirm-systemctl triggered"},
+        )
+
+    def test_confirm_alias_normalizes_to_ask(self) -> None:
+        self.assertEqual(normalize_action("confirm"), "ask")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `action: ask` support for hookify rules on PreToolUse
- normalize `action: confirm` to the same approval flow for compatibility with the issue examples
- fall back to a warning on non-PreToolUse hooks where native approval prompts are not available
- document the new action and cover it with focused unittest coverage

## Testing
- `python3 -m unittest discover -s plugins/hookify/tests -p 'test_*.py'`

Closes #46996
