### PR TITLE
fix(security-guidance): use a cross-platform Python launcher

### DIFF
--- a/plugins/security-guidance/hooks/hooks.json
+++ b/plugins/security-guidance/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/security_reminder_hook.py"
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/run_python_hook.js ${CLAUDE_PLUGIN_ROOT}/hooks/security_reminder_hook.py"
           }
         ],
         "matcher": "Edit|Write|MultiEdit"

--- a/plugins/security-guidance/hooks/run_python_hook.js
+++ b/plugins/security-guidance/hooks/run_python_hook.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const { spawnSync } = require("node:child_process");
+
+function getPythonLaunchers(platform = process.platform) {
+  if (platform === "win32") {
+    return [
+      { command: "py", args: ["-3"] },
+      { command: "python", args: [] },
+      { command: "python3", args: [] },
+    ];
+  }
+
+  return [
+    { command: "python3", args: [] },
+    { command: "python", args: [] },
+  ];
+}
+
+function runPythonHook({
+  scriptPath,
+  stdin,
+  env = process.env,
+  platform = process.platform,
+  spawnImpl = spawnSync,
+}) {
+  for (const launcher of getPythonLaunchers(platform)) {
+    const result = spawnImpl(launcher.command, [...launcher.args, scriptPath], {
+      env,
+      input: stdin,
+      stdio: ["pipe", "pipe", "pipe"],
+      encoding: "utf8",
+    });
+
+    if (result.error?.code === "ENOENT") {
+      continue;
+    }
+
+    if (typeof result.stdout === "string" && result.stdout.length > 0) {
+      process.stdout.write(result.stdout);
+    }
+    if (typeof result.stderr === "string" && result.stderr.length > 0) {
+      process.stderr.write(result.stderr);
+    }
+
+    return result.status ?? (result.error ? 1 : 0);
+  }
+
+  return 0;
+}
+
+if (require.main === module) {
+  const scriptPath = process.argv[2];
+  if (!scriptPath) {
+    process.exit(0);
+  }
+
+  const stdin = fs.readFileSync(0);
+  process.exit(runPythonHook({ scriptPath, stdin }));
+}
+
+module.exports = {
+  getPythonLaunchers,
+  runPythonHook,
+};

--- a/plugins/security-guidance/hooks/run_python_hook.test.js
+++ b/plugins/security-guidance/hooks/run_python_hook.test.js
@@ -1,0 +1,54 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { getPythonLaunchers, runPythonHook } = require("./run_python_hook.js");
+
+test("prefers platform-appropriate Python launchers", () => {
+  assert.deepEqual(getPythonLaunchers("win32"), [
+    { command: "py", args: ["-3"] },
+    { command: "python", args: [] },
+    { command: "python3", args: [] },
+  ]);
+
+  assert.deepEqual(getPythonLaunchers("linux"), [
+    { command: "python3", args: [] },
+    { command: "python", args: [] },
+  ]);
+});
+
+test("falls back to the next launcher when the first command is missing", () => {
+  const calls = [];
+  const exitCode = runPythonHook({
+    scriptPath: "/tmp/hook.py",
+    stdin: '{"tool_name":"Edit"}',
+    platform: "win32",
+    spawnImpl: (command, args, options) => {
+      calls.push({ command, args, options });
+      if (command === "py") {
+        return { error: { code: "ENOENT" }, status: null, stdout: "", stderr: "" };
+      }
+      return { status: 0, stdout: "ok", stderr: "" };
+    },
+  });
+
+  assert.equal(exitCode, 0);
+  assert.deepEqual(
+    calls.map(({ command, args }) => ({ command, args })),
+    [
+      { command: "py", args: ["-3", "/tmp/hook.py"] },
+      { command: "python", args: ["/tmp/hook.py"] },
+    ],
+  );
+  assert.equal(calls[1].options.input, '{"tool_name":"Edit"}');
+});
+
+test("silently succeeds when no Python launcher is available", () => {
+  const exitCode = runPythonHook({
+    scriptPath: "/tmp/hook.py",
+    stdin: "",
+    platform: "win32",
+    spawnImpl: () => ({ error: { code: "ENOENT" }, status: null, stdout: "", stderr: "" }),
+  });
+
+  assert.equal(exitCode, 0);
+});


### PR DESCRIPTION
## Summary

- use a small Node launcher so the security-guidance hook can find Python on Windows and Unix-like systems
- preserve stdin/stdout passthrough for the existing Python reminder hook
- add focused tests for launcher selection and fallback behavior

## Testing

- node --test plugins/security-guidance/hooks/run_python_hook.test.js

Closes #46449
