### PR TITLE
fix(security-guidance): skip doc files for substring checks

### DIFF
--- a/plugins/security-guidance/hooks/security_reminder_hook.py
+++ b/plugins/security-guidance/hooks/security_reminder_hook.py
@@ -12,6 +12,15 @@ from datetime import datetime
 
 # Debug log file
 DEBUG_LOG_FILE = "/tmp/security-warnings-log.txt"
+DOC_LIKE_EXTENSIONS = {
+    ".adoc",
+    ".asciidoc",
+    ".markdown",
+    ".md",
+    ".mdx",
+    ".rst",
+    ".txt",
+}
 
 
 def debug_log(message):
@@ -180,10 +189,17 @@ def save_state(session_id, shown_warnings):
         pass  # Fail silently if we can't save state
 
 
+def is_doc_like_path(file_path):
+    """Return True for documentation/plaintext files that should skip code heuristics."""
+    _, extension = os.path.splitext(file_path)
+    return extension.lower() in DOC_LIKE_EXTENSIONS
+
+
 def check_patterns(file_path, content):
     """Check if file path or content matches any security patterns."""
     # Normalize path by removing leading slashes
     normalized_path = file_path.lstrip("/")
+    skip_content_rules = is_doc_like_path(normalized_path)
 
     for pattern in SECURITY_PATTERNS:
         # Check path-based patterns
@@ -191,7 +207,7 @@ def check_patterns(file_path, content):
             return pattern["ruleName"], pattern["reminder"]
 
         # Check content-based patterns
-        if "substrings" in pattern and content:
+        if "substrings" in pattern and content and not skip_content_rules:
             for substring in pattern["substrings"]:
                 if substring in content:
                     return pattern["ruleName"], pattern["reminder"]

--- a/plugins/security-guidance/hooks/test_security_reminder_hook.py
+++ b/plugins/security-guidance/hooks/test_security_reminder_hook.py
@@ -1,0 +1,45 @@
+import importlib.util
+import pathlib
+import unittest
+
+
+HOOK_PATH = pathlib.Path(__file__).with_name("security_reminder_hook.py")
+SPEC = importlib.util.spec_from_file_location("security_reminder_hook", HOOK_PATH)
+HOOK = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(HOOK)
+
+
+class SecurityReminderHookPatternTests(unittest.TestCase):
+    def test_doc_files_skip_exec_false_positive(self):
+        rule_name, reminder = HOOK.check_patterns(
+            "docs/sqlite-usage.md", "Use db.exec(schema) to initialize the database."
+        )
+
+        self.assertIsNone(rule_name)
+        self.assertIsNone(reminder)
+
+    def test_doc_files_skip_other_code_keyword_false_positives(self):
+        rule_name, reminder = HOOK.check_patterns(
+            "docs/rendering.mdx",
+            "Use dangerouslySetInnerHTML only after sanitizing trusted HTML.",
+        )
+
+        self.assertIsNone(rule_name)
+        self.assertIsNone(reminder)
+
+    def test_source_files_still_trigger_exec_warning(self):
+        rule_name, _ = HOOK.check_patterns(
+            "src/runner.js", "const child = exec(userInput);"
+        )
+
+        self.assertEqual(rule_name, "child_process_exec")
+
+    def test_path_based_workflow_warning_still_runs(self):
+        rule_name, _ = HOOK.check_patterns(".github/workflows/ci.yml", "name: CI")
+
+        self.assertEqual(rule_name, "github_actions_workflow")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- skip substring-based security heuristics for documentation and plaintext file extensions
- keep path-based workflow checks and source-file warnings intact
- add focused tests for docs false positives, source-file warnings, and workflow path checks

## Testing

- python3 -m unittest plugins/security-guidance/hooks/test_security_reminder_hook.py

Closes #46720
