### PR TITLE
fix(plugin-dev): add missing .claude-plugin/plugin.json manifest

### DIFF
--- a/plugins/plugin-dev/.claude-plugin/plugin.json
+++ b/plugins/plugin-dev/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "plugin-dev",
+  "version": "0.1.0",
+  "description": "Comprehensive toolkit for developing Claude Code plugins. Includes 7 expert skills covering hooks, MCP integration, commands, agents, and best practices. AI-assisted plugin creation and validation.",
+  "author": {
+    "name": "Daisy Hollman",
+    "email": "daisy@anthropic.com"
+  }
+}


### PR DESCRIPTION
## Summary

The `plugin-dev` plugin is listed in [`.claude-plugin/marketplace.json`](https://github.com/anthropics/claude-code/blob/main/.claude-plugin/marketplace.json) but was the only plugin under `plugins/` without a `.claude-plugin/plugin.json` manifest. All 12 other plugins have one.

Without this manifest, installing `plugin-dev` from the bundled marketplace fails because the plugin loader cannot resolve its metadata at the source path.

## Change

Adds `plugins/plugin-dev/.claude-plugin/plugin.json` with `name`, `version`, `description`, and `author` matching the existing marketplace.json entry — same shape as the other plugins in this repo (e.g. hookify, feature-dev).

## Verification

```
$ ls plugins/*/.claude-plugin/plugin.json | wc -l
13   # was 12 before
$ jq . plugins/plugin-dev/.claude-plugin/plugin.json   # parses cleanly
```