### PR TITLE
docs(devcontainer): fix theme name typo in Dockerfile comment

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -68,7 +68,7 @@ ENV SHELL=/bin/zsh
 ENV EDITOR=nano
 ENV VISUAL=nano
 
-# Default powerline10k theme
+# Default powerlevel10k theme
 ARG ZSH_IN_DOCKER_VERSION=1.2.0
 RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/v${ZSH_IN_DOCKER_VERSION}/zsh-in-docker.sh)" -- \
   -p git \


### PR DESCRIPTION
## Summary

Tiny comment-only fix in `.devcontainer/Dockerfile`: the [zsh-in-docker](https://github.com/deluan/zsh-in-docker) script installs the **powerlevel10k** theme by default, not "powerline10k".

No functional change.