### PR TITLE
fix(plugins): make hookify and plugin-dev agent frontmatter valid YAML

### DIFF
--- a/plugins/hookify/agents/conversation-analyzer.md
+++ b/plugins/hookify/agents/conversation-analyzer.md
@@ -1,6 +1,13 @@
 ---
 name: conversation-analyzer
-description: Use this agent when analyzing conversation transcripts to find behaviors worth preventing with hooks. Examples: <example>Context: User is running /hookify command without arguments\nuser: "/hookify"\nassistant: "I'll analyze the conversation to find behaviors you want to prevent"\n<commentary>The /hookify command without arguments triggers conversation analysis to find unwanted behaviors.</commentary></example><example>Context: User wants to create hooks from recent frustrations\nuser: "Can you look back at this conversation and help me create hooks for the mistakes you made?"\nassistant: "I'll use the conversation-analyzer agent to identify the issues and suggest hooks."\n<commentary>User explicitly asks to analyze conversation for mistakes that should be prevented.</commentary></example>
+description: |-
+  Use this agent when analyzing conversation transcripts to find behaviors worth preventing with hooks. Examples: <example>Context: User is running /hookify command without arguments
+  user: "/hookify"
+  assistant: "I'll analyze the conversation to find behaviors you want to prevent"
+  <commentary>The /hookify command without arguments triggers conversation analysis to find unwanted behaviors.</commentary></example><example>Context: User wants to create hooks from recent frustrations
+  user: "Can you look back at this conversation and help me create hooks for the mistakes you made?"
+  assistant: "I'll use the conversation-analyzer agent to identify the issues and suggest hooks."
+  <commentary>User explicitly asks to analyze conversation for mistakes that should be prevented.</commentary></example>
 model: inherit
 color: yellow
 tools: ["Read", "Grep"]

--- a/plugins/plugin-dev/agents/agent-creator.md
+++ b/plugins/plugin-dev/agents/agent-creator.md
@@ -1,33 +1,34 @@
 ---
 name: agent-creator
-description: Use this agent when the user asks to "create an agent", "generate an agent", "build a new agent", "make me an agent that...", or describes agent functionality they need. Trigger when user wants to create autonomous agents for plugins. Examples:
+description: |-
+  Use this agent when the user asks to "create an agent", "generate an agent", "build a new agent", "make me an agent that...", or describes agent functionality they need. Trigger when user wants to create autonomous agents for plugins. Examples:
 
-<example>
-Context: User wants to create a code review agent
-user: "Create an agent that reviews code for quality issues"
-assistant: "I'll use the agent-creator agent to generate the agent configuration."
-<commentary>
-User requesting new agent creation, trigger agent-creator to generate it.
-</commentary>
-</example>
+  <example>
+  Context: User wants to create a code review agent
+  user: "Create an agent that reviews code for quality issues"
+  assistant: "I'll use the agent-creator agent to generate the agent configuration."
+  <commentary>
+  User requesting new agent creation, trigger agent-creator to generate it.
+  </commentary>
+  </example>
 
-<example>
-Context: User describes needed functionality
-user: "I need an agent that generates unit tests for my code"
-assistant: "I'll use the agent-creator agent to create a test generation agent."
-<commentary>
-User describes agent need, trigger agent-creator to build it.
-</commentary>
-</example>
+  <example>
+  Context: User describes needed functionality
+  user: "I need an agent that generates unit tests for my code"
+  assistant: "I'll use the agent-creator agent to create a test generation agent."
+  <commentary>
+  User describes agent need, trigger agent-creator to build it.
+  </commentary>
+  </example>
 
-<example>
-Context: User wants to add agent to plugin
-user: "Add an agent to my plugin that validates configurations"
-assistant: "I'll use the agent-creator agent to generate a configuration validator agent."
-<commentary>
-Plugin development with agent addition, trigger agent-creator.
-</commentary>
-</example>
+  <example>
+  Context: User wants to add agent to plugin
+  user: "Add an agent to my plugin that validates configurations"
+  assistant: "I'll use the agent-creator agent to generate a configuration validator agent."
+  <commentary>
+  Plugin development with agent addition, trigger agent-creator.
+  </commentary>
+  </example>
 
 model: sonnet
 color: magenta

--- a/plugins/plugin-dev/agents/plugin-validator.md
+++ b/plugins/plugin-dev/agents/plugin-validator.md
@@ -1,35 +1,36 @@
 ---
 name: plugin-validator
-description: Use this agent when the user asks to "validate my plugin", "check plugin structure", "verify plugin is correct", "validate plugin.json", "check plugin files", or mentions plugin validation. Also trigger proactively after user creates or modifies plugin components. Examples:
+description: |-
+  Use this agent when the user asks to "validate my plugin", "check plugin structure", "verify plugin is correct", "validate plugin.json", "check plugin files", or mentions plugin validation. Also trigger proactively after user creates or modifies plugin components. Examples:
 
-<example>
-Context: User finished creating a new plugin
-user: "I've created my first plugin with commands and hooks"
-assistant: "Great! Let me validate the plugin structure."
-<commentary>
-Plugin created, proactively validate to catch issues early.
-</commentary>
-assistant: "I'll use the plugin-validator agent to check the plugin."
-</example>
+  <example>
+  Context: User finished creating a new plugin
+  user: "I've created my first plugin with commands and hooks"
+  assistant: "Great! Let me validate the plugin structure."
+  <commentary>
+  Plugin created, proactively validate to catch issues early.
+  </commentary>
+  assistant: "I'll use the plugin-validator agent to check the plugin."
+  </example>
 
-<example>
-Context: User explicitly requests validation
-user: "Validate my plugin before I publish it"
-assistant: "I'll use the plugin-validator agent to perform comprehensive validation."
-<commentary>
-Explicit validation request triggers the agent.
-</commentary>
-</example>
+  <example>
+  Context: User explicitly requests validation
+  user: "Validate my plugin before I publish it"
+  assistant: "I'll use the plugin-validator agent to perform comprehensive validation."
+  <commentary>
+  Explicit validation request triggers the agent.
+  </commentary>
+  </example>
 
-<example>
-Context: User modified plugin.json
-user: "I've updated the plugin manifest"
-assistant: "Let me validate the changes."
-<commentary>
-Manifest modified, validate to ensure correctness.
-</commentary>
-assistant: "I'll use the plugin-validator agent to check the manifest."
-</example>
+  <example>
+  Context: User modified plugin.json
+  user: "I've updated the plugin manifest"
+  assistant: "Let me validate the changes."
+  <commentary>
+  Manifest modified, validate to ensure correctness.
+  </commentary>
+  assistant: "I'll use the plugin-validator agent to check the manifest."
+  </example>
 
 model: inherit
 color: yellow

--- a/plugins/plugin-dev/agents/skill-reviewer.md
+++ b/plugins/plugin-dev/agents/skill-reviewer.md
@@ -1,34 +1,35 @@
 ---
 name: skill-reviewer
-description: Use this agent when the user has created or modified a skill and needs quality review, asks to "review my skill", "check skill quality", "improve skill description", or wants to ensure skill follows best practices. Trigger proactively after skill creation. Examples:
+description: |-
+  Use this agent when the user has created or modified a skill and needs quality review, asks to "review my skill", "check skill quality", "improve skill description", or wants to ensure skill follows best practices. Trigger proactively after skill creation. Examples:
 
-<example>
-Context: User just created a new skill
-user: "I've created a PDF processing skill"
-assistant: "Great! Let me review the skill quality."
-<commentary>
-Skill created, proactively trigger skill-reviewer to ensure it follows best practices.
-</commentary>
-assistant: "I'll use the skill-reviewer agent to review the skill."
-</example>
+  <example>
+  Context: User just created a new skill
+  user: "I've created a PDF processing skill"
+  assistant: "Great! Let me review the skill quality."
+  <commentary>
+  Skill created, proactively trigger skill-reviewer to ensure it follows best practices.
+  </commentary>
+  assistant: "I'll use the skill-reviewer agent to review the skill."
+  </example>
 
-<example>
-Context: User requests skill review
-user: "Review my skill and tell me how to improve it"
-assistant: "I'll use the skill-reviewer agent to analyze the skill quality."
-<commentary>
-Explicit skill review request triggers the agent.
-</commentary>
-</example>
+  <example>
+  Context: User requests skill review
+  user: "Review my skill and tell me how to improve it"
+  assistant: "I'll use the skill-reviewer agent to analyze the skill quality."
+  <commentary>
+  Explicit skill review request triggers the agent.
+  </commentary>
+  </example>
 
-<example>
-Context: User modified skill description
-user: "I updated the skill description, does it look good?"
-assistant: "I'll use the skill-reviewer agent to review the changes."
-<commentary>
-Skill description modified, review for triggering effectiveness.
-</commentary>
-</example>
+  <example>
+  Context: User modified skill description
+  user: "I updated the skill description, does it look good?"
+  assistant: "I'll use the skill-reviewer agent to review the changes."
+  <commentary>
+  Skill description modified, review for triggering effectiveness.
+  </commentary>
+  </example>
 
 model: inherit
 color: cyan


### PR DESCRIPTION
## Summary

The `description:` field in four agent files under `plugins/hookify/` and `plugins/plugin-dev/` contains unquoted colon-space sequences (`Examples: `, `Context: `, `user: `, `assistant: `) that strict YAML parsers reject with:

```
yaml.scanner.ScannerError: mapping values are not allowed here
```

Claude Code's own frontmatter parser tolerates this, but third-party validators and linters fail on it (see #40370), and these are official example plugins that users copy as templates.

## Change

Wraps each `description` value in a `|-` literal block scalar with 2-space indentation. Description text is character-for-character preserved and agent body content is unchanged (one file, `plugin-validator.md`, also gains a trailing newline at EOF that was previously missing).

Files:
- `plugins/hookify/agents/conversation-analyzer.md`
- `plugins/plugin-dev/agents/agent-creator.md`
- `plugins/plugin-dev/agents/plugin-validator.md`
- `plugins/plugin-dev/agents/skill-reviewer.md`

This complements #44055, which applies the same approach to the six `pr-review-toolkit` agents but does not touch hookify or plugin-dev.

## Verification

```bash
$ for f in plugins/hookify/agents/*.md plugins/plugin-dev/agents/*.md; do
    python3 -c "import yaml; yaml.safe_load(open('$f').read().split('---',2)[1])" && echo "OK $f"
  done
OK plugins/hookify/agents/conversation-analyzer.md
OK plugins/plugin-dev/agents/agent-creator.md
OK plugins/plugin-dev/agents/plugin-validator.md
OK plugins/plugin-dev/agents/skill-reviewer.md
```

Refs #40370