### PR TITLE
feat(plugins): add usage monitor

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -25,6 +25,7 @@ Learn more in the [official plugins documentation](https://docs.claude.com/en/do
 | [pr-review-toolkit](./pr-review-toolkit/) | Comprehensive PR review agents specializing in comments, tests, error handling, type design, code quality, and code simplification | **Command:** `/pr-review-toolkit:review-pr` - Run with optional review aspects (comments, tests, errors, types, code, simplify, all)<br>**Agents:** `comment-analyzer`, `pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer`, `code-reviewer`, `code-simplifier` |
 | [ralph-wiggum](./ralph-wiggum/) | Interactive self-referential AI loops for iterative development. Claude works on the same task repeatedly until completion | **Commands:** `/ralph-loop`, `/cancel-ralph` - Start/stop autonomous iteration loops<br>**Hook:** Stop - Intercepts exit attempts to continue iteration |
 | [security-guidance](./security-guidance/) | Security reminder hook that warns about potential security issues when editing files | **Hook:** PreToolUse - Monitors 9 security patterns including command injection, XSS, eval usage, dangerous HTML, pickle deserialization, and os.system calls |
+| [usage-monitor](./usage-monitor/) | macOS SwiftBar usage widget for Claude Code with a bundled installer and cached `/usage` fetcher | **Command:** `/usage-monitor:install-swiftbar` - Install the SwiftBar widget and runtime scripts into the user profile |
 
 ## Installation
 

--- a/plugins/usage-monitor/.claude-plugin/plugin.json
+++ b/plugins/usage-monitor/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "usage-monitor",
+  "version": "1.0.0",
+  "description": "SwiftBar-backed Claude Code usage monitor for macOS with an installer command and cached usage fetcher",
+  "author": {
+    "name": "Codex"
+  }
+}

--- a/plugins/usage-monitor/README.md
+++ b/plugins/usage-monitor/README.md
@@ -1,0 +1,88 @@
+# Usage Monitor Plugin
+
+SwiftBar-backed usage monitoring for Claude Code on macOS.
+
+This plugin packages a small installer plus two shell scripts:
+
+- a cached usage fetcher that drives Claude Code’s built-in `/usage` screen in a non-interactive TTY session
+- a SwiftBar menu bar plugin that renders the latest cached totals and can trigger manual refreshes
+
+## Why this plugin exists
+
+The built-in `/usage` command is useful, but it requires opening Claude Code and checking manually. This plugin turns that same data into a glanceable macOS menu bar widget.
+
+It is intentionally scoped to macOS because the request behind it is specifically for a SwiftBar-based monitor.
+
+## What it installs
+
+- `claude-usage-fetch.sh`
+  - Captures `/usage` output through a scripted Claude Code session
+  - Parses percentages and reset windows
+  - Writes a local cache JSON file
+- `claude-usage.1m.sh`
+  - SwiftBar plugin that reads the cache
+  - Shows the current session, weekly all-model, and weekly Sonnet usage buckets
+  - Triggers background refresh when the cache is stale
+- `/usage-monitor:install-swiftbar`
+  - Copies the scripts into `~/.claude/plugins/usage-monitor`
+  - Writes a local config file with the current project as the trusted directory
+  - Symlinks the SwiftBar plugin into `~/Library/Application Support/SwiftBar/Plugins/`
+
+## Install
+
+1. Install dependencies:
+
+```bash
+brew install --cask swiftbar
+brew install jq
+```
+
+2. In a trusted project directory, run the command:
+
+```text
+/usage-monitor:install-swiftbar
+```
+
+3. Start or refresh SwiftBar.
+4. Click `Refresh now` in the menu once to seed the first cache entry.
+
+## Display format
+
+The menu bar title uses this format:
+
+```text
+🟢 7%(11am)┊34%(3d)┊19%(1d)
+```
+
+From left to right:
+
+- current session usage
+- weekly all-model usage
+- weekly Sonnet usage
+
+The icon color follows the highest visible percentage:
+
+- `🟢` under 50%
+- `🟡` from 50% to 79%
+- `🔴` at 80% or above
+
+## Configuration
+
+The installer writes `~/.claude/plugins/usage-monitor/config.env`.
+
+Supported settings:
+
+- `CLAUDE_USAGE_MONITOR_TRUSTED_DIR`
+  - Directory the fetcher `cd`s into before launching Claude Code
+- `CLAUDE_USAGE_MONITOR_REFRESH_MINUTES`
+  - Staleness window before the SwiftBar plugin triggers a background refresh
+- `CLAUDE_USAGE_MONITOR_CLAUDE_BIN`
+  - Optional explicit path to the `claude` binary
+
+To change the trusted project later, rerun the installer command from the new directory.
+
+## Notes
+
+- This plugin is macOS-only.
+- The fetcher only reads and caches `/usage`; it does not call any external APIs directly.
+- If Claude Code, SwiftBar, or `jq` are missing, the installer exits with a clear error instead of writing a partial setup.

--- a/plugins/usage-monitor/commands/install-swiftbar.md
+++ b/plugins/usage-monitor/commands/install-swiftbar.md
@@ -1,0 +1,17 @@
+---
+allowed-tools: Bash(bash ${CLAUDE_PLUGIN_ROOT}/scripts/install-swiftbar.sh:*)
+description: Install the SwiftBar usage monitor plugin for Claude Code
+---
+
+## Context
+
+- Current working directory: !`pwd`
+- Current OS: !`uname -s`
+
+## Your task
+
+1. Verify the current OS is macOS.
+2. Run `bash "${CLAUDE_PLUGIN_ROOT}/scripts/install-swiftbar.sh" --trusted-dir "$(pwd)"`.
+3. Summarize the installed paths, any dependency warnings, and the next step for the user.
+
+Do not edit anything manually outside the installer script.

--- a/plugins/usage-monitor/scripts/claude-usage-fetch.sh
+++ b/plugins/usage-monitor/scripts/claude-usage-fetch.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
+CONFIG_FILE="${SCRIPT_DIR}/config.env"
+
+if [ -f "$CONFIG_FILE" ]; then
+  # shellcheck disable=SC1090
+  source "$CONFIG_FILE"
+fi
+
+TRUSTED_DIR="${CLAUDE_USAGE_MONITOR_TRUSTED_DIR:-$HOME}"
+CACHE_FILE="${CLAUDE_USAGE_MONITOR_CACHE_FILE:-${SCRIPT_DIR}/cache.json}"
+SESSION_FILE="${CLAUDE_USAGE_MONITOR_SESSION_FILE:-${SCRIPT_DIR}/session.txt}"
+LOCK_FILE="${CLAUDE_USAGE_MONITOR_LOCK_FILE:-${SCRIPT_DIR}/fetch.lock}"
+CLAUDE_BIN="${CLAUDE_USAGE_MONITOR_CLAUDE_BIN:-$(command -v claude || true)}"
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  exit 0
+fi
+
+if [ -z "$CLAUDE_BIN" ] || [ ! -x "$CLAUDE_BIN" ]; then
+  exit 0
+fi
+
+mkdir -p "$SCRIPT_DIR"
+
+if [ -f "$LOCK_FILE" ]; then
+  lock_age=$(( $(date +%s) - $(stat -f%m "$LOCK_FILE") ))
+  if [ "$lock_age" -lt 60 ]; then
+    exit 0
+  fi
+fi
+
+printf '%s\n' "$$" >"$LOCK_FILE"
+trap 'rm -f "$LOCK_FILE"' EXIT
+
+cd "$TRUSTED_DIR"
+
+{
+  sleep 4
+  printf "\r"
+  sleep 8
+  printf "/usage\r"
+  sleep 8
+  printf "\033"
+  sleep 2
+  printf "/exit\r"
+  sleep 2
+} | TERM=dumb script -q "$SESSION_FILE" "$CLAUDE_BIN" \
+  --no-chrome \
+  --disallowedTools "Bash,Edit,Write,Read,Grep,Glob,Agent" \
+  2>/dev/null
+
+cleaned_output="$(perl -pe '
+  s/\e\[\d*C/ /g;
+  s/\e\[\?[^a-zA-Z]*[a-zA-Z]//g;
+  s/\e\[[^a-zA-Z]*[a-zA-Z]//g;
+  s/\e\][^\a]*(\a|\e\\)//g;
+  s/\e\([A-Z]//g;
+  s/\e[=>]//g;
+  s/[\x00-\x08\x0b\x0c\x0e-\x1f]//g;
+  s/\s+/ /g;
+' "$SESSION_FILE" 2>/dev/null || true)"
+
+extract_percentages() {
+  printf '%s\n' "$cleaned_output" | grep -oE '[0-9]+%[[:space:]]*used' | sed 's/% *used//' | head -3
+}
+
+extract_resets() {
+  printf '%s\n' "$cleaned_output" | perl -ne '
+    while (/Rese[\w\s]*?\s+((?:[A-Z][a-z]{2}\s+\d+[,.]?\s+)?\d+(?::\d+)?\s*[ap]?\s*m)\b/gi) {
+      print "$1\n";
+    }
+  ' | head -3
+}
+
+calc_remaining() {
+  local raw="$1"
+  [ -z "$raw" ] && printf '?\n' && return
+
+  local month
+  local day
+  month="$(printf '%s\n' "$raw" | perl -ne 'print $1 if /^([A-Z][a-z]{2})/i')"
+  day="$(printf '%s\n' "$raw" | perl -ne 'print $1 if /^[A-Za-z]{3}\s*(\d+)/')"
+
+  if [ -n "$month" ] && [ -n "$day" ]; then
+    month="$(printf '%s\n' "$month" | perl -pe '$_ = ucfirst(lc($_))')"
+    local target_epoch
+    local today_midnight
+    target_epoch="$(date -j -f "%b %d %Y %H%M" "$month $day $(date +%Y) 0000" +%s 2>/dev/null || true)"
+    today_midnight="$(date -j -f "%Y%m%d %H%M" "$(date +%Y%m%d) 0000" +%s 2>/dev/null || true)"
+    if [ -n "$target_epoch" ] && [ -n "$today_midnight" ]; then
+      local days
+      days=$(( (target_epoch - today_midnight) / 86400 ))
+      if [ "$days" -le 0 ]; then
+        printf 'today\n'
+      else
+        printf '%sd\n' "$days"
+      fi
+      return
+    fi
+  fi
+
+  local time_label
+  time_label="$(printf '%s\n' "$raw" | grep -oiE '[0-9]+(:[0-9]+)?\s*[ap]?\s*m' || true)"
+  if [ -n "$time_label" ]; then
+    time_label="$(printf '%s\n' "$time_label" | perl -pe 's/\s+//g')"
+    time_label="$(printf '%s\n' "$time_label" | perl -pe 'if (/^(\d+)(:\d+)?m$/i) { my $h=$1; $h<=6 ? s/m$/am/i : s/m$/pm/i }')"
+    printf '%s\n' "$time_label"
+    return
+  fi
+
+  printf '?\n'
+}
+
+percentages="$(extract_percentages)"
+resets="$(extract_resets)"
+
+session_pct="$(printf '%s\n' "$percentages" | sed -n '1p')"
+week_all_pct="$(printf '%s\n' "$percentages" | sed -n '2p')"
+week_sonnet_pct="$(printf '%s\n' "$percentages" | sed -n '3p')"
+
+if ! [[ "${session_pct:-}" =~ ^[0-9]+$ ]]; then
+  exit 0
+fi
+
+session_reset="$(calc_remaining "$(printf '%s\n' "$resets" | sed -n '1p')")"
+week_all_reset="$(calc_remaining "$(printf '%s\n' "$resets" | sed -n '2p')")"
+week_sonnet_reset="$(calc_remaining "$(printf '%s\n' "$resets" | sed -n '3p')")"
+
+cat >"$CACHE_FILE" <<JSON
+{
+  "session": "${session_pct}",
+  "week_all": "${week_all_pct:-?}",
+  "week_sonnet": "${week_sonnet_pct:-?}",
+  "session_reset": "${session_reset:-?}",
+  "week_all_reset": "${week_all_reset:-?}",
+  "week_sonnet_reset": "${week_sonnet_reset:-?}",
+  "updated": "$(date '+%H:%M')"
+}
+JSON

--- a/plugins/usage-monitor/scripts/claude-usage.1m.sh
+++ b/plugins/usage-monitor/scripts/claude-usage.1m.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
+CONFIG_FILE="${SCRIPT_DIR}/config.env"
+
+if [ -f "$CONFIG_FILE" ]; then
+  # shellcheck disable=SC1090
+  source "$CONFIG_FILE"
+fi
+
+CACHE_FILE="${CLAUDE_USAGE_MONITOR_CACHE_FILE:-${SCRIPT_DIR}/cache.json}"
+LOCK_FILE="${CLAUDE_USAGE_MONITOR_LOCK_FILE:-${SCRIPT_DIR}/fetch.lock}"
+FETCHER="${SCRIPT_DIR}/claude-usage-fetch.sh"
+REFRESH_MINUTES="${CLAUDE_USAGE_MONITOR_REFRESH_MINUTES:-5}"
+
+refresh_now() {
+  "$FETCHER" >/dev/null 2>&1 &
+}
+
+if [ "${1:-}" = "refresh_now" ]; then
+  refresh_now
+  exit 0
+fi
+
+session_pct="?"
+week_all_pct="?"
+week_sonnet_pct="?"
+session_reset="?"
+week_all_reset="?"
+week_sonnet_reset="?"
+updated="never"
+
+if [ -f "$CACHE_FILE" ] && command -v jq >/dev/null 2>&1; then
+  session_pct="$(jq -r '.session // "?"' "$CACHE_FILE" 2>/dev/null || printf '?\n')"
+  week_all_pct="$(jq -r '.week_all // "?"' "$CACHE_FILE" 2>/dev/null || printf '?\n')"
+  week_sonnet_pct="$(jq -r '.week_sonnet // "?"' "$CACHE_FILE" 2>/dev/null || printf '?\n')"
+  session_reset="$(jq -r '.session_reset // "?"' "$CACHE_FILE" 2>/dev/null || printf '?\n')"
+  week_all_reset="$(jq -r '.week_all_reset // "?"' "$CACHE_FILE" 2>/dev/null || printf '?\n')"
+  week_sonnet_reset="$(jq -r '.week_sonnet_reset // "?"' "$CACHE_FILE" 2>/dev/null || printf '?\n')"
+  updated="$(jq -r '.updated // "never"' "$CACHE_FILE" 2>/dev/null || printf 'never\n')"
+fi
+
+max_pct=0
+for value in "$session_pct" "$week_all_pct" "$week_sonnet_pct"; do
+  if [[ "$value" =~ ^[0-9]+$ ]] && [ "$value" -gt "$max_pct" ]; then
+    max_pct="$value"
+  fi
+done
+
+icon="🟢"
+if [ "$max_pct" -ge 80 ]; then
+  icon="🔴"
+elif [ "$max_pct" -ge 50 ]; then
+  icon="🟡"
+fi
+
+title="${session_pct}%(${session_reset})┊${week_all_pct}%(${week_all_reset})┊${week_sonnet_pct}%(${week_sonnet_reset})"
+
+if [ "$session_pct" = "?" ]; then
+  echo "☁️ --% | color=#888888"
+else
+  echo "${icon} ${title} | color=white"
+fi
+
+echo "---"
+echo "Claude Code Usage | size=14"
+echo "---"
+echo "Session:       ${session_pct}% (reset ${session_reset})"
+echo "Week (all):    ${week_all_pct}% (reset ${week_all_reset})"
+echo "Week (sonnet): ${week_sonnet_pct}% (reset ${week_sonnet_reset})"
+echo "---"
+echo "Updated: ${updated} | size=11 color=#888888"
+echo "Refresh now | bash='${SCRIPT_DIR}/claude-usage.1m.sh' param1=refresh_now terminal=false refresh=true"
+
+if [ -f "$CACHE_FILE" ]; then
+  cache_age=$(( $(date +%s) - $(stat -f%m "$CACHE_FILE") ))
+  refresh_window=$(( REFRESH_MINUTES * 60 ))
+  if [ "$cache_age" -ge "$refresh_window" ] && [ ! -f "$LOCK_FILE" ]; then
+    refresh_now
+  fi
+else
+  refresh_now
+fi

--- a/plugins/usage-monitor/scripts/install-swiftbar.sh
+++ b/plugins/usage-monitor/scripts/install-swiftbar.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "usage-monitor only supports macOS because it installs a SwiftBar plugin." >&2
+  exit 1
+fi
+
+TRUSTED_DIR="$PWD"
+REFRESH_MINUTES="5"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --trusted-dir)
+      TRUSTED_DIR="${2:?missing value for --trusted-dir}"
+      shift 2
+      ;;
+    --refresh-minutes)
+      REFRESH_MINUTES="${2:?missing value for --refresh-minutes}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$REFRESH_MINUTES" =~ ^[0-9]+$ ]] || [ "$REFRESH_MINUTES" -le 0 ]; then
+  echo "--refresh-minutes must be a positive integer." >&2
+  exit 1
+fi
+
+if [ ! -d "$TRUSTED_DIR" ]; then
+  echo "Trusted directory does not exist: $TRUSTED_DIR" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Missing dependency: jq. Install it with 'brew install jq'." >&2
+  exit 1
+fi
+
+if ! command -v script >/dev/null 2>&1; then
+  echo "Missing dependency: script (part of macOS)." >&2
+  exit 1
+fi
+
+TARGET_DIR="$HOME/.claude/plugins/usage-monitor"
+SWIFTBAR_DIR="$HOME/Library/Application Support/SwiftBar/Plugins"
+PLUGIN_SOURCE_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
+
+mkdir -p "$TARGET_DIR" "$SWIFTBAR_DIR"
+
+cp "$PLUGIN_SOURCE_DIR/claude-usage-fetch.sh" "$TARGET_DIR/claude-usage-fetch.sh"
+cp "$PLUGIN_SOURCE_DIR/claude-usage.1m.sh" "$TARGET_DIR/claude-usage.1m.sh"
+chmod +x "$TARGET_DIR/claude-usage-fetch.sh" "$TARGET_DIR/claude-usage.1m.sh"
+
+cat >"$TARGET_DIR/config.env" <<EOF
+CLAUDE_USAGE_MONITOR_TRUSTED_DIR=${TRUSTED_DIR}
+CLAUDE_USAGE_MONITOR_REFRESH_MINUTES=${REFRESH_MINUTES}
+CLAUDE_USAGE_MONITOR_CACHE_FILE=${TARGET_DIR}/cache.json
+CLAUDE_USAGE_MONITOR_SESSION_FILE=${TARGET_DIR}/session.txt
+CLAUDE_USAGE_MONITOR_LOCK_FILE=${TARGET_DIR}/fetch.lock
+EOF
+
+ln -sf "$TARGET_DIR/claude-usage.1m.sh" "$SWIFTBAR_DIR/claude-usage.1m.sh"
+
+cat <<EOF
+Installed usage-monitor.
+
+Files:
+- SwiftBar plugin: $SWIFTBAR_DIR/claude-usage.1m.sh
+- Runtime directory: $TARGET_DIR
+- Trusted directory: $TRUSTED_DIR
+
+Next steps:
+1. Install SwiftBar if needed: brew install --cask swiftbar
+2. Start or refresh SwiftBar
+3. Click "Refresh now" in the menu once to seed the initial cache
+EOF


### PR DESCRIPTION
## Summary

- adds an official `usage-monitor` plugin under `plugins/`
- includes a macOS SwiftBar installer command, cached `/usage` fetcher, and menu bar renderer instead of requiring users to stitch together external scripts manually
- keeps the install flow self-contained by copying the runtime scripts into `~/.claude/plugins/usage-monitor` and symlinking the SwiftBar entrypoint
- documents the install/config flow and adds the plugin to `plugins/README.md`

## Related issue

- Closes #46832

## Validation

- `bash -n plugins/usage-monitor/scripts/claude-usage-fetch.sh`
- `bash -n plugins/usage-monitor/scripts/claude-usage.1m.sh`
- `bash -n plugins/usage-monitor/scripts/install-swiftbar.sh`
- `jq empty plugins/usage-monitor/.claude-plugin/plugin.json`
- `HOME="$(mktemp -d)" bash plugins/usage-monitor/scripts/install-swiftbar.sh --trusted-dir "$PWD" --refresh-minutes 7`
- rendered a sample cache file through `plugins/usage-monitor/scripts/claude-usage.1m.sh` and verified the expected menu bar output
