### PR TITLE
fix(plugin-dev): align hook validator with plugin hooks format

### DIFF
--- a/plugins/plugin-dev/skills/hook-development/SKILL.md
+++ b/plugins/plugin-dev/skills/hook-development/SKILL.md
@@ -78,6 +78,7 @@ Execute bash commands for deterministic checks:
 - `description` field is optional
 - `hooks` field is required wrapper containing actual hook events
 - This is the **plugin-specific format**
+- `matcher` is optional; if omitted, the entry matches everything
 
 **Example:**
 ```json
@@ -383,6 +384,8 @@ In plugins, define hooks in `hooks/hooks.json`:
 Plugin hooks merge with user's hooks and run in parallel.
 
 ## Matchers
+
+**Important:** `matcher` is optional. If you omit it, the hook matches everything for that event.
 
 ### Tool Name Matching
 

--- a/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
@@ -4,7 +4,6 @@
 
 set -euo pipefail
 
-# Usage
 if [ $# -eq 0 ]; then
   echo "Usage: $0 <path/to/hooks.json>"
   echo ""
@@ -20,27 +19,32 @@ fi
 HOOKS_FILE="$1"
 
 if [ ! -f "$HOOKS_FILE" ]; then
-  echo "❌ Error: File not found: $HOOKS_FILE"
+  echo "Error: File not found: $HOOKS_FILE"
   exit 1
 fi
 
-echo "🔍 Validating hooks configuration: $HOOKS_FILE"
+echo "Validating hooks configuration: $HOOKS_FILE"
 echo ""
 
-# Check 1: Valid JSON
 echo "Checking JSON syntax..."
 if ! jq empty "$HOOKS_FILE" 2>/dev/null; then
-  echo "❌ Invalid JSON syntax"
+  echo "Invalid JSON syntax"
   exit 1
 fi
-echo "✅ Valid JSON"
+echo "Valid JSON"
 
-# Check 2: Root structure
+# Plugin hooks.json files use {"description": "...", "hooks": {...}}.
+# Settings-style files place events at the root. Support both layouts.
+HOOKS_QUERY="."
+if jq -e '.hooks and (.hooks | type == "object")' "$HOOKS_FILE" >/dev/null 2>&1; then
+  HOOKS_QUERY=".hooks"
+fi
+
 echo ""
 echo "Checking root structure..."
 VALID_EVENTS=("PreToolUse" "PostToolUse" "UserPromptSubmit" "Stop" "SubagentStop" "SessionStart" "SessionEnd" "PreCompact" "Notification")
 
-for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
+for event in $(jq -r "$HOOKS_QUERY | keys[]" "$HOOKS_FILE"); do
   found=false
   for valid_event in "${VALID_EVENTS[@]}"; do
     if [ "$event" = "$valid_event" ]; then
@@ -50,94 +54,85 @@ for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
   done
 
   if [ "$found" = false ]; then
-    echo "⚠️  Unknown event type: $event"
+    echo "Warning: Unknown event type: $event"
   fi
 done
-echo "✅ Root structure valid"
+echo "Root structure valid"
 
-# Check 3: Validate each hook
 echo ""
 echo "Validating individual hooks..."
 
 error_count=0
 warning_count=0
 
-for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
-  hook_count=$(jq -r ".\"$event\" | length" "$HOOKS_FILE")
+for event in $(jq -r "$HOOKS_QUERY | keys[]" "$HOOKS_FILE"); do
+  hook_count=$(jq -r "$HOOKS_QUERY.\"$event\" | length" "$HOOKS_FILE")
 
   for ((i=0; i<hook_count; i++)); do
-    # Check matcher exists
-    matcher=$(jq -r ".\"$event\"[$i].matcher // empty" "$HOOKS_FILE")
+    matcher=$(jq -r "$HOOKS_QUERY.\"$event\"[$i].matcher // empty" "$HOOKS_FILE")
     if [ -z "$matcher" ]; then
-      echo "❌ $event[$i]: Missing 'matcher' field"
-      ((error_count++))
-      continue
+      if [ "$event" = "PreToolUse" ] || [ "$event" = "PostToolUse" ]; then
+        echo "Warning: $event[$i] has no 'matcher' field and will match all tools"
+        ((warning_count++))
+      fi
     fi
 
-    # Check hooks array exists
-    hooks=$(jq -r ".\"$event\"[$i].hooks // empty" "$HOOKS_FILE")
+    hooks=$(jq -r "$HOOKS_QUERY.\"$event\"[$i].hooks // empty" "$HOOKS_FILE")
     if [ -z "$hooks" ] || [ "$hooks" = "null" ]; then
-      echo "❌ $event[$i]: Missing 'hooks' array"
+      echo "Error: $event[$i] is missing 'hooks' array"
       ((error_count++))
       continue
     fi
 
-    # Validate each hook in the array
-    hook_array_count=$(jq -r ".\"$event\"[$i].hooks | length" "$HOOKS_FILE")
+    hook_array_count=$(jq -r "$HOOKS_QUERY.\"$event\"[$i].hooks | length" "$HOOKS_FILE")
 
     for ((j=0; j<hook_array_count; j++)); do
-      hook_type=$(jq -r ".\"$event\"[$i].hooks[$j].type // empty" "$HOOKS_FILE")
+      hook_type=$(jq -r "$HOOKS_QUERY.\"$event\"[$i].hooks[$j].type // empty" "$HOOKS_FILE")
 
       if [ -z "$hook_type" ]; then
-        echo "❌ $event[$i].hooks[$j]: Missing 'type' field"
+        echo "Error: $event[$i].hooks[$j] is missing 'type' field"
         ((error_count++))
         continue
       fi
 
       if [ "$hook_type" != "command" ] && [ "$hook_type" != "prompt" ]; then
-        echo "❌ $event[$i].hooks[$j]: Invalid type '$hook_type' (must be 'command' or 'prompt')"
+        echo "Error: $event[$i].hooks[$j] has invalid type '$hook_type' (must be 'command' or 'prompt')"
         ((error_count++))
         continue
       fi
 
-      # Check type-specific fields
       if [ "$hook_type" = "command" ]; then
-        command=$(jq -r ".\"$event\"[$i].hooks[$j].command // empty" "$HOOKS_FILE")
+        command=$(jq -r "$HOOKS_QUERY.\"$event\"[$i].hooks[$j].command // empty" "$HOOKS_FILE")
         if [ -z "$command" ]; then
-          echo "❌ $event[$i].hooks[$j]: Command hooks must have 'command' field"
+          echo "Error: $event[$i].hooks[$j] command hook must have 'command' field"
           ((error_count++))
-        else
-          # Check for hardcoded paths
-          if [[ "$command" == /* ]] && [[ "$command" != *'${CLAUDE_PLUGIN_ROOT}'* ]]; then
-            echo "⚠️  $event[$i].hooks[$j]: Hardcoded absolute path detected. Consider using \${CLAUDE_PLUGIN_ROOT}"
-            ((warning_count++))
-          fi
+        elif [[ "$command" == /* ]] && [[ "$command" != *'${CLAUDE_PLUGIN_ROOT}'* ]]; then
+          echo "Warning: $event[$i].hooks[$j] uses hardcoded absolute path; consider \${CLAUDE_PLUGIN_ROOT}"
+          ((warning_count++))
         fi
-      elif [ "$hook_type" = "prompt" ]; then
-        prompt=$(jq -r ".\"$event\"[$i].hooks[$j].prompt // empty" "$HOOKS_FILE")
+      else
+        prompt=$(jq -r "$HOOKS_QUERY.\"$event\"[$i].hooks[$j].prompt // empty" "$HOOKS_FILE")
         if [ -z "$prompt" ]; then
-          echo "❌ $event[$i].hooks[$j]: Prompt hooks must have 'prompt' field"
+          echo "Error: $event[$i].hooks[$j] prompt hook must have 'prompt' field"
           ((error_count++))
         fi
 
-        # Check if prompt-based hooks are used on supported events
         if [ "$event" != "Stop" ] && [ "$event" != "SubagentStop" ] && [ "$event" != "UserPromptSubmit" ] && [ "$event" != "PreToolUse" ]; then
-          echo "⚠️  $event[$i].hooks[$j]: Prompt hooks may not be fully supported on $event (best on Stop, SubagentStop, UserPromptSubmit, PreToolUse)"
+          echo "Warning: $event[$i].hooks[$j] prompt hooks are best supported on Stop, SubagentStop, UserPromptSubmit, and PreToolUse"
           ((warning_count++))
         fi
       fi
 
-      # Check timeout
-      timeout=$(jq -r ".\"$event\"[$i].hooks[$j].timeout // empty" "$HOOKS_FILE")
+      timeout=$(jq -r "$HOOKS_QUERY.\"$event\"[$i].hooks[$j].timeout // empty" "$HOOKS_FILE")
       if [ -n "$timeout" ] && [ "$timeout" != "null" ]; then
         if ! [[ "$timeout" =~ ^[0-9]+$ ]]; then
-          echo "❌ $event[$i].hooks[$j]: Timeout must be a number"
+          echo "Error: $event[$i].hooks[$j] timeout must be a number"
           ((error_count++))
         elif [ "$timeout" -gt 600 ]; then
-          echo "⚠️  $event[$i].hooks[$j]: Timeout $timeout seconds is very high (max 600s)"
+          echo "Warning: $event[$i].hooks[$j] timeout $timeout seconds is very high (max 600s)"
           ((warning_count++))
         elif [ "$timeout" -lt 5 ]; then
-          echo "⚠️  $event[$i].hooks[$j]: Timeout $timeout seconds is very low"
+          echo "Warning: $event[$i].hooks[$j] timeout $timeout seconds is very low"
           ((warning_count++))
         fi
       fi
@@ -146,14 +141,14 @@ for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
 done
 
 echo ""
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "----------------------------------------"
 if [ $error_count -eq 0 ] && [ $warning_count -eq 0 ]; then
-  echo "✅ All checks passed!"
+  echo "All checks passed"
   exit 0
 elif [ $error_count -eq 0 ]; then
-  echo "⚠️  Validation passed with $warning_count warning(s)"
+  echo "Validation passed with $warning_count warning(s)"
   exit 0
 else
-  echo "❌ Validation failed with $error_count error(s) and $warning_count warning(s)"
+  echo "Validation failed with $error_count error(s) and $warning_count warning(s)"
   exit 1
 fi

--- a/plugins/plugin-dev/skills/plugin-structure/SKILL.md
+++ b/plugins/plugin-dev/skills/plugin-structure/SKILL.md
@@ -215,14 +215,17 @@ hooks/
 **Configuration format**:
 ```json
 {
-  "PreToolUse": [{
-    "matcher": "Write|Edit",
-    "hooks": [{
-      "type": "command",
-      "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/validate.sh",
-      "timeout": 30
+  "description": "Plugin hook configuration",
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "Write|Edit",
+      "hooks": [{
+        "type": "command",
+        "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/validate.sh",
+        "timeout": 30
+      }]
     }]
-  }]
+  }
 }
 ```
 

--- a/plugins/plugin-dev/skills/plugin-structure/references/component-patterns.md
+++ b/plugins/plugin-dev/skills/plugin-structure/references/component-patterns.md
@@ -306,10 +306,13 @@ hooks/
 **hooks.json**:
 ```json
 {
-  "PreToolUse": [...],
-  "PostToolUse": [...],
-  "Stop": [...],
-  "SessionStart": [...]
+  "description": "All hook definitions",
+  "hooks": {
+    "PreToolUse": [...],
+    "PostToolUse": [...],
+    "Stop": [...],
+    "SessionStart": [...]
+  }
 }
 ```
 
@@ -339,9 +342,12 @@ hooks/
 **hooks.json** (combines):
 ```json
 {
-  "PreToolUse": ${file:./pre-tool-use.json},
-  "PostToolUse": ${file:./post-tool-use.json},
-  "Stop": ${file:./stop.json}
+  "description": "Combined hook definitions",
+  "hooks": {
+    "PreToolUse": ${file:./pre-tool-use.json},
+    "PostToolUse": ${file:./post-tool-use.json},
+    "Stop": ${file:./stop.json}
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary
- update `validate-hook-schema.sh` to support plugin `hooks.json` wrapper format as well as direct settings-style hook maps
- make `matcher` optional during validation, with warnings only for `PreToolUse` and `PostToolUse`
- fix plugin-dev documentation examples so they consistently show wrapped plugin `hooks.json` format

## Why
The plugin-dev toolkit documented wrapped plugin hook files, but the validator still read hook events from the top-level JSON object and treated missing `matcher` as an error.

That caused the official validator to disagree with the repo’s own bundled plugin hook files and made the documentation inconsistent for plugin authors.

## Testing
- verified the edited files and resulting diff are clean with `git diff --check`
- verified the updated docs now consistently show wrapped plugin hook configuration
- could not run the bash validator directly in this Windows environment because Git Bash/MSYS fails with an access-denied error here
