### PR TITLE
fix: include cwd project dir in multi-worktree session discovery

### DIFF
--- a/src/services/session/getSessionFilesForWorktrees.ts
+++ b/src/services/session/getSessionFilesForWorktrees.ts
@@ -1,0 +1,146 @@
+/**
+ * Proposed fix for: --resume shows no sessions when cwd is a bare repo root
+ * with worktrees.
+ *
+ * Issue: https://github.com/anthropics/claude-code/issues/48110
+ *
+ * Root cause
+ * ----------
+ * `git worktree list --porcelain` does not include the bare repo root as a
+ * worktree entry — it lists only the `.bare` directory and each linked
+ * worktree.  When a user runs Claude from the bare root, sessions are created
+ * under `getProjectDir(cwd)` (e.g. `-Users-foo-work-repo`), but the resume
+ * picker's multi-worktree branch only scans project directories whose names
+ * match the *worktree* paths (e.g. `-Users-foo-work-repo--bare`,
+ * `-Users-foo-work-repo-develop`).  The bare root's project directory is
+ * never matched, so its sessions are invisible.
+ *
+ * Fix
+ * ---
+ * After the worktree-matching loop, ensure the current cwd's own project
+ * directory is always included in the scan set.  This is a no-op when the cwd
+ * is itself a worktree (already matched), and only adds a directory when the
+ * cwd falls outside the worktree list — exactly the bare-root case.
+ *
+ * The change below is shown as a complete, readable reconstruction of the
+ * function with the fix applied.  The only addition is the block marked
+ * "FIX" near the end.
+ */
+
+import { Dirent } from "fs";
+import { readdir } from "fs/promises";
+import { join, sep, basename } from "path";
+
+// -- Assumed imports from the existing codebase ----------------------------------
+// import { getCwd }            from "../cwd";
+// import { getProjectDir, getProjectsDir, sanitizePath } from "./projectDir";
+// import { getSessionFilesLite } from "./getSessionFilesLite";
+// import { deduplicateBySessionId } from "./dedup";
+
+interface SessionLog {
+  sessionId: string;
+  projectPath?: string;
+  [key: string]: unknown;
+}
+
+// Placeholder signatures — real implementations already exist in the codebase.
+declare function getCwd(): string;
+declare function getProjectDir(cwd: string): string;
+declare function getProjectsDir(): string;
+declare function sanitizePath(p: string): string;
+declare function getSessionFilesLite(
+  projectDir: string,
+  maxCount?: number,
+  projectPath?: string,
+): Promise<SessionLog[]>;
+declare function deduplicateBySessionId(logs: SessionLog[]): SessionLog[];
+declare function debug(msg: string): void;
+
+// ---------------------------------------------------------------------------
+
+export async function getSessionFilesForWorktrees(
+  worktreePaths: string[],
+  maxCount?: number,
+): Promise<SessionLog[]> {
+  const projectsDir = getProjectsDir();
+  const cwd = getCwd();
+
+  // Single / no worktree — just scan the cwd's project directory.
+  if (worktreePaths.length <= 1) {
+    return getSessionFilesLite(getProjectDir(cwd), undefined, cwd);
+  }
+
+  // Multi-worktree — scan every project directory that matches a worktree.
+  const isWindows = process.platform === "win32";
+
+  const prefixes = worktreePaths.map((wtPath) => {
+    const sanitized = sanitizePath(wtPath);
+    return {
+      path: wtPath,
+      prefix: isWindows ? sanitized.toLowerCase() : sanitized,
+    };
+  });
+
+  // Longest prefix first so the most-specific worktree wins.
+  prefixes.sort((a, b) => b.prefix.length - a.prefix.length);
+
+  const matched = new Set<string>();
+  let entries: Dirent[];
+
+  try {
+    entries = await readdir(projectsDir, { withFileTypes: true });
+  } catch (err) {
+    debug(
+      `Failed to read projects dir ${projectsDir}, falling back to current project: ${err}`,
+    );
+    return getSessionFilesLite(getProjectDir(cwd), maxCount, cwd);
+  }
+
+  const matchedDirs: Array<{ projectDir: string; wtPath: string }> = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+
+    const dirName = isWindows ? entry.name.toLowerCase() : entry.name;
+    if (matched.has(dirName)) continue;
+
+    for (const { path: wtPath, prefix } of prefixes) {
+      if (dirName === prefix || dirName.startsWith(prefix + "-")) {
+        matched.add(dirName);
+        matchedDirs.push({
+          projectDir: join(projectsDir, entry.name),
+          wtPath,
+        });
+        break;
+      }
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // FIX: Always include the cwd's own project directory.
+  //
+  // In a bare-repo layout the cwd (the repo root containing .git and .bare)
+  // is *not* listed by `git worktree list`, so the matching loop above will
+  // never pick it up — even though sessions are written there.  Adding it
+  // unconditionally is safe: deduplicateBySessionId() at the end of the
+  // pipeline already handles overlapping session IDs.
+  // -----------------------------------------------------------------------
+  const cwdProjectDir = getProjectDir(cwd);
+  const cwdDirName = isWindows
+    ? basename(cwdProjectDir).toLowerCase()
+    : basename(cwdProjectDir);
+
+  if (!matched.has(cwdDirName)) {
+    matchedDirs.push({ projectDir: cwdProjectDir, wtPath: cwd });
+  }
+  // -----------------------------------------------------------------------
+
+  // Load session files from all matched directories in parallel.
+  const allSessionFiles = await Promise.all(
+    matchedDirs.map(({ projectDir, wtPath }) =>
+      getSessionFilesLite(projectDir, undefined, wtPath),
+    ),
+  );
+
+  return deduplicateBySessionId(allSessionFiles.flat());
+}


### PR DESCRIPTION
## Summary

- Fixes `--resume` showing no sessions when the cwd is a bare repo root with linked worktrees
- Adds the cwd's own project directory to the multi-worktree scan set when it isn't already matched

Fixes #48110

## Problem

In a bare-repo + worktree layout (`git clone --bare` with `git worktree add`), `git worktree list --porcelain` does not include the bare root as a worktree entry — only `.bare` and linked worktrees appear:

```
worktree /home/user/repo/.bare
bare

worktree /home/user/repo/develop
HEAD abc123
branch refs/heads/develop
```

Session **creation** uses `getProjectDir(cwd)` which hashes the cwd directly, so sessions for `/home/user/repo` are stored in `~/.claude/projects/-home-user-repo/`.

Session **listing** (`getSessionFilesForWorktrees`) discovers worktrees via `git worktree list`, hashes each path, and scans `~/.claude/projects/` for matching directories. Since `/home/user/repo` is not in the worktree list, its project directory `-home-user-repo` is never matched — making all its sessions invisible to `--resume`.

## Fix

After the worktree-matching loop in `getSessionFilesForWorktrees`, always include `getProjectDir(getCwd())` in the scan set if it wasn't already matched:

```typescript
const cwdProjectDir = getProjectDir(cwd);
const cwdDirName = isWindows
  ? basename(cwdProjectDir).toLowerCase()
  : basename(cwdProjectDir);

if (!matched.has(cwdDirName)) {
  matchedDirs.push({ projectDir: cwdProjectDir, wtPath: cwd });
}
```

This is safe because `deduplicateBySessionId()` already handles overlapping session IDs, and it's a no-op when the cwd is itself a worktree (already matched by the loop).

## Reconstruction note

The attached file is a readable reconstruction of `getSessionFilesForWorktrees` (minified as `HaK` in the v2.1.108 bundle) with the fix applied. Since the product source is not in this repo, the file includes placeholder type declarations for the functions it calls. The actual change is the 6-line block marked `// FIX`.

## Test plan

- [ ] `git clone --bare <url> .bare && echo "gitdir: .bare" > .git && git worktree add develop develop`
- [ ] Run `claude` from the bare root, send a message, exit
- [ ] Run `claude --resume` — session should appear in the picker
- [ ] Run `claude --resume` from a linked worktree — sessions from both the worktree and bare root should appear
- [ ] Verify no regression for normal (non-bare) repos with and without worktrees