### PR TITLE
fix(hookify): support Write content for new_text rules

### DIFF
--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -237,7 +237,7 @@ class RuleEngine:
                 # Write uses 'content', Edit has 'new_string'
                 return tool_input.get('content') or tool_input.get('new_string', '')
             elif field == 'new_text' or field == 'new_string':
-                return tool_input.get('new_string', '')
+                return tool_input.get('new_string') or tool_input.get('content', '')
             elif field == 'old_text' or field == 'old_string':
                 return tool_input.get('old_string', '')
             elif field == 'file_path':


### PR DESCRIPTION
## Summary
- make `field: new_text` read `content` for Write tool payloads as well as `new_string` for Edit tool payloads

## Related issue
- Closes #48284

## Guideline alignment
- one focused runtime fix in a single plugin file
- no unrelated plugin, docs, or generated-file changes

## Validation
- `git diff --check`
- local Python assertion covering both Write and Edit extraction paths
