### PR TITLE
fix(feature-dev): use YAML lists for agent tools

### DIFF
--- a/plugins/feature-dev/agents/code-architect.md
+++ b/plugins/feature-dev/agents/code-architect.md
@@ -1,7 +1,17 @@
 ---
 name: code-architect
 description: Designs feature architectures by analyzing existing codebase patterns and conventions, then providing comprehensive implementation blueprints with specific files to create/modify, component designs, data flows, and build sequences
-tools: Glob, Grep, LS, Read, NotebookRead, WebFetch, TodoWrite, WebSearch, KillShell, BashOutput
+tools:
+  - Glob
+  - Grep
+  - LS
+  - Read
+  - NotebookRead
+  - WebFetch
+  - TodoWrite
+  - WebSearch
+  - KillShell
+  - BashOutput
 model: sonnet
 color: green
 ---

--- a/plugins/feature-dev/agents/code-explorer.md
+++ b/plugins/feature-dev/agents/code-explorer.md
@@ -1,7 +1,17 @@
 ---
 name: code-explorer
 description: Deeply analyzes existing codebase features by tracing execution paths, mapping architecture layers, understanding patterns and abstractions, and documenting dependencies to inform new development
-tools: Glob, Grep, LS, Read, NotebookRead, WebFetch, TodoWrite, WebSearch, KillShell, BashOutput
+tools:
+  - Glob
+  - Grep
+  - LS
+  - Read
+  - NotebookRead
+  - WebFetch
+  - TodoWrite
+  - WebSearch
+  - KillShell
+  - BashOutput
 model: sonnet
 color: yellow
 ---

--- a/plugins/feature-dev/agents/code-reviewer.md
+++ b/plugins/feature-dev/agents/code-reviewer.md
@@ -1,7 +1,17 @@
 ---
 name: code-reviewer
 description: Reviews code for bugs, logic errors, security vulnerabilities, code quality issues, and adherence to project conventions, using confidence-based filtering to report only high-priority issues that truly matter
-tools: Glob, Grep, LS, Read, NotebookRead, WebFetch, TodoWrite, WebSearch, KillShell, BashOutput
+tools:
+  - Glob
+  - Grep
+  - LS
+  - Read
+  - NotebookRead
+  - WebFetch
+  - TodoWrite
+  - WebSearch
+  - KillShell
+  - BashOutput
 model: sonnet
 color: red
 ---


### PR DESCRIPTION
## Summary
- convert the `tools` frontmatter in the `feature-dev` agents from a comma-separated string to proper YAML lists

## Related issue
- Part of #40370

## Guideline alignment
- one focused plugin-frontmatter fix in the `feature-dev` agent files only
- no unrelated command, README, or workflow changes

## Validation
- `git diff --check`
- local Ruby YAML parse confirming each agent now exposes `tools` as an array
