### PR TITLE
fix(plugin-dev): make agent-creator frontmatter valid YAML

### DIFF
--- a/plugins/plugin-dev/agents/agent-creator.md
+++ b/plugins/plugin-dev/agents/agent-creator.md
@@ -1,33 +1,36 @@
 ---
 name: agent-creator
-description: Use this agent when the user asks to "create an agent", "generate an agent", "build a new agent", "make me an agent that...", or describes agent functionality they need. Trigger when user wants to create autonomous agents for plugins. Examples:
+description: |
+  Use this agent when the user asks to "create an agent", "generate an agent", "build a new agent", "make me an agent that...", or describes agent functionality they need. Trigger when user wants to create autonomous agents for plugins.
 
-<example>
-Context: User wants to create a code review agent
-user: "Create an agent that reviews code for quality issues"
-assistant: "I'll use the agent-creator agent to generate the agent configuration."
-<commentary>
-User requesting new agent creation, trigger agent-creator to generate it.
-</commentary>
-</example>
+  Examples:
 
-<example>
-Context: User describes needed functionality
-user: "I need an agent that generates unit tests for my code"
-assistant: "I'll use the agent-creator agent to create a test generation agent."
-<commentary>
-User describes agent need, trigger agent-creator to build it.
-</commentary>
-</example>
+  <example>
+  Context: User wants to create a code review agent
+  user: "Create an agent that reviews code for quality issues"
+  assistant: "I'll use the agent-creator agent to generate the agent configuration."
+  <commentary>
+  User requesting new agent creation, trigger agent-creator to generate it.
+  </commentary>
+  </example>
 
-<example>
-Context: User wants to add agent to plugin
-user: "Add an agent to my plugin that validates configurations"
-assistant: "I'll use the agent-creator agent to generate a configuration validator agent."
-<commentary>
-Plugin development with agent addition, trigger agent-creator.
-</commentary>
-</example>
+  <example>
+  Context: User describes needed functionality
+  user: "I need an agent that generates unit tests for my code"
+  assistant: "I'll use the agent-creator agent to create a test generation agent."
+  <commentary>
+  User describes agent need, trigger agent-creator to build it.
+  </commentary>
+  </example>
+
+  <example>
+  Context: User wants to add agent to plugin
+  user: "Add an agent to my plugin that validates configurations"
+  assistant: "I'll use the agent-creator agent to generate a configuration validator agent."
+  <commentary>
+  Plugin development with agent addition, trigger agent-creator.
+  </commentary>
+  </example>
 
 model: sonnet
 color: magenta


### PR DESCRIPTION
## Summary
- rewrite the `agent-creator` frontmatter description as a YAML block scalar
- preserve the existing trigger examples while making the file parse cleanly

## Related Issue
- Part of #40370

## Guideline Alignment
- one focused syntax fix in a single maintained plugin file
- no behavioral or unrelated documentation changes

## Validation
- `ruby -e 'require "yaml"; ...'` to confirm the frontmatter parses and keeps the examples
- `git diff --check`
