### PR TITLE
fix(pr-review-toolkit): make code-reviewer frontmatter valid YAML

### DIFF
--- a/plugins/pr-review-toolkit/agents/code-reviewer.md
+++ b/plugins/pr-review-toolkit/agents/code-reviewer.md
@@ -1,6 +1,38 @@
 ---
 name: code-reviewer
-description: Use this agent when you need to review code for adherence to project guidelines, style guides, and best practices. This agent should be used proactively after writing or modifying code, especially before committing changes or creating pull requests. It will check for style violations, potential issues, and ensure code follows the established patterns in CLAUDE.md. Also the agent needs to know which files to focus on for the review. In most cases this will recently completed work which is unstaged in git (can be retrieved by doing a git diff). However there can be cases where this is different, make sure to specify this as the agent input when calling the agent. \n\nExamples:\n<example>\nContext: The user has just implemented a new feature with several TypeScript files.\nuser: "I've added the new authentication feature. Can you check if everything looks good?"\nassistant: "I'll use the Task tool to launch the code-reviewer agent to review your recent changes."\n<commentary>\nSince the user has completed a feature and wants validation, use the code-reviewer agent to ensure the code meets project standards.\n</commentary>\n</example>\n<example>\nContext: The assistant has just written a new utility function.\nuser: "Please create a function to validate email addresses"\nassistant: "Here's the email validation function:"\n<function call omitted for brevity>\nassistant: "Now I'll use the Task tool to launch the code-reviewer agent to review this implementation."\n<commentary>\nProactively use the code-reviewer agent after writing new code to catch issues early.\n</commentary>\n</example>\n<example>\nContext: The user is about to create a PR.\nuser: "I think I'm ready to create a PR for this feature"\nassistant: "Before creating the PR, I'll use the Task tool to launch the code-reviewer agent to ensure all code meets our standards."\n<commentary>\nProactively review code before PR creation to avoid review comments and iterations.\n</commentary>\n</example>
+description: |
+  Use this agent when you need to review code for adherence to project guidelines, style guides, and best practices. This agent should be used proactively after writing or modifying code, especially before committing changes or creating pull requests. It will check for style violations, potential issues, and ensure code follows the established patterns in CLAUDE.md. Also the agent needs to know which files to focus on for the review. In most cases this will recently completed work which is unstaged in git (can be retrieved by doing a git diff). However there can be cases where this is different, make sure to specify this as the agent input when calling the agent.
+
+  Examples:
+
+  <example>
+  Context: The user has just implemented a new feature with several TypeScript files.
+  user: "I've added the new authentication feature. Can you check if everything looks good?"
+  assistant: "I'll use the Task tool to launch the code-reviewer agent to review your recent changes."
+  <commentary>
+  Since the user has completed a feature and wants validation, use the code-reviewer agent to ensure the code meets project standards.
+  </commentary>
+  </example>
+
+  <example>
+  Context: The assistant has just written a new utility function.
+  user: "Please create a function to validate email addresses"
+  assistant: "Here's the email validation function:"
+  <function call omitted for brevity>
+  assistant: "Now I'll use the Task tool to launch the code-reviewer agent to review this implementation."
+  <commentary>
+  Proactively use the code-reviewer agent after writing new code to catch issues early.
+  </commentary>
+  </example>
+
+  <example>
+  Context: The user is about to create a PR.
+  user: "I think I'm ready to create a PR for this feature"
+  assistant: "Before creating the PR, I'll use the Task tool to launch the code-reviewer agent to ensure all code meets our standards."
+  <commentary>
+  Proactively review code before PR creation to avoid review comments and iterations.
+  </commentary>
+  </example>
 model: opus
 color: green
 ---


### PR DESCRIPTION
## Summary
- rewrite the `code-reviewer` frontmatter description as a YAML block scalar
- preserve the embedded trigger examples while making the agent file parse cleanly

## Related Issue
- Part of #40370

## Guideline Alignment
- one focused syntax fix in a single maintained plugin file
- no behavioral or unrelated review workflow changes

## Validation
- `ruby -e 'require "yaml"; ...'` to confirm the frontmatter parses and keeps the examples
- `git diff --check`
