### PR TITLE
fix(pr-review-toolkit): make code-simplifier frontmatter valid YAML

### DIFF
--- a/plugins/pr-review-toolkit/agents/code-simplifier.md
+++ b/plugins/pr-review-toolkit/agents/code-simplifier.md
@@ -1,37 +1,42 @@
 ---
 name: code-simplifier
-description: Use this agent when code has been written or modified and needs to be simplified for clarity, consistency, and maintainability while preserving all functionality. This agent should be triggered automatically after completing a coding task or writing a logical chunk of code. It simplifies code by following project best practices while retaining all functionality. The agent focuses only on recently modified code unless instructed otherwise.\n\nExamples:\n\n<example>
-Context: The assistant has just implemented a new feature that adds user authentication to an API endpoint.
-user: "Please add authentication to the /api/users endpoint"
-assistant: "I've implemented the authentication for the /api/users endpoint. Here's the code:"
-<function call omitted for brevity>
-<commentary>
-Since a logical chunk of code has been written (authentication feature), use the Task tool to launch the code-simplifier agent to improve the code's clarity and maintainability while preserving functionality.
-</commentary>
-assistant: "Now let me use the code-simplifier agent to refine this implementation for better clarity and maintainability"
-</example>
+description: |
+  Use this agent when code has been written or modified and needs to be simplified for clarity, consistency, and maintainability while preserving all functionality. This agent should be triggered automatically after completing a coding task or writing a logical chunk of code. It simplifies code by following project best practices while retaining all functionality. The agent focuses only on recently modified code unless instructed otherwise.
 
-<example>
-Context: The assistant has just fixed a bug by adding several conditional checks.
-user: "Fix the null pointer exception in the data processor"
-assistant: "I've added the necessary null checks to prevent the exception:"
-<function call omitted for brevity>
-<commentary>
-After modifying code to fix a bug, use the code-simplifier agent to ensure the fix follows best practices and maintains code quality.
-</commentary>
-assistant: "Let me refine this bug fix using the code-simplifier agent to ensure it follows our best practices"
-</example>
+  Examples:
 
-<example>
-Context: The assistant has just refactored a function to improve performance.
-user: "Optimize the data sorting algorithm for better performance"
-assistant: "I've optimized the sorting algorithm. Here's the updated implementation:"
-<function call omitted for brevity>
-<commentary>
-After completing a performance optimization task, use the code-simplifier agent to ensure the optimized code is also clear and maintainable.
-</commentary>
-assistant: "Now I'll use the code-simplifier agent to ensure the optimized code is also clear and follows our coding standards"
-</example>
+  <example>
+  Context: The assistant has just implemented a new feature that adds user authentication to an API endpoint.
+  user: "Please add authentication to the /api/users endpoint"
+  assistant: "I've implemented the authentication for the /api/users endpoint. Here's the code:"
+  <function call omitted for brevity>
+  <commentary>
+  Since a logical chunk of code has been written (authentication feature), use the Task tool to launch the code-simplifier agent to improve the code's clarity and maintainability while preserving functionality.
+  </commentary>
+  assistant: "Now let me use the code-simplifier agent to refine this implementation for better clarity and maintainability"
+  </example>
+
+  <example>
+  Context: The assistant has just fixed a bug by adding several conditional checks.
+  user: "Fix the null pointer exception in the data processor"
+  assistant: "I've added the necessary null checks to prevent the exception:"
+  <function call omitted for brevity>
+  <commentary>
+  After modifying code to fix a bug, use the code-simplifier agent to ensure the fix follows best practices and maintains code quality.
+  </commentary>
+  assistant: "Let me refine this bug fix using the code-simplifier agent to ensure it follows our best practices"
+  </example>
+
+  <example>
+  Context: The assistant has just refactored a function to improve performance.
+  user: "Optimize the data sorting algorithm for better performance"
+  assistant: "I've optimized the sorting algorithm. Here's the updated implementation:"
+  <function call omitted for brevity>
+  <commentary>
+  After completing a performance optimization task, use the code-simplifier agent to ensure the optimized code is also clear and maintainable.
+  </commentary>
+  assistant: "Now I'll use the code-simplifier agent to ensure the optimized code is also clear and follows our coding standards"
+  </example>
 model: opus
 ---
 


### PR DESCRIPTION
## Summary
- rewrite the `code-simplifier` frontmatter description as a YAML block scalar
- preserve the embedded trigger examples while making the agent file parse cleanly

## Related Issue
- Part of #40370

## Guideline Alignment
- one focused syntax fix in a single maintained plugin file
- no behavioral or unrelated review workflow changes

## Validation
- `ruby -e 'require "yaml"; ...'` to confirm the frontmatter parses and keeps the examples
- `git diff --check`
