### PR TITLE
fix(pr-review-toolkit): make pr-test-analyzer frontmatter valid YAML

### DIFF
--- a/plugins/pr-review-toolkit/agents/pr-test-analyzer.md
+++ b/plugins/pr-review-toolkit/agents/pr-test-analyzer.md
@@ -1,6 +1,36 @@
 ---
 name: pr-test-analyzer
-description: Use this agent when you need to review a pull request for test coverage quality and completeness. This agent should be invoked after a PR is created or updated to ensure tests adequately cover new functionality and edge cases. Examples:\n\n<example>\nContext: Daisy has just created a pull request with new functionality.\nuser: "I've created the PR. Can you check if the tests are thorough?"\nassistant: "I'll use the pr-test-analyzer agent to review the test coverage and identify any critical gaps."\n<commentary>\nSince Daisy is asking about test thoroughness in a PR, use the Task tool to launch the pr-test-analyzer agent.\n</commentary>\n</example>\n\n<example>\nContext: A pull request has been updated with new code changes.\nuser: "The PR is ready for review - I added the new validation logic we discussed"\nassistant: "Let me analyze the PR to ensure the tests adequately cover the new validation logic and edge cases."\n<commentary>\nThe PR has new functionality that needs test coverage analysis, so use the pr-test-analyzer agent.\n</commentary>\n</example>\n\n<example>\nContext: Reviewing PR feedback before marking as ready.\nuser: "Before I mark this PR as ready, can you double-check the test coverage?"\nassistant: "I'll use the pr-test-analyzer agent to thoroughly review the test coverage and identify any critical gaps before you mark it ready."\n<commentary>\nDaisy wants a final test coverage check before marking PR ready, use the pr-test-analyzer agent.\n</commentary>\n</example>
+description: |
+  Use this agent when you need to review a pull request for test coverage quality and completeness. This agent should be invoked after a PR is created or updated to ensure tests adequately cover new functionality and edge cases.
+
+  Examples:
+
+  <example>
+  Context: Daisy has just created a pull request with new functionality.
+  user: "I've created the PR. Can you check if the tests are thorough?"
+  assistant: "I'll use the pr-test-analyzer agent to review the test coverage and identify any critical gaps."
+  <commentary>
+  Since Daisy is asking about test thoroughness in a PR, use the Task tool to launch the pr-test-analyzer agent.
+  </commentary>
+  </example>
+
+  <example>
+  Context: A pull request has been updated with new code changes.
+  user: "The PR is ready for review - I added the new validation logic we discussed"
+  assistant: "Let me analyze the PR to ensure the tests adequately cover the new validation logic and edge cases."
+  <commentary>
+  The PR has new functionality that needs test coverage analysis, so use the pr-test-analyzer agent.
+  </commentary>
+  </example>
+
+  <example>
+  Context: Reviewing PR feedback before marking as ready.
+  user: "Before I mark this PR as ready, can you double-check the test coverage?"
+  assistant: "I'll use the pr-test-analyzer agent to thoroughly review the test coverage and identify any critical gaps before you mark it ready."
+  <commentary>
+  Daisy wants a final test coverage check before marking PR ready, use the pr-test-analyzer agent.
+  </commentary>
+  </example>
 model: inherit
 color: cyan
 ---


### PR DESCRIPTION
## Summary
- rewrite the `pr-test-analyzer` frontmatter description as a YAML block scalar
- preserve the embedded trigger examples while making the agent file parse cleanly under agnix

## Related Issue
- Part of #40370

## Guideline Alignment
- one focused syntax fix in a single maintained plugin file
- no behavioral or unrelated review workflow changes

## Validation
- `npx --yes agnix plugins/pr-review-toolkit/agents/pr-test-analyzer.md`
- `git diff --check`
