### PR TITLE
fix(pr-review-toolkit): make type-design-analyzer frontmatter valid YAML

### DIFF
--- a/plugins/pr-review-toolkit/agents/type-design-analyzer.md
+++ b/plugins/pr-review-toolkit/agents/type-design-analyzer.md
@@ -1,6 +1,25 @@
 ---
 name: type-design-analyzer
-description: Use this agent when you need expert analysis of type design in your codebase. Specifically use it: (1) when introducing a new type to ensure it follows best practices for encapsulation and invariant expression, (2) during pull request creation to review all types being added, (3) when refactoring existing types to improve their design quality. The agent will provide both qualitative feedback and quantitative ratings on encapsulation, invariant expression, usefulness, and enforcement.\n\n<example>\nContext: Daisy is writing code that introduces a new UserAccount type and wants to ensure it has well-designed invariants.\nuser: "I've just created a new UserAccount type that handles user authentication and permissions"\nassistant: "I'll use the type-design-analyzer agent to review the UserAccount type design"\n<commentary>\nSince a new type is being introduced, use the type-design-analyzer to ensure it has strong invariants and proper encapsulation.\n</commentary>\n</example>\n\n<example>\nContext: Daisy is creating a pull request and wants to review all newly added types.\nuser: "I'm about to create a PR with several new data model types"\nassistant: "Let me use the type-design-analyzer agent to review all the types being added in this PR"\n<commentary>\nDuring PR creation with new types, use the type-design-analyzer to review their design quality.\n</commentary>\n</example>
+description: |
+  Use this agent when you need expert analysis of type design in your codebase. Specifically use it: (1) when introducing a new type to ensure it follows best practices for encapsulation and invariant expression, (2) during pull request creation to review all types being added, (3) when refactoring existing types to improve their design quality. The agent will provide both qualitative feedback and quantitative ratings on encapsulation, invariant expression, usefulness, and enforcement.
+
+  <example>
+  Context: Daisy is writing code that introduces a new UserAccount type and wants to ensure it has well-designed invariants.
+  user: "I've just created a new UserAccount type that handles user authentication and permissions"
+  assistant: "I'll use the type-design-analyzer agent to review the UserAccount type design"
+  <commentary>
+  Since a new type is being introduced, use the type-design-analyzer to ensure it has strong invariants and proper encapsulation.
+  </commentary>
+  </example>
+
+  <example>
+  Context: Daisy is creating a pull request and wants to review all newly added types.
+  user: "I'm about to create a PR with several new data model types"
+  assistant: "Let me use the type-design-analyzer agent to review all the types being added in this PR"
+  <commentary>
+  During PR creation with new types, use the type-design-analyzer to review their design quality.
+  </commentary>
+  </example>
 model: inherit
 color: pink
 ---


### PR DESCRIPTION
## Summary
- rewrite the `type-design-analyzer` frontmatter description as a YAML block scalar
- preserve the embedded trigger examples while making the agent file parse cleanly under agnix

## Related Issue
- Part of #40370

## Guideline Alignment
- one focused syntax fix in a single maintained plugin file
- no behavioral or unrelated review workflow changes

## Validation
- `npx --yes agnix plugins/pr-review-toolkit/agents/type-design-analyzer.md`
- `git diff --check`
