### PR TITLE
fix(hookify): align writing-rules skill name with directory

### DIFF
--- a/plugins/hookify/skills/writing-rules/SKILL.md
+++ b/plugins/hookify/skills/writing-rules/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Writing Hookify Rules
+name: writing-rules
 description: This skill should be used when the user asks to "create a hookify rule", "write a hook rule", "configure hookify", "add a hookify rule", or needs guidance on hookify rule syntax and patterns.
 version: 0.1.0
 ---


### PR DESCRIPTION
## Summary
- rename the Hookify skill from `Writing Hookify Rules` to `writing-rules`
- align the skill name with the parent directory and agnix naming rules

## Related Issue
- Part of #40370

## Guideline Alignment
- one focused metadata fix in a single maintained plugin file
- no behavior or content changes beyond the invalid skill name

## Validation
- `npx --yes agnix plugins/hookify/skills/writing-rules/SKILL.md`
- `git diff --check`
