### PR TITLE
fix(plugin-dev): escape example tag in create-plugin docs

### DIFF
--- a/plugins/plugin-dev/commands/create-plugin.md
+++ b/plugins/plugin-dev/commands/create-plugin.md
@@ -250,7 +250,7 @@ Guide the user through creating a complete, high-quality Claude Code plugin from
    - Apply recommendations
 
 4. **Test agent triggering** (if plugin has agents):
-   - For each agent, verify <example> blocks are clear
+   - For each agent, verify `<example>` blocks are clear
    - Check triggering conditions are specific
    - Run validate-agent.sh on agent files
 


### PR DESCRIPTION
## Summary
- escape the literal `<example>` tag mention in `create-plugin.md`
- prevent agnix from treating the prose reference as an unclosed XML tag

## Related Issue
- Part of #40370

## Guideline Alignment
- one focused documentation syntax fix in a single maintained plugin file
- no workflow or behavior changes

## Validation
- `npx --yes agnix plugins/plugin-dev/commands/create-plugin.md`
- `git diff --check`
