### PR TITLE
fix(plugin-dev): align agent-development skill metadata

### DIFF
--- a/plugins/plugin-dev/skills/agent-development/SKILL.md
+++ b/plugins/plugin-dev/skills/agent-development/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Agent Development
+name: agent-development
 description: This skill should be used when the user asks to "create an agent", "add an agent", "write a subagent", "agent frontmatter", "when to use description", "agent examples", "agent tools", "agent colors", "autonomous agent", or needs guidance on agent structure, system prompts, triggering conditions, or agent development best practices for Claude Code plugins.
 version: 0.1.0
 ---
@@ -351,7 +351,7 @@ Output: [What to provide]
 | Field | Required | Format | Example |
 |-------|----------|--------|---------|
 | name | Yes | lowercase-hyphens | code-reviewer |
-| description | Yes | Text + examples | Use when... <example>... |
+| description | Yes | Text + examples | Use when... `<example>`... |
 | model | Yes | inherit/sonnet/opus/haiku | inherit |
 | color | Yes | Color name | blue |
 | tools | No | Array of tool names | ["Read", "Grep"] |


### PR DESCRIPTION
## Summary
- rename the skill to `agent-development` so it matches the directory and agnix naming rules
- escape the literal `<example>` tag mention in the field summary table

## Related Issue
- Part of #40370

## Guideline Alignment
- one focused metadata/docs syntax fix in a single maintained plugin file
- no behavior changes

## Validation
- `npx --yes agnix plugins/plugin-dev/skills/agent-development/SKILL.md`
- `git diff --check`
