### PR TITLE
fix: semgrep-run-shell-injection

### DIFF
--- a/.github/workflows/claude-dedupe-issues.yml
+++ b/.github/workflows/claude-dedupe-issues.yml
@@ -38,20 +38,22 @@ jobs:
         if: always()
         env:
           STATSIG_API_KEY: ${{ secrets.STATSIG_API_KEY }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+          REPO: ${{ github.repository }}
+          TRIGGERED_BY: ${{ github.event_name }}
+          WORKFLOW_RUN_ID: ${{ github.run_id }}
         run: |
-          ISSUE_NUMBER=${{ github.event.issue.number || inputs.issue_number }}
-          REPO=${{ github.repository }}
-          
           if [ -z "$STATSIG_API_KEY" ]; then
             echo "STATSIG_API_KEY not found, skipping Statsig logging"
             exit 0
           fi
-          
+
           # Prepare the event payload
           EVENT_PAYLOAD=$(jq -n \
             --arg issue_number "$ISSUE_NUMBER" \
             --arg repo "$REPO" \
-            --arg triggered_by "${{ github.event_name }}" \
+            --arg triggered_by "$TRIGGERED_BY" \
+            --arg workflow_run_id "$WORKFLOW_RUN_ID" \
             '{
               events: [{
                 eventName: "github_duplicate_comment_added",
@@ -60,7 +62,7 @@ jobs:
                   repository: $repo,
                   issue_number: ($issue_number | tonumber),
                   triggered_by: $triggered_by,
-                  workflow_run_id: "${{ github.run_id }}"
+                  workflow_run_id: $workflow_run_id
                 },
                 time: (now | floor | tostring)
               }]


### PR DESCRIPTION
Pull Request — Semgrep Rule Fix
Rule ID: run-shell-injection
Rule Message: Using variable interpolation ${{...}} with github context data in a run: step could allow an attacker to inject their own code into the runner. This would allow them to steal secrets and code. github context data can have arbitrary user input and should be treated as untrusted. Instead, use an intermediate environment variable with env: to store the data and use the environment variable in the run: script. Be sure to use double-quotes the environment variable, like this: "$ENVVAR".
File Path: .github/workflows/claude-dedupe-issues.yml
Line: 41