### PR TITLE
Add proposal scraper Stop hook example

### DIFF
--- a/examples/hooks/proposal_scraper_example.py
+++ b/examples/hooks/proposal_scraper_example.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+r"""
+Claude Code Hook: Proposal Scraper
+===================================
+This hook runs as a Stop hook after each assistant turn.
+It detects when the assistant has proposed options/alternatives for the user
+to choose between, and appends them to a persistent PROPOSALS.md file so the
+options survive session crashes, compaction, or context loss.
+
+Motivation: LLMs are non-deterministic. When a session crashes mid-proposal
+(API errors, network failures, context overflow), the assistant's options exist
+only in the chat transcript. Regenerating them in a new session produces
+different options — the original insights are lost. This hook persists proposals
+the moment they are generated, so the file is the source of truth and the chat
+is a view.
+
+Read more about hooks here: https://docs.anthropic.com/en/docs/claude-code/hooks
+
+Make sure to change your path to your actual script.
+
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /path/to/claude-code/examples/hooks/proposal_scraper_example.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+
+Detection heuristics:
+  - Strong signal (auto-trigger): explicit option labels like **Option A**, **C11-A**,
+    or "Option A:" appearing outside of code spans.
+  - Weak signal: two or more numbered bold items in combination with a proximity
+    keyword (options, propose, alternative, pick one, which of, choose).
+  - Matches inside backtick code spans are ignored so that documentation of the
+    trigger patterns does not self-trigger.
+
+The hook is fail-open: any error returns cleanly without blocking the turn.
+"""
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+PROPOSALS_FILENAME = "PROPOSALS.md"
+
+STRONG_PROPOSAL_PATTERNS = [
+    re.compile(r"\*\*Option [A-Z]\*\*"),
+    re.compile(r"\*\*C\d+-[A-Z]\*\*"),
+    re.compile(r"\bOption [A-Z]:"),
+]
+
+NUMBERED_PATTERN = re.compile(r"^\s*\d\.\s+\*\*[^*]+\*\*", re.MULTILINE)
+
+PROPOSAL_KEYWORDS = re.compile(
+    r"\b(?:options?|propos(?:e|ed|al|als)|alternatives?|pick\s+(?:one|from)|"
+    r"which\s+(?:of|one|do\s+you)|choose\s+(?:one|from|between))\b",
+    re.I,
+)
+
+CODE_SPAN_PATTERN = re.compile(r"```.*?```|`[^`\n]+`", re.DOTALL)
+
+
+def strip_code_spans(text: str) -> str:
+    return CODE_SPAN_PATTERN.sub(" ", text)
+
+
+def looks_like_proposal(text: str) -> bool:
+    if not text:
+        return False
+    stripped = strip_code_spans(text)
+    for pattern in STRONG_PROPOSAL_PATTERNS:
+        if pattern.search(stripped):
+            return True
+    if len(NUMBERED_PATTERN.findall(stripped)) >= 2 and PROPOSAL_KEYWORDS.search(stripped):
+        return True
+    return False
+
+
+def find_transcript_path(context: dict) -> Path | None:
+    path = context.get("transcript_path") or context.get("transcriptPath")
+    if path and Path(path).exists():
+        return Path(path)
+    return None
+
+
+def extract_last_assistant_text(transcript_path: Path) -> str | None:
+    last = None
+    try:
+        with open(transcript_path, encoding="utf-8") as f:
+            for line in f:
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                message = row.get("message", {})
+                if message.get("role") != "assistant":
+                    continue
+                content = message.get("content")
+                if isinstance(content, list):
+                    chunks = [
+                        c.get("text", "")
+                        for c in content
+                        if c.get("type") == "text"
+                    ]
+                    joined = "\n".join(c for c in chunks if c)
+                    if joined.strip():
+                        last = joined
+                elif isinstance(content, str) and content.strip():
+                    last = content
+    except OSError:
+        return None
+    return last
+
+
+def choose_output_file(context: dict) -> Path:
+    """Prefer a project-local .claude/PROPOSALS.md; fall back to the current working directory."""
+    cwd = Path(context.get("cwd") or os.getcwd())
+    for candidate in [cwd] + list(cwd.parents):
+        if (candidate / ".claude").is_dir():
+            return candidate / ".claude" / PROPOSALS_FILENAME
+    return cwd / PROPOSALS_FILENAME
+
+
+def ensure_header(path: Path) -> None:
+    if path.exists() and path.stat().st_size > 0:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "# Proposals Ledger\n\n"
+        "Canonical store for options/alternatives proposed for decision. "
+        "Appended by the proposal-scraper Stop hook.\n\n---\n",
+        encoding="utf-8",
+    )
+
+
+def append_proposal(path: Path, text: str, session_id: str) -> None:
+    ensure_header(path)
+    timestamp = datetime.now(timezone.utc).isoformat()
+    entry = (
+        f"\n## Proposal — {timestamp}\n"
+        f"**Session**: `{session_id}`\n"
+        f"**Status**: proposed\n\n"
+        f"{text.strip()}\n\n---\n"
+    )
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(entry)
+
+
+def main() -> None:
+    try:
+        context = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return
+
+    transcript = find_transcript_path(context)
+    if not transcript:
+        return
+
+    text = extract_last_assistant_text(transcript)
+    if not looks_like_proposal(text):
+        return
+
+    session_id = context.get("session_id") or context.get("sessionId") or "unknown"
+    output_path = choose_output_file(context)
+    append_proposal(output_path, text, session_id)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        # Fail-open — never block the turn on a hook error.
+        pass


### PR DESCRIPTION
## Summary

Adds a second example to `examples/hooks/` — a Stop hook that persists proposal blocks (options, alternatives) from assistant responses to a `PROPOSALS.md` file so they survive session crashes, context compaction, and API errors.

Alongside the existing `bash_command_validator_example.py` (a `PreToolUse` hook), this demonstrates a different hook type (`Stop`) and a different use case (output persistence vs input validation).

## Motivation

When an assistant proposes options for a user to choose between — `**Option A**` / `**Option B**` / `**Option C**`, or a numbered decision slate — and the session crashes before the user decides, the options exist only in the chat transcript. Regenerating them in a new session produces *different* options because LLM sampling is non-deterministic. Persisting proposals the moment they are generated makes the file the source of truth and the chat a view.

## Detection

The hook uses two layers of detection:

- **Strong signal (auto-trigger)**: explicit option labels (`**Option A**`, cycle-style IDs like `**C11-A**`, or `Option A:` prose) appearing outside of code spans.
- **Weak signal**: two or more numbered bold items *in combination with* a proximity keyword (`options`, `propose`, `alternative`, `pick one`, `which of`, `choose`). This prevents false positives on structured summaries that happen to use numbered bold lists.

Matches inside backtick code spans are stripped before detection so that documentation of the trigger patterns (including this PR description) does not self-trigger.

## Behavior

- Reads the session transcript via the `transcript_path` field from the hook context.
- Extracts the last assistant message text.
- If it looks like a proposal, appends to `.claude/PROPOSALS.md` (project-local) or falls back to the current working directory.
- Fail-open: any error returns cleanly without blocking the turn.

## Testing

The hook was developed iteratively and has been tested against a corpus of real proposal and non-proposal content, including:

- Explicit `**Option A**` / `**Option B**` blocks (triggers)
- Cycle-style `**C11-A**` labels (triggers)
- Numbered bold lists *with* "options" / "propose" keywords (triggers)
- Completion summaries using numbered bold lists *without* keywords (does not trigger)
- Documentation mentioning trigger patterns inside backticks (does not trigger)
- Plain questions and answers (does not trigger)

## Style

Follows the convention of `bash_command_validator_example.py`:
- Self-contained, stdlib-only
- Shebang + docstring with `settings.json` snippet
- Fail-open error handling
- "Change your path to your actual script" note in the docstring

## Configuration

```json
{
  "hooks": {
    "Stop": [
      {
        "hooks": [
          {
            "type": "command",
            "command": "python3 /path/to/claude-code/examples/hooks/proposal_scraper_example.py"
          }
        ]
      }
    ]
  }
}
```