### PR TITLE
[BUGFIX] Devcontainer firewall init script errors due to duplicated / overlapping ips

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -74,7 +74,7 @@ for domain in \
     "vscode.blob.core.windows.net" \
     "update.code.visualstudio.com"; do
     echo "Resolving $domain..."
-    ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}')
+    ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}' | sort -u)
     if [ -z "$ips" ]; then
         echo "ERROR: Failed to resolve $domain"
         exit 1


### PR DESCRIPTION
When trying to start dev containers the init script fails adding ips for domain since they are already added.
To make it more resilient remove the duplicates first by using sort unique