### PR TITLE
fix: use -exist flag in ipset add to prevent duplicate entry errors

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -60,7 +60,7 @@ while read -r cidr; do
         exit 1
     fi
     echo "Adding GitHub range $cidr"
-    ipset add allowed-domains "$cidr"
+    ipset add -exist allowed-domains "$cidr"
 done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
 
 # Resolve and add other allowed domains
@@ -79,14 +79,14 @@ for domain in \
         echo "ERROR: Failed to resolve $domain"
         exit 1
     fi
-    
+
     while read -r ip; do
         if [[ ! "$ip" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
             echo "ERROR: Invalid IP from DNS for $domain: $ip"
             exit 1
         fi
         echo "Adding $ip for $domain"
-        ipset add allowed-domains "$ip"
+        ipset add -exist allowed-domains "$ip"
     done < <(echo "$ips")
 done
 


### PR DESCRIPTION
## Summary
- Added `-exist` flag to both `ipset add` calls in `.devcontainer/init-firewall.sh`
- Prevents the script from failing with a "set entry already exists" error if run more than once or if IPs overlap
- Also removes trailing whitespace on line 82

## Test plan
- [ ] Run `init-firewall.sh` once — verify it completes successfully
- [ ] Run `init-firewall.sh` a second time — verify it no longer errors on duplicate ipset entries