### PR TITLE
feat(plugins): add flappy-claude terminal game

### DIFF
--- a/plugins/flappy-claude/.claude-plugin/plugin.json
+++ b/plugins/flappy-claude/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "flappy-claude",
+  "version": "1.0.0",
+  "description": "Play Flappy Bird in your terminal with a Claude-themed sprite",
+  "author": "Junhyuk Lee",
+  "license": "MIT"
+}

--- a/plugins/flappy-claude/.gitignore
+++ b/plugins/flappy-claude/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+*.pyo
+.DS_Store
+*.egg-info/

--- a/plugins/flappy-claude/LICENSE
+++ b/plugins/flappy-claude/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Junhyuk Lee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/flappy-claude/README.md
+++ b/plugins/flappy-claude/README.md
@@ -1,0 +1,66 @@
+# Flappy Claude
+
+A Flappy Bird clone for your terminal, featuring a Claude-themed sprite. Built as a Claude Code plugin.
+
+```
+    |||         |||
+    |||         |||
+    |||  ▛█▜   |||
+    |||         |||
+    |||         |||
+```
+
+## Requirements
+
+- Python 3
+- A terminal that supports Unicode block characters
+- Minimum terminal size: 60 columns x 24 rows
+- macOS or Linux
+
+## Installation
+
+Copy the plugin directory into your Claude Code plugins folder:
+
+```bash
+cp -r flappy-claude ~/.claude/plugins/
+```
+
+Claude Code will automatically detect the plugin on next launch.
+
+## Usage
+
+In Claude Code, type:
+
+```
+/flappy-claude
+```
+
+The game launches in a new terminal window automatically.
+
+## Controls
+
+| Key              | Action |
+|------------------|--------|
+| `Space` / `Up`   | Flap   |
+| `Q`              | Quit   |
+| `R`              | Restart (on game over screen) |
+
+## How It Works
+
+Flappy Claude uses Python's built-in `curses` library to render the game directly in your terminal. Since Claude Code runs in a non-interactive context without a TTY, the plugin launches a separate terminal window:
+
+- **macOS**: Uses `osascript` to open a new Terminal.app window
+- **Linux**: Uses `x-terminal-emulator` or `gnome-terminal`
+
+The game runs at 20 FPS with gravity-based physics. The Claude sprite (`▛█▜` — upper-left block, full block, upper-right block) navigates through pipe gaps. No external dependencies are required — everything uses the Python standard library.
+
+## Game Details
+
+- **Sprite**: `▛█▜` (3 characters wide, 1 row tall)
+- **Pipe gap**: 10 rows
+- **Frame rate**: 20 FPS
+- **Physics**: Gravity 0.3, flap velocity -1.5
+
+## License
+
+MIT

--- a/plugins/flappy-claude/commands/flappy-claude.md
+++ b/plugins/flappy-claude/commands/flappy-claude.md
@@ -1,0 +1,32 @@
+Launch the Flappy Claude terminal game in a new terminal window. Execute the following shell script:
+
+```bash
+#!/bin/bash
+# Resolve game path relative to this plugin's location
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PLUGIN_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
+GAME_PATH="$PLUGIN_DIR/flappy_claude.py"
+
+if [ ! -f "$GAME_PATH" ]; then
+  echo "Error: flappy_claude.py not found at $GAME_PATH"
+  exit 1
+fi
+
+# Detect OS via uname and launch in appropriate terminal
+OS="$(uname)"
+if [[ "$OS" == "Darwin" ]]; then
+  osascript -e "tell application \"Terminal\" to do script \"python3 '$GAME_PATH'\""
+elif [[ "$OS" == "Linux" ]]; then
+  if command -v x-terminal-emulator &>/dev/null; then
+    x-terminal-emulator -e python3 "$GAME_PATH"
+  elif command -v gnome-terminal &>/dev/null; then
+    gnome-terminal -- python3 "$GAME_PATH"
+  else
+    echo "No supported terminal emulator found. Run manually: python3 $GAME_PATH"
+    exit 1
+  fi
+else
+  echo "Unsupported OS: $OS. Run manually: python3 $GAME_PATH"
+  exit 1
+fi
+```

--- a/plugins/flappy-claude/flappy_claude.py
+++ b/plugins/flappy-claude/flappy_claude.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+import curses
+import time
+import random
+
+FPS = 20
+FRAME_TIME = 1.0 / FPS
+GRAVITY = 0.3
+FLAP_VEL = -1.5
+PIPE_GAP = 10
+PIPE_WIDTH = 3
+PIPE_SPEED = 1
+PIPE_SPAWN_INTERVAL = 40
+MIN_ROWS = 24
+MIN_COLS = 60
+BIRD_COL_RATIO = 4  # bird fixed at max_x // BIRD_COL_RATIO
+CLAUDE_SPRITE = [
+    "▛█▜",
+]  # ▛█▜ — Claude block logo (1 row)
+BIRD_HEIGHT = len(CLAUDE_SPRITE)
+
+
+def reset_game(max_y, max_x):
+    return {
+        "bird_y": float(max_y // 2),
+        "bird_vel": 0.0,
+        "pipes": [],
+        "score": 0,
+        "frame": 0,
+        "state": "PLAYING",
+    }
+
+
+def spawn_pipe(max_y, max_x):
+    gap_top = random.randint(2, max_y - PIPE_GAP - 3)
+    return {"x": max_x - 1, "gap_top": gap_top, "scored": False}
+
+
+def update_pipes(gs, max_y, max_x):
+    gs["frame"] += 1
+    if gs["frame"] % PIPE_SPAWN_INTERVAL == 0:
+        gs["pipes"].append(spawn_pipe(max_y, max_x))
+    for p in gs["pipes"]:
+        p["x"] -= PIPE_SPEED
+    gs["pipes"] = [p for p in gs["pipes"] if p["x"] + PIPE_WIDTH > 0]
+
+
+def check_score(gs, bird_col):
+    for p in gs["pipes"]:
+        if not p["scored"] and p["x"] + PIPE_WIDTH < bird_col:
+            p["scored"] = True
+            gs["score"] += 1
+
+
+def check_collision(gs, bird_col, max_y):
+    bird_row = int(gs["bird_y"])
+    for dr in range(BIRD_HEIGHT):
+        r = bird_row + dr
+        if r <= 0 or r >= max_y - 1:
+            return True
+        for p in gs["pipes"]:
+            if p["x"] <= bird_col <= p["x"] + PIPE_WIDTH - 1:
+                if not (p["gap_top"] <= r < p["gap_top"] + PIPE_GAP):
+                    return True
+    return False
+
+
+def draw_game(stdscr, gs, bird_col, max_y, max_x):
+    stdscr.erase()
+    try:
+        stdscr.addstr(0, 0, f"SCORE: {gs['score']}")
+    except curses.error:
+        pass
+    for p in gs["pipes"]:
+        for row in range(1, max_y - 1):
+            if row < p["gap_top"] or row >= p["gap_top"] + PIPE_GAP:
+                for col in range(p["x"], min(p["x"] + PIPE_WIDTH, max_x - 1)):
+                    if 0 <= col < max_x - 1:
+                        try:
+                            stdscr.addch(row, col, "|")
+                        except curses.error:
+                            pass
+    bird_row = int(gs["bird_y"])
+    for i, sprite_row in enumerate(CLAUDE_SPRITE):
+        r = bird_row + i
+        if 0 < r < max_y - 1 and 0 <= bird_col < max_x - 2:
+            try:
+                stdscr.addstr(r, bird_col, sprite_row)
+            except curses.error:
+                pass
+    stdscr.refresh()
+
+
+def draw_title(stdscr, max_y, max_x):
+    stdscr.erase()
+    lines = [
+        " ___ _      _   ___ ___ _   _",
+        "| __| |    /_\\ | _ \\ _ \\ | | |",
+        "| _|| |__ / _ \\|  _/  _/ |_| |",
+        "|_| |____/_/ \\_\\_| |_|  \\___/",
+        "",
+        "  ___ _      _   _   _ ___  ___",
+        " / __| |    /_\\ | | | |   \\| __|",
+        "| (__| |__ / _ \\| |_| | |) | _|",
+        " \\___|____/_/ \\_|\\___/|___/|___|",
+        "",
+        "Press SPACE to start",
+        "Press Q to quit",
+    ]
+    start_y = max_y // 2 - len(lines) // 2
+    for i, line in enumerate(lines):
+        x = max(0, max_x // 2 - len(line) // 2)
+        try:
+            stdscr.addstr(start_y + i, x, line)
+        except curses.error:
+            pass
+    stdscr.refresh()
+
+
+def draw_game_over(stdscr, score, max_y, max_x):
+    stdscr.erase()
+    lines = [
+        "GAME OVER",
+        "",
+        f"Score: {score}",
+        "",
+        "Press R to restart",
+        "Press Q to quit",
+    ]
+    start_y = max_y // 2 - len(lines) // 2
+    for i, line in enumerate(lines):
+        x = max(0, max_x // 2 - len(line) // 2)
+        try:
+            stdscr.addstr(start_y + i, x, line)
+        except curses.error:
+            pass
+    stdscr.refresh()
+
+
+def main(stdscr):
+    try:
+        curses.curs_set(0)
+    except curses.error:
+        pass
+    stdscr.nodelay(True)
+    stdscr.keypad(True)
+
+    max_y, max_x = stdscr.getmaxyx()
+    if max_y < MIN_ROWS or max_x < MIN_COLS:
+        try:
+            stdscr.addstr(
+                0,
+                0,
+                f"Terminal too small! Need {MIN_ROWS}x{MIN_COLS}, got {max_y}x{max_x}",
+            )
+            stdscr.refresh()
+        except curses.error:
+            pass
+        time.sleep(2)
+        return
+
+    bird_col = max_x // BIRD_COL_RATIO
+    gs = reset_game(max_y, max_x)
+    gs["state"] = "TITLE"
+
+    try:
+        while True:
+            key = stdscr.getch()
+
+            if key == ord("q") or key == ord("Q"):
+                return
+
+            if gs["state"] == "TITLE":
+                draw_title(stdscr, max_y, max_x)
+                if key == ord(" ") or key == curses.KEY_UP:
+                    gs["state"] = "PLAYING"
+
+            elif gs["state"] == "PLAYING":
+                if key == ord(" ") or key == curses.KEY_UP:
+                    gs["bird_vel"] = FLAP_VEL
+
+                gs["bird_vel"] += GRAVITY
+                gs["bird_y"] += gs["bird_vel"]
+
+                update_pipes(gs, max_y, max_x)
+                check_score(gs, bird_col)
+
+                if check_collision(gs, bird_col, max_y):
+                    gs["state"] = "GAME_OVER"
+                else:
+                    draw_game(stdscr, gs, bird_col, max_y, max_x)
+
+            elif gs["state"] == "GAME_OVER":
+                draw_game_over(stdscr, gs["score"], max_y, max_x)
+                if key == ord("r") or key == ord("R"):
+                    gs = reset_game(max_y, max_x)
+
+            time.sleep(FRAME_TIME)
+    except KeyboardInterrupt:
+        pass
+
+
+def run():
+    curses.wrapper(main)
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## What

Adds `plugins/flappy-claude/` — a Claude Code plugin that lets users play Flappy Bird directly in their terminal via a `/flappy-claude` slash command.

**Files added:**
- `plugins/flappy-claude/plugin.json` — plugin manifest
- `plugins/flappy-claude/flappy_claude.py` — pure Python 3 + curses game engine
- `plugins/flappy-claude/commands/flappy-claude.md` — slash command definition
- `plugins/flappy-claude/README.md` — install & usage docs
- `plugins/flappy-claude/LICENSE` — MIT
- `plugins/flappy-claude/.gitignore`

## Why

Demonstrates the Claude Code plugin system with a fun, self-contained example. The `/flappy-claude` command shows how plugins can register custom slash commands and launch external processes — useful as a reference for plugin authors.

## How

1. Install: copy `plugins/flappy-claude/` to `~/.claude/plugins/flappy-claude/`
2. The plugin registers `/flappy-claude` via `commands/flappy-claude.md`
3. On macOS: launches `flappy_claude.py` in a new Terminal window via `osascript`
4. On Linux: launches via `x-terminal-emulator`
5. Game runs fully in the terminal using Python's built-in `curses` library

## Tech

- **Language**: Pure Python 3 — zero external dependencies
- **UI**: `curses` (stdlib) for terminal rendering
- **Cross-platform TTY spawning**: `osascript` on macOS, `x-terminal-emulator` on Linux
- **Plugin format**: Claude Code plugin manifest (`plugin.json`) + slash command markdown

## Source

https://github.com/xodn348/flappy-claude