### PR TITLE
docs(changelog): fix skill name in 2.1.111 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@
 - Added `xhigh` effort level for Opus 4.7, sitting between `high` and `max`. Available via `/effort`, `--effort`, and the model picker; other models fall back to `high`
 - `/effort` now opens an interactive slider when called without arguments, with arrow-key navigation between levels and Enter to confirm
 - Added "Auto (match terminal)" theme option that matches your terminal's dark/light mode — select it from `/theme`
-- Added `/less-permission-prompts` skill — scans transcripts for common read-only Bash and MCP tool calls and proposes a prioritized allowlist for `.claude/settings.json`
+- Added `/fewer-permission-prompts` skill — scans transcripts for common read-only Bash and MCP tool calls and proposes a prioritized allowlist for `.claude/settings.json`
 - Added `/ultrareview` for running comprehensive code review in the cloud using parallel multi-agent analysis and critique — invoke with no arguments to review your current branch, or `/ultrareview <PR#>` to fetch and review a specific GitHub PR
 - Auto mode no longer requires `--enable-auto-mode`
 - Windows: PowerShell tool is progressively rolling out. Opt in or out with `CLAUDE_CODE_USE_POWERSHELL_TOOL`. On Linux and macOS, enable with `CLAUDE_CODE_USE_POWERSHELL_TOOL=1` (requires `pwsh` on PATH)


### PR DESCRIPTION
## Summary
Corrects the skill name in the CHANGELOG entry for 2.1.111 from `/less-permission-prompts` to `/fewer-permission-prompts` to match the actual skill name.

## Issue
Fixes #50226

## Changes
- `CHANGELOG.md` — one-character fix in the 2.1.111 section (line 59)

## Testing
- Docs-only change, no code affected. Verified the skill is named `fewer-permission-prompts` as documented in the Claude Code skill catalog.