### PR TITLE
Revise security policy and reporting guidelines

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,12 +1,9 @@
 # Security Policy
-Thank you for helping us keep Claude Code secure!
 
-## Reporting Security Issues
+## Reporting Vulnerabilities
 
-The security of our systems and user data is Anthropic's top priority. We appreciate the work of security researchers acting in good faith in identifying and reporting potential vulnerabilities.
+Do not disclose vulnerabilities publicly before reporting them. Use the [HackerOne submission form](https://hackerone.com/anthropic-vdp/reports/new?type=team&report_type=vulnerability) — that's the only channel we accept reports through.
 
-Our security program is managed on HackerOne and we ask that any validated vulnerability in this functionality be reported through their [submission form](https://hackerone.com/anthropic-vdp/reports/new?type=team&report_type=vulnerability).
+## Disclosure Program
 
-## Vulnerability Disclosure Program
-
-Our Vulnerability Program Guidelines are defined on our [HackerOne program page](https://hackerone.com/anthropic-vdp).
+Scope, eligibility, and rules are defined on our [HackerOne program page](https://hackerone.com/anthropic-vdp). Reports outside scope will be closed without response.


### PR DESCRIPTION
security: rewrite SECURITY.md to enforce HackerOne-only reporting and set clear out-of-scope expectations