### PR TITLE
Sort unique IPs from DNS resolution before using in ipset(8)

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -74,7 +74,7 @@ for domain in \
     "vscode.blob.core.windows.net" \
     "update.code.visualstudio.com"; do
     echo "Resolving $domain..."
-    ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}')
+    ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}' | sort -u)
     if [ -z "$ips" ]; then
         echo "ERROR: Failed to resolve $domain"
         exit 1

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -74,7 +74,7 @@ for domain in \
     "vscode.blob.core.windows.net" \
     "update.code.visualstudio.com"; do
     echo "Resolving $domain..."
-    ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}' | uniq)
+    ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}' | sort -u)
     if [ -z "$ips" ]; then
         echo "ERROR: Failed to resolve $domain"
         exit 1

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -74,7 +74,7 @@ for domain in \
     "vscode.blob.core.windows.net" \
     "update.code.visualstudio.com"; do
     echo "Resolving $domain..."
-    ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}' | sort -u)
+    ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}' | uniq)
     if [ -z "$ips" ]; then
         echo "ERROR: Failed to resolve $domain"
         exit 1


### PR DESCRIPTION
In the container, `dig` can return duplicate `A` records for certain domains due to CNAME chain expansion. This causes `ipset` to fail, and since `set -e` is set, abort the entire firewall setup, preventing the dev container from starting.

Previous proposals (#50293, #42701) address this in two places by adding `--exist` to `ipset add`. However, this fix addresses the root cause in one line by deduplicating `dig` output with `sort -u` before it reaches `ipset`.