### PR TITLE
fix: point $schema at schemastore.org (URL was 404)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
   "name": "claude-code-plugins",
   "version": "1.0.0",
   "description": "Bundled plugins for Claude Code including Agent SDK development tools, PR review toolkit, and commit workflows",


### PR DESCRIPTION
The previous `$schema` URL (`https://anthropic.com/claude-code/marketplace.schema.json`) never resolved — it 404s, which surfaces as an error in editors that fetch JSON Schemas (#9686).

This points it at SchemaStore instead, where the schema is being added in SchemaStore/schemastore#5603 (generated from the canonical Zod definitions in `claude-cli-internal`; generator landing in anthropics/claude-cli-internal#31465, validator fix already merged in anthropics/claude-cli-internal#31464).

Community PR #23974 takes the deletion approach; this one points at the real schema instead so editors get autocomplete/validation once the SchemaStore PR lands.

Fixes #9686.
Linear: CC-1723