### PR TITLE
fix: normalize whitespace in completion promise before comparison

### DIFF
--- a/plugins/ralph-wiggum/hooks/stop-hook.sh
+++ b/plugins/ralph-wiggum/hooks/stop-hook.sh
@@ -118,9 +118,12 @@ if [[ "$COMPLETION_PROMISE" != "null" ]] && [[ -n "$COMPLETION_PROMISE" ]]; then
   # .*? is non-greedy (takes FIRST tag), whitespace normalized
   PROMISE_TEXT=$(echo "$LAST_OUTPUT" | perl -0777 -pe 's/.*?<promise>(.*?)<\/promise>.*/$1/s; s/^\s+|\s+$//g; s/\s+/ /g' 2>/dev/null || echo "")
 
+  # Normalize whitespace in stored promise to match extracted text normalization
+  NORMALIZED_PROMISE=$(echo "$COMPLETION_PROMISE" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/[[:space:]]\{1,\}/ /g')
+
   # Use = for literal string comparison (not pattern matching)
   # == in [[ ]] does glob pattern matching which breaks with *, ?, [ characters
-  if [[ -n "$PROMISE_TEXT" ]] && [[ "$PROMISE_TEXT" = "$COMPLETION_PROMISE" ]]; then
+  if [[ -n "$PROMISE_TEXT" ]] && [[ "$PROMISE_TEXT" = "$NORMALIZED_PROMISE" ]]; then
     echo "✅ Ralph loop: Detected <promise>$COMPLETION_PROMISE</promise>"
     rm "$RALPH_STATE_FILE"
     exit 0


### PR DESCRIPTION
## Summary
- Normalize whitespace in the stored `COMPLETION_PROMISE` before comparing it to the extracted promise text
- The extracted text was already normalized via perl (`s/\s+/ /g`), but the stored value was not, causing comparison failures when the promise contained multiple consecutive spaces

## Test plan
- [ ] Set a completion promise with multiple spaces: `--completion-promise "TASK    DONE"`
- [ ] Verify the promise is detected when output contains `<promise>TASK DONE</promise>` (single space)
- [ ] Verify normal single-space promises still work

Fixes #52405

🤖 Generated with [Claude Code](https://claude.com/claude-code)