### PR TITLE
fix: escape regex metacharacters in frontmatter field names

### DIFF
--- a/plugins/plugin-dev/skills/plugin-settings/scripts/parse-frontmatter.sh
+++ b/plugins/plugin-dev/skills/plugin-settings/scripts/parse-frontmatter.sh
@@ -48,7 +48,9 @@ if [ -z "$FIELD" ]; then
 fi
 
 # Extract specific field
-VALUE=$(echo "$FRONTMATTER" | grep "^${FIELD}:" | sed "s/${FIELD}: *//" | sed 's/^"\(.*\)"$/\1/' | sed "s/^'\\(.*\\)'$/\\1/")
+# Escape regex metacharacters in field name before using in sed
+ESCAPED_FIELD=$(printf '%s\n' "$FIELD" | sed 's/[[\.*^$()+?{|]/\\&/g')
+VALUE=$(echo "$FRONTMATTER" | grep "^${FIELD}:" | sed "s/${ESCAPED_FIELD}: *//" | sed 's/^"\(.*\)"$/\1/' | sed "s/^'\\(.*\\)'$/\\1/")
 
 if [ -z "$VALUE" ]; then
   echo "Error: Field '$FIELD' not found in frontmatter" >&2

--- a/plugins/plugin-dev/skills/plugin-settings/scripts/validate-settings.sh
+++ b/plugins/plugin-dev/skills/plugin-settings/scripts/validate-settings.sh
@@ -74,7 +74,9 @@ done
 
 # Check 7: Validate common boolean fields
 for field in enabled strict_mode; do
-  VALUE=$(echo "$FRONTMATTER" | grep "^${field}:" | sed "s/${field}: *//" || true)
+  # Escape regex metacharacters in field name before using in sed
+  escaped_field=$(printf '%s\n' "$field" | sed 's/[[\.*^$()+?{|]/\\&/g')
+  VALUE=$(echo "$FRONTMATTER" | grep "^${field}:" | sed "s/${escaped_field}: *//" || true)
   if [ -n "$VALUE" ]; then
     if [ "$VALUE" != "true" ] && [ "$VALUE" != "false" ]; then
       echo "⚠️  Field '$field' should be boolean (true/false), got: $VALUE"


### PR DESCRIPTION
## Summary
- Escape regex metacharacters in field names before using them in sed patterns in `parse-frontmatter.sh` and `validate-settings.sh`
- Without escaping, a field like `my.setting` would match `myXsetting` since `.` is a regex wildcard

## Test plan
- [ ] Test with normal field names (enabled, strict_mode) still works
- [ ] Test with a field name containing `.` (e.g. `my.setting`) matches only the exact field

Fixes #52406

🤖 Generated with [Claude Code](https://claude.com/claude-code)