### PR TITLE
fix: add explicit sort parameters to auto-close-duplicates query

### DIFF
--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -122,7 +122,7 @@ async function autoCloseDuplicates(): Promise<void> {
   
   while (true) {
     const pageIssues: GitHubIssue[] = await githubRequest(
-      `/repos/${owner}/${repo}/issues?state=open&per_page=${perPage}&page=${page}`,
+      `/repos/${owner}/${repo}/issues?state=open&sort=created&direction=asc&per_page=${perPage}&page=${page}`,
       token
     );
     


### PR DESCRIPTION
## Summary
- Add explicit `sort=created&direction=asc` to the issues API query
- Without this, the default sort (created DESC) returns newest issues first, and the script filters for issues older than 3 days — wasting API calls on recent issues that all get filtered out
- With the 20-page safety limit (2000 issues), older eligible issues may never be reached in high-volume repos

## Test plan
- [ ] Verify the script still correctly identifies and closes duplicate issues
- [ ] Verify older issues are processed first, reducing wasted API calls

Fixes #52407

🤖 Generated with [Claude Code](https://claude.com/claude-code)