### PR TITLE
fix: prevent heredoc injection in ralph loop setup script

### DIFF
--- a/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
+++ b/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
@@ -137,17 +137,22 @@ else
   COMPLETION_PROMISE_YAML="null"
 fi
 
-cat > .claude/ralph-loop.local.md <<EOF
+# Write state file in two steps to avoid shell expansion of prompt text
+# and heredoc termination if prompt contains 'EOF' on its own line
+STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+{
+  cat <<FRONTMATTER_EOF
 ---
 active: true
 iteration: 1
 max_iterations: $MAX_ITERATIONS
 completion_promise: $COMPLETION_PROMISE_YAML
-started_at: "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+started_at: "$STARTED_AT"
 ---
 
-$PROMPT
-EOF
+FRONTMATTER_EOF
+  printf '%s\n' "$PROMPT"
+} > .claude/ralph-loop.local.md
 
 # Output setup message
 cat <<EOF


### PR DESCRIPTION
## Summary
- Split the state file write into two steps: a heredoc for frontmatter (where variable expansion is intentional) and `printf` for the prompt (where text should be written verbatim)
- Previously, the prompt was in an unquoted heredoc which could cause:
  - Early termination if the prompt contained `EOF` on its own line
  - Unintended shell expansion of `$VAR` or `$(cmd)` in the prompt text

## Test plan
- [ ] Test with a normal prompt — state file is created correctly
- [ ] Test with a prompt containing `$HOME` — should be written literally, not expanded
- [ ] Test with a prompt containing `EOF` on its own line — file should not be truncated

Fixes #52408

🤖 Generated with [Claude Code](https://claude.com/claude-code)