### PR TITLE
docs: fix stale docs URL in bash command validator example

### DIFF
--- a/examples/hooks/bash_command_validator_example.py
+++ b/examples/hooks/bash_command_validator_example.py
@@ -6,7 +6,7 @@ This hook runs as a PreToolUse hook for the Bash tool.
 It validates bash commands against a set of rules before execution.
 In this case it changes grep calls to using rg.
 
-Read more about hooks here: https://docs.anthropic.com/en/docs/claude-code/hooks
+Read more about hooks here: https://docs.claude.com/en/docs/claude-code/hooks
 
 Make sure to change your path to your actual script.
 


### PR DESCRIPTION
## Summary

The hook example references `docs.anthropic.com/en/docs/claude-code/hooks`, which is no longer the canonical URL for the hooks documentation. Updates the link to `docs.claude.com/en/docs/claude-code/hooks` to match every other doc reference in the repo (plugins/README.md, plugin-dev/skills/hook-development/SKILL.md, etc.).

## Verification

```bash
grep -rn "docs.anthropic.com" --include="*.py" --include="*.md" --include="*.json"
```

Before this PR: only `examples/hooks/bash_command_validator_example.py` and `CHANGELOG.md` (historical, intentionally unchanged) match. After: only `CHANGELOG.md`.