### PR TITLE
fix(marketplace): add version and author to agent-sdk-dev entry

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,6 +11,11 @@
     {
       "name": "agent-sdk-dev",
       "description": "Development kit for working with the Claude Agent SDK",
+      "version": "1.0.0",
+      "author": {
+        "name": "Ashwin Bhat",
+        "email": "ashwin@anthropic.com"
+      },
       "source": "./plugins/agent-sdk-dev",
       "category": "development"
     },


### PR DESCRIPTION
## Summary

The \`agent-sdk-dev\` entry in \`.claude-plugin/marketplace.json\` was the only one of 13 plugin entries missing \`version\` and \`author\` fields. Every other plugin (claude-opus-4-5-migration, code-review, commit-commands, explanatory-output-style, feature-dev, frontend-design, hookify, learning-output-style, plugin-dev, pr-review-toolkit, ralph-wiggum, security-guidance) includes both.

Values added match the plugin's own \`plugins/agent-sdk-dev/.claude-plugin/plugin.json\` manifest:

\`\`\`json
{
  "name": "agent-sdk-dev",
  "description": "Claude Agent SDK Development Plugin",
  "version": "1.0.0",
  "author": {
    "name": "Ashwin Bhat",
    "email": "ashwin@anthropic.com"
  }
}
\`\`\`

## Verification

\`\`\`bash
python3 -c "import json; json.load(open('.claude-plugin/marketplace.json'))"
# JSON valid
\`\`\`

Diff is additive only.