### PR TITLE
fix(commit-commands): cover all bash invocations in commit-push-pr allowed-tools

### DIFF
--- a/plugins/commit-commands/commands/commit-push-pr.md
+++ b/plugins/commit-commands/commands/commit-push-pr.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*)
+allowed-tools: Bash(git checkout -b:*), Bash(git switch -c:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*), Bash(git diff:*), Bash(git log:*), Bash(git branch:*)
 description: Commit, push, and open a PR
 ---
 


### PR DESCRIPTION
## Summary

`/commit-push-pr` invokes `git diff HEAD`, `git branch --show-current`, and creates a branch with either `git checkout -b` or `git switch -c`. None are covered by the current `allowed-tools` list, so under strict permissions the skill prompts mid-flow or fails outright. Also: `Bash(git checkout --branch:*)` matches nothing real because no such flag exists on `git checkout`.

## Files changed

* `plugins/commit-commands/commands/commit-push-pr.md` (frontmatter `allowed-tools` only)

Replace the dead `Bash(git checkout --branch:*)` glob with `Bash(git checkout -b:*)` and `Bash(git switch -c:*)`, and add `Bash(git diff:*)`, `Bash(git log:*)`, `Bash(git branch:*)`.

## Verification

**Setup.** Static-analysis check that compares the upstream-main version of the file against the patched version, enumerates every bash invocation the skill body uses (the three `!\`...\`` context tags on lines 8-10, plus the four task-list steps on lines 16-19, plus `git log` for commit-message style matching), and asks: does at least one `Bash(<glob>:*)` rule cover each one?

**Details.** Match logic: command matches glob if `cmd == glob` or `cmd.startswith(glob + " ")`. The skill body and the unfixed/fixed `allowed-tools` lists are read directly from disk; no harness invocation is involved. This is a static-coverage check, not a runtime test of the live Claude Code permission flow, but the matching rule is the same prefix model the harness applies.

**Comparisons.**

| Bash invocation | Origin in body | Pre-fix | Post-fix |
|---|---|---|---|
| `git status` | context line 8 | covered | covered |
| `git diff HEAD` | context line 9 | **uncovered** | covered |
| `git branch --show-current` | context line 10 | **uncovered** | covered |
| `git checkout -b feature/x` | task step 1 | **uncovered** | covered |
| `git switch -c feature/x` | task step 1 (alt form) | **uncovered** | covered |
| `git add .` | task step 2 | covered | covered |
| `git commit -m '...'` | task step 2 | covered | covered |
| `git push origin HEAD` | task step 3 | covered | covered |
| `gh pr create --fill` | task step 4 | covered | covered |
| `git log --oneline` | implicit, commit-style match | **uncovered** | covered |

Pre-fix unmatched: 5. Post-fix unmatched: 0.

**Regression.** The only rule removed is `Bash(git checkout --branch:*)`. `git checkout` has no `--branch` flag, so this glob matched no real command and its removal cannot break a previously-working invocation. All five previously-covered commands (`git status`, `git add`, `git commit`, `git push`, `gh pr create`) remain covered.

## Refs

Fixes #36741