### PR TITLE
fix: correct MacOS to macOS in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ For more installation options, uninstall steps, and troubleshooting, see the [se
 
 1. Install Claude Code:
 
-    **MacOS/Linux (Recommended):**
+    **macOS/Linux (Recommended):**
     ```bash
     curl -fsSL https://claude.ai/install.sh | bash
     ```
 
-    **Homebrew (MacOS/Linux):**
+    **Homebrew (macOS/Linux):**
     ```bash
     brew install --cask claude-code
     ```


### PR DESCRIPTION
## Summary

- Corrects `MacOS` → `macOS` in two places in the installation section of `README.md` (lines 21 and 26)

Apple's official product name is **macOS** (lowercase "m", uppercase "OS"). The CHANGELOG and all other references in this repo already use the correct casing — the README installation headers were the only inconsistency.

## Test plan

- [x] No functional changes — documentation-only fix
- [x] Verified correct casing against Apple's naming guidelines and existing CHANGELOG references

🤖 Generated with [Claude Code](https://claude.com/claude-code)