### PR TITLE
docs: clarify calculation assumptions in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -67,6 +67,7 @@ body:
       description: |
         Please provide clear, numbered steps that anyone can follow to reproduce the issue.
         **Important**: Include any necessary code, file contents, or context needed to reproduce the bug.
+        For calculation bugs, include the exact formula and assumptions (for example, fees, slippage, and rounding).
         If the issue involves specific files or code, please create a minimal example.
       placeholder: |
         1. Create a file `test.py` with this content:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This repository includes several Claude Code plugins that extend functionality w
 
 ## Reporting Bugs
 
-We welcome your feedback. Use the `/bug` command to report issues directly within Claude Code, or file a [GitHub issue](https://github.com/anthropics/claude-code/issues).
+We welcome your feedback. Use the `/bug` command to report issues directly within Claude Code, or file a [GitHub issue](https://github.com/anthropics/claude-code/issues). For calculation bugs, include the exact inputs and assumptions (for example, fees, slippage, and rounding).
 
 ## Connect on Discord
 


### PR DESCRIPTION
Added a short note to the bug-report docs asking for exact inputs and assumptions on calculation bugs, including fees, slippage, and rounding. The issue template now mirrors that guidance so reports are easier to reproduce and compare. Submitted via BillionClaw. Refs #49046.