### PR TITLE
fix(plugin-dev): document repository as string-only in manifest docs

### DIFF
--- a/plugins/plugin-dev/skills/plugin-structure/examples/advanced-plugin.md
+++ b/plugins/plugin-dev/skills/plugin-structure/examples/advanced-plugin.md
@@ -113,10 +113,7 @@ enterprise-devops/
     "url": "https://company.com/teams/devops"
   },
   "homepage": "https://docs.company.com/plugins/devops",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/company/devops-plugin.git"
-  },
+  "repository": "https://github.com/company/devops-plugin",
   "license": "Apache-2.0",
   "keywords": [
     "devops",

--- a/plugins/plugin-dev/skills/plugin-structure/references/manifest-reference.md
+++ b/plugins/plugin-dev/skills/plugin-structure/references/manifest-reference.md
@@ -132,28 +132,18 @@ Link to plugin documentation or landing page.
 
 #### repository
 
-**Type**: String (URL) or Object
+**Type**: String (URL)
 **Example**: `"https://github.com/user/plugin-name"`
 
 Source code repository location.
 
-**String format**:
 ```json
 {
   "repository": "https://github.com/user/plugin-name"
 }
 ```
 
-**Object format** (detailed):
-```json
-{
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/user/plugin-name.git",
-    "directory": "packages/plugin-name"
-  }
-}
-```
+The `repository` field accepts a plain URL string only. The npm-style object form (`{"type": "git", "url": "..."}`) is not supported and fails manifest validation with `repository: Invalid input: expected string, received object`.
 
 **Use cases**:
 - Source code access
@@ -495,10 +485,7 @@ Full configuration with all features:
     "url": "https://company.com/devops"
   },
   "homepage": "https://docs.company.com/plugins/devops",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/company/devops-plugin.git"
-  },
+  "repository": "https://github.com/company/devops-plugin",
   "license": "Apache-2.0",
   "keywords": [
     "devops",


### PR DESCRIPTION
## Summary

`plugins/plugin-dev/skills/plugin-structure/references/manifest-reference.md` documents the `repository` field as accepting both string and object formats. The runtime schema only accepts a string; passing an object fails install with `repository: Invalid input: expected string, received object`. The same file (and `examples/advanced-plugin.md`) also use the wrong object form in two complete-example blocks. Update the field docs to string-only and rewrite both examples to match.

## Files changed

* `plugins/plugin-dev/skills/plugin-structure/references/manifest-reference.md` (field docs at the `#### repository` section, plus the full-config example near the end)
* `plugins/plugin-dev/skills/plugin-structure/examples/advanced-plugin.md` (full-config example)

## Verification

**Setup.** Static check that no object-form `repository` JSON remains in the `plugins/plugin-dev/` tree, and that all pre-existing string-form `repository` instances are unchanged. Compares the upstream `main` version of the two affected files against the patched versions on this branch using `git show main:<path>`.

**Details.** Run from the fork root: `bash notes/repro-43722/verify.sh` (the script is included as a reproduction artifact in the working notes, not in this PR). The check is `grep -rnE '"repository":[[:space:]]*\{' plugins/plugin-dev` for object form, and `grep -rnE '"repository":[[:space:]]*"https' plugins/plugin-dev` for string form. The runtime install failure was not reproduced in a live harness; the schema mismatch is documented in the issue body and is the canonical justification for the fix.

**Comparisons.**

| Location | Pre-fix | Post-fix |
|---|---|---|
| `manifest-reference.md` `#### repository` (line ~150) | object form documented as supported | section says String (URL) only, with explicit "object form is not supported" callout |
| `manifest-reference.md` full-config example (line ~498) | object form | string form |
| `advanced-plugin.md` full-config example (line ~116) | object form | string form |
| `manifest-reference.md` line 142 (string-form example) | string | string (unchanged) |
| `manifest-reference.md` line 467 (string-form example) | string | string (unchanged) |
| `examples/standard-plugin.md` line 51 | string | string (unchanged) |
| `plugin-structure/SKILL.md` line 77 | string | string (unchanged) |

Pre-fix object-form instances: 3. Post-fix: 0. String-form instances unchanged: 4.

**Regression.** No previously-correct example was modified. The only content removed is the "Object format (detailed)" subsection and the two object-form example blocks; both replaced with the single supported string form.

## Refs

Fixes #43722