### PR TITLE
docs: clarify claude command purpose in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For more installation options, uninstall steps, and troubleshooting, see the [se
     npm install -g @anthropic-ai/claude-code
     ```
 
-2. Navigate to your project directory and run `claude`.
+2. Navigate to your project directory and run `claude` to open claude code.
 
 ## Plugins
 


### PR DESCRIPTION
This PR updates the CLI usage instructions to provide better context for the claude command. By explicitly stating that running the command opens Claude Code, we reduce ambiguity for first-time users and align the documentation with the actual terminal output.

Changes:

    Refined step 2 of the setup guide for better readability.

    Added "to open claude code" suffix to the command execution line.