### PR TITLE
examples/hooks: add snap_pack_on_stop.py for auto-pack on session end

### DIFF
--- a/examples/hooks/snap_pack_on_stop.py
+++ b/examples/hooks/snap_pack_on_stop.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""
+Claude Code Hook: Auto-pack session on Stop
+============================================
+
+A `Stop` hook that packs the current Claude Code session JSONL into a
+portable, lossless `.snap.jsonl` artifact when the session ends, then
+drops it at a configured path so it can be handed off to another
+device (iCloud Drive folder, Dropbox, Syncthing dir, etc.).
+
+Read more about hooks: https://docs.anthropic.com/en/docs/claude-code/hooks
+Read more about claude-snap: https://github.com/achiii800/claude-snap
+
+WIRING
+------
+This hook is opt-in. To enable, add to `~/.claude/settings.json`
+(adjust the absolute path to wherever you've placed this script):
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /absolute/path/to/snap_pack_on_stop.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+CONFIGURATION
+-------------
+Optional environment variables:
+
+  CLAUDE_SNAP_DROP_PATH   Directory to write the .snap.jsonl into.
+                          Default: ~/Documents/claude-snaps
+
+  CLAUDE_SNAP_DISABLED    If set to "1", the hook noops. Useful for
+                          temporarily turning auto-pack off without
+                          editing settings.
+
+INSTALL
+-------
+The hook calls the `claude-snap` CLI:
+
+  pip install claude-snap
+
+If `claude-snap` is not on PATH, the hook noops with a stderr
+message — it never crashes Claude Code.
+"""
+
+from __future__ import annotations
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _log(msg: str) -> None:
+    """Hooks should write diagnostics to stderr; stdout is reserved
+    for hook protocol replies on some events."""
+    print(f"[snap_pack_on_stop] {msg}", file=sys.stderr)
+
+
+def _read_event() -> dict:
+    """Read the hook event JSON from stdin. Tolerate empty input."""
+    try:
+        raw = sys.stdin.read()
+    except Exception as e:
+        _log(f"failed to read stdin: {e}")
+        return {}
+    if not raw.strip():
+        return {}
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        _log("stdin was not valid JSON; continuing with empty event")
+        return {}
+
+
+def _resolve_session_path(event: dict) -> Path | None:
+    """
+    Determine which session JSONL to pack.
+
+    Order of precedence:
+      1. Explicit `transcript_path` field on the hook event (Claude Code
+         passes this on most hook events).
+      2. Most recent .jsonl under ~/.claude/projects/<encoded-cwd>/
+         where encoded-cwd matches the current working directory.
+      3. Most recent .jsonl under ~/.claude/projects/ regardless of cwd.
+    """
+    p = event.get("transcript_path")
+    if p:
+        path = Path(p).expanduser()
+        if path.is_file():
+            return path
+
+    projects_root = Path.home() / ".claude" / "projects"
+    if not projects_root.is_dir():
+        return None
+
+    cwd = Path.cwd()
+    encoded = "-" + str(cwd).lstrip("/").replace("/", "-").replace(".", "-").replace("_", "-")
+    cwd_dir = projects_root / encoded
+    if cwd_dir.is_dir():
+        candidates = sorted(cwd_dir.glob("*.jsonl"),
+                            key=lambda f: f.stat().st_mtime,
+                            reverse=True)
+        if candidates:
+            return candidates[0]
+
+    candidates = sorted(projects_root.glob("*/*.jsonl"),
+                        key=lambda f: f.stat().st_mtime,
+                        reverse=True)
+    return candidates[0] if candidates else None
+
+
+def _resolve_drop_dir() -> Path:
+    raw = os.environ.get("CLAUDE_SNAP_DROP_PATH")
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / "Documents" / "claude-snaps"
+
+
+def _claude_snap_available() -> bool:
+    return shutil.which("claude-snap") is not None
+
+
+def main() -> int:
+    if os.environ.get("CLAUDE_SNAP_DISABLED") == "1":
+        return 0
+
+    if not _claude_snap_available():
+        _log("claude-snap not on PATH; skipping (install with `pip install claude-snap`)")
+        return 0
+
+    event = _read_event()
+    session_path = _resolve_session_path(event)
+    if session_path is None:
+        _log("no session JSONL found; skipping")
+        return 0
+
+    drop_dir = _resolve_drop_dir()
+    try:
+        drop_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        _log(f"could not create drop dir {drop_dir}: {e}; skipping")
+        return 0
+
+    out_path = drop_dir / (session_path.stem + ".snap.jsonl")
+
+    try:
+        result = subprocess.run(
+            ["claude-snap", "pack", str(session_path), "-o", str(out_path)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except subprocess.TimeoutExpired:
+        _log(f"claude-snap pack timed out after 60s; skipping")
+        return 0
+    except OSError as e:
+        _log(f"failed to invoke claude-snap: {e}; skipping")
+        return 0
+
+    if result.returncode != 0:
+        _log(f"claude-snap pack failed (rc={result.returncode}): "
+             f"{result.stderr.strip()[:200]}")
+        return 0
+
+    _log(f"packed → {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a robust opt-in `Stop` hook example that packs the current Claude Code session JSONL into a portable, lossless `.snap.jsonl` artifact when the session ends, then drops it at a configurable path (`$CLAUDE_SNAP_DROP_PATH`, default `~/Documents/claude-snaps`).

The intended use case is **hands-off cross-device session handoff** — point `$CLAUDE_SNAP_DROP_PATH` at an iCloud Drive / Dropbox / Syncthing folder, and packed sessions auto-sync to other devices where they can be loaded into a Claude chat as continuation context.

This addresses one of the recurring requests in the cross-device-session cluster (#31992, #29847, #44063, #47926, #51816 — all variations of "let me move my session to another device"). It's not the official feature; it's a working example users can wire into their own settings today, while the official UX is being designed.

## Why a hook example, not a CLI flag

The CLI flag conversation lives in #31992 ("Cross-machine session resume"). This PR doesn't try to add that — it adds the *example users can wire up today* using the existing hook system + an external codec.

## Dependency

The hook calls into [claude-snap](https://github.com/achiii800/claude-snap) ([PyPI](https://pypi.org/project/claude-snap/)) — a ~600-LOC pure-stdlib lossless codec for Claude Code session JSONLs with byte-identical roundtrip. Distinct from existing tools in the space:

| Tool | Approach | Lossless | Byte-identical roundtrip | Codec |
|---|---|---|---|---|
| claude-mem | AI summarization | no | no | no |
| cctrace | md/xml + verbatim JSONL copy | partial | partial | no (transcriber) |
| claude-conversation-extractor | markdown export | no | no | no |
| session-roam | Syncthing dir sync | yes | trivially | no (file sync) |
| claude-handoff | git bundle with path scrubbing | structurally | **no** (paths rewritten) | partial |
| **claude-snap** | sha256 content-hash refs in JSONL | yes | **yes** | yes |

Soft import: if `claude-snap` isn't on PATH, the hook noops with a stderr message — Claude Code is never affected.

## Robustness

- Soft-fails when `claude-snap` is missing (no crashes)
- Honors `CLAUDE_SNAP_DISABLED=1` for ad-hoc disable without editing settings
- Configurable destination via `CLAUDE_SNAP_DROP_PATH` env var
- Uses `subprocess.run` with arg lists (no shell injection surface)
- 60s timeout on the pack invocation
- Smoke-tested for: happy path, missing binary, disabled flag, empty stdin

## Test plan

- [x] Hook exits 0 and noops with stderr message when `claude-snap` is not on PATH
- [x] Hook exits 0 and produces `<session-id>.snap.jsonl` at `$CLAUDE_SNAP_DROP_PATH` when claude-snap is installed and a transcript path is provided
- [x] Hook exits 0 silently when `CLAUDE_SNAP_DISABLED=1`
- [x] Hook handles empty stdin (some Stop hook configs send no event JSON) by falling back to the most recent JSONL under `~/.claude/projects/`
- [x] Subprocess timeout of 60s prevents the hook from hanging Claude Code on a stuck pack
- [x] No string interpolation into shells; all subprocess calls use arg lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)