### PR TITLE
Fix: Remove stray content from plugin-validator.md

### DIFF
--- a/plugins/plugin-dev/agents/plugin-validator.md
+++ b/plugins/plugin-dev/agents/plugin-validator.md
@@ -181,4 +181,4 @@ Location: [path]
 - Corrupted files: Skip and report, continue validation
 ```
 
-Excellent work! The agent-development skill is now complete and all 6 skills are documented in the README. Would you like me to create more agents (like skill-reviewer) or work on something else?
+This agent provides comprehensive plugin validation to ensure plugin quality, correctness, and adherence to best practices.


### PR DESCRIPTION
## Summary
- Remove stray conversation content ("Excellent work! The agent-development skill is now complete...") from end of plugin-validator.md
- Replace with proper descriptive ending consistent with other agent files in the same directory

## Problem
The file ended with accidental dialogue content that appears to be leftover from an editing session, which could interfere with the agent's behavior.

## Changes
- Removed the stray content from line 184
- Added proper descriptive ending: "This agent provides comprehensive plugin validation to ensure plugin quality, correctness, and adherence to best practices."

## Verification
Compared with `agent-creator.md` and `skill-reviewer.md` in the same directory - both end with a code block followed by a single descriptive paragraph starting with "This agent..."

## Test plan
- [x] Verify file structure matches other agent files
- [x] Confirm no functional changes to agent behavior