### PR TITLE
docs: add warning against npm update -g for global upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ For more installation options, uninstall steps, and troubleshooting, see the [se
     npm install -g @anthropic-ai/claude-code
     ```
 
+    > [!WARNING]
+    > If you are using npm, **do not run `npm update -g` to upgrade** — a known bug in certain npm versions can wipe your entire global `node_modules` directory, removing npm itself in the process. Always upgrade with:
+    > ```bash
+    > npm install -g @anthropic-ai/claude-code@latest
+    > ```
+
 2. Navigate to your project directory and run `claude`.
 
 ## Plugins


### PR DESCRIPTION
## Summary

- A known bug in certain npm versions causes `npm update -g` to wipe the entire global `node_modules` directory, removing npm itself and breaking the Node environment entirely.
- Users naturally reach for `npm update -g @anthropic-ai/claude-code` when trying to upgrade, not realising the risk.
- This PR adds an explicit `[!WARNING]` callout directly below the npm install command, advising against `npm update -g` and recommending the safe alternative:

```bash
npm install -g @anthropic-ai/claude-code@latest
```

Closes #55725

## Changes

- `README.md`: added a GitHub-flavoured-markdown warning block under the **NPM (Deprecated)** install step.

## Test plan

- [x] Render the README on GitHub and verify the warning callout displays correctly.
- [x] Confirm no other content is changed.