### PR TITLE
feat: add session-persist plugin for client-side session state preservation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -145,6 +145,17 @@
       },
       "source": "./plugins/security-guidance",
       "category": "security"
+    },
+    {
+      "name": "session-persist",
+      "description": "Client-side session state persistence. Tracks a session ID per run, lets you checkpoint context with /session-save, and restores it in a future session via /session-resume or an auto-resume file.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Sanskaar Undale",
+        "email": "sanskaarundale@gmail.com"
+      },
+      "source": "./plugins/session-persist",
+      "category": "productivity"
     }
   ]
 }

--- a/plugins/session-persist/.claude-plugin/plugin.json
+++ b/plugins/session-persist/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "session-persist",
+  "version": "1.0.0",
+  "description": "Client-side session state persistence. Tracks a session ID across runs, lets you checkpoint context with /session-save, and restores it in future sessions via /session-resume.",
+  "author": {
+    "name": "Sanskaar Undale",
+    "email": "sanskaarundale@gmail.com"
+  }
+}

--- a/plugins/session-persist/README.md
+++ b/plugins/session-persist/README.md
@@ -1,0 +1,60 @@
+# Session Persist
+
+Client-side session state persistence — checkpoint work, then restore it in any future session.
+
+## Problem
+
+Every session starts from a blank slate. Close the window mid-task and you lose all context. The next session requires reconstructing what was being worked on from memory or scratch.
+
+## How it works
+
+Two hooks run automatically:
+
+| Hook | When | What it does |
+|------|------|--------------|
+| **SessionStart** | New session opens | Generates a unique `SESSION_ID` and exports it as `CLAUDE_PERSIST_SESSION_ID`. If `.claude/.session-resume` exists, loads the named session's saved context instead. |
+| **SessionEnd** | Session closes | Stamps `ended_at` on any session file that was explicitly saved during the session. |
+
+Context is checkpointed **on demand** with `/session-save`. The assistant summarises the current working state and writes it to `.claude/sessions/<session-id>.json`.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/session-save` | Checkpoint the current session with a task description and context summary |
+| `/session-list` | List all saved sessions for this project |
+| `/session-resume <id>` | Inject a saved session's context into the current conversation |
+
+## Typical workflow
+
+```
+# Working on a feature — checkpoint before closing
+/session-save
+
+# Open a new session later, restore the context manually
+/session-resume sess_20250504_143022_12345
+
+# Or auto-resume on next start
+echo "sess_20250504_143022_12345" > .claude/.session-resume
+# (next session will inject the saved context automatically)
+```
+
+## Session data
+
+Sessions are stored as JSON in `.claude/sessions/`:
+
+```json
+{
+  "session_id": "sess_20250504_143022_12345",
+  "saved_at": "2025-05-04T14:30:22Z",
+  "last_task": "Implementing the logout endpoint in auth.ts",
+  "summary": "Refactoring auth middleware to remove server-side session tokens per compliance requirements. Login flow complete. Logout and token-refresh endpoints remain.",
+  "ended_at": "2025-05-04T15:01:44Z"
+}
+```
+
+## Limitations
+
+This plugin manages **client-side** context restoration only — it snapshots what the assistant knows and replays it at the start of the next session. The underlying agent loop is still window-bound.
+
+Full server-side session persistence (keeping the agent running after the window closes, resuming mid-tool-call from another machine) requires platform-level support. This plugin is intended as a stopgap and a reference implementation for the patterns that feature will build on. See issue [#55860](https://github.com/anthropics/claude-code/issues/55860).

--- a/plugins/session-persist/commands/session-list.md
+++ b/plugins/session-persist/commands/session-list.md
@@ -1,0 +1,42 @@
+---
+description: List all saved sessions for this project
+allowed-tools: Bash(python3:*)
+---
+
+!`python3 -c "
+import json, os, glob, sys
+
+base = os.environ.get('CLAUDE_PROJECT_DIR', os.getcwd())
+sessions_dir = os.path.join(base, '.claude', 'sessions')
+
+if not os.path.isdir(sessions_dir):
+    print('No sessions directory found — no sessions have been saved yet.')
+    sys.exit(0)
+
+files = sorted(glob.glob(os.path.join(sessions_dir, '*.json')), reverse=True)
+
+if not files:
+    print('No saved sessions found. Use /session-save to checkpoint the current session.')
+    sys.exit(0)
+
+print(f'Found {len(files)} saved session(s):\n')
+for fp in files[:20]:
+    try:
+        with open(fp) as f:
+            d = json.load(f)
+        sid   = d.get('session_id', os.path.basename(fp).replace('.json', ''))
+        ts    = d.get('saved_at', 'unknown')[:19].replace('T', ' ')
+        ended = d.get('ended_at', '')[:19].replace('T', ' ')
+        task  = d.get('last_task', '')[:80]
+        if len(d.get('last_task', '')) > 80:
+            task += '...'
+        print(f'{sid}')
+        print(f'  Saved:     {ts} UTC' + (f'  |  Ended: {ended} UTC' if ended else ''))
+        if task:
+            print(f'  Last task: {task}')
+        print()
+    except Exception as e:
+        print(f'  (could not read {os.path.basename(fp)}: {e})\n')
+"`
+
+Display the sessions above. To restore a session run \`/session-resume <session-id>\`.

--- a/plugins/session-persist/commands/session-resume.md
+++ b/plugins/session-persist/commands/session-resume.md
@@ -1,0 +1,48 @@
+---
+description: Restore context from a previously saved session
+argument-hint: <session-id>
+allowed-tools: Bash(python3:*)
+---
+
+Loading session: $ARGUMENTS
+
+!`python3 -c "
+import json, os, sys
+
+sid  = '$ARGUMENTS'.strip()
+if not sid:
+    print('Provide a session ID. Run /session-list to see available sessions.')
+    sys.exit(0)
+
+base = os.environ.get('CLAUDE_PROJECT_DIR', os.getcwd())
+path = os.path.join(base, '.claude', 'sessions', sid + '.json')
+
+if not os.path.exists(path):
+    print(f'No saved session found with ID: {sid}')
+    print('Run /session-list to see available sessions.')
+    sys.exit(0)
+
+with open(path) as f:
+    d = json.load(f)
+
+print(f'=== Session {sid} ===')
+print(f'Saved at : {d.get(\"saved_at\", \"unknown\")}')
+if d.get('ended_at'):
+    print(f'Ended at : {d[\"ended_at\"]}')
+print()
+print('Last task:')
+print(d.get('last_task', '(not recorded)'))
+print()
+print('Context summary:')
+print(d.get('summary', '(not recorded)'))
+"`
+
+Based on the session data above, restore the working context. Summarise what was being worked on and confirm you are ready to continue from where this session left off.
+
+If the user wants a future new session to auto-resume this context automatically, advise them to run:
+
+\`\`\`bash
+echo "<session-id>" > .claude/.session-resume
+\`\`\`
+
+A new session started after that will pick up the saved context without any extra command.

--- a/plugins/session-persist/commands/session-save.md
+++ b/plugins/session-persist/commands/session-save.md
@@ -1,0 +1,19 @@
+---
+description: Checkpoint the current session — summarise what we're working on and write it to disk
+allowed-tools: Bash(python3:*), Bash(mkdir:*)
+---
+
+Current session ID:
+!`echo "${CLAUDE_PERSIST_SESSION_ID:-unknown}"`
+
+Do the following:
+
+1. Write a concise summary (2-3 sentences) of what we have been working on in this session: the goal, progress made, and what remains.
+2. Identify the single most recent user task or goal in one sentence.
+3. Use python3 to write `.claude/sessions/<session-id>.json` (create the directory if needed) with these fields:
+   - `session_id` — the ID printed above
+   - `saved_at` — current UTC timestamp in ISO 8601 format
+   - `last_task` — one-sentence description of the most recent task
+   - `summary` — the 2-3 sentence summary you wrote
+
+Confirm with the session ID when done.

--- a/plugins/session-persist/hooks/hooks.json
+++ b/plugins/session-persist/hooks/hooks.json
@@ -1,0 +1,25 @@
+{
+  "description": "Session persistence hooks — assign a session ID on start, mark it closed on end",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\""
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-end.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/session-persist/hooks/session-end.sh
+++ b/plugins/session-persist/hooks/session-end.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SESSION_ID="${CLAUDE_PERSIST_SESSION_ID:-}"
+[ -z "$SESSION_ID" ] && exit 0
+
+SESSIONS_DIR="${CLAUDE_PROJECT_DIR}/.claude/sessions"
+SESSION_FILE="${SESSIONS_DIR}/${SESSION_ID}.json"
+
+# Only stamp ended_at if this session was explicitly saved via /session-save
+if [ -f "$SESSION_FILE" ] && command -v python3 &>/dev/null; then
+    python3 - "${SESSION_FILE}" <<'EOF'
+import json, sys, datetime
+path = sys.argv[1]
+try:
+    with open(path) as f:
+        d = json.load(f)
+except Exception:
+    d = {}
+d["ended_at"] = datetime.datetime.utcnow().isoformat() + "Z"
+with open(path, "w") as f:
+    json.dump(d, f, indent=2)
+EOF
+fi
+
+exit 0

--- a/plugins/session-persist/hooks/session-end.sh
+++ b/plugins/session-persist/hooks/session-end.sh
@@ -12,11 +12,10 @@ if [ -f "$SESSION_FILE" ] && command -v python3 &>/dev/null; then
     python3 - "${SESSION_FILE}" <<'EOF'
 import json, sys, datetime
 path = sys.argv[1]
-try:
-    with open(path) as f:
-        d = json.load(f)
-except Exception:
-    d = {}
+with open(path) as f:
+    d = json.load(f)
+if not isinstance(d, dict):
+    raise SystemExit(f"Refusing to update non-object session file: {path}")
 d["ended_at"] = datetime.datetime.utcnow().isoformat() + "Z"
 with open(path, "w") as f:
     json.dump(d, f, indent=2)

--- a/plugins/session-persist/hooks/session-start.sh
+++ b/plugins/session-persist/hooks/session-start.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SESSIONS_DIR="${CLAUDE_PROJECT_DIR}/.claude/sessions"
+mkdir -p "$SESSIONS_DIR"
+
+RESUME_FILE="${CLAUDE_PROJECT_DIR}/.claude/.session-resume"
+
+# Resume path: a previous /session-save wrote the session ID here
+if [ -f "$RESUME_FILE" ]; then
+    SESSION_ID=$(tr -d '[:space:]' < "$RESUME_FILE")
+    rm -f "$RESUME_FILE"
+    SESSION_FILE="${SESSIONS_DIR}/${SESSION_ID}.json"
+
+    if [ -f "$SESSION_FILE" ] && command -v python3 &>/dev/null; then
+        echo "CLAUDE_PERSIST_SESSION_ID=${SESSION_ID}" >> "${CLAUDE_ENV_FILE}"
+        python3 - "${SESSION_FILE}" "${SESSION_ID}" <<'EOF'
+import json, sys
+
+path, sid = sys.argv[1], sys.argv[2]
+try:
+    with open(path) as f:
+        d = json.load(f)
+except Exception:
+    d = {}
+
+lines = [f"Resuming session {sid}."]
+if d.get("saved_at"):
+    lines.append(f"Saved: {d['saved_at']}")
+if d.get("last_task"):
+    lines.append(f"Last task: {d['last_task']}")
+if d.get("summary"):
+    lines.append(f"Context: {d['summary']}")
+
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": "\n".join(lines)
+    }
+}))
+EOF
+        exit 0
+    fi
+fi
+
+# New session: generate a fresh ID and track it for the lifetime of this session
+SESSION_ID="sess_$(date -u +%Y%m%d_%H%M%S)_$$"
+echo "CLAUDE_PERSIST_SESSION_ID=${SESSION_ID}" >> "${CLAUDE_ENV_FILE}"
+
+python3 -c "
+import json, sys
+sid = sys.argv[1]
+print(json.dumps({
+    'hookSpecificOutput': {
+        'hookEventName': 'SessionStart',
+        'additionalContext': f'Session ID: {sid}'
+    }
+}))
+" "${SESSION_ID}"
+
+exit 0


### PR DESCRIPTION
## Problem

Closing the window mid-task wipes all working context. The next session starts blank and the user has to reconstruct what was being worked on from memory.

Issue #55860 proposes a full server-side fix (agent loop running independently of the window). This PR is a **client-side stopgap** that can ship now while the deeper platform work is designed.

## What this adds

A new `session-persist` plugin with two hooks and three commands.

### Hooks (automatic)

| Hook | Behaviour |
|------|-----------|
| `SessionStart` | Generates a unique `SESSION_ID`, exports it as `CLAUDE_PERSIST_SESSION_ID`. If `.claude/.session-resume` exists, reads that session file and injects saved context as `additionalContext`, then removes the trigger file. |
| `SessionEnd` | Stamps `ended_at` on any session file that was explicitly saved during the session. |

### Commands (on demand)

| Command | Description |
|---------|-------------|
| `/session-save` | Asks the assistant to summarise the current task and write `.claude/sessions/<id>.json` |
| `/session-list` | Lists all saved sessions with timestamps and task previews |
| `/session-resume <id>` | Reads a saved session and injects its context into the current conversation |

### Auto-resume

Write a session ID to `.claude/.session-resume` and the next session start picks it up automatically — no command needed.

## Session file format

Sessions are stored as plain JSON in `.claude/sessions/` (safe to gitignore):

```
{
  "session_id": "sess_20250504_143022_12345",
  "saved_at":   "2025-05-04T14:30:22Z",
  "last_task":  "Implementing the logout endpoint in auth.ts",
  "summary":    "Refactoring auth middleware. Login done. Logout and token-refresh remain.",
  "ended_at":   "2025-05-04T15:01:44Z"
}
```

## Limitations

This addresses **context loss** only. The agent loop is still window-bound — tool calls in flight when the window closes are still interrupted. Full server-side persistence (#55860) requires platform changes; this plugin is a reference for the client-side patterns that work will build on.

## Files changed

- `plugins/session-persist/` — new plugin (hooks, commands, README, manifest)
- `.claude-plugin/marketplace.json` — registers the new plugin

## Test plan

- [ ] Start a session — verify `CLAUDE_PERSIST_SESSION_ID` is set in hooks
- [ ] Run `/session-save` — verify `.claude/sessions/<id>.json` is written with correct fields
- [ ] Run `/session-list` — verify saved sessions are listed with timestamps
- [ ] Run `/session-resume <id>` — verify context is injected and assistant resumes correctly
- [ ] Write a session ID to `.claude/.session-resume`, start a new session — verify auto-resume fires and the trigger file is deleted
- [ ] Close a session after saving — verify `ended_at` is stamped on the session file
