### PR TITLE
Remove 'statsig.anthropic.com' from firewall script

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -68,7 +68,6 @@ for domain in \
     "registry.npmjs.org" \
     "api.anthropic.com" \
     "sentry.io" \
-    "statsig.anthropic.com" \
     "statsig.com" \
     "marketplace.visualstudio.com" \
     "vscode.blob.core.windows.net" \


### PR DESCRIPTION
# Motivation

statsig.anthropic.com seems not valid anymore

```bash
% nslookup statsig.anthropic.com
** server can't find statsig.anthropic.com: NXDOMAIN
```