### PR TITLE
docs: Add Windows Developer Mode note for symlink support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ For more installation options, uninstall steps, and troubleshooting, see the [se
     winget install Anthropic.ClaudeCode
     ```
 
+    > [!NOTE]
+    > Windows users: Background agent outputs may silently fail without Developer Mode. Enable [Developer Mode](https://learn.microsoft.com/en-us/windows/advanced-settings/developer-mode) if you encounter issues.
+
     **NPM (Deprecated):**
     ```bash
     npm install -g @anthropic-ai/claude-code


### PR DESCRIPTION
## Summary
Add a note for Windows users about Developer Mode requirement for symlink support.

## Context
Issue #55263 reported that Windows users without Developer Mode may experience silent failures where background agent outputs show "0 tokens" with no error message. Windows requires Developer Mode for symlink creation, which Claude Code uses for task output files.

This adds a brief note in the README linking to Microsoft's Developer Mode documentation.

## Test Plan
- [x] Verified Developer Mode enables symlink creation on Windows
- [x] Confirmed link points to correct Microsoft documentation