### PR TITLE
Fix duplicate rules on init firewall

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -59,8 +59,10 @@ while read -r cidr; do
         echo "ERROR: Invalid CIDR range from GitHub meta: $cidr"
         exit 1
     fi
-    echo "Adding GitHub range $cidr"
-    ipset add allowed-domains "$cidr"
+    if ! ipset test allowed-domains "$cidr" >/dev/null 2>&1; then
+        echo "Adding GitHub range $cidr"
+        ipset add allowed-domains "$cidr"
+    fi
 done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
 
 # Resolve and add other allowed domains
@@ -85,8 +87,10 @@ for domain in \
             echo "ERROR: Invalid IP from DNS for $domain: $ip"
             exit 1
         fi
-        echo "Adding $ip for $domain"
-        ipset add allowed-domains "$ip"
+        if ! ipset test allowed-domains "$ip" >/dev/null 2>&1; then
+            echo "Adding $ip for $domain"
+            ipset add allowed-domains "$ip"
+        fi
     done < <(echo "$ips")
 done
 


### PR DESCRIPTION
## 📄 Description

Setting duplicate firewall rules will make the init-firewall.sh script fail.

The changes make sure to check whether the rule already exists before adding it.

## 🧪 Testing Guidelines

Clone the claude-code repository.
Open the folder in VS Code.
Wait for it to detect the Dev Container configuration.
Select "Reopen in Container"
Wait for the init-firewall.sh script to fail.

## 💡 Additional Info

This is the error modal that appears when the script fails.
<img width="433" height="125" alt="image" src="https://github.com/user-attachments/assets/d810bd37-03e9-4b4f-9c9e-9981dbe61e78" />

These are some log lines of the error:
```
[6443 ms] postStartCommand from devcontainer.json failed with exit code 1. Skipping any further user-provided commands.
[6446 ms] Error: Command failed: /bin/sh -c sudo /usr/local/bin/init-firewall.sh
```