### PR TITLE
fix(code-review): use --body-file to preserve newlines in summary comment

### DIFF
--- a/plugins/code-review/commands/code-review.md
+++ b/plugins/code-review/commands/code-review.md
@@ -62,7 +62,18 @@ Note: Still review Claude generated PR's.
 
    If `--comment` argument was NOT provided, stop here. Do not post any GitHub comments.
 
-   If `--comment` argument IS provided and NO issues were found, post a summary comment using `gh pr comment` and stop.
+   If `--comment` argument IS provided and NO issues were found, post a summary comment using `gh pr comment` and stop. **Always pass the body via a temporary file with `--body-file` to ensure newlines are preserved**:
+
+   ```bash
+   cat > /tmp/code-review.md <<'EOF'
+   ## Code review
+
+   No issues found. Checked for bugs and CLAUDE.md compliance.
+   EOF
+   gh pr comment <PR> --body-file /tmp/code-review.md
+   ```
+
+   Do **not** use `gh pr comment <PR> -b "..."` with escape sequences such as `\n` / `\t` / `\r` — bash does not interpret them inside double quotes, so they will be stored as literal backslash-n etc. and break GitHub's Markdown rendering.
 
    If `--comment` argument IS provided and issues were found, continue to step 8.
 


### PR DESCRIPTION
## Summary

The `code-review` skill (`plugins/code-review/commands/code-review.md`) instructs the LLM to use `gh pr comment` for the no-issue summary comment, but does not specify a safe quoting form. When the LLM generates:

```bash
gh pr comment 449 -b "## Code review\n\n..."
```

bash does not interpret `\n` inside double quotes, so 2 literal characters (`\` + `n`) are passed to `gh` and stored on GitHub as-is. The resulting comment renders as a single unreadable line in the GitHub UI.

This fix updates §7 of the skill prompt to mandate `--body-file` with a heredoc-written temp file, preserving real newlines through bash → gh → GitHub API.

## Tracking issue

#57197 — includes reproduction (one occurrence in 8 PRs in a private downstream repo, ~12% rate; auto-recovered on next push).

## Path coverage

This is the only LLM-driven path that handles raw bash strings:

| Path | Mechanism | Affected? |
|---|---|---|
| Inline comments (`mcp__github_inline_comment__create_inline_comment`) | Buffered to JSONL, posted via Octokit | ✅ safe (JSON) |
| `claude-code-action` orchestration (`run.ts` etc.) | Does not construct comment bodies | ✅ safe |
| Skill's `gh pr comment` instruction (§7) | LLM-generated bash | ❌ vulnerable — fixed by this PR |

## Test plan

- [ ] Trigger `/code-review:code-review --comment <PR>` against a PR with no issues
- [ ] Verify the resulting comment renders newlines correctly in the GitHub UI (no literal `\n`)
- [ ] Verify the raw body (via `gh api repos/.../issues/<N>/comments`) contains real LF characters, not `\\n`