### PR TITLE
feat(frontend-design): add Superpowers Process Gate before implementation

### DIFF
--- a/plugins/frontend-design/skills/frontend-design/SKILL.md
+++ b/plugins/frontend-design/skills/frontend-design/SKILL.md
@@ -8,6 +8,25 @@ This skill guides creation of distinctive, production-grade frontend interfaces 
 
 The user provides frontend requirements: a component, page, application, or interface to build. They may include context about the purpose, audience, or technical constraints.
 
+## Process Gate
+
+<HARD-GATE>
+Do NOT write any code, scaffold any project, or commit to an aesthetic direction until you have completed every step in this checklist and the user has approved the design. This applies to every request regardless of perceived simplicity.
+</HARD-GATE>
+
+Complete these steps in order before any implementation:
+
+1. **Explore context** — scan existing files, design system, component library, and recent commits before asking anything
+2. **Ask clarifying questions** — one at a time: who is the audience, what is the core purpose, what technical constraints exist, are there existing brand references or style guidelines?
+3. **Propose 2–3 aesthetic directions** — each with a distinct visual identity, concrete trade-offs, and your recommendation; let the user choose before proceeding
+4. **Present design direction** — in short focused sections (component architecture, color/typography, motion, layout), confirm approval after each section before continuing
+5. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`, run a quick self-check (no TODOs, no contradictions, scope is focused), then ask the user to review before proceeding
+6. **Create implementation plan** — break into 2–5 minute tasks, each with exact file paths, the minimal code change required, and a concrete verification step
+7. **Implement with visual TDD** — for each task: write the component test or visual snapshot first, confirm it fails, implement the minimal code to pass it, commit; do not bundle multiple tasks into one commit
+8. **Review before delivering** — verify each task against the plan, open the result in a browser and walk the golden path, confirm no regressions before declaring done
+
+Only after completing all 8 steps should you present the final implementation.
+
 ## Design Thinking
 
 Before coding, understand the context and commit to a BOLD aesthetic direction:


### PR DESCRIPTION
## Summary

- Adds a **Process Gate** section at the top of the `frontend-design` SKILL.md, before any implementation begins
- The gate enforces the [Superpowers methodology](https://github.com/obra/superpowers): brainstorm → plan → visual TDD → review
- All existing aesthetic guidelines (Design Thinking, Frontend Aesthetics Guidelines) are preserved **verbatim** — this is a purely additive change

## Problem

The current skill jumps straight from "understand context" to "commit to a bold aesthetic direction" without structured gates. In practice this means agents skip clarifying questions, propose no alternative directions, write no design doc, and deliver code without verifying it in a browser. The result is work that looks visually interesting but doesn't match what the user actually wanted.

## Solution

A `## Process Gate` section with a `<HARD-GATE>` block and an 8-step ordered checklist is inserted between the intro paragraph and the existing `## Design Thinking` section. The checklist mirrors the Superpowers brainstorming → writing-plans → TDD → verification workflow, adapted for visual/frontend work:

1. Explore context (files, design system, recent commits)
2. Ask clarifying questions one at a time
3. Propose 2–3 aesthetic directions with trade-offs
4. Present design direction in sections, confirm approval
5. Write design doc (`docs/superpowers/specs/…`) and ask user to review
6. Create implementation plan (2–5 min tasks, exact file paths, verification steps)
7. Implement with visual TDD (write test/snapshot → fail → implement → pass → commit)
8. Review against plan and verify in browser before declaring done

## Existing PRs

Searched open and closed PRs for "frontend-design", "process gate", "superpowers", "brainstorming". No existing PR addresses this combination.

## What Changed

- `plugins/frontend-design/skills/frontend-design/SKILL.md`: added `## Process Gate` section (~30 lines) before `## Design Thinking`; no existing content modified or removed

## Testing

Tested on Claude Code (Sonnet 4.6). Before this change: asking "Build a landing page for a SaaS app" triggered immediate code generation. After this change: agent asked one clarifying question first (audience), then proposed three aesthetic directions, then presented a short design doc for approval before touching any file.

## Environment

| Harness | Tested |
|---------|--------|
| Claude Code (VSCode extension) | ✅ |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)