### PR TITLE
Scope child_process_exec to JS/TS files (fix Python false-positive)

### DIFF
--- a/plugins/security-guidance/hooks/security_reminder_hook.py
+++ b/plugins/security-guidance/hooks/security_reminder_hook.py
@@ -68,6 +68,7 @@ Other risky inputs to be careful with:
     },
     {
         "ruleName": "child_process_exec",
+        "file_extensions": [".js", ".ts", ".tsx", ".jsx", ".cjs", ".mjs"],
         "substrings": ["child_process.exec", "exec(", "execSync("],
         "reminder": """⚠️ Security Warning: Using child_process.exec() can lead to command injection vulnerabilities.
 
@@ -180,10 +181,20 @@ def save_state(session_id, shown_warnings):
         pass  # Fail silently if we can't save state
 
 
+def _path_extension(normalized_path):
+    """Return lowercase file extension including the leading dot, or empty string."""
+    dot = normalized_path.rfind(".")
+    slash = normalized_path.rfind("/")
+    if dot <= slash or dot == -1:
+        return ""
+    return normalized_path[dot:].lower()
+
+
 def check_patterns(file_path, content):
     """Check if file path or content matches any security patterns."""
     # Normalize path by removing leading slashes
     normalized_path = file_path.lstrip("/")
+    extension = _path_extension(normalized_path)
 
     for pattern in SECURITY_PATTERNS:
         # Check path-based patterns
@@ -192,6 +203,14 @@ def check_patterns(file_path, content):
 
         # Check content-based patterns
         if "substrings" in pattern and content:
+            # Optional extension scope — skip the rule when it explicitly
+            # declares which extensions it applies to and the current file
+            # isn't one of them. Rules without `file_extensions` keep
+            # legacy behavior (apply to all files).
+            allowed_exts = pattern.get("file_extensions")
+            if allowed_exts and extension not in allowed_exts:
+                continue
+
             for substring in pattern["substrings"]:
                 if substring in content:
                     return pattern["ruleName"], pattern["reminder"]


### PR DESCRIPTION
# Scope `child_process_exec` to JS/TS files (fix Python false-positive)

## Summary

The `child_process_exec` rule in `security_reminder_hook.py` uses the substring `"exec("` to match `child_process.exec()` invocations. This substring also matches Python's `asyncio.create_subprocess_exec(`, which is the **safe** Python variant (uses `posix_spawn`, no shell, no command-injection risk).

The hook fires on first Write of any Python file containing `create_subprocess_exec(` and emits a JavaScript-flavored warning recommending `execFileNoThrow.ts` — confusing in a Python context and pure noise.

This PR adds an optional `file_extensions` field to `SECURITY_PATTERNS` entries and applies it to `child_process_exec` so the rule only fires on JS/TS files where `child_process.exec()` is actually a concept.

## Repro (before fix)

```python
# file: services/runner.py
import asyncio
async def spawn():
    proc = await asyncio.create_subprocess_exec(
        "/usr/bin/ls", "-la",
    )
```

First Write triggers the `child_process_exec` warning. Second Write is suppressed (per-session state). Cosmetic friction + misleading recommendation.

## Change

- New optional field on pattern entries: `file_extensions: list[str]` (lowercase extensions including leading dot).
- New helper `_path_extension(normalized_path)` returns the lowercase extension or empty string.
- `check_patterns()` skips a substring rule when its `file_extensions` is set and the current file's extension isn't included.
- Rules without `file_extensions` keep the legacy behavior (apply to all files) — fully backward-compatible.
- Applied to `child_process_exec` only in this PR: `[".js", ".ts", ".tsx", ".jsx", ".cjs", ".mjs"]`.

Other potentially language-specific rules (`new_function_injection`, `react_dangerously_set_html`, `document_write_xss`, `innerHTML_xss`, `pickle_deserialization`) are **intentionally untouched** in this PR to keep scope minimal. Follow-up PRs can scope each individually after this mechanism lands.

`eval_injection` is deliberately left universal — the `eval` builtin is dangerous in JS, Python, Ruby, and beyond.

## Test

Included `test_fix.py` (smoke test, not part of the PR — just included here for the reviewer's confidence). 3 cases:

| Case | Expected | Pre-fix | Post-fix |
|---|---|---|---|
| Python file w/ `asyncio.create_subprocess_exec(` | no match | false-positive | skipped |
| JS file w/ `child_process.exec(` | match `child_process_exec` | matches | matches |
| Python file w/ `eval(` | match `eval_injection` (universal) | matches | matches |

All 3 pass.

## Files changed

- `plugins/security-guidance/hooks/security_reminder_hook.py` (+20 / -0)

## Notes for reviewer

- The fix is additive — no changes to existing rule definitions or behavior.
- `_path_extension()` deliberately handles the "no extension" and "dot-in-dirname-only" cases (e.g., `/path/with.dot/no-extension` returns `""`).
- Filter uses `.lower()` so extensions in YAML/manifest comparison and case-mismatch in user paths both work.
- For maximum portability with the existing pattern data structure, the field is **optional**: any rule that doesn't declare `file_extensions` keeps universal matching.
