### PR TITLE
docs: add CLAUDE_PROJECT_DIR to MCP and plugin environment variable docs

### DIFF
--- a/plugins/plugin-dev/skills/command-development/references/plugin-features-reference.md
+++ b/plugins/plugin-dev/skills/command-development/references/plugin-features-reference.md
@@ -72,9 +72,13 @@ Avoid:
 - /do-stuff           (not descriptive)
 ```
 
-## CLAUDE_PLUGIN_ROOT Environment Variable
+## Plugin Environment Variables
 
-### Purpose
+### CLAUDE_PROJECT_DIR
+
+`${CLAUDE_PROJECT_DIR}` resolves to the project root directory. It is available as an environment variable in all subprocesses including hooks and MCP stdio servers.
+
+### CLAUDE_PLUGIN_ROOT
 
 `${CLAUDE_PLUGIN_ROOT}` is a special environment variable available in plugin commands that resolves to the absolute path of the plugin directory.
 

--- a/plugins/plugin-dev/skills/mcp-integration/SKILL.md
+++ b/plugins/plugin-dev/skills/mcp-integration/SKILL.md
@@ -168,6 +168,14 @@ Connect to WebSocket MCP servers for real-time bidirectional communication.
 
 All MCP configurations support environment variable substitution:
 
+**${CLAUDE_PROJECT_DIR}** - The project root directory:
+```json
+{
+  "command": "node",
+  "args": ["server.js", "--project", "${CLAUDE_PROJECT_DIR}"]
+}
+```
+
 **${CLAUDE_PLUGIN_ROOT}** - Plugin directory (always use for portability):
 ```json
 {
@@ -184,6 +192,8 @@ All MCP configurations support environment variable substitution:
   }
 }
 ```
+
+MCP stdio servers also receive `CLAUDE_PROJECT_DIR` as an environment variable at runtime, matching the behavior of hooks.
 
 **Best practice:** Document all required environment variables in plugin README.
 

--- a/plugins/plugin-dev/skills/mcp-integration/references/server-types.md
+++ b/plugins/plugin-dev/skills/mcp-integration/references/server-types.md
@@ -80,10 +80,11 @@ Execute local MCP servers as child processes with communication via stdin/stdout
 ### Best Practices
 
 1. **Use absolute paths or ${CLAUDE_PLUGIN_ROOT}**
-2. **Set PYTHONUNBUFFERED for Python servers**
-3. **Pass configuration via args or env, not stdin**
-4. **Handle server crashes gracefully**
-5. **Log to stderr, not stdout (stdout is for MCP protocol)**
+2. **Use `CLAUDE_PROJECT_DIR`** to reference the project root — available as an environment variable in all stdio server subprocesses, matching hooks
+3. **Set PYTHONUNBUFFERED for Python servers**
+4. **Pass configuration via args or env, not stdin**
+5. **Handle server crashes gracefully**
+6. **Log to stderr, not stdout (stdout is for MCP protocol)**
 
 ### Troubleshooting
 


### PR DESCRIPTION
MCP stdio servers receive CLAUDE_PROJECT_DIR as an environment variable (matching hooks), but this was not documented. Add it to the MCP integration skill, server-types reference, and plugin-features reference.

Fixes #58121