### PR TITLE
docs: add PostToolUse continueOnBlock option to hooks documentation

### DIFF
--- a/plugins/plugin-dev/skills/hook-development/SKILL.md
+++ b/plugins/plugin-dev/skills/hook-development/SKILL.md
@@ -178,6 +178,30 @@ Execute after tool completes. Use to react to results, provide feedback, or log.
 - Exit 2: stderr fed back to Claude
 - systemMessage included in context
 
+**`continueOnBlock` option:**
+
+Set `continueOnBlock: true` in the hook config to feed the rejection reason back to Claude and continue the turn when `decision` is `"block"`:
+
+```json
+{
+  "PostToolUse": [
+    {
+      "matcher": "Edit",
+      "hooks": [
+        {
+          "type": "prompt",
+          "prompt": "Check the edit for issues. If problematic, return 'block' with reason.",
+          "continueOnBlock": true
+        }
+      ]
+    }
+  ]
+}
+```
+
+- Without `continueOnBlock`: `decision: "block"` adds the reason next to the tool result. Claude still sees the original output.
+- With `continueOnBlock: true`: the rejection reason is fed back to Claude and the turn continues, allowing Claude to react to the feedback.
+
 ### Stop
 
 Execute when main agent considers stopping. Use to validate completeness.

--- a/plugins/plugin-dev/skills/hook-development/references/advanced.md
+++ b/plugins/plugin-dev/skills/hook-development/references/advanced.md
@@ -253,6 +253,18 @@ if [ "$tool_name" = "Bash" ]; then
 fi
 ```
 
+**PostToolUse with `continueOnBlock`:**
+
+To feed the block reason back to Claude and let it continue (instead of just showing it in the transcript), set `continueOnBlock: true` in the hook config:
+
+```json
+{
+  "type": "command",
+  "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/check-quality.sh",
+  "continueOnBlock": true
+}
+```
+
 **Stop - Verify based on tracking:**
 ```bash
 #!/bin/bash


### PR DESCRIPTION
Document the continueOnBlock config option for PostToolUse hooks, which feeds the rejection reason back to Claude and continues the turn when decision is "block". Added to the main hook development skill and the advanced reference.

Fixes #58120