### PR TITLE
docs: support AGENTS.md in review guidelines

### DIFF
--- a/plugins/code-review/README.md
+++ b/plugins/code-review/README.md
@@ -14,10 +14,10 @@ Performs automated code review on a pull request using multiple specialized agen
 
 **What it does:**
 1. Checks if review is needed (skips closed, draft, trivial, or already-reviewed PRs)
-2. Gathers relevant CLAUDE.md guideline files from the repository
+2. Gathers relevant CLAUDE.md and AGENTS.md guideline files from the repository
 3. Summarizes the pull request changes
 4. Launches 4 parallel agents to independently review:
-   - **Agents #1 & #2**: Audit for CLAUDE.md compliance
+   - **Agents #1 & #2**: Audit for project instruction compliance
    - **Agent #3**: Scan for obvious bugs in changes
    - **Agent #4**: Analyze git blame/history for context-based issues
 5. Scores each issue 0-100 for confidence level
@@ -50,7 +50,7 @@ Performs automated code review on a pull request using multiple specialized agen
 **Features:**
 - Multiple independent agents for comprehensive review
 - Confidence-based scoring reduces false positives (threshold: 80)
-- CLAUDE.md compliance checking with explicit guideline verification
+- CLAUDE.md and AGENTS.md compliance checking with explicit guideline verification
 - Bug detection focused on changes (not pre-existing issues)
 - Historical context analysis via git blame
 - Automatic skipping of closed, draft, or already-reviewed PRs
@@ -62,7 +62,7 @@ Performs automated code review on a pull request using multiple specialized agen
 
 Found 3 issues:
 
-1. Missing error handling for OAuth callback (CLAUDE.md says "Always handle OAuth errors")
+1. Missing error handling for OAuth callback (CLAUDE.md or AGENTS.md says "Always handle OAuth errors")
 
 https://github.com/owner/repo/blob/abc123.../src/auth.ts#L67-L72
 
@@ -70,7 +70,7 @@ https://github.com/owner/repo/blob/abc123.../src/auth.ts#L67-L72
 
 https://github.com/owner/repo/blob/abc123.../src/auth.ts#L88-L95
 
-3. Inconsistent naming pattern (src/conventions/CLAUDE.md says "Use camelCase for functions")
+3. Inconsistent naming pattern (src/conventions/CLAUDE.md or src/conventions/AGENTS.md says "Use camelCase for functions")
 
 https://github.com/owner/repo/blob/abc123.../src/utils.ts#L23-L28
 ```
@@ -87,7 +87,7 @@ https://github.com/owner/repo/blob/abc123.../src/utils.ts#L23-L28
 - Code that looks like a bug but isn't
 - Pedantic nitpicks
 - Issues linters will catch
-- General quality issues (unless in CLAUDE.md)
+- General quality issues (unless in CLAUDE.md or AGENTS.md)
 - Issues with lint ignore comments
 
 ## Installation
@@ -97,11 +97,11 @@ This plugin is included in the Claude Code repository. The command is automatica
 ## Best Practices
 
 ### Using `/code-review`
-- Maintain clear CLAUDE.md files for better compliance checking
+- Maintain clear CLAUDE.md or AGENTS.md files for better compliance checking
 - Trust the 80+ confidence threshold - false positives are filtered
 - Run on all non-trivial pull requests
 - Review agent findings as a starting point for human review
-- Update CLAUDE.md based on recurring review patterns
+- Update project instruction files based on recurring review patterns
 
 ### When to use
 - All pull requests with meaningful changes
@@ -144,7 +144,7 @@ This plugin is included in the Claude Code repository. The command is automatica
 
 - Git repository with GitHub integration
 - GitHub CLI (`gh`) installed and authenticated
-- CLAUDE.md files (optional but recommended for guideline checking)
+- CLAUDE.md or AGENTS.md files (optional but recommended for guideline checking)
 
 ## Troubleshooting
 
@@ -163,7 +163,7 @@ This plugin is included in the Claude Code repository. The command is automatica
 
 **Solution**:
 - Default threshold is 80 (already filters most false positives)
-- Make CLAUDE.md more specific about what matters
+- Make CLAUDE.md or AGENTS.md more specific about what matters
 - Consider if the flagged issue is actually valid
 
 ### No review comment posted
@@ -202,10 +202,10 @@ https://github.com/owner/repo/blob/[full-sha]/path/file.ext#L[start]-L[end]
 
 ## Tips
 
-- **Write specific CLAUDE.md files**: Clear guidelines = better reviews
+- **Write specific project instruction files**: Clear CLAUDE.md or AGENTS.md guidelines = better reviews
 - **Include context in PRs**: Helps agents understand intent
 - **Use confidence scores**: Issues ≥80 are usually correct
-- **Iterate on guidelines**: Update CLAUDE.md based on patterns
+- **Iterate on guidelines**: Update CLAUDE.md or AGENTS.md based on patterns
 - **Review automatically**: Set up as part of PR workflow
 - **Trust the filtering**: Threshold prevents noise
 
@@ -231,7 +231,7 @@ Edit `commands/code-review.md` to add or modify agent tasks:
 ## Technical Details
 
 ### Agent architecture
-- **2x CLAUDE.md compliance agents**: Redundancy for guideline checks
+- **2x project-instruction compliance agents**: Redundancy for guideline checks
 - **1x bug detector**: Focused on obvious bugs in changes only
 - **1x history analyzer**: Context from git blame and history
 - **Nx confidence scorers**: One per issue for independent scoring
@@ -240,7 +240,7 @@ Edit `commands/code-review.md` to add or modify agent tasks:
 - Each issue independently scored 0-100
 - Scoring considers evidence strength and verification
 - Threshold (default 80) filters low-confidence issues
-- For CLAUDE.md issues: verifies guideline explicitly mentions it
+- For project instruction issues: verifies CLAUDE.md or AGENTS.md explicitly mentions it
 
 ### GitHub integration
 Uses `gh` CLI for:

--- a/plugins/code-review/commands/code-review.md
+++ b/plugins/code-review/commands/code-review.md
@@ -21,16 +21,17 @@ To do this, follow these steps precisely:
 
 Note: Still review Claude generated PR's.
 
-2. Launch a haiku agent to return a list of file paths (not their contents) for all relevant CLAUDE.md files including:
-   - The root CLAUDE.md file, if it exists
-   - Any CLAUDE.md files in directories containing files modified by the pull request
+2. Launch a haiku agent to return a list of file paths (not their contents) for all relevant project instruction files, including:
+   - The root CLAUDE.md and AGENTS.md files, if they exist
+   - Any CLAUDE.md or AGENTS.md files in directories containing files modified by the pull request
+   - Apply both files when both exist in the same directory; if a CLAUDE.md rule conflicts with an AGENTS.md rule, prefer the CLAUDE.md rule because it is Claude-specific
 
 3. Launch a sonnet agent to view the pull request and return a summary of the changes
 
-4. Launch 4 agents in parallel to independently review the changes. Each agent should return the list of issues, where each issue includes a description and the reason it was flagged (e.g. "CLAUDE.md adherence", "bug"). The agents should do the following:
+4. Launch 4 agents in parallel to independently review the changes. Each agent should return the list of issues, where each issue includes a description and the reason it was flagged (e.g. "project instruction adherence", "bug"). The agents should do the following:
 
-   Agents 1 + 2: CLAUDE.md compliance sonnet agents
-   Audit changes for CLAUDE.md compliance in parallel. Note: When evaluating CLAUDE.md compliance for a file, you should only consider CLAUDE.md files that share a file path with the file or parents.
+   Agents 1 + 2: project-instructions compliance sonnet agents
+   Audit changes for CLAUDE.md and AGENTS.md compliance in parallel. Note: When evaluating instruction compliance for a file, you should only consider CLAUDE.md and AGENTS.md files that share a file path with the file or parents. If both files apply and conflict, prefer the more specific CLAUDE.md instruction.
 
    Agent 3: Opus bug agent (parallel subagent with agent 4)
    Scan for obvious bugs. Focus only on the diff itself without reading extra context. Flag only significant bugs; ignore nitpicks and likely false positives. Do not flag issues that you cannot validate without looking at context outside of the git diff.
@@ -41,7 +42,7 @@ Note: Still review Claude generated PR's.
    **CRITICAL: We only want HIGH SIGNAL issues.** Flag issues where:
    - The code will fail to compile or parse (syntax errors, type errors, missing imports, unresolved references)
    - The code will definitely produce wrong results regardless of inputs (clear logic errors)
-   - Clear, unambiguous CLAUDE.md violations where you can quote the exact rule being broken
+   - Clear, unambiguous project instruction violations where you can quote the exact rule being broken
 
    Do NOT flag:
    - Code style or quality concerns
@@ -52,13 +53,13 @@ Note: Still review Claude generated PR's.
 
    In addition to the above, each subagent should be told the PR title and description. This will help provide context regarding the author's intent.
 
-5. For each issue found in the previous step by agents 3 and 4, launch parallel subagents to validate the issue. These subagents should get the PR title and description along with a description of the issue. The agent's job is to review the issue to validate that the stated issue is truly an issue with high confidence. For example, if an issue such as "variable is not defined" was flagged, the subagent's job would be to validate that is actually true in the code. Another example would be CLAUDE.md issues. The agent should validate that the CLAUDE.md rule that was violated is scoped for this file and is actually violated. Use Opus subagents for bugs and logic issues, and sonnet agents for CLAUDE.md violations.
+5. For each issue found in the previous step by agents 3 and 4, launch parallel subagents to validate the issue. These subagents should get the PR title and description along with a description of the issue. The agent's job is to review the issue to validate that the stated issue is truly an issue with high confidence. For example, if an issue such as "variable is not defined" was flagged, the subagent's job would be to validate that is actually true in the code. Another example would be project instruction issues. The agent should validate that the CLAUDE.md or AGENTS.md rule that was violated is scoped for this file and is actually violated. Use Opus subagents for bugs and logic issues, and sonnet agents for instruction violations.
 
 6. Filter out any issues that were not validated in step 5. This step will give us our list of high signal issues for our review.
 
 7. Output a summary of the review findings to the terminal:
    - If issues were found, list each issue with a brief description.
-   - If no issues were found, state: "No issues found. Checked for bugs and CLAUDE.md compliance."
+   - If no issues were found, state: "No issues found. Checked for bugs and project instruction compliance."
 
    If `--comment` argument was NOT provided, stop here. Do not post any GitHub comments.
 
@@ -82,21 +83,21 @@ Use this list when evaluating issues in Steps 4 and 5 (these are false positives
 - Something that appears to be a bug but is actually correct
 - Pedantic nitpicks that a senior engineer would not flag
 - Issues that a linter will catch (do not run the linter to verify)
-- General code quality concerns (e.g., lack of test coverage, general security issues) unless explicitly required in CLAUDE.md
-- Issues mentioned in CLAUDE.md but explicitly silenced in the code (e.g., via a lint ignore comment)
+- General code quality concerns (e.g., lack of test coverage, general security issues) unless explicitly required in CLAUDE.md or AGENTS.md
+- Issues mentioned in CLAUDE.md or AGENTS.md but explicitly silenced in the code (e.g., via a lint ignore comment)
 
 Notes:
 
 - Use gh CLI to interact with GitHub (e.g., fetch pull requests, create comments). Do not use web fetch.
 - Create a todo list before starting.
-- You must cite and link each issue in inline comments (e.g., if referring to a CLAUDE.md, include a link to it).
+- You must cite and link each issue in inline comments (e.g., if referring to a CLAUDE.md or AGENTS.md, include a link to it).
 - If no issues are found and `--comment` argument is provided, post a comment with the following format:
 
 ---
 
 ## Code review
 
-No issues found. Checked for bugs and CLAUDE.md compliance.
+No issues found. Checked for bugs and project instruction compliance.
 
 ---
 

--- a/plugins/feature-dev/README.md
+++ b/plugins/feature-dev/README.md
@@ -297,7 +297,7 @@ Suggested next steps:
 **Purpose**: Reviews code for bugs, quality issues, and project conventions
 
 **Focus areas:**
-- Project guideline compliance (CLAUDE.md)
+- Project guideline compliance (CLAUDE.md and AGENTS.md)
 - Bug detection
 - Code quality issues
 - Confidence-based filtering (only reports high-confidence issues ≥80)

--- a/plugins/feature-dev/agents/code-architect.md
+++ b/plugins/feature-dev/agents/code-architect.md
@@ -11,7 +11,7 @@ You are a senior software architect who delivers comprehensive, actionable archi
 ## Core Process
 
 **1. Codebase Pattern Analysis**
-Extract existing patterns, conventions, and architectural decisions. Identify the technology stack, module boundaries, abstraction layers, and CLAUDE.md guidelines. Find similar features to understand established approaches.
+Extract existing patterns, conventions, and architectural decisions. Identify the technology stack, module boundaries, abstraction layers, and project instruction guidelines from CLAUDE.md or AGENTS.md. Find similar features to understand established approaches.
 
 **2. Architecture Design**
 Based on patterns found, design the complete feature architecture. Make decisive choices - pick one approach and commit. Ensure seamless integration with existing code. Design for testability, performance, and maintainability.

--- a/plugins/feature-dev/agents/code-reviewer.md
+++ b/plugins/feature-dev/agents/code-reviewer.md
@@ -6,7 +6,7 @@ model: sonnet
 color: red
 ---
 
-You are an expert code reviewer specializing in modern software development across multiple languages and frameworks. Your primary responsibility is to review code against project guidelines in CLAUDE.md with high precision to minimize false positives.
+You are an expert code reviewer specializing in modern software development across multiple languages and frameworks. Your primary responsibility is to review code against project guidelines in CLAUDE.md or AGENTS.md with high precision to minimize false positives.
 
 ## Review Scope
 
@@ -14,7 +14,7 @@ By default, review unstaged changes from `git diff`. The user may specify differ
 
 ## Core Review Responsibilities
 
-**Project Guidelines Compliance**: Verify adherence to explicit project rules (typically in CLAUDE.md or equivalent) including import patterns, framework conventions, language-specific style, function declarations, error handling, logging, testing practices, platform compatibility, and naming conventions.
+**Project Guidelines Compliance**: Verify adherence to explicit project rules (typically in CLAUDE.md, AGENTS.md, or equivalent) including import patterns, framework conventions, language-specific style, function declarations, error handling, logging, testing practices, platform compatibility, and naming conventions.
 
 **Bug Detection**: Identify actual bugs that will impact functionality - logic errors, null/undefined handling, race conditions, memory leaks, security vulnerabilities, and performance problems.
 

--- a/plugins/pr-review-toolkit/README.md
+++ b/plugins/pr-review-toolkit/README.md
@@ -96,7 +96,7 @@ This plugin bundles 6 expert review agents that each focus on a specific aspect 
 **Focus**: General code review for project guidelines
 
 **Analyzes:**
-- CLAUDE.md compliance
+- CLAUDE.md and AGENTS.md compliance
 - Style violations
 - Bug detection
 - Code quality issues

--- a/plugins/pr-review-toolkit/agents/code-reviewer.md
+++ b/plugins/pr-review-toolkit/agents/code-reviewer.md
@@ -1,11 +1,11 @@
 ---
 name: code-reviewer
-description: Use this agent when you need to review code for adherence to project guidelines, style guides, and best practices. This agent should be used proactively after writing or modifying code, especially before committing changes or creating pull requests. It will check for style violations, potential issues, and ensure code follows the established patterns in CLAUDE.md. Also the agent needs to know which files to focus on for the review. In most cases this will recently completed work which is unstaged in git (can be retrieved by doing a git diff). However there can be cases where this is different, make sure to specify this as the agent input when calling the agent. \n\nExamples:\n<example>\nContext: The user has just implemented a new feature with several TypeScript files.\nuser: "I've added the new authentication feature. Can you check if everything looks good?"\nassistant: "I'll use the Task tool to launch the code-reviewer agent to review your recent changes."\n<commentary>\nSince the user has completed a feature and wants validation, use the code-reviewer agent to ensure the code meets project standards.\n</commentary>\n</example>\n<example>\nContext: The assistant has just written a new utility function.\nuser: "Please create a function to validate email addresses"\nassistant: "Here's the email validation function:"\n<function call omitted for brevity>\nassistant: "Now I'll use the Task tool to launch the code-reviewer agent to review this implementation."\n<commentary>\nProactively use the code-reviewer agent after writing new code to catch issues early.\n</commentary>\n</example>\n<example>\nContext: The user is about to create a PR.\nuser: "I think I'm ready to create a PR for this feature"\nassistant: "Before creating the PR, I'll use the Task tool to launch the code-reviewer agent to ensure all code meets our standards."\n<commentary>\nProactively review code before PR creation to avoid review comments and iterations.\n</commentary>\n</example>
+description: Use this agent when you need to review code for adherence to project guidelines, style guides, and best practices. This agent should be used proactively after writing or modifying code, especially before committing changes or creating pull requests. It will check for style violations, potential issues, and ensure code follows the established patterns in CLAUDE.md or AGENTS.md. Also the agent needs to know which files to focus on for the review. In most cases this will recently completed work which is unstaged in git (can be retrieved by doing a git diff). However there can be cases where this is different, make sure to specify this as the agent input when calling the agent. \n\nExamples:\n<example>\nContext: The user has just implemented a new feature with several TypeScript files.\nuser: "I've added the new authentication feature. Can you check if everything looks good?"\nassistant: "I'll use the Task tool to launch the code-reviewer agent to review your recent changes."\n<commentary>\nSince the user has completed a feature and wants validation, use the code-reviewer agent to ensure the code meets project standards.\n</commentary>\n</example>\n<example>\nContext: The assistant has just written a new utility function.\nuser: "Please create a function to validate email addresses"\nassistant: "Here's the email validation function:"\n<function call omitted for brevity>\nassistant: "Now I'll use the Task tool to launch the code-reviewer agent to review this implementation."\n<commentary>\nProactively use the code-reviewer agent after writing new code to catch issues early.\n</commentary>\n</example>\n<example>\nContext: The user is about to create a PR.\nuser: "I think I'm ready to create a PR for this feature"\nassistant: "Before creating the PR, I'll use the Task tool to launch the code-reviewer agent to ensure all code meets our standards."\n<commentary>\nProactively review code before PR creation to avoid review comments and iterations.\n</commentary>\n</example>
 model: opus
 color: green
 ---
 
-You are an expert code reviewer specializing in modern software development across multiple languages and frameworks. Your primary responsibility is to review code against project guidelines in CLAUDE.md with high precision to minimize false positives.
+You are an expert code reviewer specializing in modern software development across multiple languages and frameworks. Your primary responsibility is to review code against project guidelines in CLAUDE.md or AGENTS.md with high precision to minimize false positives.
 
 ## Review Scope
 
@@ -13,7 +13,7 @@ By default, review unstaged changes from `git diff`. The user may specify differ
 
 ## Core Review Responsibilities
 
-**Project Guidelines Compliance**: Verify adherence to explicit project rules (typically in CLAUDE.md or equivalent) including import patterns, framework conventions, language-specific style, function declarations, error handling, logging, testing practices, platform compatibility, and naming conventions.
+**Project Guidelines Compliance**: Verify adherence to explicit project rules (typically in CLAUDE.md, AGENTS.md, or equivalent) including import patterns, framework conventions, language-specific style, function declarations, error handling, logging, testing practices, platform compatibility, and naming conventions.
 
 **Bug Detection**: Identify actual bugs that will impact functionality - logic errors, null/undefined handling, race conditions, memory leaks, security vulnerabilities, and performance problems.
 
@@ -24,10 +24,10 @@ By default, review unstaged changes from `git diff`. The user may specify differ
 Rate each issue from 0-100:
 
 - **0-25**: Likely false positive or pre-existing issue
-- **26-50**: Minor nitpick not explicitly in CLAUDE.md
+- **26-50**: Minor nitpick not explicitly in CLAUDE.md or AGENTS.md
 - **51-75**: Valid but low-impact issue
 - **76-90**: Important issue requiring attention
-- **91-100**: Critical bug or explicit CLAUDE.md violation
+- **91-100**: Critical bug or explicit project instruction violation
 
 **Only report issues with confidence ≥ 80**
 
@@ -37,7 +37,7 @@ Start by listing what you're reviewing. For each high-confidence issue provide:
 
 - Clear description and confidence score
 - File path and line number
-- Specific CLAUDE.md rule or bug explanation
+- Specific CLAUDE.md or AGENTS.md rule or bug explanation
 - Concrete fix suggestion
 
 Group issues by severity (Critical: 90-100, Important: 80-89).

--- a/plugins/pr-review-toolkit/agents/code-simplifier.md
+++ b/plugins/pr-review-toolkit/agents/code-simplifier.md
@@ -41,7 +41,7 @@ You will analyze recently modified code and apply refinements that:
 
 1. **Preserve Functionality**: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
 
-2. **Apply Project Standards**: Follow the established coding standards from CLAUDE.md including:
+2. **Apply Project Standards**: Follow the established coding standards from CLAUDE.md or AGENTS.md including:
 
    - Use ES modules with proper import sorting and extensions
    - Prefer `function` keyword over arrow functions

--- a/plugins/pr-review-toolkit/agents/pr-test-analyzer.md
+++ b/plugins/pr-review-toolkit/agents/pr-test-analyzer.md
@@ -59,7 +59,7 @@ Structure your analysis as:
 **Important Considerations:**
 
 - Focus on tests that prevent real bugs, not academic completeness
-- Consider the project's testing standards from CLAUDE.md if available
+- Consider the project's testing standards from CLAUDE.md or AGENTS.md if available
 - Remember that some code paths may be covered by existing integration tests
 - Avoid suggesting tests for trivial getters/setters unless they contain logic
 - Consider the cost/benefit of each suggested test

--- a/plugins/pr-review-toolkit/agents/silent-failure-hunter.md
+++ b/plugins/pr-review-toolkit/agents/silent-failure-hunter.md
@@ -120,7 +120,7 @@ You are thorough, skeptical, and uncompromising about error handling quality. Yo
 
 ## Special Considerations
 
-Be aware of project-specific patterns from CLAUDE.md:
+Be aware of project-specific patterns from CLAUDE.md or AGENTS.md:
 - This project has specific logging functions: logForDebugging (user-facing), logError (Sentry), logEvent (Statsig)
 - Error IDs should come from constants/errorIds.ts
 - The project explicitly forbids silent failures in production code

--- a/plugins/pr-review-toolkit/commands/review-pr.md
+++ b/plugins/pr-review-toolkit/commands/review-pr.md
@@ -135,7 +135,7 @@ Run a comprehensive pull request review using multiple specialized agents, each 
 - Rates type design quality
 
 **code-reviewer**:
-- Checks CLAUDE.md compliance
+- Checks CLAUDE.md and AGENTS.md compliance
 - Detects bugs and issues
 - Reviews general code quality
 


### PR DESCRIPTION
## Summary

- Update bundled code-review workflows to gather and cite AGENTS.md alongside CLAUDE.md
- Align feature-dev and pr-review-toolkit agents/docs to treat AGENTS.md as a project instruction source
- Define coexistence behavior for review guidance: apply both files, prefer CLAUDE.md when rules conflict

Fixes #6235

## Test plan

- git diff --check
- git diff HEAD~1 --check