### PR TITLE
fix: avoid positional substitution in clean_gone

### DIFF
--- a/plugins/commit-commands/commands/clean_gone.md
+++ b/plugins/commit-commands/commands/clean_gone.md
@@ -26,10 +26,10 @@ You need to execute the following bash commands to clean up stale local branches
    Execute this command:
    ```bash
    # Process all [gone] branches, removing '+' prefix if present
-   git branch -v | grep '\[gone\]' | sed 's/^[+* ]//' | awk '{print $1}' | while read branch; do
+   git branch -v | grep '\[gone\]' | sed 's/^[+* ]//; s/[[:space:]].*$//' | while read branch; do
      echo "Processing branch: $branch"
      # Find and remove worktree if it exists
-     worktree=$(git worktree list | grep "\\[$branch\\]" | awk '{print $1}')
+     worktree=$(git worktree list | grep "\\[$branch\\]" | sed 's/[[:space:]].*$//')
      if [ ! -z "$worktree" ] && [ "$worktree" != "$(git rev-parse --show-toplevel)" ]; then
        echo "  Removing worktree: $worktree"
        git worktree remove --force "$worktree"
@@ -50,4 +50,3 @@ After executing these commands, you will:
 - Provide feedback on which worktrees and branches were removed
 
 If no branches are marked as [gone], report that no cleanup was needed.
-


### PR DESCRIPTION
## Summary
- Replace awk '{print $1}' snippets in /clean_gone with sed field extraction
- Avoid Claude Code command positional substitution stripping literal $1 and breaking branch/worktree parsing

Fixes #52226.

## Test plan
- rg -n "awk '\\{print \$1\\}'|\$1" plugins/commit-commands/commands/clean_gone.md
- git diff --check