### PR TITLE
docs: clarify instruction precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ For more installation options, uninstall steps, and troubleshooting, see the [se
 
 2. Navigate to your project directory and run `claude`.
 
+## Instruction Files
+
+Claude Code can load instructions from multiple locations. More specific
+locations take precedence over broader locations. From broadest to most
+specific:
+
+1. Managed policy instructions for all users and projects
+2. User instructions in `~/.claude/CLAUDE.md`
+3. Project instructions in `CLAUDE.md`
+4. Local project instructions that apply only to you
+
+Use user instructions for preferences that should apply across your projects,
+and project instructions for rules that should override those preferences in a
+specific repository.
+
 ## Plugins
 
 This repository includes several Claude Code plugins that extend functionality with custom commands and agents. See the [plugins directory](./plugins/README.md) for detailed documentation on available plugins.


### PR DESCRIPTION
## Summary
- Add README guidance for instruction file precedence from broadest to most specific
- Clarify that user instructions apply across projects while project instructions override them for a repository

Addresses #58564.

Note: this repository does not contain the docs/en/memory page referenced by the issue, so this PR adds the same corrected precedence guidance to the public README.

## Test plan
- git diff --check