### PR TITLE
fix: use git diff --stat in commit-commands to avoid context bloat

### DIFF
--- a/plugins/commit-commands/commands/commit-push-pr.md
+++ b/plugins/commit-commands/commands/commit-push-pr.md
@@ -6,7 +6,7 @@ description: Commit, push, and open a PR
 ## Context
 
 - Current git status: !`git status`
-- Current git diff (staged and unstaged changes): !`git diff HEAD`
+- Current git diff (staged and unstaged changes): !`git diff HEAD --stat`
 - Current branch: !`git branch --show-current`
 
 ## Your task

--- a/plugins/commit-commands/commands/commit.md
+++ b/plugins/commit-commands/commands/commit.md
@@ -6,7 +6,7 @@ description: Create a git commit
 ## Context
 
 - Current git status: !`git status`
-- Current git diff (staged and unstaged changes): !`git diff HEAD`
+- Current git diff (staged and unstaged changes): !`git diff HEAD --stat`
 - Current branch: !`git branch --show-current`
 - Recent commits: !`git log --oneline -10`
 


### PR DESCRIPTION
## Summary

- Replace `` !`git diff HEAD` `` with `` !`git diff HEAD --stat` `` in `plugins/commit-commands/commands/commit.md` and `plugins/commit-commands/commands/commit-push-pr.md`
- The full unified diff was being loaded into Claude's context on every `/commit` or `/commit-push-pr` invocation
- On large commits (e.g. SQL regen with 50+ auto-generated files) this bloated context by 700KB+, slowing all subsequent LLM responses in the session
- The `--stat` summary (file names + insertion/deletion counts) is sufficient for generating a commit message; full per-file diffs can be fetched on demand if needed

Fixes #58372

## Test plan

- [ ] Run `/commit` on a repo with a small diff — stat summary appears in context, commit message is generated correctly
- [ ] Run `/commit` on a repo with a large diff (many files) — context stays small, no 700KB+ injection
- [ ] Run `/commit-push-pr` — same behaviour, PR is created successfully

🤖 Generated with [Claude Code](https://claude.ai/claude-code)