### PR TITLE
fix(hookify): map prompt patterns to user_prompt

### DIFF
--- a/plugins/hookify/core/config_loader.py
+++ b/plugins/hookify/core/config_loader.py
@@ -63,6 +63,8 @@ class Rule:
                 field = 'command'
             elif event == 'file':
                 field = 'new_text'
+            elif event == 'prompt':
+                field = 'user_prompt'
             else:
                 field = 'content'
 

--- a/plugins/hookify/tests/test_legacy_pattern_mapping.py
+++ b/plugins/hookify/tests/test_legacy_pattern_mapping.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Regression tests for hookify legacy `pattern:` field mapping."""
+
+import sys
+import unittest
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PLUGIN_ROOT.parent))
+
+from hookify.core.config_loader import Rule
+from hookify.core.rule_engine import RuleEngine
+
+
+class LegacyPatternMappingTest(unittest.TestCase):
+    def test_prompt_pattern_matches_user_prompt_submit_payload(self):
+        rule = Rule.from_dict(
+            {
+                "name": "catch prompt keyword",
+                "event": "prompt",
+                "pattern": "deploy",
+            },
+            "Prompt rule fired",
+        )
+
+        engine = RuleEngine()
+        result = engine.evaluate_rules(
+            [rule],
+            {
+                "hook_event_name": "UserPromptSubmit",
+                "user_prompt": "please deploy the preview",
+            },
+        )
+
+        self.assertIn("Prompt rule fired", result["systemMessage"])
+
+    def test_explicit_prompt_condition_still_matches_user_prompt(self):
+        rule = Rule.from_dict(
+            {
+                "name": "explicit prompt condition",
+                "event": "prompt",
+                "conditions": [
+                    {
+                        "field": "user_prompt",
+                        "operator": "contains",
+                        "pattern": "deploy",
+                    }
+                ],
+            },
+            "Explicit condition fired",
+        )
+
+        engine = RuleEngine()
+        result = engine.evaluate_rules(
+            [rule],
+            {
+                "hook_event_name": "UserPromptSubmit",
+                "user_prompt": "please deploy the preview",
+            },
+        )
+
+        self.assertIn("Explicit condition fired", result["systemMessage"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Map hookify legacy `event: prompt` + `pattern:` rules to the actual `UserPromptSubmit` payload field, `user_prompt`
- Add regression coverage for both simple prompt patterns and explicit `conditions` rules

## Why

`Rule.from_dict()` converted legacy prompt `pattern:` rules to `field: content`, but `RuleEngine` reads prompt text from `user_prompt` for `UserPromptSubmit` events. That made simple prompt rules valid-looking but ineffective, while the more verbose `conditions: field: user_prompt` form worked.

## Tests

- `python3 -m unittest plugins/hookify/tests/test_legacy_pattern_mapping.py`
