### PR TITLE
fix(examples/hooks): bash_command_validator regex false negatives (#59441)

### DIFF
--- a/examples/hooks/bash_command_validator_example.py
+++ b/examples/hooks/bash_command_validator_example.py
@@ -32,14 +32,18 @@ import json
 import re
 import sys
 
-# Define validation rules as a list of (regex pattern, message) tuples
+# Define validation rules as a list of (regex pattern, message) tuples.
+#
+# Each pattern is anchored to the start of the command (^) so it matches
+# only when the listed command is the leading binary of the pipeline.
+# Downstream uses (e.g. `cat foo | grep bar`) are intentionally not flagged.
 _VALIDATION_RULES = [
     (
-        r"^grep\b(?!.*\|)",
+        r"^grep\b",
         "Use 'rg' (ripgrep) instead of 'grep' for better performance and features",
     ),
     (
-        r"^find\s+\S+\s+-name\b",
+        r"^find\s+\S+.*\s-name\b",
         "Use 'rg --files | rg pattern' or 'rg --files -g pattern' instead of 'find -name' for better performance",
     ),
 ]


### PR DESCRIPTION
Fixes #59441.

The `_VALIDATION_RULES` in `examples/hooks/bash_command_validator_example.py` had two regex bugs that caused silent false negatives on common command shapes:

1. **grep:** `^grep\b(?!.*\|)` exempted `grep` even when it was the *leading* command of a pipeline (e.g. `grep foo | wc -l`), because the `(?!.*\|)` lookahead fails on any pipe anywhere in the string. The lookahead was apparently intended to exempt downstream uses like `cat foo | grep bar`, but the `^grep` anchor already handles that — the lookahead was dead code that turned into a false-negative source. Dropped it.

2. **find:** `^find\s+\S+\s+-name\b` only matched the `find PATH -name` shape. The most common real-world form — `find PATH -type f -name '*.log'` — was missed because of the rigid `\S+\s+-name` adjacency. Changed to `^find\s+\S+.*\s-name\b` to allow arbitrary predicates between the path and `-name`.

## Case matrix (matches the issue body)

| Command | Before | After |
|---|---|---|
| `grep foo \| wc -l` | not flagged | flagged ✓ |
| `grep foo bar.txt \| head -5` | not flagged | flagged ✓ |
| `find / -type f -name '*.log'` | not flagged | flagged ✓ |
| `find . -type d -name node_modules` | not flagged | flagged ✓ |
| `find . -maxdepth 2 -name '*.md'` | not flagged | flagged ✓ |

Regression guards (still NOT flagged):

| Command | Status |
|---|---|
| `cat foo \| grep bar` | not flagged ✓ (downstream grep) |
| `xargs find . -name foo` | not flagged ✓ (anchored to start) |
| `find / -type f -newer foo.txt` | not flagged ✓ (no `-name`) |
| `findstr foo` | not flagged ✓ (`\b` after `find`) |

Considered switching to `shlex`-based parsing to also catch prefix forms (`sudo grep`, `time grep`) but that would expand the example's scope significantly; happy to do as a follow-up if the maintainers prefer that direction.