### PR TITLE
chore(ci): SHA-pin remaining actions/checkout and actions/github-script

### DIFF
--- a/.github/workflows/auto-close-duplicates.yml
+++ b/.github/workflows/auto-close-duplicates.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1 (sha-pinned)
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0 (sha-pinned)

--- a/.github/workflows/backfill-duplicate-comments.yml
+++ b/.github/workflows/backfill-duplicate-comments.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1 (sha-pinned)
       
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0 (sha-pinned)

--- a/.github/workflows/claude-dedupe-issues.yml
+++ b/.github/workflows/claude-dedupe-issues.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1 (sha-pinned)
 
       - name: Run Claude Code slash command
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1 (sha-pinned)
 
       - name: Run Claude Code for Issue Triage
         timeout-minutes: 5

--- a/.github/workflows/issue-lifecycle-comment.yml
+++ b/.github/workflows/issue-lifecycle-comment.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1 (sha-pinned)
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0 (sha-pinned)

--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Lock closed issues after 7 days of inactivity
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0 (sha-pinned)
         with:
           script: |
             const sevenDaysAgo = new Date();

--- a/.github/workflows/remove-autoclose-label.yml
+++ b/.github/workflows/remove-autoclose-label.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Remove autoclose label
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0 (sha-pinned)
         with:
           script: |
             console.log(`Removing autoclose label from issue #${context.issue.number} due to new comment from ${context.payload.comment.user.login}`);

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1 (sha-pinned)
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0 (sha-pinned)


### PR DESCRIPTION
Follow-up to #56784, SHA-pinning the third-party action references that weren't in the first pass.

- `actions/checkout@v4` to SHA `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1) in 6 workflows (`auto-close-duplicates`, `backfill-duplicate-comments`, `claude-dedupe-issues`, `claude-issue-triage`, `issue-lifecycle-comment`, `sweep`)
- `actions/github-script@v7` to SHA `f28e40c7f34bde8b3046d885e986cb6290c5673b` (v7.1.0) in 2 workflows (`lock-closed-issues`, `remove-autoclose-label`)

Comment format matches the `<sha> # vX.Y.Z (sha-pinned)` style established in #56784.

`anthropics/claude-code-action@v1` references in `claude-dedupe-issues.yml`, `claude-issue-triage.yml`, and `claude.yml` left tag-pinned per SLSA convention for own-org actions. Happy to pin those too if you'd rather.

CVE-2025-30066 motivation. YAML validated locally with `yaml.safe_load`.