### PR TITLE
Preserve labels when auto-closing duplicates

### DIFF
--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -76,7 +76,15 @@ async function closeIssueAsDuplicate(
     'PATCH',
     {
       state: 'closed',
-      state_reason: 'duplicate',
+      state_reason: 'duplicate'
+    }
+  );
+
+  await githubRequest(
+    `/repos/${owner}/${repo}/issues/${issueNumber}/labels`,
+    token,
+    'POST',
+    {
       labels: ['duplicate']
     }
   );


### PR DESCRIPTION
Fixes #60656

## Summary

- Close duplicate issues without replacing their labels
- Add the `duplicate` label through the additive issue labels endpoint
- Preserve existing platform, area, priority, and lifecycle labels when the workflow closes a duplicate

## Validation

- `npm exec --yes --package typescript -- tsc --noEmit --target ES2022 --module ESNext --lib ES2022,DOM --skipLibCheck scripts/auto-close-duplicates.ts`
- `git diff --check`