### PR TITLE
docs: polish plugins README wording

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,6 +1,6 @@
 # Claude Code Plugins
 
-This directory contains some official Claude Code plugins that extend functionality through custom commands, agents, and workflows. These are examples of what's possible with the Claude Code plugin system—many more plugins are available through community marketplaces.
+This directory contains some official Claude Code plugins that extend functionality through custom commands, agents, and workflows. These are examples of what's possible with the Claude Code plugin system—many more plugins are available in community marketplaces.
 
 ## What are Claude Code Plugins?
 


### PR DESCRIPTION
## Summary\n- tweak one sentence in  to read a bit more naturally\n\n## Why\nThis is a tiny documentation polish in a user-facing sentence that describes the plugin ecosystem. It keeps the meaning unchanged while improving the wording slightly.\n\n## Verification\n- verified the updated sentence reads: "many more plugins are available in community marketplaces"