### PR TITLE
fix(security-guidance): add exclude_substrings to cut false positives

### DIFF
--- a/plugins/security-guidance/hooks/security_reminder_hook.py
+++ b/plugins/security-guidance/hooks/security_reminder_hook.py
@@ -69,6 +69,29 @@ Other risky inputs to be careful with:
     {
         "ruleName": "child_process_exec",
         "substrings": ["child_process.exec", "exec(", "execSync("],
+        # Bare "exec(" matches many unrelated APIs (sqlite db.exec, prepared
+        # statements, regex .exec, Python's builtin exec, doc/code-fence
+        # mentions). Exclude common non-shell shapes to cut false positives
+        # without losing coverage of aliased `const { exec } = require('child_process')`.
+        "exclude_substrings": [
+            "db.exec(",
+            "this.db.exec(",
+            ".exec(/",  # regex.exec(/pattern/)
+            "stmt.exec(",
+            "statement.exec(",
+            "cursor.exec(",
+            "session.exec(",
+            "tx.exec(",
+            "trx.exec(",
+            "conn.exec(",
+            "connection.exec(",
+            "`exec(",  # markdown/code-fence: `exec(...)`
+            "'exec('",
+            '"exec("',
+            "# exec(",  # python/shell comment lines
+            "// exec(",  # js/ts comment lines
+            "* exec(",  # jsdoc/block comment lines
+        ],
         "reminder": """⚠️ Security Warning: Using child_process.exec() can lead to command injection vulnerabilities.
 
 This codebase provides a safer alternative: src/utils/execFileNoThrow.ts
@@ -91,11 +114,29 @@ Only use exec() if you absolutely need shell features and the input is guarantee
     {
         "ruleName": "new_function_injection",
         "substrings": ["new Function"],
+        # "new Function" matches identifier prefixes like "new Functionality",
+        # "new FunctionComponent" (React), "new FunctionDeclaration" (AST libs).
+        # The real risk shape is the constructor call: `new Function(`.
+        "exclude_substrings": [
+            "new Functionality",
+            "new FunctionComponent",
+            "new FunctionDeclaration",
+            "new FunctionExpression",
+            "new FunctionType",
+        ],
         "reminder": "⚠️ Security Warning: Using new Function() with dynamic strings can lead to code injection vulnerabilities. Consider alternative approaches that don't evaluate arbitrary code. Only use new Function() if you truly need to evaluate arbitrary dynamic code.",
     },
     {
         "ruleName": "eval_injection",
         "substrings": ["eval("],
+        # ast.literal_eval is the Python stdlib safe alternative to eval and
+        # should not be flagged. Each excluded substring must be the only
+        # match in the content — see _exclude_covers_all_matches below.
+        "exclude_substrings": [
+            "ast.literal_eval(",
+            "literal_eval(",
+            "safe_eval(",
+        ],
         "reminder": "⚠️ Security Warning: eval() executes arbitrary code and is a major security risk. Consider using JSON.parse() for data parsing or alternative design patterns that don't require code evaluation. Only use eval() if you truly need to evaluate arbitrary code.",
     },
     {
@@ -116,6 +157,21 @@ Only use exec() if you absolutely need shell features and the input is guarantee
     {
         "ruleName": "pickle_deserialization",
         "substrings": ["pickle"],
+        # Bare "pickle" matches identifiers like "pickled", "pickle_jar",
+        # variable/file names, and prose. The actual risk is calls to
+        # pickle.load / pickle.loads. Exclude common non-risky shapes that
+        # don't perform deserialization.
+        "exclude_substrings": [
+            "import pickle",
+            "from pickle",
+            "pickled",
+            "pickle_jar",
+            "# pickle",
+            "// pickle",
+            "pickle.dump",  # serialization (write) is not the deserialization risk
+            "pickle.HIGHEST_PROTOCOL",
+            "pickle.DEFAULT_PROTOCOL",
+        ],
         "reminder": "⚠️ Security Warning: Using pickle with untrusted content can lead to arbitrary code execution. Consider using JSON or other safe serialization formats instead. Only use pickle if it is explicitly needed or requested by the user.",
     },
     {
@@ -180,6 +236,35 @@ def save_state(session_id, shown_warnings):
         pass  # Fail silently if we can't save state
 
 
+def _exclude_covers_all_matches(content, substring, exclude_substrings):
+    """Return True if every occurrence of `substring` in `content` is part of
+    some entry in `exclude_substrings`. Used to suppress known false-positive
+    shapes (e.g. `ast.literal_eval(` for the `eval(` trigger) without losing
+    real matches that appear in the same file alongside an excluded one.
+    """
+    if not exclude_substrings:
+        return False
+
+    start = 0
+    while True:
+        idx = content.find(substring, start)
+        if idx == -1:
+            return True
+        covered = False
+        for exclude in exclude_substrings:
+            ex_idx = content.find(exclude)
+            while ex_idx != -1:
+                if ex_idx <= idx and idx + len(substring) <= ex_idx + len(exclude):
+                    covered = True
+                    break
+                ex_idx = content.find(exclude, ex_idx + 1)
+            if covered:
+                break
+        if not covered:
+            return False
+        start = idx + 1
+
+
 def check_patterns(file_path, content):
     """Check if file path or content matches any security patterns."""
     # Normalize path by removing leading slashes
@@ -192,9 +277,13 @@ def check_patterns(file_path, content):
 
         # Check content-based patterns
         if "substrings" in pattern and content:
+            exclude_substrings = pattern.get("exclude_substrings", [])
             for substring in pattern["substrings"]:
-                if substring in content:
-                    return pattern["ruleName"], pattern["reminder"]
+                if substring not in content:
+                    continue
+                if _exclude_covers_all_matches(content, substring, exclude_substrings):
+                    continue
+                return pattern["ruleName"], pattern["reminder"]
 
     return None, None
 

--- a/plugins/security-guidance/hooks/test_security_reminder_hook.py
+++ b/plugins/security-guidance/hooks/test_security_reminder_hook.py
@@ -1,0 +1,169 @@
+"""Unit tests for security_reminder_hook.
+
+Run with: python3 -m unittest plugins/security-guidance/hooks/test_security_reminder_hook.py
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from security_reminder_hook import (  # noqa: E402
+    _exclude_covers_all_matches,
+    check_patterns,
+)
+
+
+class ExcludeCoverageTests(unittest.TestCase):
+    def test_no_excludes_returns_false(self):
+        self.assertFalse(_exclude_covers_all_matches("eval(x)", "eval(", []))
+
+    def test_single_match_inside_exclude(self):
+        self.assertTrue(
+            _exclude_covers_all_matches(
+                "ast.literal_eval(s)", "eval(", ["ast.literal_eval("]
+            )
+        )
+
+    def test_match_outside_exclude_returns_false(self):
+        self.assertFalse(
+            _exclude_covers_all_matches(
+                "ast.literal_eval(s); eval(bad)", "eval(", ["ast.literal_eval("]
+            )
+        )
+
+    def test_multiple_matches_all_covered(self):
+        content = "a = ast.literal_eval(x)\nb = ast.literal_eval(y)"
+        self.assertTrue(
+            _exclude_covers_all_matches(content, "eval(", ["ast.literal_eval("])
+        )
+
+    def test_no_trigger_returns_true(self):
+        # No occurrences of substring at all → vacuously covered.
+        self.assertTrue(_exclude_covers_all_matches("nothing here", "eval(", ["foo"]))
+
+
+class EvalInjectionRuleTests(unittest.TestCase):
+    def test_ast_literal_eval_not_flagged(self):
+        rule, _ = check_patterns("script.py", "value = ast.literal_eval(raw)\n")
+        self.assertIsNone(rule)
+
+    def test_bare_literal_eval_not_flagged(self):
+        rule, _ = check_patterns(
+            "script.py", "from ast import literal_eval\nx = literal_eval(s)\n"
+        )
+        self.assertIsNone(rule)
+
+    def test_real_eval_still_flagged(self):
+        rule, _ = check_patterns("script.py", "result = eval(user_input)\n")
+        self.assertEqual(rule, "eval_injection")
+
+    def test_real_eval_alongside_literal_eval_still_flagged(self):
+        content = "safe = ast.literal_eval(a)\nbad = eval(b)\n"
+        rule, _ = check_patterns("script.py", content)
+        self.assertEqual(rule, "eval_injection")
+
+
+class ChildProcessExecRuleTests(unittest.TestCase):
+    def test_db_exec_not_flagged(self):
+        rule, _ = check_patterns(
+            "db.ts", "db.exec(schema);\nstmt.exec(params);\n"
+        )
+        self.assertIsNone(rule)
+
+    def test_child_process_exec_still_flagged(self):
+        rule, _ = check_patterns(
+            "runner.js",
+            "const { exec } = require('child_process');\nchild_process.exec(cmd);\n",
+        )
+        self.assertEqual(rule, "child_process_exec")
+
+    def test_exec_in_markdown_code_fence_not_flagged(self):
+        content = "Example: `exec(query)` runs the prepared statement.\n"
+        rule, _ = check_patterns("README.md", content)
+        self.assertIsNone(rule)
+
+    def test_execsync_still_flagged(self):
+        rule, _ = check_patterns(
+            "script.js", "const out = execSync('ls');\n"
+        )
+        self.assertEqual(rule, "child_process_exec")
+
+    def test_regex_dot_exec_not_flagged(self):
+        rule, _ = check_patterns(
+            "parse.js", "const m = re.exec(/^foo/);\n"
+        )
+        self.assertIsNone(rule)
+
+
+class NewFunctionRuleTests(unittest.TestCase):
+    def test_new_functionality_not_flagged(self):
+        rule, _ = check_patterns(
+            "notes.md", "We added new Functionality for users.\n"
+        )
+        self.assertIsNone(rule)
+
+    def test_new_function_constructor_still_flagged(self):
+        rule, _ = check_patterns(
+            "evil.js", "const f = new Function('return ' + userCode);\n"
+        )
+        self.assertEqual(rule, "new_function_injection")
+
+
+class PickleRuleTests(unittest.TestCase):
+    def test_pickled_identifier_not_flagged(self):
+        rule, _ = check_patterns(
+            "data.py", "pickled = True\nreturn pickled\n"
+        )
+        self.assertIsNone(rule)
+
+    def test_pickle_load_still_flagged(self):
+        rule, _ = check_patterns(
+            "loader.py", "import pickle\nobj = pickle.load(f)\n"
+        )
+        self.assertEqual(rule, "pickle_deserialization")
+
+    def test_pickle_dump_alone_not_flagged(self):
+        rule, _ = check_patterns(
+            "saver.py", "import pickle\npickle.dump(obj, f)\n"
+        )
+        self.assertIsNone(rule)
+
+
+class PathBasedRuleTests(unittest.TestCase):
+    def test_github_workflow_path_flagged(self):
+        rule, _ = check_patterns(
+            ".github/workflows/ci.yml", "name: CI\non: push\n"
+        )
+        self.assertEqual(rule, "github_actions_workflow")
+
+    def test_non_workflow_yml_not_flagged(self):
+        rule, _ = check_patterns("config.yml", "name: CI\non: push\n")
+        self.assertIsNone(rule)
+
+
+class UnchangedRulesTests(unittest.TestCase):
+    def test_dangerously_set_inner_html_still_flagged(self):
+        rule, _ = check_patterns(
+            "App.tsx", "<div dangerouslySetInnerHTML={{__html: x}} />\n"
+        )
+        self.assertEqual(rule, "react_dangerously_set_html")
+
+    def test_document_write_still_flagged(self):
+        rule, _ = check_patterns("page.js", "document.write('hi');\n")
+        self.assertEqual(rule, "document_write_xss")
+
+    def test_inner_html_still_flagged(self):
+        rule, _ = check_patterns("page.js", "el.innerHTML = userInput;\n")
+        self.assertEqual(rule, "innerHTML_xss")
+
+    def test_os_system_still_flagged(self):
+        rule, _ = check_patterns(
+            "deploy.py", "import os\nos.system('rm -rf /')\n"
+        )
+        self.assertEqual(rule, "os_system_injection")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The `security-guidance` plugin's content-based rules use plain substring matching, which produces well-known false positives for several common identifier and call shapes:

- `eval(` matches `ast.literal_eval(` (Python stdlib's safe parser) — see #55464
- `exec(` matches `db.exec(...)`, `stmt.exec(...)`, regex `.exec(/.../)`, doc/code-fence mentions, etc. — see #46720
- `new Function` matches `new Functionality`, `new FunctionComponent`
- `pickle` matches `pickled`, `pickle_jar`, and bare `import pickle` / `pickle.dump` (serialization, not deserialization)

This PR adds an optional `exclude_substrings` field to the SECURITY_PATTERNS schema. A rule matches only if at least one occurrence of its trigger substring is **not** inside any excluded substring, so:

- Files containing only excluded shapes are skipped (no warning)
- Files containing both an excluded shape and a real risk shape still fire on the real one
- Rules without `exclude_substrings` behave exactly as before (backward compatible)

Schema follows the design proposed by the issue author in #55464.

## Case matrix

| Content | Trigger | Before | After |
| --- | --- | --- | --- |
| `value = ast.literal_eval(raw)` | `eval(` | flagged | not flagged |
| `result = eval(user_input)` | `eval(` | flagged | **still flagged** |
| `ast.literal_eval(a); eval(b)` | `eval(` | flagged | **still flagged** (on the real `eval(b)`) |
| `db.exec(schema)` | `exec(` | flagged | not flagged |
| `child_process.exec(cmd)` | `exec(` | flagged | **still flagged** |
| `\`exec(query)\`` in markdown | `exec(` | flagged | not flagged |
| `new Functionality` | `new Function` | flagged | not flagged |
| `new Function('return ' + x)` | `new Function` | flagged | **still flagged** |
| `import pickle; pickle.dump(o,f)` | `pickle` | flagged | not flagged |
| `import pickle; pickle.load(f)` | `pickle` | flagged | **still flagged** |

## Test plan

- [x] `python3 -m unittest plugins/security-guidance/hooks/test_security_reminder_hook.py` — 25 tests, all pass locally
- [x] Path-based GitHub Actions workflow rule still fires
- [x] Existing content rules with no exclusions (dangerouslySetInnerHTML, document.write, innerHTML, os.system) unchanged

## Closes / refs

- Closes #55464 (`ast.literal_eval` false positive)
- Refs #46720 (markdown `exec(` false positive — addressed at the substring level rather than via a file-extension allowlist, so source-file false positives are also covered)
- Alternative to #47514, which scopes substring checks off for doc-like extensions. The two approaches are complementary; happy to defer or combine if a maintainer prefers that route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)