### PR TITLE
Use workload identity federation for Claude auth in CI workflows

### DIFF
--- a/.github/workflows/claude-dedupe-issues.yml
+++ b/.github/workflows/claude-dedupe-issues.yml
@@ -17,6 +17,8 @@ jobs:
     permissions:
       contents: read
       issues: write
+      # Required to mint the OIDC token exchanged for a Claude API access token (Workload Identity Federation)
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -31,7 +33,13 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_non_write_users: "*"
           prompt: "/dedupe ${{ github.repository }}/issues/${{ github.event.issue.number || inputs.issue_number }}"
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Authenticate to the Claude API via Workload Identity Federation
+          # (the workflow's OIDC token is exchanged for a short-lived access
+          # token) instead of a static API key.
+          anthropic_federation_rule_id: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
+          anthropic_organization_id: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
+          anthropic_service_account_id: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}
+          anthropic_workspace_id: ${{ vars.ANTHROPIC_WORKSPACE_ID }}
           claude_args: "--model claude-sonnet-4-5-20250929"
 
       - name: Log duplicate comment event to Statsig

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -18,6 +18,8 @@ jobs:
     permissions:
       contents: read
       issues: write
+      # Required to mint the OIDC token exchanged for a Claude API access token (Workload Identity Federation)
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -34,6 +36,12 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_non_write_users: "*"
           prompt: "/triage-issue REPO: ${{ github.repository }} ISSUE_NUMBER: ${{ github.event.issue.number }} EVENT: ${{ github.event_name }}"
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Authenticate to the Claude API via Workload Identity Federation
+          # (the workflow's OIDC token is exchanged for a short-lived access
+          # token) instead of a static API key.
+          anthropic_federation_rule_id: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
+          anthropic_organization_id: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
+          anthropic_service_account_id: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}
+          anthropic_workspace_id: ${{ vars.ANTHROPIC_WORKSPACE_ID }}
           claude_args: |
             --model claude-opus-4-6

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,6 +33,12 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Authenticate to the Claude API via Workload Identity Federation
+          # (the workflow's OIDC token is exchanged for a short-lived access
+          # token) instead of a static API key.
+          anthropic_federation_rule_id: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
+          anthropic_organization_id: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
+          anthropic_service_account_id: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}
+          anthropic_workspace_id: ${{ vars.ANTHROPIC_WORKSPACE_ID }}
           claude_args: "--model claude-sonnet-4-5-20250929"
 


### PR DESCRIPTION
## What

Switches this repository's Claude automation workflows from the static `ANTHROPIC_API_KEY` secret to [Workload Identity Federation](https://platform.claude.com/docs/en/manage-claude/workload-identity-federation): the workflow's GitHub OIDC token is exchanged for a short-lived Claude API access token at runtime, so no long-lived API key needs to be stored in the repository.

| Workflow | Change |
| --- | --- |
| `claude.yml` | `anthropic_api_key` → federation inputs (already requests `id-token: write`) |
| `claude-issue-triage.yml` | `anthropic_api_key` → federation inputs, plus `id-token: write` |
| `claude-dedupe-issues.yml` | `anthropic_api_key` → federation inputs, plus `id-token: write` |

This is the same feature [`claude-code-action`](https://github.com/anthropics/claude-code-action) ships for its users (anthropics/claude-code-action#1338, [`docs/setup.md`](https://github.com/anthropics/claude-code-action/blob/main/docs/setup.md)).

## How it activates

The federation rule, organization, service account, and workspace IDs are read from repository **variables** (`vars.ANTHROPIC_FEDERATION_RULE_ID`, `vars.ANTHROPIC_ORGANIZATION_ID`, `vars.ANTHROPIC_SERVICE_ACCOUNT_ID`, `vars.ANTHROPIC_WORKSPACE_ID`). These are identifiers, not credentials. Until a repo admin sets them, the action fails fast at env validation with a clear "authentication required" message — so this PR is safe to merge ahead of that, and switching over is a settings change rather than another PR.

The `ANTHROPIC_API_KEY` secret is intentionally left in place until the federated path has produced green runs; rollback is reverting this PR.

## Behavior notes

- These workflows are triggered by issue/comment/review events, so they always run in the base repository context where the OIDC token is available. Fork-triggered `pull_request` runs don't receive `id-token: write` (GitHub withholds it the same way it withholds secrets), so behavior for forks is unchanged from the secret-based setup.
