### PR TITLE
[docs] Add DISABLE_1M_CONTEXT workaround for Sonnet 4.6 usage-credits false positive (#61692)

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -30,6 +30,24 @@ These may be applied at any level of the [settings hierarchy](https://code.claud
 
 To distribute these settings as enterprise-managed policy through Jamf, Iru (Kandji), Intune, or Group Policy, see the deployment templates in [`../mdm`](../mdm).
 
+## Troubleshooting
+
+### "Usage credits required for 1M context" on Sonnet 4.6
+
+If you see `API Error: Usage credits required for 1M context` when using Sonnet 4.6,
+set the `CLAUDE_CODE_DISABLE_1M_CONTEXT` environment variable to force standard 200K context:
+
+```bash
+export CLAUDE_CODE_DISABLE_1M_CONTEXT=1
+claude
+```
+
+This bypasses the usage-credits check for Pro plan users who don't have 1M context access.
+Sonnet 4.6 on Pro plan should use standard context (200K) without requiring usage credits.
+See issues [#61692](https://github.com/anthropics/claude-code/issues/61692),
+[#61089](https://github.com/anthropics/claude-code/issues/61089), and
+[#60707](https://github.com/anthropics/claude-code/issues/60707) for details.
+
 ## Full Documentation
 
 See https://code.claude.com/docs/en/settings for complete documentation on all available managed settings.


### PR DESCRIPTION
## Summary

Documents the `CLAUDE_CODE_DISABLE_1M_CONTEXT` environment variable workaround for users hitting a false "Usage credits required for 1M context" error on Sonnet 4.6.

Closes #61692

## Problem

Sonnet 4.6 is incorrectly blocked by `API Error: Usage credits required for 1M context` on Pro plan. The error should only apply to Opus with extended 1M context. The API's plan-tier check is treating Sonnet 4.6 as a 1M-context model for Pro users who don't have usage credits.

This affects both CLI (v2.1.147) and VSCode extension users. See also #61089 and #60707.

## Workaround

`CLAUDE_CODE_DISABLE_1M_CONTEXT=1` forces standard 200K context, bypassing the usage-credits check entirely. This env var was added in v2.1.49 (CHANGELOG line 2106) but is not widely documented.

## The Permanent Fix

The API's model-to-plan-tier mapping for 1M context needs correction:
- Pro plan: Sonnet 4.6 uses standard 200K context (no usage credits needed)
- Max/Team/Enterprise: Sonnet 4.6 can use 1M context (usage credits apply)
