### PR TITLE
[docs] Add workaround for system-reminder blocks leaking into WebFetch results (#61690)

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -30,6 +30,23 @@ These may be applied at any level of the [settings hierarchy](https://code.claud
 
 To distribute these settings as enterprise-managed policy through Jamf, Iru (Kandji), Intune, or Group Policy, see the deployment templates in [`../mdm`](../mdm).
 
+## Troubleshooting
+
+### `<system-reminder>` blocks leaking into WebFetch results (v2.1.150)
+
+In Claude Code **v2.1.150**, `<system-reminder>` blocks (TaskCreate/TaskUpdate nudges,
+tool-availability reminders) are incorrectly appended to `WebFetch` tool result content
+instead of being delivered as separate system messages. This is a routing regression
+introduced by internal refactoring in v2.1.150.
+
+**Workaround**: downgrade to v2.1.149:
+
+```bash
+npm install -g @anthropic-ai/claude-code@2.1.149
+```
+
+See issue [#61690](https://github.com/anthropics/claude-code/issues/61690) for details.
+
 ## Full Documentation
 
 See https://code.claude.com/docs/en/settings for complete documentation on all available managed settings.


### PR DESCRIPTION
## Summary

Documents the v2.1.150 regression where system-reminder blocks leak into WebFetch tool result content. Includes the downgrade workaround and the proposed fix approach from community analysis.

Closes #61690

## Problem

In v2.1.150, system-reminder blocks (TaskCreate/TaskUpdate nudges, tool-availability reminders) are appended to WebFetch tool_result content instead of being delivered as separate system messages. This is a routing regression from internal refactoring affecting all deferred tools (WebFetch, WebSearch, Glob with large patterns).

## Workaround

npm install -g @anthropic-ai/claude-code@2.1.149

## Proposed Fix

Two-layer approach from community analysis (see issue comments by @jshaofa-ui):

Layer 1 (immediate safety net): Strip system-reminder blocks from deferred tool results in formatResult():

`
const SYSTEM_REMINDER_RE = /<system-reminder>[\s\S]*?<\/system-reminder>/g;
`

Applied in WebFetchTool.formatResult(), WebSearch, Glob, and any tool using deferred result callbacks.

Layer 2 (permanent): Fix the deferred-result callback to flush the reminder buffer to the system-reminder slot before writing tool_result.content. The v2.1.150 refactor introduced this routing bug: the reminder scheduler fires during the deferred callback and writes into the wrong buffer.