### PR TITLE
[docs] Add workaround for background tasks silently relaunched as duplicates (#61689)

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -30,6 +30,31 @@ These may be applied at any level of the [settings hierarchy](https://code.claud
 
 To distribute these settings as enterprise-managed policy through Jamf, Iru (Kandji), Intune, or Group Policy, see the deployment templates in [`../mdm`](../mdm).
 
+## Troubleshooting
+
+### Background tasks silently relaunched as duplicates
+
+If background tasks (via Agent tool or `run_in_background`) are silently
+duplicated after ~90–120 seconds while the original is still running,
+this is a regression of a previously-fixed bug (CHANGELOG v2.1.78 line 1452):
+*"Fixed background subagents becoming invisible after context compaction,
+which could cause duplicate agents to be spawned"*.
+
+**Workaround options**:
+
+1. **Disable backgrounding entirely** (only if you don't need parallelism):
+   ```bash
+   export CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1
+   ```
+
+2. **Batch sequential checks inside a single task** (preserves parallelism for
+   independent work while avoiding duplicates for heavy commands):
+   ```bash
+   npx tsc --noEmit && pnpm lint
+   ```
+
+See issue [#61689](https://github.com/anthropics/claude-code/issues/61689) for details.
+
 ## Full Documentation
 
 See https://code.claude.com/docs/en/settings for complete documentation on all available managed settings.


### PR DESCRIPTION
## Summary

Documents the background task duplicate relaunch issue. Incorporates the proposed three-layer fix approach from community analysis.

Closes #61689

## Problem

Background tasks are silently duplicated after ~90-120 seconds when context compaction strips task metadata. The scheduler forgets which tasks are running and treats them as stale, spawning duplicates alongside still-running originals.

## Workaround

```bash
export CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1
```
Note: this is a full kill switch ? only use if you don't need background parallelism.

For users who need parallelism: batch sequential work in a single Bash call instead of using run_in_background.

## Proposed Fix (three layers)

### Layer 1 ? Preserve task metadata across compaction (permanent)
Ensure background task records survive context compaction so the scheduler knows about running tasks.

### Layer 2 ? PGID tracking + health check tolerance (@jshaofa-ui)
Track tasks by process group, require 3 consecutive health check failures before relaunch:

```ts
interface TrackedTask { pid: number; pgid: number; healthCheckFailures: number; }
```

### Layer 3 ? Deduplication gate on launch
Before spawning any task, verify no task with the same command + PGID is already tracked.

## Related

Regression of the v2.1.78 fix (CHANGELOG line 1452).