### PR TITLE
[docs] Add cleanup doc for failed telemetry events accumulating without retry (#61687)

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -30,6 +30,26 @@ These may be applied at any level of the [settings hierarchy](https://code.claud
 
 To distribute these settings as enterprise-managed policy through Jamf, Iru (Kandji), Intune, or Group Policy, see the deployment templates in [`../mdm`](../mdm).
 
+## Troubleshooting
+
+### Failed telemetry events accumulate in ~/.claude/telemetry/
+
+If telemetry submission fails, `1p_failed_events.*.json` files accumulate
+in `~/.claude/telemetry/` and are never retried on subsequent startups.
+These are internal product telemetry (not user data) and can be safely removed.
+
+**Cleanup**:
+```bash
+rm -f ~/.claude/telemetry/1p_failed_events.*.json
+```
+
+**Prevent future accumulation**:
+```bash
+export DISABLE_TELEMETRY=1
+```
+
+See issue [#61687](https://github.com/anthropics/claude-code/issues/61687) for details.
+
 ## Full Documentation
 
 See https://code.claude.com/docs/en/settings for complete documentation on all available managed settings.


### PR DESCRIPTION
## Summary

Documents the cleanup workaround for failed telemetry events that accumulate in ~/.claude/telemetry/ and are never retried.

Closes #61687

## Problem

\1p_failed_events.*.json\ files accumulate in \~/.claude/telemetry/\ when telemetry submission fails, and are never retried on subsequent startups. Files from Jan-Mar 2026 persist through multiple version upgrades.

## Workaround

\\\ash
rm -f ~/.claude/telemetry/1p_failed_events.*.json
export DISABLE_TELEMETRY=1
\\\

## Fixes Needed (CLI internal)

1. Add startup scan of telemetry directory to retry failed event files
2. Delete file after successful flush
3. Age out files older than 30 days