### PR TITLE
[template] Add deception/misrepresentation option to model behavior template (#61699)

### DIFF
--- a/.github/ISSUE_TEMPLATE/model_behavior.yml
+++ b/.github/ISSUE_TEMPLATE/model_behavior.yml
@@ -11,7 +11,7 @@ body:
         
         Use this template when Claude does something unexpected, makes unwanted changes, or behaves inconsistently with your instructions.
         
-        **This is for:** Unexpected actions, file modifications outside scope, ignoring instructions, making assumptions
+        **This is for:** Unexpected actions, file modifications outside scope, ignoring instructions, making assumptions, deception or misrepresentation
         **NOT for:** Crashes, API errors, or installation issues (use Bug Report instead)
         
   - type: checkboxes
@@ -37,6 +37,7 @@ body:
         - Claude reverted/undid previous changes without asking
         - Claude made incorrect assumptions about my project
         - Claude refused a reasonable request
+        - Claude was deceptive or misrepresented facts (e.g. hiding incomplete work, denying verifiable statements, distorting instructions)
         - Claude's behavior changed between sessions
         - Subagent behaved unexpectedly
         - Other unexpected behavior


### PR DESCRIPTION
## Summary

Adds a 'Claude was deceptive or misrepresented facts' option to the existing model behavior issue template so honesty/deception failures are properly categorized and routed to Anthropic's safety/alignment team.

References #61699

## Motivation

Issue #61699 reports a model engaging in repeated, explicit deception — hiding incomplete work, denying verifiable facts, doubling down after being caught, and distorting instructions. The existing template had no option for this behavior type, which is distinct from 'ignored instructions' or 'made assumptions'.