### PR TITLE
[docs] Add stats cache freeze troubleshooting entry for lastComputedDate stagnation (#61686)

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -36,7 +36,7 @@ To distribute these settings as enterprise-managed policy through Jamf, Iru (Kan
 
 If `/usage` or the stats dashboard shows stale data and
 `~/.claude/stats-cache.json` has an old `lastComputedDate`, the
-incremental recompute may be silently failing on a session file.
+incremental recompute may be silently failing.
 
 **Check**:
 ```bash
@@ -49,9 +49,15 @@ rm ~/.claude/stats-cache.json
 # Restart Claude Code — cache will rebuild from all session files.
 ```
 
-**Known triggers**: unknown model IDs (models released after your
-cache froze), multi-day sessions, or corrupt session files.
-See issue [#61686](https://github.com/anthropics/claude-code/issues/61686).
+**Root cause**: three compounding bugs in the stats recompute pipeline:
+1. Cache serialization fails on unknown model IDs (e.g. new models released after the cache froze) — `modelUsage` schema has no key for them
+2. No error handling in incremental recompute — a single failure aborts the entire pass and `lastComputedDate` never advances
+3. No staleness cap — once frozen, the cache stays frozen permanently with no forced full-rebuild fallback
+
+**Proposed fix** (from community analysis, see [#61686](https://github.com/anthropics/claude-code/issues/61686)):
+- Add a cache version field with auto-migration for schema changes
+- Wrap per-session processing in try/catch — skip bad files, advance the cursor
+- Force full rebuild if `lastComputedDate` is >30 days behind
 
 ## Full Documentation
 

--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -30,6 +30,29 @@ These may be applied at any level of the [settings hierarchy](https://code.claud
 
 To distribute these settings as enterprise-managed policy through Jamf, Iru (Kandji), Intune, or Group Policy, see the deployment templates in [`../mdm`](../mdm).
 
+## Troubleshooting
+
+### Stats cache `lastComputedDate` not advancing
+
+If `/usage` or the stats dashboard shows stale data and
+`~/.claude/stats-cache.json` has an old `lastComputedDate`, the
+incremental recompute may be silently failing on a session file.
+
+**Check**:
+```bash
+jq -r '.lastComputedDate' ~/.claude/stats-cache.json
+```
+
+**Fix** (force a full rebuild):
+```bash
+rm ~/.claude/stats-cache.json
+# Restart Claude Code — cache will rebuild from all session files.
+```
+
+**Known triggers**: unknown model IDs (models released after your
+cache froze), multi-day sessions, or corrupt session files.
+See issue [#61686](https://github.com/anthropics/claude-code/issues/61686).
+
 ## Full Documentation
 
 See https://code.claude.com/docs/en/settings for complete documentation on all available managed settings.


### PR DESCRIPTION
## Summary

Adds a troubleshooting entry for ~/.claude/stats-cache.json lastComputedDate stagnation. Incorporates the proposed fix approach from community analysis (cache versioning with auto-migration).

Closes #61686

## Problem

Three compounding bugs cause the stats cache to freeze permanently:

1. **Cache serialization fails on unknown model IDs** ? modelUsage schema lacks keys for new models (claude-opus-4-7, claude-haiku-4-5-20251001), so the incremental merge throws
2. **No try/catch in recompute** ? a single failure aborts the entire pass; lastComputedDate never advances
3. **No staleness cap** ? once frozen, stays frozen forever; no forced full-rebuild fallback

## Workaround

```bash
rm ~/.claude/stats-cache.json
# Restart Claude Code to force a full rebuild
```

## Proposed Fix (from @jshaofa-ui)

Add cache version field with auto-migration:

```ts
interface StatsCache { version: number; lastComputedDate: string; modelUsage: Record<string, ModelUsage>; }
function migrateCache(cache: any): StatsCache {
  // v1 -> v2: normalize schema, add new model IDs
}
function loadStatsCache(): StatsCache {
  try { return migrateCache(JSON.parse(fs.readFileSync(CACHE_PATH))); }
  catch { return createFreshCache(); }
}
```

Also needed: per-session try/catch in incremental recompute, and a staleness guard (force full rebuild if lastComputedDate >30 days behind).

## Related

- #46139 ? same freeze
- #50404 ? cache drops days on reinstall
- #48213 ? streak broken