### PR TITLE
[docs] Add troubleshooting entry for false usage/context limits after version upgrade (#61703)

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -30,6 +30,20 @@ These may be applied at any level of the [settings hierarchy](https://code.claud
 
 To distribute these settings as enterprise-managed policy through Jamf, Iru (Kandji), Intune, or Group Policy, see the deployment templates in [`../mdm`](../mdm).
 
+## Troubleshooting
+
+### False usage/context limits after updating
+
+After a version upgrade, sessions created before the update may
+show false-positive usage limits, context limits, or safety
+guardrail blocks. This is caused by a session-format mismatch
+between versions.
+
+**Workaround**: start a new session instead of resuming the old one.
+If the old session is critical, downgrade to the previous version.
+
+See issue [#61703](https://github.com/anthropics/claude-code/issues/61703).
+
 ## Full Documentation
 
 See https://code.claude.com/docs/en/settings for complete documentation on all available managed settings.


### PR DESCRIPTION
## Summary

Adds a troubleshooting entry for false usage limit errors after long Sonnet sessions. Documents the real root cause and model-switch workaround.

Closes #61703
Closes #50321

## Root cause (corrected)

The false usage limit error is a context overflow to failed compaction to wrong error message chain:

1. Context grows past Sonnet's 200K window in a long session
2. /compact is triggered but fails (requires 1M context tier)
3. The compact failure is mis-mapped to the usage limit reached error message
4. User checks plan to quota available to confusion

The v2.1.149 /usage per-category rewrite may have changed when this fires, but the underlying fault predates it and is at the error-routing layer.

Why Sonnet only: Sonnet defaults to 200K context vs Opus's larger/compaction-friendly window. Switching to Opus lets /compact succeed, confirming it is a context issue, not a plan limit.

## Workaround

If stuck with usage limit reached but plan shows quota:
- Switch to Opus via /model, run /compact, switch back
- Or start a new session

## Related

- #50321 (same root cause)