### PR TITLE
[docs] Add troubleshooting entry for invalid model identifier after update (#61707)

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -45,6 +45,7 @@ or Bedrock, where model IDs like `claude-opus-4-7` may not be recognized.
 - Select a different model in the model picker (e.g. `claude-sonnet-4-6`)
 - Clear settings: delete `settings.json` from the app config directory
 - If using Bedrock, verify region prefix: `apac.` / `eu.` / `us.`
+- If `AWS_REGION` / `CLAUDE_CODE_USE_BEDROCK` env vars are set, unset them — they cause the model resolver to pick up Bedrock region prefixes while the desktop auth flow calls the direct Anthropic API, rejecting the prefixed model ID with 400
 
 See issue [#61707](https://github.com/anthropics/claude-code/issues/61707).
 

--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -30,6 +30,24 @@ These may be applied at any level of the [settings hierarchy](https://code.claud
 
 To distribute these settings as enterprise-managed policy through Jamf, Iru (Kandji), Intune, or Group Policy, see the deployment templates in [`../mdm`](../mdm).
 
+## Troubleshooting
+
+### Model identifier invalid after update
+
+If you see `API Error: 400 The provided model identifier is invalid`
+after an update, the update may have changed the default model ID
+while your regional API endpoint still expects the old format.
+
+This commonly affects users in APAC/EU regions using the desktop app
+or Bedrock, where model IDs like `claude-opus-4-7` may not be recognized.
+
+**Workarounds**:
+- Select a different model in the model picker (e.g. `claude-sonnet-4-6`)
+- Clear settings: delete `settings.json` from the app config directory
+- If using Bedrock, verify region prefix: `apac.` / `eu.` / `us.`
+
+See issue [#61707](https://github.com/anthropics/claude-code/issues/61707).
+
 ## Full Documentation
 
 See https://code.claude.com/docs/en/settings for complete documentation on all available managed settings.


### PR DESCRIPTION
## Summary

Adds a troubleshooting entry for the 400 model identifier invalid error. Incorporates community finding that AWS_REGION + CLAUDE_CODE_USE_BEDROCK env vars cause model ID prefix mismatch between Bedrock region resolution and Anthropic API auth.

Closes #61707

## Problem

Desktop app shows "400 The provided model identifier is invalid" error with apac. or other region-prefixed model IDs. Two distinct root causes:

1. **Server-side routing regression** (original report): Desktop app version 1.8555.1 on Windows with apac. Bedrock region prefix ? all models broken, no env vars set
2. **Env var conflict** (@d4sh): AWS_REGION + CLAUDE_CODE_USE_BEDROCK env vars cause the model resolver to pick up Bedrock region prefixes, but the desktop auth flow calls the direct Anthropic API which rejects the prefixed ID

## Workaround

If you have AWS_region env vars set:
```bash
unset AWS_REGION AWS_DEFAULT_REGION CLAUDE_CODE_USE_BEDROCK
```

For the server-side regression: downgrade to working version or use the CLI which handles region prefixes correctly.