### PR TITLE
Add missing plugin.json manifest for plugin-dev (fixes #61710)

### DIFF
--- a/plugins/plugin-dev/.claude-plugin/plugin.json
+++ b/plugins/plugin-dev/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "plugin-dev",
+  "version": "0.1.0",
+  "description": "Comprehensive toolkit for developing Claude Code plugins. Includes 7 expert skills covering hooks, MCP integration, commands, agents, and best practices. AI-assisted plugin creation and validation.",
+  "author": {
+    "name": "Daisy Hollman",
+    "email": "daisy@anthropic.com"
+  }
+}


### PR DESCRIPTION
## Summary

Adds the missing .claude-plugin/plugin.json manifest for plugin-dev. Without this file, Claude Code's plugin auto-discovery cannot load the plugin, even though it is listed in marketplace.json and has all its skills/commands/agents structured correctly.

Closes #61710

## Changes

- Created plugins/plugin-dev/.claude-plugin/plugin.json with metadata matching marketplace.json