### PR TITLE
[docs] Add troubleshooting entry for desktop app localization gaps (#61712)

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -30,6 +30,20 @@ These may be applied at any level of the [settings hierarchy](https://code.claud
 
 To distribute these settings as enterprise-managed policy through Jamf, Iru (Kandji), Intune, or Group Policy, see the deployment templates in [`../mdm`](../mdm).
 
+## Troubleshooting
+
+### Desktop app UI strings not localized (e.g. "New session")
+
+Some desktop app sidebar strings like "New session" are hardcoded
+in the JavaScript bundle rather than pulled from locale files
+like `ja-JP.json`. This is a known desktop app localization gap —
+the locale file exists and is loaded, but certain UI elements bypass it.
+
+**No user-side workaround** — the strings cannot be overridden.
+This must be fixed by the desktop app team.
+
+See issue [#61712](https://github.com/anthropics/claude-code/issues/61712).
+
 ## Full Documentation
 
 See https://code.claude.com/docs/en/settings for complete documentation on all available managed settings.


### PR DESCRIPTION
## Summary

Adds a troubleshooting entry documenting that some desktop app UI strings (e.g. 'New session' in the sidebar) are hardcoded in the JavaScript bundle and cannot be overridden via locale files like ja-JP.json.

Closes #61712

## Note

The actual fix is in the desktop app team codebase and cannot be done from this repo.