### PR TITLE
[docs] Add troubleshooting for ScheduleWakeup non-persistence / stuck sessions (#61735)

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -1,6 +1,6 @@
 # Settings Examples
 
-Example Claude Code settings files, primarily intended for organization-wide deployments. Use these as starting points — adjust them to fit your needs.
+Example Claude Code settings files, primarily intended for organization-wide deployments. Use these as starting points - adjust them to fit your needs.
 
 These may be applied at any level of the [settings hierarchy](https://code.claude.com/docs/en/settings#settings-files), though certain properties only take effect if specified in enterprise settings (e.g. `strictKnownMarketplaces`, `allowManagedHooksOnly`, `allowManagedPermissionRulesOnly`).
 
@@ -12,13 +12,13 @@ These may be applied at any level of the [settings hierarchy](https://code.claud
 
 | Setting | [`settings-lax.json`](./settings-lax.json) | [`settings-strict.json`](./settings-strict.json) | [`settings-bash-sandbox.json`](./settings-bash-sandbox.json) |
 |---------|:---:|:---:|:---:|
-| Disable `--dangerously-skip-permissions` | ✅ | ✅ | |
-| Block plugin marketplaces | ✅ | ✅ | |
-| Block user and project-defined permission `allow` / `ask` / `deny` | | ✅ | ✅ |
-| Block user and project-defined hooks | | ✅ | |
-| Deny web fetch and search tools | | ✅ | |
-| Bash tool requires approval | | ✅ | |
-| Bash tool must run inside of sandbox | | | ✅ |
+| Disable `--dangerously-skip-permissions` | ? | ? | |
+| Block plugin marketplaces | ? | ? | |
+| Block user and project-defined permission `allow` / `ask` / `deny` | | ? | ? |
+| Block user and project-defined hooks | | ? | |
+| Deny web fetch and search tools | | ? | |
+| Bash tool requires approval | | ? | |
+| Bash tool must run inside of sandbox | | | ? |
 
 ## Tips
 - Consider merging snippets of the above examples to reach your desired configuration
@@ -33,3 +33,11 @@ To distribute these settings as enterprise-managed policy through Jamf, Iru (Kan
 ## Full Documentation
 
 See https://code.claude.com/docs/en/settings for complete documentation on all available managed settings.
+
+## Troubleshooting
+
+### ScheduleWakeup lost after process crash / disconnect
+
+`ScheduleWakeup` stores pending wakeups only in memory. If the session process dies (OOM, crash, terminal hang, cluster recycle), all scheduled wakeups are lost with no recovery mechanism. The session becomes silently stuck with no way to interrupt it remotely.
+
+**Workaround:** Do not rely on `ScheduleWakeup` for critical autonomous tasks. Use an external scheduler (`systemd --user` timers, cron) instead. If you need long-running self-paced loops, set up a watchdog that monitors session liveness externally (e.g. a script that checks process existence and alerts via Telegram, email, or system notification).


### PR DESCRIPTION
## Summary

Adds a troubleshooting entry for the ScheduleWakeup non-persistence bug. Pending wakeups are stored only in memory ? when the session process dies (crash, OOM, terminal hang), all wakeups vanish with no recovery mechanism. The session becomes silently stuck with no way to interrupt it remotely.

Reference implementation for the watchdog + remote interrupt workaround: https://github.com/honzastim/claude-code-stuck-session-workaround

Closes #61735