### PR TITLE
[docs] Add troubleshooting for Sonnet 4.6 context window meter showing 200K instead of 1M (#61734)

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -1,6 +1,6 @@
 # Settings Examples
 
-Example Claude Code settings files, primarily intended for organization-wide deployments. Use these as starting points — adjust them to fit your needs.
+Example Claude Code settings files, primarily intended for organization-wide deployments. Use these as starting points - adjust them to fit your needs.
 
 These may be applied at any level of the [settings hierarchy](https://code.claude.com/docs/en/settings#settings-files), though certain properties only take effect if specified in enterprise settings (e.g. `strictKnownMarketplaces`, `allowManagedHooksOnly`, `allowManagedPermissionRulesOnly`).
 
@@ -12,13 +12,13 @@ These may be applied at any level of the [settings hierarchy](https://code.claud
 
 | Setting | [`settings-lax.json`](./settings-lax.json) | [`settings-strict.json`](./settings-strict.json) | [`settings-bash-sandbox.json`](./settings-bash-sandbox.json) |
 |---------|:---:|:---:|:---:|
-| Disable `--dangerously-skip-permissions` | ✅ | ✅ | |
-| Block plugin marketplaces | ✅ | ✅ | |
-| Block user and project-defined permission `allow` / `ask` / `deny` | | ✅ | ✅ |
-| Block user and project-defined hooks | | ✅ | |
-| Deny web fetch and search tools | | ✅ | |
-| Bash tool requires approval | | ✅ | |
-| Bash tool must run inside of sandbox | | | ✅ |
+| Disable `--dangerously-skip-permissions` | ? | ? | |
+| Block plugin marketplaces | ? | ? | |
+| Block user and project-defined permission `allow` / `ask` / `deny` | | ? | ? |
+| Block user and project-defined hooks | | ? | |
+| Deny web fetch and search tools | | ? | |
+| Bash tool requires approval | | ? | |
+| Bash tool must run inside of sandbox | | | ? |
 
 ## Tips
 - Consider merging snippets of the above examples to reach your desired configuration
@@ -33,3 +33,11 @@ To distribute these settings as enterprise-managed policy through Jamf, Iru (Kan
 ## Full Documentation
 
 See https://code.claude.com/docs/en/settings for complete documentation on all available managed settings.
+
+## Troubleshooting
+
+### Context window meter shows 200K for Sonnet 4.6 (should be 1M)
+
+The status bar context window meter shows 200K when using `claude-sonnet-4-6`, but Sonnet 4.6 actually supports a 1M token context window. This is a display bug in the CLI — the internal model capabilities config has the wrong `max_input_tokens` value for this model. The actual API requests use the full 1M window; only the meter display is affected.
+
+**No workaround available.** This requires a CLI update to correct the hardcoded model config.


### PR DESCRIPTION
## Summary

Adds a troubleshooting entry for the Sonnet 4.6 context window display/limit bug ? **a regression in v2.1.150**. The status bar shows 200K and the actual context is capped to 200K, even though Sonnet 4.6 supports 1M tokens per the API.

**Root cause:** v2.1.150's "internal infrastructure improvements" likely reset Sonnet 4.6's `max_input_tokens` from 1M back to the default 200K in the model capabilities config. This is the same class of bug as the Opus 4.7 fix in v2.1.117. No user-side workaround exists ? requires a CLI patch to restore the correct value.

Closes #61734