### PR TITLE
[docs] Add troubleshooting for FleetView zombie remote session entries (#61733)

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -1,6 +1,6 @@
 # Settings Examples
 
-Example Claude Code settings files, primarily intended for organization-wide deployments. Use these as starting points — adjust them to fit your needs.
+Example Claude Code settings files, primarily intended for organization-wide deployments. Use these as starting points - adjust them to fit your needs.
 
 These may be applied at any level of the [settings hierarchy](https://code.claude.com/docs/en/settings#settings-files), though certain properties only take effect if specified in enterprise settings (e.g. `strictKnownMarketplaces`, `allowManagedHooksOnly`, `allowManagedPermissionRulesOnly`).
 
@@ -12,13 +12,13 @@ These may be applied at any level of the [settings hierarchy](https://code.claud
 
 | Setting | [`settings-lax.json`](./settings-lax.json) | [`settings-strict.json`](./settings-strict.json) | [`settings-bash-sandbox.json`](./settings-bash-sandbox.json) |
 |---------|:---:|:---:|:---:|
-| Disable `--dangerously-skip-permissions` | ✅ | ✅ | |
-| Block plugin marketplaces | ✅ | ✅ | |
-| Block user and project-defined permission `allow` / `ask` / `deny` | | ✅ | ✅ |
-| Block user and project-defined hooks | | ✅ | |
-| Deny web fetch and search tools | | ✅ | |
-| Bash tool requires approval | | ✅ | |
-| Bash tool must run inside of sandbox | | | ✅ |
+| Disable `--dangerously-skip-permissions` | ? | ? | |
+| Block plugin marketplaces | ? | ? | |
+| Block user and project-defined permission `allow` / `ask` / `deny` | | ? | ? |
+| Block user and project-defined hooks | | ? | |
+| Deny web fetch and search tools | | ? | |
+| Bash tool requires approval | | ? | |
+| Bash tool must run inside of sandbox | | | ? |
 
 ## Tips
 - Consider merging snippets of the above examples to reach your desired configuration
@@ -33,3 +33,13 @@ To distribute these settings as enterprise-managed policy through Jamf, Iru (Kan
 ## Full Documentation
 
 See https://code.claude.com/docs/en/settings for complete documentation on all available managed settings.
+
+## Troubleshooting
+
+### FleetView remote session entries persist after TUI exits (zombie entries)
+
+After closing the FleetView TUI (`claude agents`), the remote session entry on the Code tab (Claude Desktop / mobile apps) remains visible for 10+ minutes with no cleanup. Entries accumulate with each FleetView invocation and tapping them produces no response.
+
+**Root cause:** The relay connection teardown when the TUI exits does not trigger server-side entry removal. There is no client-side API to unregister the entry on graceful exit, and no heartbeat timeout to detect disconnects.
+
+**No workaround available.** Keep FleetView open in a dedicated tmux/screen session to minimize re-invocations. Zombie entries eventually clear after an unknown server-side timeout period.


### PR DESCRIPTION
## Summary

Adds a troubleshooting entry for FleetView remote session entries persisting after the TUI exits (zombie entries). The relay disconnect on TUI exit does not trigger server-side cleanup, causing entries to accumulate for 10+ minutes with no response when tapped.

Closes #61733