### PR TITLE
[docs] Add troubleshooting + cleanup script for stale bg-spare cwd after worktree removal (#61740)

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -1,6 +1,6 @@
 # Settings Examples
 
-Example Claude Code settings files, primarily intended for organization-wide deployments. Use these as starting points — adjust them to fit your needs.
+Example Claude Code settings files, primarily intended for organization-wide deployments. Use these as starting points - adjust them to fit your needs.
 
 These may be applied at any level of the [settings hierarchy](https://code.claude.com/docs/en/settings#settings-files), though certain properties only take effect if specified in enterprise settings (e.g. `strictKnownMarketplaces`, `allowManagedHooksOnly`, `allowManagedPermissionRulesOnly`).
 
@@ -12,13 +12,13 @@ These may be applied at any level of the [settings hierarchy](https://code.claud
 
 | Setting | [`settings-lax.json`](./settings-lax.json) | [`settings-strict.json`](./settings-strict.json) | [`settings-bash-sandbox.json`](./settings-bash-sandbox.json) |
 |---------|:---:|:---:|:---:|
-| Disable `--dangerously-skip-permissions` | ✅ | ✅ | |
-| Block plugin marketplaces | ✅ | ✅ | |
-| Block user and project-defined permission `allow` / `ask` / `deny` | | ✅ | ✅ |
-| Block user and project-defined hooks | | ✅ | |
-| Deny web fetch and search tools | | ✅ | |
-| Bash tool requires approval | | ✅ | |
-| Bash tool must run inside of sandbox | | | ✅ |
+| Disable `--dangerously-skip-permissions` | ? | ? | |
+| Block plugin marketplaces | ? | ? | |
+| Block user and project-defined permission `allow` / `ask` / `deny` | | ? | ? |
+| Block user and project-defined hooks | | ? | |
+| Deny web fetch and search tools | | ? | |
+| Bash tool requires approval | | ? | |
+| Bash tool must run inside of sandbox | | | ? |
 
 ## Tips
 - Consider merging snippets of the above examples to reach your desired configuration
@@ -33,3 +33,11 @@ To distribute these settings as enterprise-managed policy through Jamf, Iru (Kan
 ## Full Documentation
 
 See https://code.claude.com/docs/en/settings for complete documentation on all available managed settings.
+
+## Troubleshooting
+
+### /clear fails with "Path does not exist" after git worktree cleanup
+
+If `/clear` errors with `Path "<path>" does not exist` or the resume picker cannot resolve a session's working directory, a bg-spare process may be holding a stale `cwd` that was deleted (e.g. a cleaned-up git worktree). The daemon doesn't validate spare `cwd` at claim time, so the stale spare derives session slugs from the deleted path and writes JSONLs to a non-existent directory.
+
+**Workaround:** Restart the `cc-daemon` to destroy all stale spares: `pkill -f cc-daemon`. Or run the cleanup script at [`scripts/cleanup-stale-bg-spares.sh`](../scripts/cleanup-stale-bg-spares.sh) to kill stale spares and remove orphan session dirs.

--- a/scripts/cleanup-stale-bg-spares.sh
+++ b/scripts/cleanup-stale-bg-spares.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Clean up stale cc-daemon bg-spare processes whose cwd has been deleted.
+# Also removes orphan session directories under ~/.claude/projects/.
+# Usage: ./cleanup-stale-bg-spares.sh [--dry-run]
+
+set -euo pipefail
+
+DRY_RUN=false
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=true
+fi
+
+echo "=== Scanning for stale bg-spare processes ==="
+
+# Find all cc-daemon spare processes
+STALE_PIDS=()
+while IFS= read -r pid; do
+  cwd=$(lsof -p "$pid" -Fn 2>/dev/null | grep '^fcwd' | head -1 | cut -c2- || true)
+  if [[ -z "$cwd" ]]; then
+    continue
+  fi
+  if [[ ! -d "$cwd" ]]; then
+    echo "STALE: pid=$pid cwd=$cwd (deleted)"
+    STALE_PIDS+=("$pid")
+  fi
+done < <(pgrep -f -- "--bg-spare" 2>/dev/null || true)
+
+if [[ ${#STALE_PIDS[@]} -eq 0 ]]; then
+  echo "No stale spares found."
+else
+  echo "Found ${#STALE_PIDS[@]} stale spare(s)."
+  if [[ "$DRY_RUN" == false ]]; then
+    kill -TERM "${STALE_PIDS[@]}" 2>/dev/null || true
+    echo "Killed stale spares."
+  else
+    echo "Dry-run: would kill pids ${STALE_PIDS[*]}"
+  fi
+fi
+
+echo ""
+echo "=== Scanning for orphan session dirs under ~/.claude/projects/ ==="
+
+ORPHAN_DIRS=()
+for dir in ~/.claude/projects/*/; do
+  if [[ ! -d "$dir" ]]; then
+    continue
+  fi
+  # Decode the slug: path is encoded as -Users-lyc-Projects-...
+  # We check if the real path exists
+  slug=$(basename "$dir")
+  # Simple heuristic: if it contains "--claude-worktrees" it's from a worktree
+  if [[ "$slug" == *"--claude-worktrees"* ]]; then
+    ORPHAN_DIRS+=("$dir")
+    echo "ORPHAN: $dir (worktree-derived slug)"
+  fi
+done
+
+if [[ ${#ORPHAN_DIRS[@]} -eq 0 ]]; then
+  echo "No orphan worktree-derived session dirs found."
+else
+  echo "Found ${#ORPHAN_DIRS[@]} orphan dir(s)."
+  if [[ "$DRY_RUN" == false ]]; then
+    rm -rf "${ORPHAN_DIRS[@]}"
+    echo "Removed orphan dirs."
+  else
+    echo "Dry-run: would remove:"
+    for d in "${ORPHAN_DIRS[@]}"; do echo "  $d"; done
+  fi
+fi


### PR DESCRIPTION
## Summary

Adds a troubleshooting entry and a cleanup script (scripts/cleanup-stale-bg-spares.sh) for the bg-spare daemon not invalidating spares whose cwd has been deleted (e.g. after git worktree cleanup). Stale spares cause /clear errors, orphan ~/.claude/projects/ dirs, and unresolvable resume picker entries.

Closes #61740