### PR TITLE
fix: correct state file path in ralph-wiggum help.md

### DIFF
--- a/plugins/ralph-wiggum/commands/help.md
+++ b/plugins/ralph-wiggum/commands/help.md
@@ -46,7 +46,7 @@ Start a Ralph loop in your current session.
 - `--completion-promise <text>` - Promise phrase to signal completion
 
 **How it works:**
-1. Creates `.claude/.ralph-loop.local.md` state file
+1. Creates `.claude/ralph-loop.local.md` state file
 2. You work on the task
 3. When you try to exit, stop hook intercepts
 4. Same prompt fed back
@@ -66,7 +66,7 @@ Cancel an active Ralph loop (removes the loop state file).
 
 **How it works:**
 - Checks for active loop state file
-- Removes `.claude/.ralph-loop.local.md`
+- Removes `.claude/ralph-loop.local.md`
 - Reports cancellation with iteration count
 
 ---


### PR DESCRIPTION
Fixes #61764

## What

Corrects the state file path in `plugins/ralph-wiggum/commands/help.md` from `.claude/.ralph-loop.local.md` (with a leading dot before `ralph`) to `.claude/ralph-loop.local.md` (no leading dot), matching the actual paths used in `setup-ralph-loop.sh`, `stop-hook.sh`, and `cancel-ralph.md`.

## Verification

- Build: N/A (documentation-only change)
- Tests: N/A (Markdown file)
- Lint: N/A
- Type check: N/A
- Self-review: confirmed all other references use `ralph-loop.local.md` without leading dot
- Scope: 1 file, 2 lines changed