### PR TITLE
[docs] Add troubleshooting for unauthorized messages in tmux (#61962)

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -30,6 +30,27 @@ These may be applied at any level of the [settings hierarchy](https://code.claud
 
 To distribute these settings as enterprise-managed policy through Jamf, Iru (Kandji), Intune, or Group Policy, see the deployment templates in [`../mdm`](../mdm).
 
+## Troubleshooting
+
+### Unauthorized messages sent without initiation (tmux)
+
+If messages appear to be sent on your behalf without your input, and
+you are using **tmux**, the likely cause is tmux forwarding terminal
+control sequences (focus events, bracketed paste) that Claude Code's
+TUI input reader interprets as keypresses.
+
+**To confirm the trigger**, run Claude Code outside tmux (directly in
+Terminal.app or iTerm2). If phantom messages stop, the issue is tmux
+input forwarding.
+
+**Fix in tmux**:
+```bash
+# Disable focus event forwarding
+set -g focus-events off
+```
+
+See issue [#61962](https://github.com/anthropics/claude-code/issues/61962).
+
 ## Full Documentation
 
 See https://code.claude.com/docs/en/settings for complete documentation on all available managed settings.


### PR DESCRIPTION
## Summary

Adds a troubleshooting entry for unauthorized phantom messages appearing in tmux sessions. Documents the likely root cause (tmux forwarding control sequences interpreted as keypresses) and workaround (disable focus-events or run outside tmux).

Closes #61962

## Problem

In v2.1.150 on macOS with tmux, messages may appear to be sent on the user's behalf without their input. The TUI input reader interprets terminal control sequences (focus events, bracketed paste) forwarded by tmux as actual keypresses or text input.

## Workaround

Run outside tmux to confirm the trigger. In tmux, disable focus events:
`
set -g focus-events off
`

## Related

- #27128 / #28627 � similar symptom (unauthorized messages) but different root cause (model generating fake Human: turns in multi-agent sessions)