### PR TITLE
[docs] Add troubleshooting for AskUserQuestion rewind checkpoint gap (#61965)

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -30,6 +30,23 @@ These may be applied at any level of the [settings hierarchy](https://code.claud
 
 To distribute these settings as enterprise-managed policy through Jamf, Iru (Kandji), Intune, or Group Policy, see the deployment templates in [`../mdm`](../mdm).
 
+## Troubleshooting
+
+### AskUserQuestion answers don't create rewind checkpoints
+
+When Claude asks questions via `AskUserQuestion`, user answers flow back
+as `tool_result` blocks inside an assistant turn — not as user messages.
+The Rewind system checkpoints only at user-typed message boundaries, so
+you cannot rewind to individual question/answer pairs.
+
+**Workaround**: Ask the agent to echo each answer back as a brief
+paraphrase before asking the next question, e.g.:
+> "You said the endpoint is /api/v2. Next question..."
+
+This creates a real user-message boundary for Rewind to checkpoint on.
+
+See issue [#61965](https://github.com/anthropics/claude-code/issues/61965).
+
 ## Full Documentation
 
 See https://code.claude.com/docs/en/settings for complete documentation on all available managed settings.


### PR DESCRIPTION
## Summary

Adds a troubleshooting entry for AskUserQuestion answers not creating rewind checkpoints. Documents the root cause (Rewind keyed to user-message boundaries, but AskUserQuestion answers come as tool_result blocks inside assistant turns) and the echo-back workaround.

Closes #61965

## Problem

The Rewind system checkpoints at user-typed message boundaries only. AskUserQuestion returns answers as tool_result blocks inside assistant turns, so there is no user-message boundary to checkpoint on. Users can only rewind to the last typed message, which may be several questions ago.

## Workaround

Ask the agent to echo each answer back as a brief paraphrase before asking the next question. This creates a real user-message boundary for Rewind to checkpoint on.

## The real fix (CLI internal)

The Rewind checkpoint logic needs to recognize tool_result blocks from AskUserQuestion as implicit turn boundaries and checkpoint after each one, regardless of the turn's author attribution.