### PR TITLE
fix(workflow): word-boundary @claude trigger to avoid @claude-* false positives

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,13 +24,28 @@ jobs:
       issues: read
       id-token: write
     steps:
+      - name: Verify @claude trigger is at a word boundary
+        id: trigger_check
+        env:
+          BODY: ${{ github.event.comment.body || github.event.review.body || github.event.issue.body }}
+          TITLE: ${{ github.event.issue.title }}
+        run: |
+          if printf '%s\n%s' "$BODY" "$TITLE" | grep -Pq '@claude(?![a-zA-Z0-9_-])'; then
+            echo "matched=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "matched=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Substring '@claude' found but not at a word boundary (e.g. @claude-plugins-official) — skipping Claude Code job."
+          fi
+
       - name: Checkout repository
+        if: steps.trigger_check.outputs.matched == 'true'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
+        if: steps.trigger_check.outputs.matched == 'true'
         uses: anthropics/claude-code-action@v1
         with:
           # Authenticate to the Claude API via Workload Identity Federation


### PR DESCRIPTION
## Summary

The job-level `if:` in `.github/workflows/claude.yml` uses `contains(..., '@claude')`, which is a literal substring check. Comments that reference any plugin marketplace whose name begins with `@claude-` (e.g. `@claude-plugins-official`, `@claude-code-slack-channel`) match this filter even though no `@claude` mention is intended.

When that happens, the workflow starts, the action correctly emits `No trigger was met for @claude`, but has already requested an OIDC token. For comments from users without write access, the subsequent OIDC → app-token exchange returns 401 and the run ends in `failure`.

## Observed

Six such failures today, triggered by comments that mentioned `@claude-plugins-official` on #36431 / #36837 — example run [#26360938809](https://github.com/anthropics/claude-code/actions/runs/26360938809):

```
No trigger was met for @claude
Auto-detected mode: agent for event: issue_comment
Requesting OIDC token...
App token exchange failed: 401 Unauthorized - User does not have write access on this repository
```

## Fix

Add a small shell step that performs a Perl-regex word-boundary check (`@claude(?![a-zA-Z0-9_-])`) over the relevant body/title fields, passed via env vars (no inline interpolation, no script-injection surface). The two downstream steps (`Checkout`, `Run Claude Code`) gate on `steps.trigger_check.outputs.matched == 'true'`.

Real `@claude` mentions still match; only substring false positives no longer produce misleading failures in the Actions UI.

## Why a step-level shell check instead of refining `if:` directly

GitHub Actions expression language has no regex; an expression-only fix would need an OR-chain over `@claude `, end-of-string, and punctuation forms × 4 event types × multiple body fields — visually noisy and brittle. A single shell step with proper `\b` semantics is shorter and more maintainable.

## Local verification

Ran the regex against 10 cases (GNU grep `-P`, `LC_ALL=C.UTF-8`):

| Case | Input | Expected | Actual |
|------|-------|----------|--------|
| 1 | `@claude please review` | match | match |
| 2 | `look at @claude-plugins-official` | nomatch | nomatch |
| 3 | `see @claude-code-slack-channel for community` | nomatch | nomatch |
| 4 | `ping @claude.bot` | match | match |
| 5 | `EOL: @claude` | match | match |
| 6 | `punct: @claude!` | match | match |
| 7 | `underscore: @claude_bot` | nomatch | nomatch |
| 8 | multiline body containing `@claude` | match | match |
| A | full Comment-A body (`@claude-plugins-official…`) | nomatch | nomatch |
| B | full Comment-B body (`@claude — this IS…`) | match | match |

End-to-end Actions integration was not exercised on my fork (billing-locked account; jobs do not start), so the test plan below is for a reviewer with running CI.

## Test plan

- [ ] Comment containing `@claude please review` triggers a full run as before.
- [ ] Comment containing only `@claude-plugins-official` (or similar `@claude-…`) starts the workflow, the `trigger_check` step emits the notice, and the job exits cleanly without attempting OIDC exchange.
- [ ] Same for `pull_request_review_comment`, `pull_request_review`, and `issues` event types — covered by the `BODY: || ||` env fallback.