### PR TITLE
feat: add sandbox filesystem example settings with allowSkillsWrites

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -10,15 +10,17 @@ These may be applied at any level of the [settings hierarchy](https://code.claud
 > [!WARNING]
 > These examples are community-maintained snippets which may be unsupported or incorrect. You are responsible for the correctness of your own settings configuration.
 
-| Setting | [`settings-lax.json`](./settings-lax.json) | [`settings-strict.json`](./settings-strict.json) | [`settings-bash-sandbox.json`](./settings-bash-sandbox.json) |
-|---------|:---:|:---:|:---:|
-| Disable `--dangerously-skip-permissions` | ✅ | ✅ | |
-| Block plugin marketplaces | ✅ | ✅ | |
-| Block user and project-defined permission `allow` / `ask` / `deny` | | ✅ | ✅ |
-| Block user and project-defined hooks | | ✅ | |
-| Deny web fetch and search tools | | ✅ | |
-| Bash tool requires approval | | ✅ | |
-| Bash tool must run inside of sandbox | | | ✅ |
+| Setting | [`settings-lax.json`](./settings-lax.json) | [`settings-strict.json`](./settings-strict.json) | [`settings-bash-sandbox.json`](./settings-bash-sandbox.json) | [`settings-sandbox-filesystem.json`](./settings-sandbox-filesystem.json) |
+|---------|:---:|:---:|:---:|:---:|
+| Disable `--dangerously-skip-permissions` | ✅ | ✅ | | |
+| Block plugin marketplaces | ✅ | ✅ | | |
+| Block user and project-defined permission `allow` / `ask` / `deny` | | ✅ | ✅ | |
+| Block user and project-defined hooks | | ✅ | | |
+| Deny web fetch and search tools | | ✅ | | |
+| Bash tool requires approval | | ✅ | | |
+| Bash tool must run inside of sandbox | | | ✅ | ✅ |
+| Sandbox filesystem restrictions (`allowWrite`, `denyRead`, etc.) | | | | ✅ |
+| Allow skills directory writes in sandbox | | | | ⚠️ |
 
 ## Tips
 - Consider merging snippets of the above examples to reach your desired configuration

--- a/examples/settings/settings-sandbox-filesystem.json
+++ b/examples/settings/settings-sandbox-filesystem.json
@@ -1,0 +1,24 @@
+{
+  "allowManagedPermissionRulesOnly": true,
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": false,
+    "allowUnsandboxedCommands": false,
+    "excludedCommands": [],
+    "network": {
+      "allowUnixSockets": [],
+      "allowAllUnixSockets": false,
+      "allowLocalBinding": false,
+      "allowedDomains": [],
+      "httpProxyPort": null,
+      "socksProxyPort": null
+    },
+    "enableWeakerNestedSandbox": false,
+    "filesystem": {
+      "denyRead": ["/etc/secrets", "/var/keys"],
+      "allowRead": ["/etc/secrets/app.crt"],
+      "denyWrite": [".venv/", "node_modules/"],
+      "allowWrite": [".claude/skills/"]
+    }
+  }
+}


### PR DESCRIPTION
/skills/\]\ entry demonstrates the config override requested in #62259.

2. **Updated \examples/settings/README.md\** — Added the new example to the comparison table with an \llowSkillsWrites\ row (marked as proposed/new).

## Related Issue

Addresses #62259 — provides a concrete settings example for the proposed \sandbox.filesystem.allowSkillsWrites\ configuration pattern.