### PR TITLE
fix: prevent dedupe from suggesting or auto-closing as duplicate of closed/duplicate issues

### DIFF
--- a/.claude/commands/dedupe.md
+++ b/.claude/commands/dedupe.md
@@ -10,7 +10,7 @@ To do this, follow these steps precisely:
 1. Use an agent to check if the Github issue (a) is closed, (b) does not need to be deduped (eg. because it is broad product feedback without a specific solution, or positive feedback), or (c) already has a duplicates comment that you made earlier. If so, do not proceed.
 2. Use an agent to view a Github issue, and ask the agent to return a summary of the issue
 3. Then, launch 5 parallel agents to search Github for duplicates of this issue, using diverse keywords and search approaches, using the summary from #1
-4. Next, feed the results from #1 and #2 into another agent, so that it can filter out false positives, that are likely not actually duplicates of the original issue. If there are no duplicates remaining, do not proceed.
+4. Next, feed the results from #1 and #2 into another agent, so that it can filter out false positives, that are likely not actually duplicates of the original issue. Only consider OPEN issues as potential duplicates — skip any that are closed, already marked as duplicate, or whose duplicate status is unknown. If there are no duplicates remaining, do not proceed.
 5. Finally, use the comment script to post duplicates:
    ```
    ./scripts/comment-on-duplicates.sh --potential-duplicates <dup1> <dup2> <dup3>

--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -248,6 +248,31 @@ async function autoCloseDuplicates(): Promise<void> {
       continue;
     }
 
+    // Verify the target issue is still open and not itself a duplicate
+    try {
+      const targetIssue: GitHubIssue & { state: string; state_reason?: string } = await githubRequest(
+        `/repos/${owner}/${repo}/issues/${duplicateIssueNumber}`,
+        token
+      );
+      if (targetIssue.state !== "open") {
+        console.log(
+          `[DEBUG] Issue #${issue.number} - target #${duplicateIssueNumber} is not open (state: ${targetIssue.state}), skipping`
+        );
+        continue;
+      }
+      if (targetIssue.state_reason === "duplicate") {
+        console.log(
+          `[DEBUG] Issue #${issue.number} - target #${duplicateIssueNumber} is itself marked as duplicate, skipping`
+        );
+        continue;
+      }
+    } catch {
+      console.log(
+        `[DEBUG] Issue #${issue.number} - could not verify target #${duplicateIssueNumber}, skipping`
+      );
+      continue;
+    }
+
     candidateCount++;
     const issueUrl = `https://github.com/${owner}/${repo}/issues/${issue.number}`;
     


### PR DESCRIPTION
﻿## Summary

Addresses the meta-issue raised in #62257: the dedupe bot and auto-close script should not suggest or auto-close issues as duplicates of issues that are themselves closed or marked as duplicate.

## Changes

### 1. `.claude/commands/dedupe.md` (step 4)
Added explicit instruction to only consider OPEN issues as potential duplicates, skipping any that are closed or already marked as duplicate.

### 2. `scripts/auto-close-duplicates.ts`
Added a verification step before auto-closing: fetches the target duplicate issue and checks:
- The target is still **open** (not closed)
- The target is not itself marked as **duplicate** (`state_reason === "duplicate"`)

If either check fails, the script skips the auto-close for that issue instead of propagating the chain.

## Related Issue

Addresses #62257 meta-issue (duplicate chain resolution). The primary bug (stale system prompt after /model switch) requires changes in the CLI source code.
