### PR TITLE
fix: resolve 10 bugs across scripts and workflows (#1)

### DIFF
--- a/.github/workflows/auto-close-duplicates.yml
+++ b/.github/workflows/auto-close-duplicates.yml
@@ -27,5 +27,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
-          GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}
+          GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name || 'claude-code' }}
           STATSIG_API_KEY: ${{ secrets.STATSIG_API_KEY }}

--- a/.github/workflows/log-issue-events.yml
+++ b/.github/workflows/log-issue-events.yml
@@ -19,22 +19,21 @@ jobs:
           AUTHOR: ${{ github.event.issue.user.login }}
           CREATED_AT: ${{ github.event.issue.created_at }}
         run: |
-          # All values are now safely passed via environment variables
-          # No direct templating in the shell script to prevent injection attacks
-          
+          if [ -z "$STATSIG_API_KEY" ]; then
+            echo "STATSIG_API_KEY is not set, skipping"
+            exit 0
+          fi
+
+          PAYLOAD=$(jq -n \
+            --arg issue_number "$ISSUE_NUMBER" \
+            --arg repository "$REPO" \
+            --arg title "$ISSUE_TITLE" \
+            --arg author "$AUTHOR" \
+            --arg created_at "$CREATED_AT" \
+            --argjson time "$(date +%s)000" \
+            '{events: [{eventName: "github_issue_created", metadata: {issue_number: $issue_number, repository: $repository, title: $title, author: $author, created_at: $created_at}, time: $time}]}')
+
           curl -X POST "https://events.statsigapi.net/v1/log_event" \
             -H "Content-Type: application/json" \
             -H "statsig-api-key: $STATSIG_API_KEY" \
-            -d '{
-              "events": [{
-                "eventName": "github_issue_created",
-                "metadata": {
-                  "issue_number": "'"$ISSUE_NUMBER"'",
-                  "repository": "'"$REPO"'",
-                  "title": "'"$(echo "$ISSUE_TITLE" | sed "s/\"/\\\\\"/g")"'",
-                  "author": "'"$AUTHOR"'",
-                  "created_at": "'"$CREATED_AT"'"
-                },
-                "time": '"$(date +%s)000"'
-              }]
-            }'
+            -d "$PAYLOAD"

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -28,4 +28,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
-          GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}
+          GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name || 'claude-code' }}

--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -264,6 +264,9 @@ async function autoCloseDuplicates(): Promise<void> {
         `[ERROR] Failed to close issue #${issue.number} as duplicate: ${error}`
       );
     }
+
+    // Rate-limit writes to avoid hitting GitHub API secondary rate limits
+    await new Promise(resolve => setTimeout(resolve, 1000));
   }
 
   console.log(

--- a/scripts/backfill-duplicate-comments.ts
+++ b/scripts/backfill-duplicate-comments.ts
@@ -86,8 +86,8 @@ Environment Variables:
   }
   console.log("[DEBUG] GitHub token found");
 
-  const owner = "anthropics";
-  const repo = "claude-code";
+  const owner = process.env.GITHUB_REPOSITORY_OWNER || "anthropics";
+  const repo = process.env.GITHUB_REPOSITORY_NAME || "claude-code";
   const dryRun = process.env.DRY_RUN !== "false";
   const maxIssueNumber = parseInt(process.env.MAX_ISSUE_NUMBER || "4050", 10);
   const minIssueNumber = parseInt(process.env.MIN_ISSUE_NUMBER || "1", 10);
@@ -110,8 +110,8 @@ Environment Variables:
     if (pageIssues.length === 0) break;
     
     // Filter to only include issues within the specified range
-    const filteredIssues = pageIssues.filter(issue => 
-      issue.number >= minIssueNumber && issue.number < maxIssueNumber
+    const filteredIssues = pageIssues.filter(issue =>
+      issue.number >= minIssueNumber && issue.number <= maxIssueNumber
     );
     allIssues.push(...filteredIssues);
     

--- a/scripts/comment-on-duplicates.sh
+++ b/scripts/comment-on-duplicates.sh
@@ -8,7 +8,7 @@
 
 set -euo pipefail
 
-REPO="anthropics/claude-code"
+REPO="${GITHUB_REPOSITORY:-anthropics/claude-code}"
 
 # Read from event payload so the issue number is bound to the triggering event.
 # Falls back to workflow_dispatch inputs for manual runs.

--- a/scripts/edit-issue-labels.sh
+++ b/scripts/edit-issue-labels.sh
@@ -38,6 +38,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ ${#ADD_LABELS[@]} -eq 0 && ${#REMOVE_LABELS[@]} -eq 0 ]]; then
+  echo "Error: at least one --add-label or --remove-label is required" >&2
   exit 1
 fi
 

--- a/scripts/lifecycle-comment.ts
+++ b/scripts/lifecycle-comment.ts
@@ -18,7 +18,7 @@ if (!issueNumber) throw new Error("ISSUE_NUMBER required");
 
 const entry = lifecycle.find((l) => l.label === label);
 if (!entry) {
-  console.log(`No lifecycle entry for label "${label}", skipping`);
+  console.warn(`Warning: no lifecycle entry found for label "${label}" — check for a typo in the label name`);
   process.exit(0);
 }
 

--- a/scripts/sweep.ts
+++ b/scripts/sweep.ts
@@ -51,11 +51,15 @@ async function markStale(owner: string, repo: string) {
 
   console.log(`\n=== marking stale (${staleDays}d inactive) ===`);
 
-  for (let page = 1; page <= 10; page++) {
+  const PAGE_LIMIT = 10;
+  for (let page = 1; page <= PAGE_LIMIT; page++) {
     const issues = await githubRequest<any[]>(
       `/repos/${owner}/${repo}/issues?state=open&sort=updated&direction=asc&per_page=100&page=${page}`
     );
     if (issues.length === 0) break;
+    if (page === PAGE_LIMIT && issues.length === 100) {
+      console.warn(`Warning: reached page limit (${PAGE_LIMIT * 100} issues) — some issues may not have been processed`);
+    }
 
     for (const issue of issues) {
       if (issue.pull_request) continue;


### PR DESCRIPTION
- comment-on-duplicates.sh: replace hardcoded REPO with GITHUB_REPOSITORY env var fallback so the script works in forks
- sweep.yml, auto-close-duplicates.yml: add safe fallback for github.event.repository.name which can be null on schedule/workflow_dispatch events
- edit-issue-labels.sh: add error message before silent exit when no labels are provided
- log-issue-events.yml: guard against empty STATSIG_API_KEY; replace fragile sed-based JSON escaping with jq to prevent injection via special characters in issue titles
- backfill-duplicate-comments.ts: fix off-by-one (< maxIssueNumber → <= maxIssueNumber) so the boundary issue is not silently skipped; replace hardcoded owner/repo with env vars for portability
- auto-close-duplicates.ts: add 1s delay between close operations to avoid GitHub secondary rate limits
- sweep.ts: emit a warning when the pagination limit is hit so silently skipped issues are surfaced
- lifecycle-comment.ts: upgrade silent console.log to console.warn for unknown label names to surface typos

