### PR TITLE
fix(ralph-wiggum): prefix Stop hook command with bash for Windows spaced-path safety

### DIFF
--- a/plugins/ralph-wiggum/hooks/hooks.json
+++ b/plugins/ralph-wiggum/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.sh\""
           }
         ]
       }


### PR DESCRIPTION
## Problem

The `ralph-wiggum` plugin's Stop hook (`plugins/ralph-wiggum/hooks/hooks.json`) defines its command as a **bare quoted script path with no interpreter prefix**:

```json
"command": "${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.sh"
```

On the Windows hook runner (Git Bash / MSYS), `${CLAUDE_PLUGIN_ROOT}` expands to an MSYS-style path. When the user profile contains a space — e.g. `C:\Users\Martin Workspace\` → `/c/Users/Martin Workspace/...` — the quoting is lost on exec, the space word-splits, and bash tries to execute the first token as the program:

```
bash: /c/Users/Martin: No such file or directory
```

The Stop hook then fails on every invocation, breaking the ralph-wiggum loop entirely for any Windows user whose profile path contains a space (a very common case).

## Fix

Prefix the command with `bash ` so the script path is passed as an *argument* to `bash` rather than being exec'd directly. This is a one-token change:

```json
"command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.sh\""
```

## Precedent

The sibling **`ralph-loop`** plugin (in the `anthropics/claude-plugins-official` marketplace) does exactly the same job and already uses the correct form:

```json
"command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.sh\""
```

This PR brings `ralph-wiggum` in line with `ralph-loop`. The diff is a single line in `plugins/ralph-wiggum/hooks/hooks.json`; no behavioural change on platforms that were already working, and a fix for Windows spaced-path environments.
