### PR TITLE
fix(ralph-wiggum): correctly read last assistant text from transcript

### DIFF
--- a/plugins/ralph-wiggum/hooks/stop-hook.sh
+++ b/plugins/ralph-wiggum/hooks/stop-hook.sh
@@ -77,26 +77,17 @@ if ! grep -q '"role":"assistant"' "$TRANSCRIPT_PATH"; then
   exit 0
 fi
 
-# Extract last assistant message with explicit error handling
-LAST_LINE=$(grep '"role":"assistant"' "$TRANSCRIPT_PATH" | tail -1)
-if [[ -z "$LAST_LINE" ]]; then
-  echo "⚠️  Ralph loop: Failed to extract last assistant message" >&2
-  echo "   Ralph loop is stopping." >&2
-  rm "$RALPH_STATE_FILE"
-  exit 0
-fi
-
-# Parse JSON with error handling
-LAST_OUTPUT=$(echo "$LAST_LINE" | jq -r '
-  .message.content |
-  map(select(.type == "text")) |
-  map(.text) |
-  join("\n")
-' 2>&1)
-
-# Check if jq succeeded
-if [[ $? -ne 0 ]]; then
-  echo "⚠️  Ralph loop: Failed to parse assistant message JSON" >&2
+# Extract the most recent assistant TEXT from the transcript.
+# Claude Code writes each content block (thinking / text / tool_use) as a
+# SEPARATE JSONL line, so reading only the last line breaks when it happens
+# to be a tool_use or thinking block. Slurp all assistant lines, skip
+# subagent (sidechain) output, collect every text block, take the last one.
+if ! LAST_OUTPUT=$(grep '"role":"assistant"' "$TRANSCRIPT_PATH" | jq -rs '
+  map(select(.isSidechain != true)
+      | .message.content[]? | select(.type == "text") | .text)
+  | last // ""
+' 2>&1); then
+  echo "⚠️  Ralph loop: Failed to parse assistant messages JSON" >&2
   echo "   Error: $LAST_OUTPUT" >&2
   echo "   This may indicate a transcript format issue" >&2
   echo "   Ralph loop is stopping." >&2


### PR DESCRIPTION
## Problem

The Ralph Wiggum stop hook silently terminates active loops. When it runs, it reads only the last line of the transcript (`grep '"role":"assistant"' | tail -1`) and tries to extract text blocks from that single line.

Claude Code writes each content block (`thinking`, `text`, `tool_use`) as a **separate** JSONL entry rather than one entry per turn. As a result the last assistant line is frequently a `tool_use` or `thinking` block with no text. In that case the hook reports "Assistant message contained no text content", deletes `.claude/ralph-loop.local.md`, and exits 0 — ending the loop instead of continuing it. This makes the loop appear broken, especially for tasks whose turns end with a tool call.

## Fix

Slurp all assistant lines and take the last `text` block across the transcript instead of inspecting only the final line. Subagent (sidechain) output is skipped so a subagent cannot accidentally satisfy the completion promise.

## Testing

Verified against a real transcript and synthetic fixtures:

- Loop with no completion promise → blocks exit, increments iteration.
- Completion promise set but absent → loop continues.
- Completion promise present in the last text block → loop completes and removes the state file.
- `<promise>` emitted by a sidechain/subagent → correctly ignored.