### PR TITLE
Use PR template in /commit-push-pr command

### DIFF
--- a/.claude/commands/commit-push-pr.md
+++ b/.claude/commands/commit-push-pr.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*)
+allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*), Bash(cat:*)
 description: Commit, push, and open a PR
 ---
 
@@ -8,6 +8,7 @@ description: Commit, push, and open a PR
 - Current git status: !`git status`
 - Current git diff (staged and unstaged changes): !`git diff HEAD`
 - Current branch: !`git branch --show-current`
+- PR template: !`cat .github/PULL_REQUEST_TEMPLATE.md 2>/dev/null || echo "no .github/PULL_REQUEST_TEMPLATE.md found"`
 
 ## Your task
 

--- a/plugins/commit-commands/commands/commit-push-pr.md
+++ b/plugins/commit-commands/commands/commit-push-pr.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*)
+allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*), Bash(cat:*)
 description: Commit, push, and open a PR
 ---
 
@@ -8,6 +8,7 @@ description: Commit, push, and open a PR
 - Current git status: !`git status`
 - Current git diff (staged and unstaged changes): !`git diff HEAD`
 - Current branch: !`git branch --show-current`
+- PR template: !`cat .github/PULL_REQUEST_TEMPLATE.md 2>/dev/null || echo "no .github/PULL_REQUEST_TEMPLATE.md found"`
 
 ## Your task
 


### PR DESCRIPTION
## Summary
- `/commit-push-pr` now cats `.github/PULL_REQUEST_TEMPLATE.md` (if present) into context so the generated PR body follows the repo's template structure instead of a freeform description.
- Applied to both `.claude/commands/commit-push-pr.md` and `plugins/commit-commands/commands/commit-push-pr.md`.
- Added `Bash(cat:*)` to `allowed-tools`.

## Test plan
- [ ] Run `/commit-push-pr` in a repo with a `.github/PULL_REQUEST_TEMPLATE.md` and confirm the PR body follows the template.
- [ ] Run `/commit-push-pr` in a repo without one and confirm it still works (falls back to the "no ... found" message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)