### PR TITLE
feat: add side-threads plugin (/thread and /back)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -145,6 +145,17 @@
       },
       "source": "./plugins/security-guidance",
       "category": "security"
+    },
+    {
+      "name": "side-threads",
+      "description": "Side-thread commands (/thread and /back) for branching conversations Slack-style.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Yihao Liang",
+        "email": "yl3058@princeton.edu"
+      },
+      "source": "./plugins/side-threads",
+      "category": "productivity"
     }
   ]
 }

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -25,6 +25,7 @@ Learn more in the [official plugins documentation](https://docs.claude.com/en/do
 | [pr-review-toolkit](./pr-review-toolkit/) | Comprehensive PR review agents specializing in comments, tests, error handling, type design, code quality, and code simplification | **Command:** `/pr-review-toolkit:review-pr` - Run with optional review aspects (comments, tests, errors, types, code, simplify, all)<br>**Agents:** `comment-analyzer`, `pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer`, `code-reviewer`, `code-simplifier` |
 | [ralph-wiggum](./ralph-wiggum/) | Interactive self-referential AI loops for iterative development. Claude works on the same task repeatedly until completion | **Commands:** `/ralph-loop`, `/cancel-ralph` - Start/stop autonomous iteration loops<br>**Hook:** Stop - Intercepts exit attempts to continue iteration |
 | [security-guidance](./security-guidance/) | Security reminder hook that warns about potential security issues when editing files | **Hook:** PreToolUse - Monitors 9 security patterns including command injection, XSS, eval usage, dangerous HTML, pickle deserialization, and os.system calls |
+| [side-threads](./side-threads/) | Branch a Claude Code conversation into a multi-turn side discussion (Slack-style threads). | **Commands:** `/thread`, `/back` — open and close a visually fenced side thread, with no-nesting and multi-turn follow-ups |
 
 ## Installation
 

--- a/plugins/side-threads/.claude-plugin/plugin.json
+++ b/plugins/side-threads/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "side-threads",
+  "version": "1.0.0",
+  "description": "Branch the conversation into a side thread with /thread; resume with /back. Slack-style threading for Claude Code.",
+  "author": {
+    "name": "Yihao Liang",
+    "email": "yl3058@princeton.edu"
+  },
+  "license": "MIT",
+  "keywords": ["thread", "conversation", "branching", "productivity"]
+}

--- a/plugins/side-threads/README.md
+++ b/plugins/side-threads/README.md
@@ -1,0 +1,61 @@
+# Side Threads
+
+Branch a Claude Code conversation into a multi-turn side discussion — like a Slack thread on a parent message — without derailing the main work.
+
+## Commands
+
+| Command | Effect |
+|---|---|
+| `/thread <question>` | Open a side thread on the side question. Visual fence opens; multi-turn discussion happens inside. |
+| `/back` | Close the current side thread and resume the main conversation. |
+
+Threads are **flat** — running `/thread` while already inside a thread is refused. (Mirrors Slack: threads don't nest.)
+
+## What it looks like
+
+```
+... main conversation ...
+
+>>> /thread what's the difference between mutex and semaphore?
+
+┌─── SIDE THREAD · 14:32 ───────────────────
+│ A mutex is binary, owned by one thread at a time; a semaphore is
+│ a counter that lets up to N threads in. So a mutex is the right
+│ tool for protecting a single critical section; a semaphore models
+│ a pool of N resources.
+│
+│ >>> follow-up: when would I prefer one over the other?
+│
+│ Use a mutex when there's exactly one shared thing... [continues]
+│
+│ >>> /back
+└─── back to main ───────────────────
+
+Back to the main thread. Where we were: ...
+```
+
+## How it works
+
+There is no persistent state — no snapshot file, no transcript log. The plugin is two command prompts that tell the model to draw the fence, stay inside it for follow-up turns, and resume when `/back` is invoked. Claude's own conversation memory holds the main-thread context, so resume is just "continue what we were doing."
+
+This is **deliberately minimal**. A more elaborate version with persisted snapshots and per-domain extensions exists in the `ai-tutor` skill ([prior art](https://github.com/yihao-liang/AI-tutor-skill)), which proved the conversation-branching pattern in practice. This plugin is the stripped-down generalization usable in any Claude Code session.
+
+## Install
+
+After installing this marketplace:
+
+```
+/plugin install side-threads@claude-code-plugins
+```
+
+Then start a conversation and try `/thread <anything>` followed by `/back`.
+
+## Limitations
+
+- **Detection is heuristic.** The model decides whether you're inside a thread by reading recent assistant turns for a `┌───` without a matching `└───`. If conversation history is compacted away or the fence lines are filtered out by a custom output style, detection may misfire. If that happens to you in practice, please open an issue.
+- **One thread at a time.** No nested threads, no parallel side discussions.
+- **One session at a time.** If a session ends inside a thread, the next session starts on the main conversation. Nothing is persisted.
+
+## License
+
+MIT.

--- a/plugins/side-threads/commands/back.md
+++ b/plugins/side-threads/commands/back.md
@@ -1,0 +1,25 @@
+---
+description: Close the current side thread and resume the main conversation
+---
+The user is closing a SIDE THREAD opened earlier with `/thread`. Resume the main conversation.
+
+## Protocol
+
+1. **Detect prior thread state.** Read your recent assistant turns. If no `┌─── SIDE THREAD` opening fence appears (or every opening fence already has a matching `└─── back to main` closing fence), there is no thread to close. Reply briefly:
+
+   *"No side thread is open."*
+
+   Do nothing else.
+
+2. **Otherwise, close the thread.** On a new line, write the closing fence — the first line is still inside the fence (so it has the `│ ` prefix), the second line is the closing fence character:
+
+   ```
+   │ >>> /back
+   └─── back to main ───────────────────
+   ```
+
+3. **Resume the main conversation.** From the next line on, drop the `│ ` prefix. Give a brief one-line acknowledgement that you're back (e.g. *"Back to the main thread."*), then continue addressing whatever the user was working on before the thread opened. Your own conversation memory holds that context — pick up the main work naturally.
+
+## Why
+
+`/back` is the explicit signal that the side discussion is done. Without it, replies would stay inside the fence indefinitely; with it, the visual and contextual switch is unambiguous. The closing fence on its own line is the scroll-back marker that says "everything below here is main conversation again."

--- a/plugins/side-threads/commands/thread.md
+++ b/plugins/side-threads/commands/thread.md
@@ -1,0 +1,36 @@
+---
+description: Branch the conversation into a side thread for a side question, without disrupting the main work
+argument-hint: "<your side question>"
+---
+The user is opening a SIDE THREAD — a multi-turn side discussion that should not derail or pollute the main conversation. Treat the side discussion as visually fenced and contextually isolated, in the spirit of a Slack thread on a parent message.
+
+Their side question (everything after `/thread`): "$ARGUMENTS"
+
+## Protocol
+
+1. **Detect prior thread state.** Read your recent assistant turns. If a `┌─── SIDE THREAD` opening fence appears without a matching `└─── back to main` closing fence, the conversation is already inside a thread. Refuse with:
+
+   *"You're already in a side thread. Close this one with `/back` first."*
+
+   Do not open a nested thread.
+
+2. **Otherwise, open the thread.** Emit an opening fence on its own line:
+
+   ```
+   ┌─── SIDE THREAD · HH:MM ───────────────────
+   ```
+
+   where `HH:MM` is the current wall-clock time (24-hour). Then continue every line of your reply with the prefix `│ ` (vertical bar + space). Answer the side question inside the fence.
+
+3. **Multi-turn behavior.** Until the user runs `/back`, stay in thread mode:
+   - Every line of every reply begins with `│ `.
+   - Each new user message is a thread turn — answer inside the fence.
+   - Do not perform main-conversation work (file edits, code-task work, tool calls related to the main task) inside the fence, unless the user explicitly asks for it inside the thread.
+
+4. **Closing.** Closing is handled by the `/back` command — see `commands/back.md` in this plugin. Do not close the fence on your own initiative.
+
+## Why
+
+A side question shouldn't derail what you're working on, but answering it inline turns the scrollback into a tangle. The fence makes the side discussion visually obvious; the multi-turn rule lets you actually have the side conversation rather than getting one terse answer; the no-nest rule keeps the structure flat (mirroring Slack, where threads don't nest either).
+
+There is no snapshot file or transcript. Your own conversation memory holds the main thread; the fence is purely a visual and contextual boundary.


### PR DESCRIPTION
## Summary

Adds a small general-purpose plugin, **side-threads**, that introduces a Slack-style threading pattern to any Claude Code conversation:

- \`/thread <question>\` opens a multi-turn side discussion in a visual fence.
- \`/back\` closes the fence and resumes the main conversation.
- Threads are flat — no nesting.
- No persistent state. The model's own conversation memory holds the main-thread context.

## Why

A side question mid-task derails the main conversation today. Inline answers turn scrollback into a tangle; there's no built-in way to branch and return. This plugin provides one.

The pattern was first prototyped in the [ai-tutor skill](https://github.com/yihao-liang/AI-tutor-skill) with tutor-specific extensions (snapshot file for resuming a structured micro-loop, optional profile entries). This PR contributes the stripped-down generalization — just the fence, flow, and no-nest rule.

## Files

- New plugin under \`plugins/side-threads/\` (manifest, two commands, README).
- One new entry in \`.claude-plugin/marketplace.json\`.
- One new row in \`plugins/README.md\`.

## How to test

\`\`\`
/plugin marketplace add anthropics/claude-code
/plugin install side-threads@claude-code-plugins
\`\`\`

Then in a conversation:

1. \`/thread what's the difference between mutex and semaphore?\` — opens fence, answers inside.
2. Follow up with another question — answered inside the same fence (multi-turn).
3. \`/thread foo\` inside an open thread — refused with the no-nesting message.
4. \`/back\` — closes the fence, resumes the main conversation.
5. \`/back\` with no thread open — replies "No side thread is open."

## Notes for maintainers

The \`plugins/\` directory looks like Anthropic-curated examples (all existing plugins authored by \`@anthropic.com\`). This is a community submission — totally understand if you'd prefer it live on a community marketplace instead. The plugin is independently installable from this fork either way. Happy to revise scope, naming, or framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
