### PR TITLE
Fix Hookify tests example semantics

### DIFF
--- a/plugins/hookify/README.md
+++ b/plugins/hookify/README.md
@@ -197,7 +197,13 @@ action: block
 conditions:
   - field: transcript
     operator: not_contains
-    pattern: npm test|pytest|cargo test
+    pattern: npm test
+  - field: transcript
+    operator: not_contains
+    pattern: pytest
+  - field: transcript
+    operator: not_contains
+    pattern: cargo test
 ---
 
 **Tests not detected in transcript!**

--- a/plugins/hookify/examples/require-tests-stop.local.md
+++ b/plugins/hookify/examples/require-tests-stop.local.md
@@ -6,7 +6,13 @@ action: block
 conditions:
   - field: transcript
     operator: not_contains
-    pattern: npm test|pytest|cargo test
+    pattern: npm test
+  - field: transcript
+    operator: not_contains
+    pattern: pytest
+  - field: transcript
+    operator: not_contains
+    pattern: cargo test
 ---
 
 **Tests not detected in transcript!**


### PR DESCRIPTION
## Summary
- Split the Hookify tests-before-stop example into three literal `not_contains` checks
- Update the README example to match the engine's actual substring-based behavior

## Why
The previous example used `npm test|pytest|cargo test` under `not_contains`, which reads like a regex but is evaluated as a literal substring. That made the example misleading and potentially ineffective.

## Notes
- No runtime code changes were needed
- This is a docs/example-only fix