### PR TITLE
docs: update deprecated npm install instructions in plugins/README.md

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -30,10 +30,17 @@ Learn more in the [official plugins documentation](https://docs.claude.com/en/do
 
 These plugins are included in the Claude Code repository. To use them in your own projects:
 
-1. Install Claude Code globally:
+1. Install Claude Code using one of the recommended methods:
+
+    **MacOS/Linux:**
 ```bash
-npm install -g @anthropic-ai/claude-code
+    curl -fsSL https://claude.ai/install.sh | bash
 ```
+    **Windows:**
+```powershell
+    irm https://claude.ai/install.ps1 | iex
+```
+    > **Note:** Installation via npm (`npm install -g @anthropic-ai/claude-code`) is deprecated.
 
 2. Navigate to your project and run Claude Code:
 ```bash


### PR DESCRIPTION
The plugins/README.md installation section still references npm install -g which is marked as deprecated in the main README. This PR updates it to match the recommended installation methods (curl/irm) and adds a deprecation note for npm.