### PR TITLE
docs: add Windows gh CLI install instruction in commit-commands README

### DIFF
--- a/plugins/commit-commands/README.md
+++ b/plugins/commit-commands/README.md
@@ -197,7 +197,9 @@ This plugin is included in the Claude Code repository. The commands are automati
 **Issue**: `gh pr create` command fails
 
 **Solution**:
-- Install GitHub CLI: `brew install gh` (macOS) or see [GitHub CLI installation](https://cli.github.com/)
+- Install GitHub CLI — see [GitHub CLI installation](https://cli.github.com/) for all platforms, or use a quick method:
+  - **macOS/Linux:** `brew install gh`
+  - **Windows:** `winget install --id GitHub.cli`
 - Authenticate: `gh auth login`
 - Ensure repository has a GitHub remote
 


### PR DESCRIPTION
The troubleshooting section for /commit-push-pr only mentioned macOS (brew install gh) for installing the GitHub CLI. This PR adds the Windows equivalent (winget install --id GitHub.cli) and links to the official installation page for all platforms.