### PR TITLE
Bump stale and autoclose timeouts from 14 to 90 days

### DIFF
--- a/scripts/issue-lifecycle.ts
+++ b/scripts/issue-lifecycle.ts
@@ -21,7 +21,7 @@ export const lifecycle = [
   },
   {
     label: "stale",
-    days: 14,
+    days: 90,
     reason: "inactive for too long",
     nudge: "This issue has been automatically marked as stale due to inactivity.",
   },

--- a/scripts/issue-lifecycle.ts
+++ b/scripts/issue-lifecycle.ts
@@ -27,7 +27,7 @@ export const lifecycle = [
   },
   {
     label: "autoclose",
-    days: 14,
+    days: 90,
     reason: "inactive for too long",
     nudge: "This issue has been marked for automatic closure.",
   },


### PR DESCRIPTION
## Summary

- Changes both the `stale` and `autoclose` lifecycle entries in `scripts/issue-lifecycle.ts` from 14 days to 90 days.
- The `stale` knob governs both "mark as stale after N days of inactivity" and "close N days after the stale label is applied" in `scripts/sweep.ts`; the `autoclose` knob governs the same close-after-label timer for issues that get the `autoclose` label directly. So the effective window before an untouched issue gets auto-closed goes from ~4 weeks to ~6 months for both paths.

## Why

The current 14-day timer assumes a maintainer will look at an issue within two weeks. In practice that's not what happens in this repo — plenty of issues with real reproductions, long comment threads, and clear bug signal get auto-closed because nobody on the Anthropic side triaged them in time. The workaround users have settled on is to keep bumping their own threads ("any update?", "+1", "still happening on 1.x") purely to keep the bot from killing the issue. That's not a healthy signal — it's load-bearing nagging.

Bumping the timeouts to 90 days doesn't fix the underlying problem (issues actually getting looked at), but it at least stops the bot from closing things faster than they can plausibly be triaged, and removes the incentive to spam comments just to keep a bug alive.

## Test plan

- [ ] Confirm `scripts/sweep.ts --dry-run` reports the new 90-day windows in its log output for both `stale` and `autoclose`.
- [ ] Confirm no other workflow hardcodes the 14-day value (only `issue-lifecycle.ts` should own it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)