### PR TITLE
fix: [DOCS] Plugin .mcp.json example incorrectly uses mcpServers wrapper

### DIFF
--- a/plugins/plugin-dev/skills/plugin-structure/examples/advanced-plugin.md
+++ b/plugins/plugin-dev/skills/plugin-structure/examples/advanced-plugin.md
@@ -146,30 +146,28 @@ enterprise-devops/
 
 ```json
 {
-  "mcpServers": {
-    "kubernetes": {
-      "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/servers/kubernetes-mcp/index.js"],
-      "env": {
-        "KUBECONFIG": "${KUBECONFIG}",
-        "K8S_NAMESPACE": "${K8S_NAMESPACE:-default}"
-      }
-    },
-    "terraform": {
-      "command": "python",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/servers/terraform-mcp/main.py"],
-      "env": {
-        "TF_STATE_BUCKET": "${TF_STATE_BUCKET}",
-        "AWS_REGION": "${AWS_REGION}"
-      }
-    },
-    "github-actions": {
-      "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/servers/github-actions-mcp/server.js"],
-      "env": {
-        "GITHUB_TOKEN": "${GITHUB_TOKEN}",
-        "GITHUB_ORG": "${GITHUB_ORG}"
-      }
+  "kubernetes": {
+    "command": "node",
+    "args": ["${CLAUDE_PLUGIN_ROOT}/servers/kubernetes-mcp/index.js"],
+    "env": {
+      "KUBECONFIG": "${KUBECONFIG}",
+      "K8S_NAMESPACE": "${K8S_NAMESPACE:-default}"
+    }
+  },
+  "terraform": {
+    "command": "python",
+    "args": ["${CLAUDE_PLUGIN_ROOT}/servers/terraform-mcp/main.py"],
+    "env": {
+      "TF_STATE_BUCKET": "${TF_STATE_BUCKET}",
+      "AWS_REGION": "${AWS_REGION}"
+    }
+  },
+  "github-actions": {
+    "command": "node",
+    "args": ["${CLAUDE_PLUGIN_ROOT}/servers/github-actions-mcp/server.js"],
+    "env": {
+      "GITHUB_TOKEN": "${GITHUB_TOKEN}",
+      "GITHUB_ORG": "${GITHUB_ORG}"
     }
   }
 }


### PR DESCRIPTION
## Summary

## Root Cause

The `.mcp.json` examples in the plugin documentation incorrectly wrapped server entries in a `mcpServers` key. The `mcpServers` key is a `plugin.json` manifest concept (used to point to an external file or define servers inline). The `.mcp.json` file itself uses a **flat format** where server names are top-level keys — consistent with all official plugins in `anthropics/claude-plugins-official`.

## Change Made

Fixed two files that showed `.mcp.json` examples with the incorrect `mcpServers` wrapper:

1. **`plugins/plugin-dev/skills/plugin-structure/SKILL.md`** (line ~242):  
   Removed the `mcpServers` wrapper from the "Example format" code block under "MCP Servers".

2. **`plugins/plugin-dev/skills/plugin-structure/examples/advanced-plugin.md`** (line ~148):  
   Removed the `mcpServers` wrapper from the `.mcp.json` section of the advanced plugin example (kubernetes, terraform, github-actions servers).

Both changes convert the examples from:
```json
{
  "mcpServers": {
    "server-name": { ... }
  }
}
```
to the correct flat format:
```json
{
  "server-name": { ... }
}
```



## Issue

Fixes #63694

**Issue URL:** https://github.com/anthropics/claude-code/issues/63694


## Changes

```
.../plugin-dev/skills/plugin-structure/SKILL.md    | 12 +++---
 .../plugin-structure/examples/advanced-plugin.md   | 46 +++++++++++-----------
 2 files changed, 27 insertions(+), 31 deletions(-)
```


## Testing


- Agent ran relevant tests during development

- Linting checks passed

- Changes are minimal and focused on the issue


## AI Assistance Disclosure


This pull request was prepared with the assistance of AI coding tools (GitHub Copilot). The change has been read, understood, and is owned by the human contributor submitting it, who will respond to review feedback.
