### PR TITLE
Remove stale statsig.anthropic.com from devcontainer firewall allowlist

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -68,7 +68,6 @@ for domain in \
     "registry.npmjs.org" \
     "api.anthropic.com" \
     "sentry.io" \
-    "statsig.anthropic.com" \
     "statsig.com" \
     "marketplace.visualstudio.com" \
     "vscode.blob.core.windows.net" \


### PR DESCRIPTION
## Summary

`.devcontainer/init-firewall.sh` whitelists `statsig.anthropic.com`, but that hostname no longer resolves in public DNS. The script exits on any failed resolution, so the reference devcontainer fails to come up out of the box with:

```
ERROR: Failed to resolve statsig.anthropic.com to any IP addresses
```

This PR drops the dead entry. `statsig.com` is left in place since it still resolves.

## Reproduction

```
$ dig +short @8.8.8.8 statsig.anthropic.com
(empty)
$ dig +short @1.1.1.1 statsig.anthropic.com
(empty)
$ dig statsig.anthropic.com
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN
```

## Rationale

The current [network configuration docs](https://code.claude.com/docs/en/network-config) no longer list any Statsig domain among Claude Code's required URLs — telemetry is documented as going to `api.anthropic.com`, error reporting to `sentry.io`. So removing the stale entry should be safe.

## Test plan

- [x] `dig` confirms NXDOMAIN against public resolvers
- [x] `bash -n .devcontainer/init-firewall.sh` parses cleanly
- [ ] Maintainer to confirm Claude Code no longer depends on the `statsig.anthropic.com` proxy