### PR TITLE
fix(plugins): add missing plugin.json manifest for plugin-dev

### DIFF
--- a/plugins/plugin-dev/.claude-plugin/plugin.json
+++ b/plugins/plugin-dev/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "plugin-dev",
+  "version": "0.1.0",
+  "description": "Comprehensive toolkit for developing Claude Code plugins with expert guidance on hooks, MCP integration, plugin structure, and marketplace publishing.",
+  "author": {
+    "name": "Anthropic",
+    "email": "support@anthropic.com"
+  }
+}


### PR DESCRIPTION
## Summary
- Added missing `.claude-plugin/plugin.json` manifest for the `plugin-dev` plugin
- This fixes discovery and installation through normal plugin mechanisms

## Changes
| File | Change |
|------|--------|
| `plugins/plugin-dev/.claude-plugin/plugin.json` | New manifest with name, version, description, and author |

## Root Cause
The `plugin-dev` plugin was the only plugin in the repository missing a `plugin.json` manifest. This prevented it from being discovered or installed through standard plugin mechanisms, even though `marketplace.json` references it.

## Test Plan
- [x] JSON syntax validated
- [x] Verified consistency with other plugin manifests
- [x] All 13 plugins now have plugin.json

Fixes #61760
Fixes #61758
