### PR TITLE
docs(agent-development): document ${CLAUDE_PLUGIN_ROOT} limitation in subagents

### DIFF
--- a/plugins/plugin-dev/skills/agent-development/SKILL.md
+++ b/plugins/plugin-dev/skills/agent-development/SKILL.md
@@ -153,6 +153,8 @@ tools: ["Read", "Write", "Grep", "Bash"]
 
 **Best practice:** Limit tools to minimum needed (principle of least privilege)
 
+> **Note — `tools:` is a hard capability boundary.** Unlike command `allowed-tools` (which only gates prompting), tools not listed here are genuinely unavailable to the agent even under `bypassPermissions`. See the MCP integration skill for a full comparison.
+
 **Common tool sets:**
 - Read-only analysis: `["Read", "Grep", "Glob"]`
 - Code generation: `["Read", "Write", "Grep"]`
@@ -374,6 +376,25 @@ Output: [What to provide]
 - ❌ Write vague system prompts
 - ❌ Skip testing
 
+## Known Limitations
+
+### `${CLAUDE_PLUGIN_ROOT}` and `${CLAUDE_PROJECT_DIR}` are not resolved in subagents
+
+**Affected versions:** Claude Code ≤ 2.1.166 (tracked in [issue #65768](https://github.com/anthropics/claude-code/issues/65768))
+
+These environment variable tokens resolve correctly in hooks and slash commands, but subagents receive them as **literal strings**. A `Read` call inside a subagent with path `${CLAUDE_PLUGIN_ROOT}/kernel/STANDARDS.md` will fail with "File does not exist."
+
+| Context | `${CLAUDE_PLUGIN_ROOT}` | `${CLAUDE_PROJECT_DIR}` |
+|---------|------------------------|------------------------|
+| SessionStart hooks | ✅ Resolves | ✅ Resolves |
+| Slash commands | ✅ Resolves | ✅ Resolves |
+| Subagents | ❌ Literal string | ❌ Literal string |
+
+**Workarounds** (see `references/subagent-plugin-root-workaround.md` for full details):
+
+1. **SessionStart hook staging (recommended)** — Copy plugin files to a project-relative path on session start so subagents can read them via relative paths.
+2. **Inject via orchestrator** — Have a parent command read the shared file and pass its content as text in the subagent's spawn prompt.
+
 ## Additional Resources
 
 ### Reference Files
@@ -383,6 +404,7 @@ For detailed guidance, consult:
 - **`references/system-prompt-design.md`** - Complete system prompt patterns
 - **`references/triggering-examples.md`** - Example formats and best practices
 - **`references/agent-creation-system-prompt.md`** - The exact prompt from Claude Code
+- **`references/subagent-plugin-root-workaround.md`** - Workarounds for `${CLAUDE_PLUGIN_ROOT}` in subagents
 
 ### Example Files
 

--- a/plugins/plugin-dev/skills/agent-development/references/subagent-plugin-root-workaround.md
+++ b/plugins/plugin-dev/skills/agent-development/references/subagent-plugin-root-workaround.md
@@ -1,0 +1,163 @@
+# Workaround: `${CLAUDE_PLUGIN_ROOT}` Not Resolved in Subagents
+
+## The Problem
+
+In Claude Code ≤ 2.1.166, `${CLAUDE_PLUGIN_ROOT}` and `${CLAUDE_PROJECT_DIR}` are substituted correctly in hooks and slash commands, but **not** in subagents. When a subagent tries to read a plugin-bundled file, the token is passed as a literal string and the `Read` tool fails with "File does not exist."
+
+This affects multi-agent plugins that need subagents to access shared resources (standards documents, prompt partials, schemas) bundled in the plugin directory.
+
+**Tracked in:** [github.com/anthropics/claude-code/issues/65768](https://github.com/anthropics/claude-code/issues/65768)
+
+---
+
+## Workaround 1: SessionStart Hook Staging (Recommended)
+
+Copy plugin files into the project directory on session start. Subagents can then read them via relative paths without needing `${CLAUDE_PLUGIN_ROOT}`.
+
+### How It Works
+
+A `SessionStart` hook copies selected plugin files into a hidden subdirectory of the project (e.g., `.plugin-cache/<plugin-name>/`). Because subagents run with the project as their working directory, they can read these files using predictable relative paths.
+
+### Hook Implementation
+
+Create `hooks/stage-plugin-files.sh` in your plugin:
+
+```bash
+#!/usr/bin/env bash
+# Stages plugin-bundled files into the project so subagents can read them.
+# Runs on SessionStart. Safe to run multiple times (idempotent copy).
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
+PROJECT_DIR="${CLAUDE_PROJECT_DIR}"
+PLUGIN_NAME="my-plugin"   # Change to your plugin name
+STAGE_DIR="${PROJECT_DIR}/.plugin-cache/${PLUGIN_NAME}"
+SOURCE_DIR="${PLUGIN_ROOT}/kernel"
+
+# Only stage if source files have changed (avoid unnecessary disk writes)
+if [ -d "${STAGE_DIR}" ]; then
+  if diff -rq --exclude="*.tmp" "${SOURCE_DIR}" "${STAGE_DIR}" > /dev/null 2>&1; then
+    exit 0  # Nothing to update
+  fi
+fi
+
+mkdir -p "${STAGE_DIR}"
+cp -r "${SOURCE_DIR}/." "${STAGE_DIR}/"
+```
+
+Register it in `hooks/hooks.json`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "type": "command",
+        "command": "${CLAUDE_PLUGIN_ROOT}/hooks/stage-plugin-files.sh"
+      }
+    ]
+  }
+}
+```
+
+### Subagent Usage
+
+After staging, subagents read files using the stable relative path:
+
+```markdown
+---
+name: standards-checker
+description: Use this agent when reviewing code against project standards.
+model: inherit
+color: blue
+tools: ["Read", "Grep", "Glob"]
+---
+
+You are a code standards checker.
+
+Start by reading the standards document at:
+`.plugin-cache/my-plugin/STANDARDS.md`
+
+Apply every rule from that document when reviewing the code.
+```
+
+### Gitignore
+
+Add the cache directory to `.gitignore` in your plugin's project template, or document that users should add it:
+
+```gitignore
+.plugin-cache/
+```
+
+### Trade-offs
+
+| | |
+|---|---|
+| ✅ Reliable | Works without any engine fix |
+| ✅ Idempotent | Safe to re-run on every session start |
+| ✅ Fast | Only copies when source changes |
+| ⚠️ Pollutes project dir | Adds `.plugin-cache/` to every project |
+| ⚠️ Stale on plugin update | Files stay in cache until next session start |
+
+---
+
+## Workaround 2: Orchestrator Injection
+
+Have a parent command read the shared plugin file and inject its content as text into the subagent's spawn prompt. This avoids touching the project filesystem but couples file delivery to one command.
+
+### Implementation
+
+In a command that spawns the subagent:
+
+```markdown
+---
+description: Analyze code using bundled standards
+allowed-tools: [Read, Task]
+---
+
+# Standards-Aware Analysis
+
+Steps:
+1. Read the standards file at `${CLAUDE_PLUGIN_ROOT}/kernel/STANDARDS.md` and store its content
+2. Spawn the analysis subagent with the standards content injected into the task description:
+   "Review this code. Standards to apply:\n\n[STANDARDS CONTENT]\n\nCode to review:\n[CODE]"
+```
+
+### Trade-offs
+
+| | |
+|---|---|
+| ✅ No project filesystem pollution | Clean approach |
+| ✅ Always current | Reads live from plugin directory |
+| ⚠️ Bloats context | Standards text is repeated in every spawn |
+| ⚠️ Coupled to command | Only works when this specific command is the entry point |
+| ⚠️ Prompt size limit | Large shared files may hit context limits |
+
+---
+
+## Choosing a Workaround
+
+| Scenario | Recommended workaround |
+|----------|------------------------|
+| Subagent needs a small (<2KB) shared config | Orchestrator injection |
+| Subagent needs a large reference doc | SessionStart staging |
+| Multiple subagents share the same files | SessionStart staging (copy once, read many) |
+| Plugin must not touch project filesystem | Orchestrator injection |
+| Need to support fully autonomous agent spawning | SessionStart staging |
+
+---
+
+## When the Engine Bug Is Fixed
+
+Once [issue #65768](https://github.com/anthropics/claude-code/issues/65768) is resolved, subagents will resolve `${CLAUDE_PLUGIN_ROOT}` natively. At that point:
+
+- Remove the `SessionStart` staging hook
+- Remove the `.plugin-cache/` references from subagent system prompts
+- Replace relative cache paths with `${CLAUDE_PLUGIN_ROOT}/kernel/...`
+- Remove the `.gitignore` entry
+
+To make migration easy, consider defining the path as a variable in your subagent system prompt:
+
+```markdown
+The standards document is at: `.plugin-cache/my-plugin/STANDARDS.md`
+<!-- TODO(#65768): replace with ${CLAUDE_PLUGIN_ROOT}/kernel/STANDARDS.md once fixed -->
+```


### PR DESCRIPTION

Subagents receive ${CLAUDE_PLUGIN_ROOT} and ${CLAUDE_PROJECT_DIR} as literal strings instead of resolved paths (issue #65768, affects ≤ 2.1.166). This breaks any subagent that tries to read plugin-bundled files.

Adds a Known Limitations section to SKILL.md with a resolution matrix and pointers to workarounds, plus a new reference file documenting two concrete workarounds:
- SessionStart hook staging: copies plugin files to .plugin-cache/ so subagents can read them via stable relative paths (recommended for multi-agent plugins with shared resources)
- Orchestrator injection: parent command reads the file and passes content as text in the subagent spawn prompt (better for small, single-use cases)

Also clarifies that the `tools:` frontmatter field is a hard capability boundary (not just a prompt-gating mechanism like command `allowed-tools`).
issue #65768 