### PR TITLE
fix(plugin-dev): validator scripts abort on first finding due to `set -e`

### DIFF
--- a/plugins/plugin-dev/skills/agent-development/scripts/validate-agent.sh
+++ b/plugins/plugin-dev/skills/agent-development/scripts/validate-agent.sh
@@ -2,7 +2,7 @@
 # Agent File Validator
 # Validates agent markdown files for correct structure and content
 
-set -euo pipefail
+set -uo pipefail
 
 # Usage
 if [ $# -eq 0 ]; then

--- a/plugins/plugin-dev/skills/hook-development/scripts/hook-linter.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/hook-linter.sh
@@ -2,7 +2,7 @@
 # Hook Linter
 # Checks hook scripts for common issues and best practices
 
-set -euo pipefail
+set -uo pipefail
 
 # Usage
 if [ $# -eq 0 ]; then

--- a/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
@@ -2,7 +2,7 @@
 # Hook Schema Validator
 # Validates hooks.json structure and checks for common issues
 
-set -euo pipefail
+set -uo pipefail
 
 # Usage
 if [ $# -eq 0 ]; then


### PR DESCRIPTION
## Problem

Three validator scripts in `plugin-dev` use `set -euo pipefail`:

- `plugins/plugin-dev/skills/agent-development/scripts/validate-agent.sh`
- `plugins/plugin-dev/skills/hook-development/scripts/hook-linter.sh`
- `plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh`

These are "check each item → accumulate errors/warnings → print a summary"
validators. But several commands they rely on legitimately return non-zero
during normal operation, and with `-e` any of them aborts the whole script
at the first finding — before the summary or correct exit code is reached:

- `((counter++))` returns exit code 1 when the counter goes from 0 → 1
  (post-increment evaluates to the old value `0`, which is arithmetically false).
- `grep '^description:'` returns non-zero when an optional field is absent.
- `jq` returns non-zero when indexing a malformed structure.

Result: the validators silently fail exactly when the input has problems —
the case they exist to handle.

### Repro

    $ bash validate-agent.sh some-agent-with-errors.md
    # stops at the first ❌, no summary, output truncated

## Fix

Change `set -euo pipefail` → `set -uo pipefail` in all three scripts.
`-u` and `pipefail` are kept. All fatal conditions (missing file, missing
args, malformed frontmatter) already use explicit `exit 1`, so error handling
behavior is unchanged.

## Verification

- Malformed inputs now run all checks and print the correct summary + exit code.
- Valid inputs still exit 0 with "✅ All checks passed!".
- `bash -n` passes on all three files.
