### PR TITLE
fix(ralph-wiggum): restore dead error handlers broken by set -euo pipefail

### DIFF
--- a/plugins/ralph-wiggum/hooks/stop-hook.sh
+++ b/plugins/ralph-wiggum/hooks/stop-hook.sh
@@ -19,10 +19,12 @@ fi
 
 # Parse markdown frontmatter (YAML between ---) and extract values
 FRONTMATTER=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$RALPH_STATE_FILE")
-ITERATION=$(echo "$FRONTMATTER" | grep '^iteration:' | sed 's/iteration: *//')
-MAX_ITERATIONS=$(echo "$FRONTMATTER" | grep '^max_iterations:' | sed 's/max_iterations: *//')
+# Use `|| true` so a missing field (grep exits 1) doesn't trigger set -e;
+# the validation below handles empty values explicitly.
+ITERATION=$(echo "$FRONTMATTER" | grep '^iteration:' | sed 's/iteration: *//' || true)
+MAX_ITERATIONS=$(echo "$FRONTMATTER" | grep '^max_iterations:' | sed 's/max_iterations: *//' || true)
 # Extract completion_promise and strip surrounding quotes if present
-COMPLETION_PROMISE=$(echo "$FRONTMATTER" | grep '^completion_promise:' | sed 's/completion_promise: *//' | sed 's/^"\(.*\)"$/\1/')
+COMPLETION_PROMISE=$(echo "$FRONTMATTER" | grep '^completion_promise:' | sed 's/completion_promise: *//' | sed 's/^"\(.*\)"$/\1/' || true)
 
 # Validate numeric fields before arithmetic operations
 if [[ ! "$ITERATION" =~ ^[0-9]+$ ]]; then
@@ -87,22 +89,21 @@ if [[ -z "$LAST_LINE" ]]; then
 fi
 
 # Parse JSON with error handling
+# Capture stderr into LAST_OUTPUT via 2>&1; use || to handle set -e on jq failure
+# so the error block is reached instead of the script silently exiting.
 LAST_OUTPUT=$(echo "$LAST_LINE" | jq -r '
   .message.content |
   map(select(.type == "text")) |
   map(.text) |
   join("\n")
-' 2>&1)
-
-# Check if jq succeeded
-if [[ $? -ne 0 ]]; then
+' 2>&1) || {
   echo "⚠️  Ralph loop: Failed to parse assistant message JSON" >&2
   echo "   Error: $LAST_OUTPUT" >&2
   echo "   This may indicate a transcript format issue" >&2
   echo "   Ralph loop is stopping." >&2
   rm "$RALPH_STATE_FILE"
   exit 0
-fi
+}
 
 if [[ -z "$LAST_OUTPUT" ]]; then
   echo "⚠️  Ralph loop: Assistant message contained no text content" >&2


### PR DESCRIPTION
## Problem

`stop-hook.sh` sets `set -euo pipefail` on line 7, but two patterns in the script silently exit the process **before** reaching their own error-handling code.

### 1. Frontmatter field extraction (lines 21–25)

```bash
ITERATION=$(echo "$FRONTMATTER" | grep '^iteration:' | sed 's/iteration: *//')
```

With `pipefail`, a `grep` no-match (exit 1) propagates as the pipeline exit code. `set -e` then exits the whole script immediately if any frontmatter field is absent from the state file (e.g. due to corruption or manual editing).

The corruption-detection guards on lines 28–48 can **never** be reached in that scenario, so the state file is left behind and the loop silently fails on every subsequent turn instead of cleaning up and stopping.

### 2. jq JSON parsing (lines 90–105)

```bash
LAST_OUTPUT=$(echo "$LAST_LINE" | jq -r '...' 2>&1)

# Check if jq succeeded
if [[ $? -ne 0 ]]; then   # ← dead code: set -e already exited above
  ...
fi
```

If `jq` fails (malformed transcript JSON), `set -e` exits the script before `$?` is ever checked. The state file is not cleaned up, and the loop remains stuck.

## Fix

**Frontmatter extraction** — append `|| true` to each pipeline so a missing field evaluates to an empty string rather than triggering `set -e`. The existing `[[ ! "$FIELD" =~ ^[0-9]+$ ]]` guards then handle the empty-string case correctly.

**jq parsing** — replace the separate `if [[ $? -ne 0 ]]` block with an inline `|| { ... exit 0; }`. `$LAST_OUTPUT` is already set (via `2>&1`) when the `||` block executes, preserving the diagnostic message.

## Testing

`bash -n stop-hook.sh` passes. Manually verified the three scenarios:
- Normal (valid state file + valid transcript) → loop continues as before
- Missing `iteration:` field in state file → corruption message printed, state file removed, hook exits 0
- Malformed transcript JSON fed to `jq` → parse-error message printed, state file removed, hook exits 0