### PR TITLE
fix(pr-review-toolkit): use full author name in plugin.json

### DIFF
--- a/plugins/pr-review-toolkit/.claude-plugin/plugin.json
+++ b/plugins/pr-review-toolkit/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Comprehensive PR review agents specializing in comments, tests, error handling, type design, code quality, and code simplification",
   "author": {
-    "name": "Daisy",
+    "name": "Daisy Hollman",
     "email": "daisy@anthropic.com"
   }
 }


### PR DESCRIPTION
## Summary

The `author.name` field in `plugins/pr-review-toolkit/.claude-plugin/plugin.json` was set to `"Daisy"` instead of the full `"Daisy Hollman"`.

This is inconsistent with the same author's other plugins in this repository:
- `hookify` → `"name": "Daisy Hollman"`
- `ralph-wiggum` → `"name": "Daisy Hollman"`

One-line fix: `"Daisy"` → `"Daisy Hollman"`.

Closes #61768