### PR TITLE
fix(marketplace): sync security-guidance version and description with plugin.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -137,8 +137,8 @@
     },
     {
       "name": "security-guidance",
-      "description": "Security reminder hook that warns about potential security issues when editing files, including command injection, XSS, and unsafe code patterns",
-      "version": "1.0.0",
+      "description": "Security review for Claude-generated code. Pattern-based warnings on edits, LLM-powered diff review on Stop, and an agentic commit reviewer that catches injection, XSS, SSRF, hardcoded secrets, and 25+ other vulnerability classes.",
+      "version": "2.0.0",
       "author": {
         "name": "David Dworken",
         "email": "dworken@anthropic.com"


### PR DESCRIPTION
## Problem

The `security-guidance` entry in `.claude-plugin/marketplace.json` is out of sync with the plugin's own `plugin.json`:

| Field | marketplace.json | plugin.json |
|-------|-----------------|-------------|
| `version` | `1.0.0` | `2.0.0` |
| `description` | "Security reminder hook that warns about potential security issues when editing files, including command injection, XSS, and unsafe code patterns" | "Security review for Claude-generated code. Pattern-based warnings on edits, LLM-powered diff review on Stop, and an agentic commit reviewer that catches injection, XSS, SSRF, hardcoded secrets, and 25+ other vulnerability classes." |

The plugin was substantially upgraded to v2.0.0 when LLM-powered diff review and the agentic commit reviewer were added, but the marketplace entry was never updated.

## Fix

Copy the current `version` and `description` from `plugin.json` into `marketplace.json` so the marketplace reflects the plugin's actual capabilities.

## Changes

- `.claude-plugin/marketplace.json`: update `security-guidance` version from `1.0.0` → `2.0.0` and sync description from plugin.json