### PR TITLE
fix(pr-review-toolkit): use full author name in plugin manifest

### DIFF
--- a/plugins/pr-review-toolkit/.claude-plugin/plugin.json
+++ b/plugins/pr-review-toolkit/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Comprehensive PR review agents specializing in comments, tests, error handling, type design, code quality, and code simplification",
   "author": {
-    "name": "Daisy",
+    "name": "Daisy Hollman",
     "email": "daisy@anthropic.com"
   }
 }


### PR DESCRIPTION
## Summary

The `pr-review-toolkit` plugin manifest lists its author name as `"Daisy"`, while the same author (`daisy@anthropic.com`) is listed with the full name `"Daisy Hollman"` in the other plugins they authored in this repo. This corrects the name for consistency across the bundled plugins.

Fixes #61768.

## Details

`plugins/pr-review-toolkit/.claude-plugin/plugin.json` line 6:

```diff
   "author": {
-    "name": "Daisy",
+    "name": "Daisy Hollman",
     "email": "daisy@anthropic.com"
   }
```

The same email is used in two other bundled plugins, both with the full name:

- `plugins/ralph-wiggum/.claude-plugin/plugin.json` → `"name": "Daisy Hollman"`
- `plugins/hookify/.claude-plugin/plugin.json` → `"name": "Daisy Hollman"`

## Verification

- `python3 -c "import json; json.load(open('plugins/pr-review-toolkit/.claude-plugin/plugin.json'))"` — manifest is still valid JSON.
- Only the author display name changes; `name`, `version`, `description`, and `email` are untouched.
