### PR TITLE
fix(ralph-wiggum): case-insensitive completion promise matching

### DIFF
--- a/plugins/ralph-wiggum/README.md
+++ b/plugins/ralph-wiggum/README.md
@@ -131,7 +131,7 @@ Always use `--max-iterations` as a safety net to prevent infinite loops on impos
 #  - Suggest alternative approaches"
 ```
 
-**Note**: The `--completion-promise` uses exact string matching, so you cannot use it for multiple completion conditions (like "SUCCESS" vs "BLOCKED"). Always rely on `--max-iterations` as your primary safety mechanism.
+**Note**: The `--completion-promise` uses case-insensitive string matching with whitespace normalization, so `COMPLETE`, `Complete`, and `complete` are all equivalent. However, it does not support multiple completion conditions (like "SUCCESS" vs "BLOCKED"). Always rely on `--max-iterations` as your primary safety mechanism.
 
 ## Philosophy
 

--- a/plugins/ralph-wiggum/hooks/stop-hook.sh
+++ b/plugins/ralph-wiggum/hooks/stop-hook.sh
@@ -118,9 +118,11 @@ if [[ "$COMPLETION_PROMISE" != "null" ]] && [[ -n "$COMPLETION_PROMISE" ]]; then
   # .*? is non-greedy (takes FIRST tag), whitespace normalized
   PROMISE_TEXT=$(echo "$LAST_OUTPUT" | perl -0777 -pe 's/.*?<promise>(.*?)<\/promise>.*/$1/s; s/^\s+|\s+$//g; s/\s+/ /g' 2>/dev/null || echo "")
 
-  # Use = for literal string comparison (not pattern matching)
-  # == in [[ ]] does glob pattern matching which breaks with *, ?, [ characters
-  if [[ -n "$PROMISE_TEXT" ]] && [[ "$PROMISE_TEXT" = "$COMPLETION_PROMISE" ]]; then
+  # Normalize and lowercase both sides for case-insensitive, whitespace-tolerant matching
+  # Uses tr for portability (${var,,} requires Bash 4+ but macOS ships Bash 3)
+  PROMISE_LOWER=$(echo "$PROMISE_TEXT" | tr '[:upper:]' '[:lower:]')
+  EXPECTED_LOWER=$(echo "$COMPLETION_PROMISE" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//; s/[[:space:]]\{1,\}/ /g' | tr '[:upper:]' '[:lower:]')
+  if [[ -n "$PROMISE_TEXT" ]] && [[ "$PROMISE_LOWER" = "$EXPECTED_LOWER" ]]; then
     echo "✅ Ralph loop: Detected <promise>$COMPLETION_PROMISE</promise>"
     rm "$RALPH_STATE_FILE"
     exit 0


### PR DESCRIPTION
## Summary

- Completion promise matching now uses **case-insensitive comparison** with **whitespace normalization**, preventing false negatives when Claude outputs casing that differs from the configured promise (e.g. `Complete` vs `COMPLETE`)
- Uses `tr` instead of `${var,,}` for portability with macOS default Bash 3
- Updated README to reflect the new matching behavior

## Problem

The stop hook used exact string comparison for completion promises. This caused loops to continue unnecessarily when:
- Claude output `<promise>Complete</promise>` but the promise was set to `COMPLETE`
- YAML parsing introduced leading/trailing whitespace in the configured promise

## Test plan

- [x] Verified case-insensitive matching (`COMPLETE` vs `Complete`) — matches
- [x] Verified whitespace normalization (`DONE` vs `  DONE  `) — matches
- [x] Verified non-matching strings (`SUCCESS` vs `COMPLETE`) — correctly rejects
- [x] Verified portability with Bash 3 on macOS (no `${var,,}` syntax)

🤖 Generated with [Claude Code](https://claude.com/claude-code)