### PR TITLE
fix(scripts): don't auto-close assigned issues in sweep

### DIFF
--- a/scripts/sweep.ts
+++ b/scripts/sweep.ts
@@ -106,6 +106,7 @@ async function closeExpired(owner: string, repo: string) {
       for (const issue of issues) {
         if (issue.pull_request) continue;
         if (issue.locked) continue;
+        if (issue.assignees?.length > 0) continue;
 
         const thumbsUp = issue.reactions?.["+1"] ?? 0;
         if (thumbsUp >= STALE_UPVOTE_THRESHOLD) continue;


### PR DESCRIPTION
## Summary

`scripts/sweep.ts` has two stages: `markStale` (labels inactive issues) and `closeExpired` (closes issues whose lifecycle label has timed out).

`markStale` deliberately skips assigned issues:

```ts
if (issue.assignees?.length > 0) continue;
```

…so an issue that someone owns is never labeled stale. But `closeExpired` only skips pull requests and locked issues — **not** assigned ones. So an issue that is assigned to a maintainer but still carries a lifecycle label (e.g. it was labeled stale *before* being assigned, or the triage workflow didn't strip the label on assignment) can be **auto-closed despite being actively owned**.

## Fix

Add the same assignee guard to `closeExpired` so the two stages are consistent and assigned issues are never auto-closed:

```ts
if (issue.assignees?.length > 0) continue;
```

One line, mirroring the existing check in `markStale`. No behavior change for unassigned issues.
