### PR TITLE
fix: correct Ralph Wiggum state file path docs

### DIFF
--- a/plugins/ralph-wiggum/commands/help.md
+++ b/plugins/ralph-wiggum/commands/help.md
@@ -46,7 +46,7 @@ Start a Ralph loop in your current session.
 - `--completion-promise <text>` - Promise phrase to signal completion
 
 **How it works:**
-1. Creates `.claude/.ralph-loop.local.md` state file
+1. Creates `.claude/ralph-loop.local.md` state file
 2. You work on the task
 3. When you try to exit, stop hook intercepts
 4. Same prompt fed back
@@ -66,7 +66,7 @@ Cancel an active Ralph loop (removes the loop state file).
 
 **How it works:**
 - Checks for active loop state file
-- Removes `.claude/.ralph-loop.local.md`
+- Removes `.claude/ralph-loop.local.md`
 - Reports cancellation with iteration count
 
 ---


### PR DESCRIPTION
## Summary
Resolves #61764

## Changes Made
- Corrected the Ralph Wiggum help text to reference `.claude/ralph-loop.local.md`, matching the setup script, stop hook, and cancel command.

## Testing
- [x] Unit tests added/updated (not applicable; docs-only plugin help text change)
- [x] All existing tests pass (`rg -n "\.claude/\.?ralph-loop\.local\.md" plugins/ralph-wiggum`; `bash -n plugins/ralph-wiggum/scripts/setup-ralph-loop.sh`; `bash -n plugins/ralph-wiggum/hooks/stop-hook.sh`; `git diff --check`)

## Related Issue
Closes #61764
