### PR TITLE
fix(hookify): PostToolUse hooks cannot return permissionDecision: deny

### DIFF
--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -69,7 +69,8 @@ class RuleEngine:
                     "reason": combined_message,
                     "systemMessage": combined_message
                 }
-            elif hook_event in ['PreToolUse', 'PostToolUse']:
+            elif hook_event == 'PreToolUse':
+                # PreToolUse can deny the tool before it executes
                 return {
                     "hookSpecificOutput": {
                         "hookEventName": hook_event,
@@ -78,7 +79,7 @@ class RuleEngine:
                     "systemMessage": combined_message
                 }
             else:
-                # For other events, just show message
+                # PostToolUse and other events: tool already ran, can only inject a message
                 return {
                     "systemMessage": combined_message
                 }


### PR DESCRIPTION
## Problem

In `plugins/hookify/core/rule_engine.py`, the `evaluate_rules` function returned `permissionDecision: "deny"` for **both** `PreToolUse` and `PostToolUse` hook events:

```python
# before
elif hook_event in ['PreToolUse', 'PostToolUse']:
    return {"hookSpecificOutput": {"hookEventName": hook_event, "permissionDecision": "deny"}, ...}
```

`PostToolUse` fires **after** the tool has already executed. The Claude Code hook protocol explicitly states that `permissionDecision` is only meaningful for `PreToolUse`. Sending it for `PostToolUse` produces undefined behaviour (the field is silently ignored or causes a protocol error depending on the runtime version).

## Fix

Split the two cases:

- `PreToolUse` → returns `permissionDecision: "deny"` as before (correct)
- `PostToolUse` and all other non-Stop events → returns only `systemMessage` (the only valid output for post-execution hooks)

## Testing

Covered by reading the hook protocol spec and tracing `evaluate_rules` call sites in `pretooluse.py` and `posttooluse.py`.

🤖 Generated with [Claude Code](https://claude.ai/code)