### PR TITLE
fix(hookify): rename shadowed 'field' variable and fix inline dict comma parsing

### DIFF
--- a/plugins/hookify/core/config_loader.py
+++ b/plugins/hookify/core/config_loader.py
@@ -60,14 +60,14 @@ class Rule:
             # Infer field from event
             event = frontmatter.get('event', 'all')
             if event == 'bash':
-                field = 'command'
+                field_name = 'command'
             elif event == 'file':
-                field = 'new_text'
+                field_name = 'new_text'
             else:
-                field = 'content'
+                field_name = 'content'
 
             conditions = [Condition(
-                field=field,
+                field=field_name,
                 operator='regex_match',
                 pattern=simple_pattern
             )]
@@ -163,8 +163,12 @@ def extract_frontmatter(content: str) -> tuple[Dict[str, Any], str]:
             # Check if this is an inline dict (key: value on same line)
             if ':' in item_text and ',' in item_text:
                 # Inline comma-separated dict: "- field: command, operator: regex_match"
+                # Split only on commas that are followed by a key (word chars then colon),
+                # so commas inside quoted values or regex patterns are preserved.
                 item_dict = {}
-                for part in item_text.split(','):
+                import re as _re
+                parts = _re.split(r',\s*(?=\w[\w\s]*:)', item_text)
+                for part in parts:
                     if ':' in part:
                         k, v = part.split(':', 1)
                         item_dict[k.strip()] = v.strip().strip('"').strip("'")


### PR DESCRIPTION
## Description

Fixes two bugs in `plugins/hookify/core/config_loader.py`.

### Bug 1: Shadowed `field` variable

`Rule.from_dict()` assigned a local variable named `field`, shadowing the module-level `field` imported from `dataclasses`. Any future use of `field()` inside that method would call a string instead, raising `TypeError`.

**Fix:** Renamed the local to `field_name`.

### Bug 2: Inline dict comma parsing

`extract_frontmatter()` split inline YAML dicts on every comma using `str.split(',')`, breaking values that legitimately contain commas (e.g. regex patterns like `rm,-rf` or URLs).

**Fix:** Replaced `str.split(',')` with `re.split` using a lookahead that only splits on commas preceding a new key (`word:`), preserving commas inside quoted values or regex patterns.

### Changes

- `plugins/hookify/core/config_loader.py` — +9 / -5 lines
