### PR TITLE
fix(security-guidance): block symlink escape in extensibility config reads

### DIFF
--- a/plugins/security-guidance/hooks/extensibility.py
+++ b/plugins/security-guidance/hooks/extensibility.py
@@ -102,11 +102,35 @@ def _config_paths(cwd: Optional[str], basename: str) -> List[Tuple[str, str]]:
     return paths
 
 
+def _resolve_safe(path: str) -> Optional[str]:
+    """Resolve symlinks and verify the real path stays within its parent directory.
+
+    Prevents a malicious repo from committing a symlink that points outside
+    .claude/ (e.g. to ~/.ssh/id_rsa), which would cause the plugin to read and
+    send that file's content to the Anthropic API as project security guidance.
+    Returns the real path when safe, or None if the file escapes its boundary.
+    """
+    try:
+        real = os.path.realpath(path)
+        boundary = os.path.realpath(os.path.dirname(path))
+        if not (real == boundary or real.startswith(boundary + os.sep)):
+            debug_log(
+                f"extensibility: skipping {path}: symlink escapes {boundary} → {real}"
+            )
+            return None
+        return real
+    except OSError:
+        return None
+
+
 def _load_guidance(cwd: Optional[str]) -> str:
     parts = []
     for label, path in _config_paths(cwd, GUIDANCE_BASENAME):
+        real = _resolve_safe(path)
+        if real is None:
+            continue
         try:
-            with open(path, encoding="utf-8") as f:
+            with open(real, encoding="utf-8") as f:
                 txt = f.read().strip()
         except OSError:
             continue
@@ -170,8 +194,11 @@ def _load_user_patterns(cwd: Optional[str]) -> List[Dict[str, Any]]:
 
 def _read_config(path: str) -> Optional[Dict[str, Any]]:
     """Read a YAML or JSON config file. Returns None on missing/malformed."""
+    real = _resolve_safe(path)
+    if real is None:
+        return None
     try:
-        with open(path, encoding="utf-8") as f:
+        with open(real, encoding="utf-8") as f:
             raw = f.read()
     except OSError:
         return None


### PR DESCRIPTION
## Description

Prevents a symlink-based local file disclosure vulnerability in the security-guidance plugin.

A malicious repository could commit `.claude/claude-security-guidance.md` (or `security-patterns.*`) as a **symlink** pointing to any locally readable file (e.g. `~/.ssh/id_rsa`). The plugin would then read that file and send its content to the Anthropic API wrapped in `<project-security-guidance>` tags on every hook invocation.

### Fix

Adds `_resolve_safe()` in `plugins/security-guidance/hooks/extensibility.py` which:
1. Resolves the path with `os.path.realpath()`
2. Verifies the result stays within the file's parent directory (`.claude/`)
3. If the resolved path escapes that boundary, the file is skipped with a `debug_log` entry and treated as absent

Normal files (no symlink) are unaffected since their realpath is the file itself within the same directory.

### Changes

- `plugins/security-guidance/hooks/extensibility.py` — +29 / -2 lines

Fixes #64582
