### PR TITLE
fix(ralph-wiggum): correct state file path in help.md

### DIFF
--- a/plugins/ralph-wiggum/commands/help.md
+++ b/plugins/ralph-wiggum/commands/help.md
@@ -46,7 +46,7 @@ Start a Ralph loop in your current session.
 - `--completion-promise <text>` - Promise phrase to signal completion
 
 **How it works:**
-1. Creates `.claude/.ralph-loop.local.md` state file
+1. Creates `.claude/ralph-loop.local.md` state file
 2. You work on the task
 3. When you try to exit, stop hook intercepts
 4. Same prompt fed back
@@ -66,7 +66,7 @@ Cancel an active Ralph loop (removes the loop state file).
 
 **How it works:**
 - Checks for active loop state file
-- Removes `.claude/.ralph-loop.local.md`
+- Removes `.claude/ralph-loop.local.md`
 - Reports cancellation with iteration count
 
 ---


### PR DESCRIPTION
## Summary

The help documentation for the `ralph-wiggum` plugin referenced the state file path as `.claude/.ralph-loop.local.md` (with a leading dot before `ralph-loop`), but the actual implementation creates the file at `.claude/ralph-loop.local.md` (without the dot).

## Change

Fixed both occurrences in `plugins/ralph-wiggum/commands/help.md`:
- `start` command docs: `.claude/.ralph-loop.local.md` → `.claude/ralph-loop.local.md`
- `cancel` command docs: `.claude/.ralph-loop.local.md` → `.claude/ralph-loop.local.md`

Documentation-only fix — no code changes.