### PR TITLE
fix(pr-review-toolkit): complete author name in plugin.json

### DIFF
--- a/plugins/pr-review-toolkit/.claude-plugin/plugin.json
+++ b/plugins/pr-review-toolkit/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Comprehensive PR review agents specializing in comments, tests, error handling, type design, code quality, and code simplification",
   "author": {
-    "name": "Daisy",
+    "name": "Daisy Hollman",
     "email": "daisy@anthropic.com"
   }
 }


### PR DESCRIPTION
## Summary

`plugins/pr-review-toolkit/.claude-plugin/plugin.json` has the author name truncated to just `"Daisy"` instead of `"Daisy Hollman"`.

**Before:**
```json
"author": {
  "name": "Daisy",
  "email": "daisy@anthropic.com"
}
```

**After:**
```json
"author": {
  "name": "Daisy Hollman",
  "email": "daisy@anthropic.com"
}
```

All other official plugins (`ralph-wiggum`, `hookify`, etc.) use full names in their `plugin.json`. This brings `pr-review-toolkit` in line.

Fixes #61768

🤖 Generated with [Claude Code](https://claude.com/claude-code)