### PR TITLE
fix(scripts): add duplicate label additively, don't replace existing labels

### DIFF
--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -77,8 +77,16 @@ async function closeIssueAsDuplicate(
     {
       state: 'closed',
       state_reason: 'duplicate',
-      labels: ['duplicate']
     }
+  );
+
+  // Add the duplicate label additively — PATCH with `labels` replaces the
+  // entire label set, which would erase platform/area/priority metadata.
+  await githubRequest(
+    `/repos/${owner}/${repo}/issues/${issueNumber}/labels`,
+    token,
+    'POST',
+    { labels: ['duplicate'] }
   );
 
   await githubRequest(


### PR DESCRIPTION
## Summary

When `closeIssueAsDuplicate` closes an issue, it was passing `labels: [duplicate]` in the PATCH request to update the issue state. However, GitHub PATCH on an issue **replaces** the entire label set, which silently erases any platform/area/priority labels that had already been applied.

## Change

Moved the `duplicate` label assignment to a separate POST request to `/repos/:owner/:repo/issues/:number/labels`, which adds the label additively without touching existing labels. The PATCH call no longer includes `labels`.

This is a one-line semantic fix — no new dependencies, no behavioral change beyond preserving existing labels.