### PR TITLE
fix(security-guidance): normalize CLAUDE_PLUGIN_ROOT path separators on Windows

### DIFF
--- a/plugins/security-guidance/hooks/hooks.json
+++ b/plugins/security-guidance/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/sg-python.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/ensure_agent_sdk.py\"",
+            "command": "bash -c 'R=$(echo \"$CLAUDE_PLUGIN_ROOT\" | tr \\\\ /); bash \"$R/hooks/sg-python.sh\" \"$R/hooks/ensure_agent_sdk.py\"'",
             "timeout": 180
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/sg-python.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/security_reminder_hook.py\""
+            "command": "bash -c 'R=$(echo \"$CLAUDE_PLUGIN_ROOT\" | tr \\\\ /); bash \"$R/hooks/sg-python.sh\" \"$R/hooks/security_reminder_hook.py\"'"
           }
         ]
       }
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/sg-python.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/security_reminder_hook.py\""
+            "command": "bash -c 'R=$(echo \"$CLAUDE_PLUGIN_ROOT\" | tr \\\\ /); bash \"$R/hooks/sg-python.sh\" \"$R/hooks/security_reminder_hook.py\"'"
           }
         ],
         "matcher": "Edit|Write|MultiEdit|NotebookEdit"
@@ -36,7 +36,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/sg-python.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/security_reminder_hook.py\"",
+            "command": "bash -c 'R=$(echo \"$CLAUDE_PLUGIN_ROOT\" | tr \\\\ /); bash \"$R/hooks/sg-python.sh\" \"$R/hooks/security_reminder_hook.py\"'",
             "if": "Bash(git commit:*)",
             "asyncRewake": true,
             "rewakeMessage": "Background security review of commit — address or acknowledge the findings below, then continue with the user's original request or continue waiting for their reply:",
@@ -44,7 +44,7 @@
           },
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/sg-python.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/security_reminder_hook.py\"",
+            "command": "bash -c 'R=$(echo \"$CLAUDE_PLUGIN_ROOT\" | tr \\\\ /); bash \"$R/hooks/sg-python.sh\" \"$R/hooks/security_reminder_hook.py\"'",
             "if": "Bash(git push:*)",
             "asyncRewake": true,
             "rewakeMessage": "Background security review of pushed commits not yet reviewed — address or acknowledge the findings below, then continue with the user's original request or continue waiting for their reply:",
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/sg-python.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/security_reminder_hook.py\"",
+            "command": "bash -c 'R=$(echo \"$CLAUDE_PLUGIN_ROOT\" | tr \\\\ /); bash \"$R/hooks/sg-python.sh\" \"$R/hooks/security_reminder_hook.py\"'",
             "asyncRewake": true,
             "rewakeMessage": "Background security review feedback — address or acknowledge the findings below, then continue with the user's original request or continue waiting for their reply. This is supplementary, not a replacement for your previous response:",
             "rewakeSummary": "Background security review found issues"


### PR DESCRIPTION
## Summary

On Windows, `CLAUDE_PLUGIN_ROOT` contains backslash path separators (e.g. `C:\Users\...`), which break bash inline scripts that reference `${CLAUDE_PLUGIN_ROOT}` in hook commands.

## Changes

All six hook commands in `hooks/hooks.json` now normalize `CLAUDE_PLUGIN_ROOT` by converting backslashes to forward slashes using an inline `tr \\ /` substitution wrapped in `bash -c`. This ensures paths are valid in bash contexts on Windows without requiring any external tooling or configuration changes.