### PR TITLE
fix(hookify): add Python wrapper and normalize plugin root paths on Windows

### DIFF
--- a/plugins/hookify/hooks/hfy-python.sh
+++ b/plugins/hookify/hooks/hfy-python.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Find a working Python 3 interpreter and exec the hookify hook with it.
+#
+# On Windows + Git Bash, `python3` typically resolves to the Microsoft Store
+# stub which exits 49 silently in non-TTY subprocess context. This shim probes
+# each candidate and skips any that fails, so the Store stub falls through to
+# the real python.org install or the `py -3` launcher.
+#
+# Order:
+#   1. python3   — canonical on macOS/Linux
+#   2. python    — python.org installs on Windows
+#   3. py -3     — Windows Python launcher
+#
+# Args after the shim path are passed straight through to the chosen
+# interpreter.
+set -e
+
+probe() {
+    "$@" -c 'import sys; print(sys.version_info[0])' 2>/dev/null
+}
+
+for cmd in "python3" "python" "py -3"; do
+    # shellcheck disable=SC2086
+    v=$(probe $cmd | tr -d '\r') || continue
+    if [ "$v" = "3" ]; then
+        # shellcheck disable=SC2086
+        exec $cmd "$@"
+    fi
+done
+
+echo "hookify: no working Python 3 interpreter found." >&2
+echo "  tried: python3, python, py -3" >&2
+echo "  on Windows, install Python from https://python.org (NOT the Microsoft Store)" >&2
+exit 1

--- a/plugins/hookify/hooks/hooks.json
+++ b/plugins/hookify/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse.py",
+            "command": "bash -c 'R=$(echo \"$CLAUDE_PLUGIN_ROOT\" | tr \\\\ /); bash \"$R/hooks/hfy-python.sh\" \"$R/hooks/pretooluse.py\"'",
             "timeout": 10
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/posttooluse.py",
+            "command": "bash -c 'R=$(echo \"$CLAUDE_PLUGIN_ROOT\" | tr \\\\ /); bash \"$R/hooks/hfy-python.sh\" \"$R/hooks/posttooluse.py\"'",
             "timeout": 10
           }
         ]
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/stop.py",
+            "command": "bash -c 'R=$(echo \"$CLAUDE_PLUGIN_ROOT\" | tr \\\\ /); bash \"$R/hooks/hfy-python.sh\" \"$R/hooks/stop.py\"'",
             "timeout": 10
           }
         ]
@@ -39,7 +39,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/userpromptsubmit.py",
+            "command": "bash -c 'R=$(echo \"$CLAUDE_PLUGIN_ROOT\" | tr \\\\ /); bash \"$R/hooks/hfy-python.sh\" \"$R/hooks/userpromptsubmit.py\"'",
             "timeout": 10
           }
         ]


### PR DESCRIPTION
## Summary

On Windows, `CLAUDE_PLUGIN_ROOT` contains backslash path separators, which break inline bash scripts in hook commands. Additionally, the Microsoft Store `python3` stub returns exit code 49 silently when run in a non-TTY subprocess context, preventing the hookify plugin from working.

## Changes

### New file: `hooks/hfy-python.sh`
A Python interpreter discovery shim that probes candidates in order (`python3`, `python`, `py -3`), skipping any that fail the probe (e.g. the Store stub). This ensures a working Python 3 is found on both Unix and Windows.

### Modified: `hooks/hooks.json`
All four hook commands now:
1. Normalize backslashes to forward slashes in `CLAUDE_PLUGIN_ROOT` via `tr \ /` so paths are valid in bash.
2. Invoke `hfy-python.sh` instead of calling `python3` directly, so Python discovery works reliably on Windows.