### PR TITLE
fix(learning-output-style): add bash prefix and normalize plugin root path for Windows

### DIFF
--- a/plugins/learning-output-style/hooks/hooks.json
+++ b/plugins/learning-output-style/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks-handlers/session-start.sh"
+            "command": "bash -c 'R=$(echo \"$CLAUDE_PLUGIN_ROOT\" | tr \\\\ /); bash \"$R/hooks-handlers/session-start.sh\"'"
           }
         ]
       }


### PR DESCRIPTION
## Summary

The `SessionStart` hook in `learning-output-style` was invoked as a bare path:
```
${CLAUDE_PLUGIN_ROOT}/hooks-handlers/session-start.sh
```

Two problems:
- On Windows, `CLAUDE_PLUGIN_ROOT` contains backslashes → path is invalid in bash
- Without an explicit `bash` prefix, the command depends on the file's executable bit, which git doesn't always preserve

Applies the same `tr \\ /` normalization pattern established by the security-guidance fix (BUG-20).

## Test plan

- [ ] On macOS/Linux: SessionStart hook still fires and injects learning-mode context
- [ ] On Windows (Git Bash): hook no longer fails with path error

🤖 Generated with [Claude Code](https://claude.ai/code)