### PR TITLE
fix(security-guidance): strip CRLF from Python version probe on Windows

### DIFF
--- a/plugins/learning-output-style/hooks/hooks.json
+++ b/plugins/learning-output-style/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks-handlers/session-start.sh"
+            "command": "bash -c 'R=$(echo \"$CLAUDE_PLUGIN_ROOT\" | tr \\\\ /); bash \"$R/hooks-handlers/session-start.sh\"'"
           }
         ]
       }

--- a/plugins/security-guidance/hooks/sg-python.sh
+++ b/plugins/security-guidance/hooks/sg-python.sh
@@ -31,7 +31,7 @@ probe() {
 for cmd in "python3" "python" "py -3"; do
     # Word-split intentionally so `py -3` works
     # shellcheck disable=SC2086
-    v=$(probe $cmd) || continue
+    v=$(probe $cmd | tr -d '\r') || continue
     if [ "$v" = "3" ]; then
         # shellcheck disable=SC2086
         exec $cmd "$@"


### PR DESCRIPTION
## Description

Two Windows compatibility fixes across learning-output-style and security-guidance plugins.

## Changes

### 1. Strip CRLF from Python version probe (`security-guidance`)

On Windows, Python outputs `\r\n` line endings, which caused the version comparison `[ "$v" = "3" ]` to fail since the variable contained a trailing carriage return. Added `tr -d '\r'` to strip CR from the probe output.

### 2. Normalize Windows paths in hook command (`learning-output-style`)

When `CLAUDE_PLUGIN_ROOT` contains backslashes (Windows paths), the hook handler cannot source the script directly. Wrapped the command in `bash -c` with path normalization via `tr \\\\ /` to convert backslashes to forward slashes.

## Testing

- Verified Python detection succeeds on Windows (CRLF stripped from probe output)
- Verified hook script executes correctly when `CLAUDE_PLUGIN_ROOT` contains Windows-style paths