### PR TITLE
fix(ralph-wiggum): guard PROMPT_PARTS expansion against set -u on bash 3.x (macOS)

### DIFF
--- a/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
+++ b/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
@@ -110,7 +110,7 @@ HELP_EOF
 done
 
 # Join all prompt parts with spaces
-PROMPT="${PROMPT_PARTS[*]}"
+PROMPT="${PROMPT_PARTS[*]:-}"
 
 # Validate prompt is non-empty
 if [[ -z "$PROMPT" ]]; then


### PR DESCRIPTION
## Description

On macOS, bash 3.x enables `set -u` by default, which causes an unbound variable error when expanding an empty array `${PROMPT_PARTS[*]}`. This breaks the ralph-wiggum plugin setup script on macOS systems.

## Fix

Changed `${PROMPT_PARTS[*]}` to `${PROMPT_PARTS[*]:-}` to provide a default empty string fallback, preventing the unbound variable error while preserving the existing behavior when the array is populated.

## Testing

- Verified the script completes successfully on macOS bash 3.x with `set -u` active
- Behavior on bash 5.x (Linux) remains unchanged