### PR TITLE
feat(bug-reporter): add /bug command to file GitHub issues from the terminal

### DIFF
--- a/plugins/bug-reporter/.claude-plugin/plugin.json
+++ b/plugins/bug-reporter/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "bug-reporter",
+  "description": "File bug reports and feature requests directly to the Claude Code GitHub repository without leaving the terminal",
+  "version": "1.0.0",
+  "author": {
+    "name": "Anthropic",
+    "email": "support@anthropic.com"
+  }
+}

--- a/plugins/bug-reporter/README.md
+++ b/plugins/bug-reporter/README.md
@@ -1,0 +1,22 @@
+# bug-reporter
+
+File bug reports directly to the Claude Code GitHub repository without leaving the terminal.
+
+## Commands
+
+### `/bug`
+
+Guides you through describing a bug, shows you a preview of the GitHub issue, and files it after your confirmation.
+
+```
+/bug
+/bug Claude crashes when I resize the window below 10 lines
+```
+
+**Flow:**
+1. Collects your Claude Code version and OS automatically
+2. Asks what went wrong and how to reproduce it
+3. Drafts the issue in GitHub format and shows it to you
+4. Files it only after you confirm — or lets you edit first
+
+**Requirements:** `gh` CLI authenticated (`gh auth login`)

--- a/plugins/bug-reporter/commands/bug.md
+++ b/plugins/bug-reporter/commands/bug.md
@@ -1,0 +1,109 @@
+---
+description: "Report a bug in Claude Code — drafts and files a GitHub issue without leaving the terminal"
+argument-hint: "Optional: one-line description of the bug"
+allowed-tools: ["Bash", "AskUserQuestion"]
+---
+
+# Report a Bug in Claude Code
+
+Your goal is to help the user file a well-structured bug report on the `anthropics/claude-code` GitHub repository. Follow these steps exactly.
+
+## Step 1 — Gather context automatically
+
+Run these commands silently to collect environment info:
+
+```bash
+claude --version 2>/dev/null || echo "unknown"
+uname -s 2>/dev/null || echo "unknown"
+uname -r 2>/dev/null || echo "unknown"
+```
+
+## Step 2 — Get the bug description
+
+If `$ARGUMENTS` is non-empty, use it as the starting description and skip directly to step 3.
+
+Otherwise, use AskUserQuestion to ask:
+
+**Question 1:** "What's the bug?"
+- Header: "Bug type"
+- Options:
+  - "Crash / error message" — Claude Code crashed or showed an error
+  - "Wrong behavior" — Claude Code did something unexpected
+  - "UI / display issue" — visual glitch, layout problem
+  - "Performance" — slow, freezing, high memory usage
+
+**Question 2:** "Describe what happened" (free text via Other option)
+- Header: "Description"
+- Options: one placeholder option so the user uses "Other" to type freely
+
+## Step 3 — Ask for reproduction steps
+
+Use AskUserQuestion:
+
+**Question:** "Can you reproduce it reliably?"
+- Header: "Reproducible?"
+- Options:
+  - "Yes, always" — happens every time
+  - "Sometimes" — intermittent
+  - "Only happened once" — one-off
+
+Then ask the user to describe the steps to reproduce (use "Other" for free text).
+
+## Step 4 — Draft the issue
+
+Build the GitHub issue using this exact template:
+
+```
+**Describe the bug**
+[User's description]
+
+**Steps to reproduce**
+[User's steps, or "Not provided" if they skipped]
+
+**Expected behavior**
+[What should have happened]
+
+**Actual behavior**
+[What actually happened]
+
+**Environment**
+- Claude Code version: [from step 1]
+- OS: [from step 1]
+
+**Additional context**
+[Anything else relevant, or remove this section]
+```
+
+Show the full draft to the user in a code block.
+
+## Step 5 — Confirm before filing
+
+Use AskUserQuestion:
+
+**Question:** "File this issue on GitHub?"
+- Header: "Confirm"
+- Options:
+  - "Yes, file it" — proceed
+  - "Edit first" — ask what to change, update the draft, repeat step 5
+  - "Cancel" — abort with message "Issue not filed."
+
+## Step 6 — File the issue
+
+Extract a short, clear title (max 72 chars) from the description.
+
+Run:
+```bash
+gh issue create \
+  --repo anthropics/claude-code \
+  --title "[BUG] <title>" \
+  --label "bug" \
+  --body "<escaped body>"
+```
+
+If `gh` is not authenticated, tell the user:
+> Run `gh auth login` first, then try `/bug` again.
+
+## Step 7 — Confirm success
+
+Show the issue URL and say:
+> "Issue filed. Thank you for the report — the Claude Code team will take a look."


### PR DESCRIPTION
Adds a new `bug-reporter` plugin with a `/bug` slash command that lets users file bug reports on the `anthropics/claude-code` repository entirely from the terminal.

**What it includes:**
- `plugins/bug-reporter/.claude-plugin/plugin.json` — plugin manifest
- `plugins/bug-reporter/README.md` — user-facing docs and requirements
- `plugins/bug-reporter/commands/bug.md` — the slash command implementation

**How it works:**
1. Auto-collects Claude Code version and OS via `claude --version` and `uname`
2. If provided, uses the argument as a starting description; otherwise asks about the bug type and description
3. Asks for reproduction steps and reliability
4. Drafts a standard GitHub issue template and shows a preview
5. Confirms with the user before filing (with an edit-first option)
6. Uses `gh issue create` to file it with the `bug` label
7. Returns the issue URL on success

Addresses the long-standing request for a first-party in-terminal feedback mechanism (issue #49413). The built-in `/feedback` command opens a browser form; this plugin keeps everything inside the terminal via `gh`.

**Requirements:** `gh` CLI must be authenticated (`gh auth login`).