### PR TITLE
fix(plugin-dev): avoid shell injection in test-hook.sh via stdin redirection

### DIFF
--- a/plugins/plugin-dev/skills/hook-development/scripts/test-hook.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/test-hook.sh
@@ -187,7 +187,7 @@ echo ""
 start_time=$(date +%s)
 
 set +e
-output=$(timeout "$TIMEOUT" bash -c "cat '$TEST_INPUT' | $HOOK_SCRIPT" 2>&1)
+output=$(timeout "$TIMEOUT" bash -c "$HOOK_SCRIPT" < "$TEST_INPUT" 2>&1)
 exit_code=$?
 set -e
 


### PR DESCRIPTION
## Problem

`test-hook.sh` line 190 runs the hook using:

```bash
output=$(timeout "$TIMEOUT" bash -c "cat '$TEST_INPUT' | $HOOK_SCRIPT" 2>&1)
```

`$TEST_INPUT` is embedded inside single quotes within a double-quoted `bash -c` string. When the outer shell expands `$TEST_INPUT`, the resulting value becomes part of the `bash -c` command string without any escaping. If `$TEST_INPUT` contains a single quote — for example `/tmp/user's-test.json` or any path typed by a developer — the inner shell sees unbalanced quotes and exits with a syntax error:

```
bash: -c: line 0: unexpected EOF while looking for matching `''
bash: -c: line 1: syntax error: unexpected end of file
```

The error message is cryptic and gives no hint that the problem is the path, not the hook.

## Fix

Redirect stdin from the file directly instead of building a `cat` pipe into the shell string:

```bash
output=$(timeout "$TIMEOUT" bash -c "$HOOK_SCRIPT" < "$TEST_INPUT" 2>&1)
```

This avoids embedding `$TEST_INPUT` in a shell string entirely. `bash -c "$HOOK_SCRIPT"` reads from its inherited stdin, which is redirected from `$TEST_INPUT` by the outer shell before the command runs. The hook receives identical input — only the mechanism changes.

## Testing

```bash
# Create a test input with a single quote in the path
cp test-input.json "/tmp/user's-test.json"
./test-hook.sh validate-bash.sh "/tmp/user's-test.json"
# Before: bash syntax error
# After:  hook runs correctly
```