### PR TITLE
fix(scripts): add error message to edit-issue-labels.sh when called with no label arguments

### DIFF
--- a/scripts/edit-issue-labels.sh
+++ b/scripts/edit-issue-labels.sh
@@ -38,6 +38,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ ${#ADD_LABELS[@]} -eq 0 && ${#REMOVE_LABELS[@]} -eq 0 ]]; then
+  echo "Error: at least one --add-label or --remove-label is required" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Problem

`edit-issue-labels.sh` exits silently with code 1 when called with no `--add-label` or `--remove-label` arguments:

```bash
if [[ ${#ADD_LABELS[@]} -eq 0 && ${#REMOVE_LABELS[@]} -eq 0 ]]; then
  exit 1   # no message written to stderr
fi
```

The caller (CI workflow or manual run) receives a non-zero exit code with no output, making it impossible to distinguish this user-error from any other failure (network error, GitHub API error, permission denied, etc.).

## Fix

Print an explicit error message to stderr before exiting:

```bash
if [[ ${#ADD_LABELS[@]} -eq 0 && ${#REMOVE_LABELS[@]} -eq 0 ]]; then
  echo "Error: at least one --add-label or --remove-label is required" >&2
  exit 1
fi
```

This follows the existing pattern in the script (lines 34, 42, 48) where every other error path writes a message to stderr before exiting.

## Testing

```bash
GITHUB_EVENT_PATH=<(echo '{"issue":{"number":1}}') ./edit-issue-labels.sh
# Before: exits 1 with no output
# After:  "Error: at least one --add-label or --remove-label is required" on stderr, exits 1
```