### PR TITLE
Fix lock-closed-issues workflow: use search API instead of offset pagination

### DIFF
--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -22,71 +22,56 @@ jobs:
           script: |
             const sevenDaysAgo = new Date();
             sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+            const cutoff = sevenDaysAgo.toISOString().split('T')[0];
 
             const lockComment = `This issue has been automatically locked since it was closed and has not had any activity for 7 days. If you're experiencing a similar issue, please file a new issue and reference this one if it's relevant.`;
 
-            let page = 1;
-            let hasMore = true;
+            const query = `repo:${context.repo.owner}/${context.repo.repo} is:issue is:closed is:unlocked updated:<${cutoff}`;
+            console.log(`Search query: ${query}`);
+
+            const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+            const MAX_PER_RUN = 250;
+            const processed = new Set();
             let totalLocked = 0;
 
-            while (hasMore) {
-              // Get closed issues (pagination)
-              const { data: issues } = await github.rest.issues.listForRepo({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                state: 'closed',
+            while (totalLocked < MAX_PER_RUN) {
+              const { data } = await github.rest.search.issuesAndPullRequests({
+                q: query,
                 sort: 'updated',
-                direction: 'asc',
+                order: 'asc',
                 per_page: 100,
-                page: page
               });
-              
-              if (issues.length === 0) {
-                hasMore = false;
-                break;
+
+              if (totalLocked === 0) {
+                console.log(`Total candidates: ${data.total_count}`);
               }
-              
-              for (const issue of issues) {
-                // Skip if already locked
-                if (issue.locked) continue;
-                
-                // Skip pull requests
-                if (issue.pull_request) continue;
-                
-                // Check if updated more than 7 days ago
-                const updatedAt = new Date(issue.updated_at);
-                if (updatedAt > sevenDaysAgo) {
-                  // Since issues are sorted by updated_at ascending, 
-                  // once we hit a recent issue, all remaining will be recent too
-                  hasMore = false;
-                  break;
-                }
-                
+
+              const fresh = data.items.filter((i) => !processed.has(i.number));
+              if (fresh.length === 0) break;
+
+              for (const issue of fresh) {
+                if (totalLocked >= MAX_PER_RUN) break;
+                processed.add(issue.number);
                 try {
-                  // Add comment before locking
                   await github.rest.issues.createComment({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: issue.number,
-                    body: lockComment
+                    body: lockComment,
                   });
-                  
-                  // Lock the issue
                   await github.rest.issues.lock({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: issue.number,
-                    lock_reason: 'resolved'
+                    lock_reason: 'resolved',
                   });
-                  
                   totalLocked++;
                   console.log(`Locked issue #${issue.number}: ${issue.title}`);
+                  await sleep(1000);
                 } catch (error) {
                   console.error(`Failed to lock issue #${issue.number}: ${error.message}`);
                 }
               }
-              
-              page++;
             }
 
             console.log(`Total issues locked: ${totalLocked}`);


### PR DESCRIPTION
## What this does

Fixes the **Lock Stale Issues** scheduled workflow, which has been failing every day since **2026-04-27** (53 consecutive failures).

## Why now

Run [27769109325](https://github.com/anthropics/claude-code/actions/runs/27769109325) and every recent run fails with:

```
HttpError: Pagination with the page parameter is not supported for large datasets,
please use cursor based pagination (after/before)
url: .../issues?state=closed&sort=updated&direction=asc&per_page=100&page=100
status: 422
```

The script pages through **all** closed issues sorted by `updated asc` looking for unlocked ones. Issues locked months ago have the oldest `updated_at`, so ~10k of them sit at the front of the list. With ~58k closed issues in the repo, the script hits `page=100` and GitHub now rejects deep offset pagination. (The first failures in late April were timeouts at `page=110`; GitHub later started returning an explicit 422.)

Because the job has been broken for ~7 weeks, there's a backlog of **~14k closed-but-unlocked issues**.

## What changed

Replace `issues.listForRepo` + `page=N` with the search API:

```
repo:<owner>/<repo> is:issue is:closed is:unlocked updated:<YYYY-MM-DD>
```

This returns **only** the issues that actually need locking — no paging past thousands of already-locked ones. The loop re-fetches page 1, locks each result, and stops when there's nothing fresh or it hits a per-run cap of 250 (with a 1s sleep between locks to stay under GitHub's secondary rate limits).

The removed in-loop filters (`issue.locked`, `issue.pull_request`, `updatedAt > sevenDaysAgo`) are now expressed as search qualifiers (`is:unlocked`, `is:issue`, `updated:<cutoff`).

## How we know it works

- YAML validates.
- Verified the search query against the live API: returns 14,149 candidates, all `state:closed`, `locked:false`, `updated_at` older than the cutoff.
- `github.rest.search.issuesAndPullRequests` is available in `actions/github-script@v7`.
- Loop is provably bounded (every iteration grows `processed` or breaks; search results are capped at 1000).

## After merge

- Trigger once via **workflow_dispatch** to confirm it runs green.
- Search-index lag means each run will likely lock ~100 issues in practice (the first re-fetch of page 1 returns mostly just-locked items). The 14k backlog will drain over daily runs; trigger `workflow_dispatch` a few extra times if you want to clear it faster.

