### PR TITLE
fix(hookify): use root-relative imports to fix marketplace install

### DIFF
--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -7,7 +7,7 @@ from functools import lru_cache
 from typing import List, Dict, Any, Optional
 
 # Import from local module
-from hookify.core.config_loader import Rule, Condition
+from core.config_loader import Rule, Condition
 
 
 # Cache compiled regexes (max 128 patterns)
@@ -275,7 +275,7 @@ class RuleEngine:
 
 # For testing
 if __name__ == '__main__':
-    from hookify.core.config_loader import Condition, Rule
+    from core.config_loader import Condition, Rule
 
     # Test rule evaluation
     rule = Rule(

--- a/plugins/hookify/hooks/posttooluse.py
+++ b/plugins/hookify/hooks/posttooluse.py
@@ -19,8 +19,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)

--- a/plugins/hookify/hooks/pretooluse.py
+++ b/plugins/hookify/hooks/pretooluse.py
@@ -23,8 +23,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     # If imports fail, allow operation and log error
     error_msg = {"systemMessage": f"Hookify import error: {e}"}

--- a/plugins/hookify/hooks/stop.py
+++ b/plugins/hookify/hooks/stop.py
@@ -19,8 +19,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)

--- a/plugins/hookify/hooks/userpromptsubmit.py
+++ b/plugins/hookify/hooks/userpromptsubmit.py
@@ -19,8 +19,8 @@ if PLUGIN_ROOT:
         sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from hookify.core.config_loader import load_rules
-    from hookify.core.rule_engine import RuleEngine
+    from core.config_loader import load_rules
+    from core.rule_engine import RuleEngine
 except ImportError as e:
     error_msg = {"systemMessage": f"Hookify import error: {e}"}
     print(json.dumps(error_msg), file=sys.stdout)


### PR DESCRIPTION
## Problem                                                                                                                                        
                                                                                                                                                  
  The hookify plugin is completely broken for marketplace users. When installed, `CLAUDE_PLUGIN_ROOT` points to a versioned path (e.g.              
  `hookify/0.1.0/`), so `os.path.dirname(PLUGIN_ROOT)` resolves to `hookify/` — which contains no inner `hookify` package.
                                                                                                                                                    
  All 4 hook scripts fail silently with:                                                                                                            
   
  ```                                                                                                                                               
  Hookify import error: No module named 'hookify'                                                                                                 
  ```

  No user rules are evaluated. The plugin appears installed but does nothing.

  ## Fix

  Replace all `from hookify.core.*` imports with `from core.*` across 5 files (6 locations). Since `CLAUDE_PLUGIN_ROOT` is already in `sys.path`,   
  root-relative imports work regardless of install path.
                                                                                                                                                    
  ## Files changed                                                                                                                                
  - `hooks/pretooluse.py`
  - `hooks/posttooluse.py`
  - `hooks/stop.py`                                                                                                                                 
  - `hooks/userpromptsubmit.py`
  - `core/rule_engine.py`                                                                                                                           
                                                                                                                                                  
  ## Testing

  Simulated the marketplace directory structure locally (`hookify/0.1.0/` with no outer package) and confirmed all 4 hooks return `{}` with no      
  import error.
                                                                                                                                                    
  Fixes #69665