### PR TITLE
fix(workflows): send Statsig event time in milliseconds

### DIFF
--- a/.github/workflows/claude-dedupe-issues.yml
+++ b/.github/workflows/claude-dedupe-issues.yml
@@ -72,7 +72,7 @@ jobs:
                   triggered_by: $triggered_by,
                   workflow_run_id: $workflow_run_id
                 },
-                time: (now | floor | tostring)
+                time: (now * 1000 | floor)
               }]
             }')
           


### PR DESCRIPTION
## What

`claude-dedupe-issues.yml` sent the Statsig `time` field as epoch **seconds** (`now | floor`) and as a **string**.

Statsig's `/v1/log_event` API expects `time` as epoch **milliseconds** (number). The sibling workflow `log-issue-events.yml` already does this correctly via `$(date +%s)000`.

```diff
-                time: (now | floor | tostring)
+                time: (now * 1000 | floor)
```

## Why

As-is, every `github_duplicate_comment_added` event is timestamped ~1000x in the past (1970-era when interpreted as ms), so events are misdated or dropped. This aligns the dedupe workflow with the sibling workflow's millisecond, numeric format.

## Spec reference

Per the [Statsig Log Custom Events API](https://docs.statsig.com/api-reference/events/log-custom-events), `time` accepts a "unix timestamp in **milliseconds** or ISO date string", with the example value `"time": 1616826986211` (13-digit number). Epoch seconds is not an accepted format, and a numeric string (e.g. `"1781958740"`) is neither a millisecond number nor an ISO date string. The fix produces the documented numeric-millisecond form.

## Verification

```
$ echo | jq -n '{time: (now * 1000 | floor)}'
{ "time": 1781958740731 }   # 13-digit ms, numeric
```
