### PR TITLE
fix(hookify): match file rules against Write tool content

### DIFF
--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -237,7 +237,8 @@ class RuleEngine:
                 # Write uses 'content', Edit has 'new_string'
                 return tool_input.get('content') or tool_input.get('new_string', '')
             elif field == 'new_text' or field == 'new_string':
-                return tool_input.get('new_string', '')
+                # Write uses 'content', Edit has 'new_string'
+                return tool_input.get('new_string') or tool_input.get('content', '')
             elif field == 'old_text' or field == 'old_string':
                 return tool_input.get('old_string', '')
             elif field == 'file_path':


### PR DESCRIPTION
## What

A simple-pattern hookify rule with `event: file` (e.g. the README's "Warn About Debug Code" example, `pattern: console\.log\(`) silently never fired when Claude **created a new file** via the `Write` tool.

## Root cause

`config_loader` infers the field name `new_text` for `event: file` simple-pattern rules. In `rule_engine._extract_field`, the `new_text`/`new_string` branch only read `tool_input['new_string']` (the **Edit** field):

```python
elif field == 'new_text' or field == 'new_string':
    return tool_input.get('new_string', '')   # Write content is in 'content', not 'new_string'
```

The `Write` tool stores file content in `tool_input['content']`, so the branch returned `''` and the pattern never matched. The adjacent `content` branch already does the right fallback.

## Fix

```python
elif field == 'new_text' or field == 'new_string':
    # Write uses 'content', Edit has 'new_string'
    return tool_input.get('new_string') or tool_input.get('content', '')
```

## Verification

`event: file`, `pattern: console\.log\(`:

| tool | before | after |
|------|--------|-------|
| Write (new file, `content`) | ❌ no match | ✅ match |
| Edit (`new_string`)         | ✅ match | ✅ match |

```
$ python3 -c "..."   # via RuleEngine._rule_matches
before: Write=False Edit=True
after:  Write=True  Edit=True
```
