### PR TITLE
fix: print error message before silent exit in edit-issue-labels.sh

### DIFF
--- a/scripts/edit-issue-labels.sh
+++ b/scripts/edit-issue-labels.sh
@@ -38,6 +38,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ ${#ADD_LABELS[@]} -eq 0 && ${#REMOVE_LABELS[@]} -eq 0 ]]; then
+  echo "Error: at least one --add-label or --remove-label argument is required" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Fixes: #69913 


## What this does  
  
Fixes a silent `exit 1` in `scripts/edit-issue-labels.sh` when the script is called with no `--add-label` or `--remove-label` arguments.  
  
## Why now  
  
The `Claude Issue Triage` workflow calls `edit-issue-labels.sh` via the `triage-issue` command. If Claude ever invokes the script with no label arguments — which the triage prompt explicitly allows on comment events ("it's okay to make no changes if nothing applies") — the script exits with code 1 and prints **nothing** to stdout or stderr.  
  
Because the workflow runs with `set -euo pipefail`, this causes the step to fail silently. The GitHub Actions log shows a non-zero exit with zero diagnostic output, making the failure impossible to diagnose without reading the source.  
  
Every other error path in the same script prints a message to stderr before exiting:  
  
```bash  
# Line 15 — prints before exit  [header-1](#header-1)
echo "Error: no issue number in event payload" >&2; exit 1  
  
# Line 34 — prints before exit  [header-2](#header-2)
echo "Error: unknown argument (only --add-label and --remove-label are accepted)" >&2; exit 1  
  
# Line 40 — silent, prints nothing ← this PR  [header-3](#header-3)
if [[ ${#ADD_LABELS[@]} -eq 0 && ${#REMOVE_LABELS[@]} -eq 0 ]]; then  
  exit 1  
fi
```
## What changed

Added a single `echo` to stderr before the `exit 1` at line 40–42 of `scripts/edit-issue-labels.sh`, making it consistent with every other error path in the file:
``` bash
 if [[ ${#ADD_LABELS[@]} -eq 0 && ${#REMOVE_LABELS[@]} -eq 0 ]]; then  
+  echo "Error: at least one --add-label or --remove-label argument is required" >&2  
   exit 1  
 fi
```

## How we know it works

Reproduces the silent failure before the fix:
```bash
export GITHUB_EVENT_PATH=$(mktemp)  
echo '{"issue":{"number":1}}' > "$GITHUB_EVENT_PATH"  
bash scripts/edit-issue-labels.sh   # exits 1, no output
```
After the fix, the same invocation prints Error: at least one `--add-label` or `--remove-label` argument is required to stderr before exiting 1.

All other code paths are unchanged and are passing valid labels still works normally. ShellCheck passes on the modified file.

## After merge

No workflow triggers or backfill needed. The fix is purely defensive — it makes a latent silent failure loud so it can be diagnosed if it ever occurs.