### PR TITLE
docs: fix stale marketplace name in plugin-dev README

### DIFF
--- a/plugins/plugin-dev/README.md
+++ b/plugins/plugin-dev/README.md
@@ -195,10 +195,10 @@ Use this workflow for structured, high-quality plugin development from concept t
 
 ## Installation
 
-Install from claude-code-marketplace:
+Install from claude-code-plugins:
 
 ```bash
-/plugin install plugin-dev@claude-code-marketplace
+/plugin install plugin-dev@claude-code-plugins
 ```
 
 Or for development, use directly:
@@ -378,7 +378,7 @@ All skills emphasize:
 
 ## Contributing
 
-This plugin is part of the claude-code-marketplace. To contribute improvements:
+This plugin is part of the claude-code-plugins. To contribute improvements:
 
 1. Fork the marketplace repository
 2. Make changes to plugin-dev/


### PR DESCRIPTION
Fixes #70064

## Problem

The plugin-dev README references `claude-code-marketplace` but the marketplace was renamed to `claude-code-plugins` (per `.claude-plugin/marketplace.json`).

## What changed

Replaced 3 occurrences of `claude-code-marketplace` → `claude-code-plugins` in `plugins/plugin-dev/README.md`.