### PR TITLE
fix(commit-commands): detect [gone] branches with `git branch -vv` in clean_gone

### DIFF
--- a/plugins/commit-commands/commands/clean_gone.md
+++ b/plugins/commit-commands/commands/clean_gone.md
@@ -11,10 +11,11 @@ You need to execute the following bash commands to clean up stale local branches
 1. **First, list branches to identify any with [gone] status**
    Execute this command:
    ```bash
-   git branch -v
+   git branch -vv
    ```
-   
-   Note: Branches with a '+' prefix have associated worktrees and must have their worktrees removed before deletion.
+
+   Note: The `[gone]` marker only appears with `-vv` (verbose tracking info); plain `git branch -v` does not show it.
+   Branches with a '+' prefix have associated worktrees and must have their worktrees removed before deletion.
 
 2. **Next, identify worktrees that need to be removed for [gone] branches**
    Execute this command:
@@ -25,8 +26,9 @@ You need to execute the following bash commands to clean up stale local branches
 3. **Finally, remove worktrees and delete [gone] branches (handles both regular and worktree branches)**
    Execute this command:
    ```bash
-   # Process all [gone] branches, removing '+' prefix if present
-   git branch -v | grep '\[gone\]' | sed 's/^[+* ]//' | awk '{print $1}' | while read branch; do
+   # Process all [gone] branches (remote-tracking branch deleted), stripping leading * / + / space markers.
+   # The marker format is "[origin/<branch>: gone]", so match ": gone]" (NOT a literal "[gone]").
+   git branch -vv | grep ': gone]' | sed 's/^[+* ]*//' | awk '{print $1}' | while read branch; do
      echo "Processing branch: $branch"
      # Find and remove worktree if it exists
      worktree=$(git worktree list | grep "\\[$branch\\]" | awk '{print $1}')
@@ -50,4 +52,3 @@ After executing these commands, you will:
 - Provide feedback on which worktrees and branches were removed
 
 If no branches are marked as [gone], report that no cleanup was needed.
-


### PR DESCRIPTION
## Summary

`/clean_gone` never deletes anything because its `[gone]` detection is broken.

## Root cause

The command lists branches with `git branch -v` and filters with `grep '\[gone\]'`:

```bash
git branch -v | grep '\[gone\]' | sed 's/^[+* ]//' | awk '{print $1}'
```

Two problems:

1. **`git branch -v` does not print the `[gone]` marker.** The upstream-tracking
   state (including `gone`) is only emitted by `git branch -vv` (double `v`).
   With single `-v` the pipeline matches nothing.
2. **The marker is never the literal `[gone]`.** Git formats it as
   `[origin/<branch>: gone]`, so `grep '\[gone\]'` would not match even with
   `-vv`.

Net effect: the loop body never runs and no stale branches are removed.

## Fix

- List with `git branch -vv` (both in step 1 and the deletion pipeline).
- Match the real marker with `grep ': gone]'`.
- Minor hardening: `sed 's/^[+* ]*//'` (strip all leading `*`/`+`/space markers)
  and clarifying comments.

```bash
git branch -vv | grep ': gone]' | sed 's/^[+* ]*//' | awk '{print $1}' | while read branch; do
  ...
done
```

## Verification

Against `git branch -vv` style input:

```
  feat-a   1234567 [origin/feat-a: gone] msg
* main     89abcde [origin/main] msg
+ wt-br    abc1234 [origin/wt-br: gone] msg
  active   def5678 [origin/active: behind 2] msg
```

- Old logic (`git branch -v | grep '\[gone\]'`): 0 matches.
- New logic: outputs `feat-a` and `wt-br` only (correctly excludes `main` and the
  `behind` branch, and keeps the `+` worktree branch).