### PR TITLE
docs(sandbox): note that prompt-approved hosts are session-scoped

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -25,6 +25,7 @@ These may be applied at any level of the [settings hierarchy](https://code.claud
 - Settings files must be valid JSON
 - Before deploying configuration files to your organization, test them locally by applying to `managed-settings.json`, `settings.json` or `settings.local.json`
 - The `sandbox` property only applies to the `Bash` tool; it does not apply to other tools (like Read, Write, WebSearch, WebFetch, MCPs), hooks, or internal commands
+- Approving a network domain at the Claude Code prompt allows it for the current session only. To persist the decision across sessions, add the host to `sandbox.network.allowedDomains` in your settings (see `settings-bash-sandbox.json`). See [Network isolation](https://code.claude.com/docs/en/sandboxing#network-isolation).
 
 ## Deploying via MDM
 


### PR DESCRIPTION
## What this changes

`examples/settings/README.md` — one bullet added to the **Tips** section.

## Why

`settings-bash-sandbox.json` already shows `sandbox.network.allowedDomains`, but the file and its README say nothing about the difference between prompt-time approval (session-scoped, lost on restart) and the persistent `allowedDomains` list. Users who hit a network block, approve it at the prompt, and then restart Claude Code are surprised to hit the same block again because there is no documentation of this distinction.

Contributes to #70702 (the authoritative sandboxing docs live in the private docs repo; this PR covers the public examples README).

## Scope

Documentation only — no code or behaviour changes.

---
*Drafted with AI assistance (Claude Code); reviewed and verified by the author.*