### PR TITLE
docs(examples/hooks): note Bash tool_input also exposes run_in_background/description/timeout

### DIFF
--- a/examples/hooks/bash_command_validator_example.py
+++ b/examples/hooks/bash_command_validator_example.py
@@ -68,6 +68,15 @@ def main():
     tool_input = input_data.get("tool_input", {})
     command = tool_input.get("command", "")
 
+    # NOTE: for the Bash tool, `tool_input` carries more than just `command`.
+    # It also includes `description` and `run_in_background` (bool), plus
+    # `timeout` when set; the top-level payload additionally includes
+    # `tool_use_id`. A hook can read these, e.g. to treat a backgrounded
+    # command differently from a foreground one:
+    #     run_in_background = tool_input.get("run_in_background", False)
+    # (These fields are not yet shown in the hooks docs example -- see
+    #  https://github.com/anthropics/claude-code/issues/72262.)
+
     if not command:
         sys.exit(0)
 


### PR DESCRIPTION
### What

The `bash_command_validator_example.py` hook reads only `tool_input.command`, which can give the impression that `command` is the only field available on a `PreToolUse` Bash payload. This adds a short comment documenting the other fields the payload actually carries.

### Why

Verified empirically on **Claude Code 2.1.195** (by dumping the raw stdin of a `PreToolUse` `Bash` hook): `tool_input` also includes `description` and `run_in_background` (bool), plus `timeout` when set, and the top-level payload includes `tool_use_id`. The `run_in_background` field is the consequential one — a hook cannot distinguish a foreground Bash call from a backgrounded one without it.

The hooks docs example currently shows `tool_input` as only `{ "command": "…" }`; tracked separately in #72262. This example is a natural place to surface the fuller shape for hook authors.

### Change

- Comment-only addition next to the existing `tool_input.command` extraction. **No behavior change.**

Refs #72262
