### PR TITLE
Gateway GCP example: Agent Platform rebrand and README cleanup

### DIFF
--- a/examples/gateway/gcp/README.md
+++ b/examples/gateway/gcp/README.md
@@ -1,18 +1,17 @@
 # Claude Gateway on Google Cloud
 
-Reference deployment artifacts for running Claude Gateway on GCP with Vertex AI
-as the upstream: Cloud Run or GKE, Cloud SQL for PostgreSQL, Secret Manager, and
-service-account auth to Vertex AI.
+Reference deployment artifacts for running Claude Gateway on GCP with Agent
+Platform (formerly Vertex AI) as the upstream: Cloud Run or GKE, Cloud SQL for
+PostgreSQL, Secret Manager, and service-account auth to Agent Platform.
 
 These files are provided as a working example rather than a supported production
 deployment. Adapt them to your own environment.
 
 - **Walkthrough**: https://code.claude.com/docs/en/claude-apps-gateway-on-gcp
-- **Public mirror**: https://github.com/anthropics/claude-code/tree/main/examples/gateway/gcp
 
 | File | Purpose |
 |---|---|
 | `setup.sh` | Scripts the walkthrough end to end via `gcloud` |
 | `Dockerfile` | Runtime image for the `claude gateway` binary |
-| `gateway.yaml.example` | Gateway config template, GCP-shaped (Vertex upstream, Google Workspace IdP) |
+| `gateway.yaml.example` | Gateway config template, GCP-shaped (Agent Platform upstream, Google Workspace IdP) |
 | `terraform/` | Provisions the full architecture (two-pass apply — see `terraform/README.md`) |

--- a/examples/gateway/gcp/gateway.yaml.example
+++ b/examples/gateway/gcp/gateway.yaml.example
@@ -1,7 +1,8 @@
 # gateway.yaml.example — Claude Gateway config template, GCP-shaped (walkthrough §6).
 #
-# Google Workspace IdP + Vertex upstream, following the walkthrough at
-# https://code.claude.com/docs/en/claude-apps-gateway-on-gcp. The active sections
+# Google Workspace IdP + Agent Platform (formerly Vertex AI) upstream, following
+# the walkthrough at https://code.claude.com/docs/en/claude-apps-gateway-on-gcp.
+# The active sections
 # below are a strict subset of the full configuration reference at
 # https://code.claude.com/docs/en/claude-apps-gateway; optional keys are included
 # commented-out.
@@ -88,11 +89,11 @@ session:
 store:
   postgres_url: ${GATEWAY_POSTGRES_URL}   # private-IP Cloud SQL; built with ?sslmode=require by setup.sh
 
-# ── Upstreams — Vertex AI ────────────────────────────────────────────────────
+# ── Upstreams — Agent Platform ───────────────────────────────────────────────
 upstreams:
   - provider: vertex
     region: us-east5              # a region where the Claude models you need are published in Model Garden
-    project_id: REPLACE_ME        # your GCP project ID for Vertex access
+    project_id: REPLACE_ME        # your GCP project ID for Agent Platform access
     auth: {}                      # ADC via Cloud Run SA / GKE Workload Identity (preferred — no static keys)
     # base_url: https://us-east5-aiplatform.p.googleapis.com   # Private Service Connect endpoint
   # Add more upstreams for failover (tried top→bottom on 5xx/timeout/501): a

--- a/examples/gateway/gcp/setup.sh
+++ b/examples/gateway/gcp/setup.sh
@@ -29,7 +29,7 @@ set -euo pipefail
 
 # ---- configuration (env-overridable) ----------------------------------------
 PROJECT_ID="${PROJECT_ID:-$(gcloud config get-value project 2>/dev/null)}"
-REGION="${REGION:-${CLOUDSDK_COMPUTE_REGION:-us-east5}}"   # guide §1 uses us-east5 (Vertex model region)
+REGION="${REGION:-${CLOUDSDK_COMPUTE_REGION:-us-east5}}"   # guide §1 uses us-east5 (Agent Platform model region)
 
 SA_NAME="${SA_NAME:-claude-gateway}"                       # §2 service account
 SA_EMAIL="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
@@ -157,7 +157,7 @@ fi
 # and GKE.
 gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
   --member="serviceAccount:${SA_EMAIL}" \
-  --role="roles/aiplatform.user" --condition=None >/dev/null    # Vertex inference (§2)
+  --role="roles/aiplatform.user" --condition=None >/dev/null    # Agent Platform inference (§2)
 
 # ---- 3 Build & push image to Artifact Registry ----------------------------
 log "Ensuring Artifact Registry repo and image (§3)"
@@ -390,7 +390,7 @@ fi
 # Direct VPC egress (--network/--subnet/--vpc-egress) puts the service on the
 # VPC so it reaches the Cloud SQL PRIVATE IP directly — matching the private-IP
 # connection string in the postgres-url secret. private-ranges-only keeps public
-# egress (Vertex, accounts.google.com) off the VPC, so no Cloud NAT is needed.
+# egress (Agent Platform, accounts.google.com) off the VPC, so no Cloud NAT is needed.
 # We deliberately do NOT use --add-cloudsql-instances (that's the Auth Proxy /
 # socket path, which would need a different connection string).
 #

--- a/examples/gateway/gcp/terraform/main.tf
+++ b/examples/gateway/gcp/terraform/main.tf
@@ -50,7 +50,7 @@ resource "google_service_account" "gateway" {
 # Run and GKE.
 resource "google_project_iam_member" "vertex" {
   project = var.project_id
-  role    = "roles/aiplatform.user" # Vertex inference
+  role    = "roles/aiplatform.user" # Agent Platform inference
   member  = "serviceAccount:${google_service_account.gateway.email}"
 }
 
@@ -310,7 +310,7 @@ resource "google_cloud_run_v2_service" "gateway" {
         network    = google_compute_network.vpc.id
         subnetwork = google_compute_subnetwork.subnet.id
       }
-      egress = "PRIVATE_RANGES_ONLY" # public egress (Vertex, accounts.google.com) bypasses the VPC -> no Cloud NAT needed
+      egress = "PRIVATE_RANGES_ONLY" # public egress (Agent Platform, accounts.google.com) bypasses the VPC -> no Cloud NAT needed
     }
 
     containers {

--- a/examples/gateway/gcp/terraform/variables.tf
+++ b/examples/gateway/gcp/terraform/variables.tf
@@ -6,7 +6,7 @@ variable "project_id" {
 }
 
 variable "region" {
-  description = "Infra region for Artifact Registry, Cloud SQL, subnet, and Cloud Run. (Vertex region is set separately inside gateway.yaml.)"
+  description = "Infra region for Artifact Registry, Cloud SQL, subnet, and Cloud Run. (Agent Platform region is set separately inside gateway.yaml.)"
   type        = string
   default     = "us-east5"
 }


### PR DESCRIPTION
## Summary

Prose-only updates to `examples/gateway/gcp/`:

- **Agent Platform rebrand**: prose references to Vertex AI renamed across the example (READMEs, script and Terraform comments, config template), with "(formerly Vertex AI)" kept on first mentions for searchability. Functional identifiers are deliberately unchanged — the gateway config's `provider: vertex` / `upstream_model: { vertex: ... }` keys, `roles/aiplatform.user`, `aiplatform.googleapis.com`, and the Terraform resource label `google_project_iam_member.vertex` (renaming it would needlessly recreate the IAM binding for existing deployments).
- **README cleanup**: dropped the self-referential public-mirror link (it pointed at this same path).

## Test plan

- [x] `bash -n setup.sh` passes
- [x] Remaining `vertex` matches audited: only the functional identifiers above and the two "(formerly Vertex AI)" mentions