### PR TITLE
fix: remove statsig.anthropic.com from init-firewall.sh

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -68,7 +68,6 @@ for domain in \
     "registry.npmjs.org" \
     "api.anthropic.com" \
     "sentry.io" \
-    "statsig.anthropic.com" \
     "statsig.com" \
     "marketplace.visualstudio.com" \
     "vscode.blob.core.windows.net" \


### PR DESCRIPTION
## Summary

Remove `statsig.anthropic.com` from the firewall initialisation allowlist.

## Why

The hostname `statsig.anthropic.com` no longer resolves. During devcontainer startup, `init-firewall.sh` attempts to resolve every hostname in the allowlist and exits with an error if any lookup fails.

This caused the `postStartCommand` to fail with:

```text
ERROR: Failed to resolve statsig.anthropic.com
```

which prevented the devcontainer from completing startup.

## Changes

* Remove `statsig.anthropic.com` from the list of hostnames resolved by `init-firewall.sh`.

## Testing

* Rebuilt/reloaded the devcontainer.
* Verified that the firewall initialisation completes successfully.
* Verified that the devcontainer starts without the DNS resolution error.
