### PR TITLE
docs: fix Github -> GitHub typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [npm]: https://img.shields.io/npm/v/@anthropic-ai/claude-code.svg?style=flat-square
 
-Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows -- all through natural language commands. Use it in your terminal, IDE, or tag @claude on Github.
+Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows -- all through natural language commands. Use it in your terminal, IDE, or tag @claude on GitHub.
 
 **Learn more in the [official documentation](https://code.claude.com/docs/en/overview)**.
 


### PR DESCRIPTION
## Summary
- Fixes a small capitalization typo in the README: "Github" -> "GitHub"

## Test plan
- Docs-only change, no build/test needed