### PR TITLE
docs: fix GitHub capitalization in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [npm]: https://img.shields.io/npm/v/@anthropic-ai/claude-code.svg?style=flat-square
 
-Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows -- all through natural language commands. Use it in your terminal, IDE, or tag @claude on Github.
+Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows -- all through natural language commands. Use it in your terminal, IDE, or tag @claude on GitHub.
 
 **Learn more in the [official documentation](https://code.claude.com/docs/en/overview)**.
 


### PR DESCRIPTION
## Summary
- Fixes a minor capitalization typo in README.md: "Github" -> "GitHub" (matches the correct spelling used elsewhere in the file, e.g. the "GitHub issue" link).

## Test plan
- Doc-only change, no functional impact. Visually verified the corrected line in README.md.