### PR TITLE
fix(plugin-dev): use "asks to" in skill-development and plugin-settings descriptions

### DIFF
--- a/plugins/plugin-dev/skills/plugin-settings/SKILL.md
+++ b/plugins/plugin-dev/skills/plugin-settings/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Plugin Settings
-description: This skill should be used when the user asks about "plugin settings", "store plugin configuration", "user-configurable plugin", ".local.md files", "plugin state files", "read YAML frontmatter", "per-project plugin settings", or wants to make plugin behavior configurable. Documents the .claude/plugin-name.local.md pattern for storing plugin-specific configuration with YAML frontmatter and markdown content.
+description: This skill should be used when the user asks about "plugin settings", "store plugin configuration", "user-configurable plugin", ".local.md files", "plugin state files", "read YAML frontmatter", "per-project plugin settings", or asks to make plugin behavior configurable. Documents the .claude/plugin-name.local.md pattern for storing plugin-specific configuration with YAML frontmatter and markdown content.
 version: 0.1.0
 ---
 


### PR DESCRIPTION
## Summary

Completes the consistency fix from #13204 which changed "wants to" to "asks to" across plugin-dev skill descriptions. Two skills were missed:

- `plugins/plugin-dev/skills/skill-development/SKILL.md`
- `plugins/plugin-dev/skills/plugin-settings/SKILL.md`

This PR fixes both so all 7 plugin-dev skills consistently use "asks to".

## Changes

2 files changed, 2 insertions(+), 2 deletions(-)

## Test plan

- [x] Verified all 7 plugin-dev SKILL.md files now use "asks to" consistently
- [x] No functional changes, only description wording