### PR TITLE
feat(commit-commands): support Conventional Branch naming in /commit-push-pr

### DIFF
--- a/plugins/commit-commands/README.md
+++ b/plugins/commit-commands/README.md
@@ -57,7 +57,8 @@ Complete workflow command that commits, pushes, and creates a pull request in on
 
 **Usage:**
 ```bash
-/commit-push-pr
+/commit-push-pr              # default branch naming
+/commit-push-pr conventional # Conventional Branch naming
 ```
 
 **Example workflow:**
@@ -73,6 +74,18 @@ Complete workflow command that commits, pushes, and creates a pull request in on
 # - Open a PR with summary and test plan
 # - Give you the PR URL to review
 ```
+
+**Conventional Branch naming:**
+
+Pass `conventional` to name the new branch per the
+[Conventional Branch 1.0.0 spec](https://conventionalbranch.org/):
+
+- Format: `<type>/<description>` (e.g. `feature/add-oauth-login`,
+  `bugfix/fix-header-overflow`, `chore/bump-typescript-5-6`).
+- `<type>` is inferred from the diff: `feature`, `bugfix`, `hotfix`,
+  `release`, `chore`, `docs`, or `test`.
+- `<description>` is lowercase, hyphen-separated, alphanumeric + hyphens
+  only, with no consecutive or trailing hyphens.
 
 **Features:**
 - Analyzes all commits in the branch (not just the latest)

--- a/plugins/commit-commands/commands/commit-push-pr.md
+++ b/plugins/commit-commands/commands/commit-push-pr.md
@@ -1,6 +1,7 @@
 ---
 allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*)
 description: Commit, push, and open a PR
+argument-hint: "[conventional]"
 ---
 
 ## Context
@@ -8,12 +9,18 @@ description: Commit, push, and open a PR
 - Current git status: !`git status`
 - Current git diff (staged and unstaged changes): !`git diff HEAD`
 - Current branch: !`git branch --show-current`
+- Arguments: "$ARGUMENTS"
 
 ## Your task
 
 Based on the above changes:
 
-1. Create a new branch if on main
+1. Create a new branch if on main.
+   - **Default naming**: `<custom-prefix>/<generated-name>` as you would normally choose.
+   - **Conventional Branch naming**: if the arguments contain `conventional`, name the branch following the Conventional Branch 1.0.0 spec (https://conventionalbranch.org/):
+     - Format: `<type>/<description>`
+     - Pick `<type>` from the diff: `feature` (new capability), `bugfix` (fix), `hotfix` (urgent prod fix), `release` (release prep), `chore` (tooling/deps/maintenance), `docs` (docs-only), `test` (tests-only).
+     - `<description>` rules: lowercase, hyphen-separated, alphanumeric + hyphens only, no consecutive hyphens, no trailing hyphens, short and descriptive.
 2. Create a single commit with an appropriate message
 3. Push the branch to origin
 4. Create a pull request using `gh pr create`


### PR DESCRIPTION
## Summary
- Adds an optional `conventional` argument to `/commit-push-pr` that names the new branch per the [Conventional Branch 1.0.0 spec](https://conventionalbranch.org/): `<type>/<description>` with `type` (`feature`, `bugfix`, `hotfix`, `release`, `chore`, `docs`, `test`) inferred from the diff.
- Default behavior (`/commit-push-pr` with no args) is unchanged — still `<custom-prefix>/<generated-name>`.
- Updates the plugin README with usage, an example, and the description-formatting rules (lowercase, hyphen-separated, alphanumeric + hyphens only, no consecutive/trailing hyphens).

## Test plan
- [x] Run `/commit-push-pr` on a branch off `main` with staged changes — branch name matches previous default behavior.
- [x] Run `/commit-push-pr conventional` on a bug fix — branch is named `bugfix/<slug>`.
- [x] Run `/commit-push-pr conventional` on a new feature — branch is named `feature/<slug>`.
- [x] Run `/commit-push-pr conventional` on a docs-only or chore change — branch is named `docs/<slug>` or `chore/<slug>` respectively.
- [x] Verify slugs contain only lowercase alphanumerics and single hyphens, with no trailing hyphen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)