### PR TITLE
docs: clarify plugin MCP configuration scope

### DIFF
--- a/plugins/plugin-dev/skills/mcp-integration/SKILL.md
+++ b/plugins/plugin-dev/skills/mcp-integration/SKILL.md
@@ -20,6 +20,8 @@ Model Context Protocol (MCP) enables Claude Code plugins to integrate with exter
 
 Plugins can bundle MCP servers in two ways:
 
+> Note: This section describes MCP server definitions bundled with a plugin, either in `.mcp.json` or in the plugin manifest's `mcpServers` field. It is separate from Claude Code's user-level MCP allow/deny list settings in `~/.claude.json`, such as `enabledMcpServers` and `disabledMcpServers`.
+
 ### Method 1: Dedicated .mcp.json (Recommended)
 
 Create `.mcp.json` at plugin root:

--- a/plugins/plugin-dev/skills/plugin-structure/references/manifest-reference.md
+++ b/plugins/plugin-dev/skills/plugin-structure/references/manifest-reference.md
@@ -297,6 +297,8 @@ Hook configuration location or inline definition.
 
 #### mcpServers
 
+Defines MCP server configurations bundled with the plugin, or points to a plugin-local MCP configuration file. This field is separate from Claude Code's user-level MCP allow/deny list settings in `~/.claude.json`, such as `enabledMcpServers` and `disabledMcpServers`.
+
 **Type**: String (path to JSON file) or Object (inline configuration)
 **Default**: `./.mcp.json`
 


### PR DESCRIPTION
Clarifies that plugin `mcpServers` configuration is for plugin-bundled MCP server definitions and is separate from Claude Code's user-level MCP allow/deny list settings in `~/.claude.json`.

This helps avoid confusion between plugin MCP server configuration and settings such as `enabledMcpServers` and `disabledMcpServers`.

Tested:
- Ran `git diff --check`
- Documentation-only change