### PR TITLE
fix(hook-development): recognize all five hook handler types

### DIFF
--- a/plugins/plugin-dev/skills/hook-development/SKILL.md
+++ b/plugins/plugin-dev/skills/hook-development/SKILL.md
@@ -19,6 +19,18 @@ Hooks are event-driven automation scripts that execute in response to Claude Cod
 
 ## Hook Types
 
+There are five hook handler types. Each object in a `hooks` array is one handler:
+
+| Type | Field(s) required | Runs |
+|------|-------------------|------|
+| `command` | `command` | A shell command |
+| `prompt` | `prompt` | An LLM evaluation in the current session |
+| `http` | `url` | An HTTP POST to an endpoint |
+| `mcp_tool` | `server`, `tool` | A tool on a configured MCP server |
+| `agent` | `prompt` | A spawned subagent (experimental) |
+
+All types also accept the common fields `timeout`, `statusMessage`, `if`, and `once`.
+
 ### Prompt-Based Hooks (Recommended)
 
 Use LLM-driven decision making for context-aware validation:
@@ -56,6 +68,51 @@ Execute bash commands for deterministic checks:
 - File system operations
 - External tool integrations
 - Performance-critical checks
+
+### HTTP Hooks
+
+Send the hook payload as an HTTP POST to an external endpoint:
+
+```json
+{
+  "type": "http",
+  "url": "http://localhost:8080/hooks/pre-tool-use",
+  "headers": { "Authorization": "Bearer $MY_TOKEN" },
+  "allowedEnvVars": ["MY_TOKEN"],
+  "timeout": 30
+}
+```
+
+**Use for:** delegating decisions to an out-of-process service. `url` is required; `headers` and `allowedEnvVars` are optional.
+
+### MCP Tool Hooks
+
+Invoke a tool on a configured MCP server:
+
+```json
+{
+  "type": "mcp_tool",
+  "server": "my_server",
+  "tool": "security_scan",
+  "input": { "file_path": "${tool_input.file_path}" }
+}
+```
+
+**Use for:** reusing validation logic already exposed by an MCP server. `server` and `tool` are required; `input` is optional. For a plugin-bundled server, use the scoped name: `"server": "plugin:my-plugin:db"`.
+
+### Agent Hooks (Experimental)
+
+Spawn a subagent to evaluate the event:
+
+```json
+{
+  "type": "agent",
+  "prompt": "Review the changes in $ARGUMENTS and return approval",
+  "model": "claude-opus-4-1-20250805"
+}
+```
+
+**Use for:** multi-step reasoning that benefits from its own agent context. `prompt` is required; `model` is optional. Use `$ARGUMENTS` as the placeholder for the hook input JSON. Agent hooks are experimental and may change.
 
 ## Hook Configuration Formats
 

--- a/plugins/plugin-dev/skills/hook-development/scripts/README.md
+++ b/plugins/plugin-dev/skills/hook-development/scripts/README.md
@@ -15,7 +15,7 @@ Validates `hooks.json` configuration files for correct structure and common issu
 - Valid JSON syntax
 - Required fields present
 - Valid hook event names
-- Proper hook types (command/prompt)
+- Proper hook types (command/prompt/http/mcp_tool/agent)
 - Timeout values in valid ranges
 - Hardcoded path detection
 - Prompt hook event compatibility

--- a/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
@@ -38,7 +38,16 @@ echo "✅ Valid JSON"
 # Check 2: Root structure
 echo ""
 echo "Checking root structure..."
-VALID_EVENTS=("PreToolUse" "PostToolUse" "UserPromptSubmit" "Stop" "SubagentStop" "SessionStart" "SessionEnd" "PreCompact" "Notification")
+VALID_EVENTS=(
+  "SessionStart" "Setup" "UserPromptSubmit" "UserPromptExpansion"
+  "PreToolUse" "PermissionRequest" "PermissionDenied" "PostToolUse"
+  "PostToolUseFailure" "PostToolBatch" "Notification" "MessageDisplay"
+  "SubagentStart" "SubagentStop" "TaskCreated" "TaskCompleted"
+  "Stop" "StopFailure" "TeammateIdle" "InstructionsLoaded"
+  "ConfigChange" "CwdChanged" "FileChanged" "WorktreeCreate"
+  "WorktreeRemove" "PreCompact" "PostCompact" "Elicitation"
+  "ElicitationResult" "SessionEnd"
+)
 
 for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
   found=false
@@ -94,11 +103,14 @@ for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
         continue
       fi
 
-      if [ "$hook_type" != "command" ] && [ "$hook_type" != "prompt" ]; then
-        echo "❌ $event[$i].hooks[$j]: Invalid type '$hook_type' (must be 'command' or 'prompt')"
-        ((error_count++))
-        continue
-      fi
+      case "$hook_type" in
+        command|prompt|http|mcp_tool|agent) ;;
+        *)
+          echo "❌ $event[$i].hooks[$j]: Invalid type '$hook_type' (must be 'command', 'prompt', 'http', 'mcp_tool', or 'agent')"
+          ((error_count++))
+          continue
+          ;;
+      esac
 
       # Check type-specific fields
       if [ "$hook_type" = "command" ]; then
@@ -124,6 +136,29 @@ for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
         if [ "$event" != "Stop" ] && [ "$event" != "SubagentStop" ] && [ "$event" != "UserPromptSubmit" ] && [ "$event" != "PreToolUse" ]; then
           echo "⚠️  $event[$i].hooks[$j]: Prompt hooks may not be fully supported on $event (best on Stop, SubagentStop, UserPromptSubmit, PreToolUse)"
           ((warning_count++))
+        fi
+      elif [ "$hook_type" = "http" ]; then
+        url=$(jq -r ".\"$event\"[$i].hooks[$j].url // empty" "$HOOKS_FILE")
+        if [ -z "$url" ]; then
+          echo "❌ $event[$i].hooks[$j]: HTTP hooks must have 'url' field"
+          ((error_count++))
+        fi
+      elif [ "$hook_type" = "mcp_tool" ]; then
+        server=$(jq -r ".\"$event\"[$i].hooks[$j].server // empty" "$HOOKS_FILE")
+        if [ -z "$server" ]; then
+          echo "❌ $event[$i].hooks[$j]: MCP tool hooks must have 'server' field"
+          ((error_count++))
+        fi
+        tool=$(jq -r ".\"$event\"[$i].hooks[$j].tool // empty" "$HOOKS_FILE")
+        if [ -z "$tool" ]; then
+          echo "❌ $event[$i].hooks[$j]: MCP tool hooks must have 'tool' field"
+          ((error_count++))
+        fi
+      elif [ "$hook_type" = "agent" ]; then
+        prompt=$(jq -r ".\"$event\"[$i].hooks[$j].prompt // empty" "$HOOKS_FILE")
+        if [ -z "$prompt" ]; then
+          echo "❌ $event[$i].hooks[$j]: Agent hooks must have 'prompt' field"
+          ((error_count++))
         fi
       fi
 


### PR DESCRIPTION
## Problem

The `plugin-dev` **hook-development** skill teaches plugin authors how to write `hooks.json`, but it only knew **two** of the five hook handler types Claude Code actually supports. Both the docs and the bundled validator had drifted from the product:

- `scripts/validate-hook-schema.sh` accepted only `command` and `prompt`, and reported `http`, `mcp_tool`, and `agent` hooks as **errors** — even though all three are valid, documented types. So the tool failed valid configs it was meant to certify.
- `SKILL.md`'s "Hook Types" section documented only 2 of the 5 types (the root cause of the drift).
- The event allowlist in the validator was missing many valid events.

Verified against the official docs (https://code.claude.com/docs/en/hooks): the five handler types are `command`, `prompt`, `http`, `mcp_tool`, and `agent`.

## Changes

- **`scripts/validate-hook-schema.sh`**
  - Accept all five handler types instead of erroring on `http`/`mcp_tool`/`agent`.
  - Add per-type required-field validation matching the documented schemas: `http` -> `url`, `mcp_tool` -> `server` + `tool`, `agent` -> `prompt`.
  - Expand the event allowlist from 9 to the full documented set (adds `FileChanged`, `PostCompact`, `PermissionRequest`, etc.) so valid events are no longer flagged as unknown.
- **`SKILL.md`** — add a five-type overview table plus dedicated subsections for HTTP, MCP-tool, and Agent hooks with required/optional fields and examples.
- **`scripts/README.md`** — list all five types instead of `command/prompt`.

## Testing

Ran the validator against fixtures built from the official docs:

| Case | Before | After |
|------|--------|-------|
| Valid `http`/`mcp_tool`/`agent` config | rejected (`Invalid type 'http'`, exit 1) | passes, exit 0 |
| `http` hook missing `url` | (never reached) | errors |
| `mcp_tool` missing `tool` | (never reached) | errors |
| Genuinely invalid type (`webhook`) | errors | errors |
| Config using `FileChanged` event | "unknown event" warning | no warning |
| Original `command`/`prompt` config | passes | passes (no regression) |