### PR TITLE
fix(sweep): unstarve markStale via search API; snapshot listings before mutating

### DIFF
--- a/scripts/sweep-lib.test.ts
+++ b/scripts/sweep-lib.test.ts
@@ -1,0 +1,123 @@
+import { test, expect } from "bun:test";
+import { buildStaleQuery, isStaleCandidate, collectPages } from "./sweep-lib.ts";
+
+const CUTOFF = new Date("2026-06-25T13:45:00Z");
+const THRESHOLD = 10;
+
+// Helper: a minimal issue that IS a stale candidate; tests override one field
+// at a time to prove each disqualifier works in isolation.
+const candidate = (overrides: Record<string, unknown> = {}) => ({
+  number: 1,
+  updated_at: "2026-01-01T00:00:00Z",
+  locked: false,
+  assignees: [],
+  labels: [{ name: "bug" }],
+  reactions: { "+1": 0 },
+  ...overrides,
+});
+
+// -- buildStaleQuery ---------------------------------------------------------
+
+test("query targets exactly the labelable set, with a date-only cutoff", () => {
+  expect(buildStaleQuery("anthropics", "claude-code", CUTOFF)).toBe(
+    "repo:anthropics/claude-code is:issue is:open updated:<2026-06-25 -label:stale -label:autoclose no:assignee"
+  );
+});
+
+// -- isStaleCandidate --------------------------------------------------------
+
+test("an old, unlabeled, unassigned, quiet issue is a candidate", () => {
+  expect(isStaleCandidate(candidate(), CUTOFF, THRESHOLD)).toBe(true);
+});
+
+test("pull requests are never candidates", () => {
+  expect(
+    isStaleCandidate(candidate({ pull_request: { url: "x" } }), CUTOFF, THRESHOLD)
+  ).toBe(false);
+});
+
+test("locked issues are not candidates", () => {
+  expect(isStaleCandidate(candidate({ locked: true }), CUTOFF, THRESHOLD)).toBe(false);
+});
+
+test("assigned issues are not candidates", () => {
+  expect(
+    isStaleCandidate(candidate({ assignees: [{ login: "a" }] }), CUTOFF, THRESHOLD)
+  ).toBe(false);
+});
+
+test("issues already labeled stale or autoclose are not candidates", () => {
+  expect(
+    isStaleCandidate(candidate({ labels: [{ name: "stale" }] }), CUTOFF, THRESHOLD)
+  ).toBe(false);
+  expect(
+    isStaleCandidate(candidate({ labels: [{ name: "autoclose" }] }), CUTOFF, THRESHOLD)
+  ).toBe(false);
+});
+
+test("issues at or above the upvote threshold are not candidates", () => {
+  expect(
+    isStaleCandidate(candidate({ reactions: { "+1": THRESHOLD } }), CUTOFF, THRESHOLD)
+  ).toBe(false);
+  expect(
+    isStaleCandidate(candidate({ reactions: { "+1": THRESHOLD - 1 } }), CUTOFF, THRESHOLD)
+  ).toBe(true);
+});
+
+test("issues updated on or after the cutoff are not candidates", () => {
+  expect(
+    isStaleCandidate(candidate({ updated_at: "2026-07-01T00:00:00Z" }), CUTOFF, THRESHOLD)
+  ).toBe(false);
+  expect(
+    isStaleCandidate(candidate({ updated_at: CUTOFF.toISOString() }), CUTOFF, THRESHOLD)
+  ).toBe(false);
+});
+
+test("missing optional fields do not disqualify an old issue", () => {
+  expect(
+    isStaleCandidate({ number: 2, updated_at: "2026-01-01T00:00:00Z" }, CUTOFF, THRESHOLD)
+  ).toBe(true);
+});
+
+// -- collectPages ------------------------------------------------------------
+
+// Fake paginated backend: `pages` is the full dataset served 100 at a time.
+const backend = (all: number[], perPage = 100) => {
+  const calls: number[] = [];
+  const fetchPage = async (page: number) => {
+    calls.push(page);
+    return all.slice((page - 1) * perPage, page * perPage);
+  };
+  return { calls, fetchPage };
+};
+
+test("collects every page until a short page, preserving order", async () => {
+  const all = Array.from({ length: 250 }, (_, i) => i);
+  const { calls, fetchPage } = backend(all);
+  const result = await collectPages(fetchPage);
+  expect(result).toEqual(all);
+  expect(calls).toEqual([1, 2, 3]); // 100, 100, 50 — stops on the short page
+});
+
+test("stops on an empty page when the last full page ends the dataset", async () => {
+  const all = Array.from({ length: 200 }, (_, i) => i);
+  const { calls, fetchPage } = backend(all);
+  const result = await collectPages(fetchPage);
+  expect(result).toEqual(all);
+  expect(calls).toEqual([1, 2, 3]); // page 3 is empty
+});
+
+test("a short first page needs exactly one fetch", async () => {
+  const { calls, fetchPage } = backend([1, 2, 3]);
+  const result = await collectPages(fetchPage);
+  expect(result).toEqual([1, 2, 3]);
+  expect(calls).toEqual([1]);
+});
+
+test("respects the maxPages safety cap", async () => {
+  const all = Array.from({ length: 500 }, (_, i) => i);
+  const { calls, fetchPage } = backend(all);
+  const result = await collectPages(fetchPage, { maxPages: 2 });
+  expect(result).toEqual(all.slice(0, 200));
+  expect(calls).toEqual([1, 2]);
+});

--- a/scripts/sweep-lib.test.ts
+++ b/scripts/sweep-lib.test.ts
@@ -1,5 +1,10 @@
 import { test, expect } from "bun:test";
-import { buildStaleQuery, isStaleCandidate, collectPages } from "./sweep-lib.ts";
+import {
+  buildStaleQuery,
+  isStaleCandidate,
+  collectPages,
+  withRateLimitRetry,
+} from "./sweep-lib.ts";
 
 const CUTOFF = new Date("2026-06-25T13:45:00Z");
 const THRESHOLD = 10;
@@ -120,4 +125,59 @@ test("respects the maxPages safety cap", async () => {
   const result = await collectPages(fetchPage, { maxPages: 2 });
   expect(result).toEqual(all.slice(0, 200));
   expect(calls).toEqual([1, 2]);
+});
+
+// -- withRateLimitRetry --------------------------------------------------------
+
+// Fake flaky call: fails `n` times with `error`, then returns "ok".
+const failNTimes = (n: number, error: string) => {
+  let calls = 0;
+  const fn = async () => {
+    calls++;
+    if (calls <= n) throw new Error(error);
+    return "ok";
+  };
+  return { fn, calls: () => calls };
+};
+
+test("returns the result without sleeping when the call succeeds", async () => {
+  const sleeps: number[] = [];
+  const { fn, calls } = failNTimes(0, "");
+  const result = await withRateLimitRetry(fn, {
+    sleeper: async (ms) => void sleeps.push(ms),
+  });
+  expect(result).toBe("ok");
+  expect(calls()).toBe(1);
+  expect(sleeps).toEqual([]);
+});
+
+test("backs off and retries when GitHub reports a secondary rate limit", async () => {
+  const sleeps: number[] = [];
+  const { fn, calls } = failNTimes(2, "GitHub API 403: secondary rate limit");
+  const result = await withRateLimitRetry(fn, {
+    sleeper: async (ms) => void sleeps.push(ms),
+  });
+  expect(result).toBe("ok");
+  expect(calls()).toBe(3);
+  expect(sleeps).toEqual([60000, 120000]);
+});
+
+test("retries 429 responses too", async () => {
+  const { fn, calls } = failNTimes(1, "GitHub API 429: too many requests");
+  expect(await withRateLimitRetry(fn, { sleeper: async () => {} })).toBe("ok");
+  expect(calls()).toBe(2);
+});
+
+test("rethrows non-rate-limit errors immediately", async () => {
+  const { fn, calls } = failNTimes(5, "GitHub API 500: boom");
+  await expect(withRateLimitRetry(fn, { sleeper: async () => {} })).rejects.toThrow("500");
+  expect(calls()).toBe(1);
+});
+
+test("gives up after the attempt budget", async () => {
+  const { fn, calls } = failNTimes(99, "GitHub API 403: rate limit");
+  await expect(
+    withRateLimitRetry(fn, { attempts: 3, sleeper: async () => {} })
+  ).rejects.toThrow("403");
+  expect(calls()).toBe(3);
 });

--- a/scripts/sweep-lib.ts
+++ b/scripts/sweep-lib.ts
@@ -1,0 +1,59 @@
+// Pure decision logic for sweep.ts, split out so it can be unit tested
+// without network access (same pattern as issue-lifecycle.ts).
+
+export interface SweepIssue {
+  number: number;
+  updated_at: string;
+  locked?: boolean;
+  pull_request?: unknown;
+  assignees?: unknown[];
+  labels?: { name: string }[];
+  reactions?: Record<string, number>;
+}
+
+// Search query for exactly the set markStale may label. The plain issues
+// listing can't serve as a work queue: it interleaves PRs and permanently
+// skipped issues (upvoted, assigned, already stale) which accumulate at the
+// front of the oldest-updated-first sort until no candidate is reachable
+// within any fixed page budget. The search API excludes all of those
+// server-side. Search's `updated:` qualifier has date granularity, so the
+// cutoff is truncated to a date; isStaleCandidate re-checks the exact time.
+export function buildStaleQuery(owner: string, repo: string, cutoff: Date): string {
+  const cutoffDate = cutoff.toISOString().split("T")[0];
+  return `repo:${owner}/${repo} is:issue is:open updated:<${cutoffDate} -label:stale -label:autoclose no:assignee`;
+}
+
+// Client-side re-check of everything the query filters (the search index can
+// lag) plus the two conditions search can't express: the exact cutoff time
+// and the 👍-reaction threshold (search's `reactions:` counts all kinds).
+export function isStaleCandidate(
+  issue: SweepIssue,
+  cutoff: Date,
+  upvoteThreshold: number
+): boolean {
+  if (issue.pull_request) return false;
+  if (issue.locked) return false;
+  if ((issue.assignees?.length ?? 0) > 0) return false;
+  if (issue.labels?.some((l) => l.name === "stale" || l.name === "autoclose")) return false;
+  if ((issue.reactions?.["+1"] ?? 0) >= upvoteThreshold) return false;
+  return new Date(issue.updated_at) < cutoff;
+}
+
+// Snapshot a paginated listing in full BEFORE acting on it. Offset pagination
+// over a listing that the loop itself is mutating (labeling reorders the
+// updated-sort; closing removes items) skips one item per mutation at every
+// page boundary — collecting first makes the walk immune to that.
+export async function collectPages<T>(
+  fetchPage: (page: number) => Promise<T[]>,
+  opts: { perPage?: number; maxPages?: number } = {}
+): Promise<T[]> {
+  const perPage = opts.perPage ?? 100;
+  const maxPages = opts.maxPages ?? 30;
+  const results: T[] = [];
+  for (let page = 1; page <= maxPages; page++) {
+    const items = await fetchPage(page);
+    results.push(...items);
+    if (items.length < perPage) break;
+  }
+  return results;
+}

--- a/scripts/sweep-lib.ts
+++ b/scripts/sweep-lib.ts
@@ -39,6 +39,27 @@ export function isStaleCandidate(
   return new Date(issue.updated_at) < cutoff;
 }
 
+// GitHub's secondary rate limits reject bursts with 403/429 and ask callers
+// to pause before retrying. Back off attempt×60s (the docs say "wait a few
+// minutes") for those; anything else propagates immediately.
+export async function withRateLimitRetry<T>(
+  fn: () => Promise<T>,
+  opts: { attempts?: number; sleeper?: (ms: number) => Promise<void> } = {}
+): Promise<T> {
+  const attempts = opts.attempts ?? 3;
+  const sleeper =
+    opts.sleeper ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt >= attempts || !/GitHub API (403|429)/.test(String(err))) throw err;
+      console.log(`rate limited — waiting ${attempt}min before retrying`);
+      await sleeper(attempt * 60_000);
+    }
+  }
+}
+
 // Snapshot a paginated listing in full BEFORE acting on it. Offset pagination
 // over a listing that the loop itself is mutating (labeling reorders the
 // updated-sort; closing removes items) skips one item per mutation at every

--- a/scripts/sweep.ts
+++ b/scripts/sweep.ts
@@ -5,6 +5,7 @@ import {
   buildStaleQuery,
   collectPages,
   isStaleCandidate,
+  withRateLimitRetry,
   type SweepIssue,
 } from "./sweep-lib.ts";
 
@@ -73,10 +74,10 @@ async function markStale(owner: string, repo: string) {
     // Pace search requests: the search API's secondary rate limit rejects
     // rapid bursts well before the 30-requests/minute primary limit.
     if (page > 1) await sleep(2000);
-    const result = await githubRequest<{
-      items?: (SweepIssue & { title?: string })[];
-    }>(
-      `/search/issues?q=${encodeURIComponent(query)}&sort=updated&order=asc&per_page=100&page=${page}`
+    const result = await withRateLimitRetry(() =>
+      githubRequest<{ items?: (SweepIssue & { title?: string })[] }>(
+        `/search/issues?q=${encodeURIComponent(query)}&sort=updated&order=asc&per_page=100&page=${page}`
+      )
     );
     return result.items ?? [];
   };

--- a/scripts/sweep.ts
+++ b/scripts/sweep.ts
@@ -69,10 +69,17 @@ async function markStale(owner: string, repo: string) {
   // reorders the listing underneath the pagination. Ask the search API for
   // exactly the labelable set instead (same approach as lock-closed-issues).
   const query = buildStaleQuery(owner, repo, cutoff);
-  const searchPage = (page: number) =>
-    githubRequest<{ items?: (SweepIssue & { title?: string })[] }>(
+  const searchPage = async (page: number) => {
+    // Pace search requests: the search API's secondary rate limit rejects
+    // rapid bursts well before the 30-requests/minute primary limit.
+    if (page > 1) await sleep(2000);
+    const result = await githubRequest<{
+      items?: (SweepIssue & { title?: string })[];
+    }>(
       `/search/issues?q=${encodeURIComponent(query)}&sort=updated&order=asc&per_page=100&page=${page}`
-    ).then((r) => r.items ?? []);
+    );
+    return result.items ?? [];
+  };
   const processed = new Set<number>();
 
   // Labeling removes an issue from the query results, so each round the

--- a/scripts/sweep.ts
+++ b/scripts/sweep.ts
@@ -1,11 +1,22 @@
 #!/usr/bin/env bun
 
 import { lifecycle, STALE_UPVOTE_THRESHOLD } from "./issue-lifecycle.ts";
+import {
+  buildStaleQuery,
+  collectPages,
+  isStaleCandidate,
+  type SweepIssue,
+} from "./sweep-lib.ts";
 
 // --
 
 const NEW_ISSUE = "https://github.com/anthropics/claude-code/issues/new/choose";
 const DRY_RUN = process.argv.includes("--dry-run");
+
+// Bounds label writes per run while the backlog drains — same per-run cap and
+// pacing as the lock-closed-issues workflow.
+const MAX_STALE_LABELS_PER_RUN = 250;
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 const CLOSE_MESSAGE = (reason: string) =>
   `Closing for now — ${reason}. Please [open a new issue](${NEW_ISSUE}) if this is still relevant.`;
@@ -51,36 +62,43 @@ async function markStale(owner: string, repo: string) {
 
   console.log(`\n=== marking stale (${staleDays}d inactive) ===`);
 
-  for (let page = 1; page <= 10; page++) {
-    const issues = await githubRequest<any[]>(
-      `/repos/${owner}/${repo}/issues?state=open&sort=updated&direction=asc&per_page=100&page=${page}`
-    );
-    if (issues.length === 0) break;
+  // The plain issues listing can't serve as a work queue here: it interleaves
+  // PRs and permanently skipped issues (upvoted, assigned, already stale),
+  // which pile up at the front of the oldest-updated-first sort until no
+  // candidate is reachable within any fixed page budget — and labeling
+  // reorders the listing underneath the pagination. Ask the search API for
+  // exactly the labelable set instead (same approach as lock-closed-issues).
+  const query = buildStaleQuery(owner, repo, cutoff);
+  const searchPage = (page: number) =>
+    githubRequest<{ items?: (SweepIssue & { title?: string })[] }>(
+      `/search/issues?q=${encodeURIComponent(query)}&sort=updated&order=asc&per_page=100&page=${page}`
+    ).then((r) => r.items ?? []);
+  const processed = new Set<number>();
 
-    for (const issue of issues) {
-      if (issue.pull_request) continue;
-      if (issue.locked) continue;
-      if (issue.assignees?.length > 0) continue;
+  // Labeling removes an issue from the query results, so each round the
+  // window refills with older candidates. `processed` skips issues we chose
+  // not to label (upvote threshold) and ones the search index still returns.
+  // Rounds are needed because search serves at most 1000 results per query.
+  while (labeled < MAX_STALE_LABELS_PER_RUN) {
+    const issues = await collectPages(searchPage, { maxPages: 10 });
+    const fresh = issues.filter((i) => !processed.has(i.number));
+    if (fresh.length === 0) break;
 
-      const updatedAt = new Date(issue.updated_at);
-      if (updatedAt > cutoff) return labeled;
-
-      const alreadyStale = issue.labels?.some(
-        (l: any) => l.name === "stale" || l.name === "autoclose"
-      );
-      if (alreadyStale) continue;
-
-      const thumbsUp = issue.reactions?.["+1"] ?? 0;
-      if (thumbsUp >= STALE_UPVOTE_THRESHOLD) continue;
+    for (const issue of fresh) {
+      if (labeled >= MAX_STALE_LABELS_PER_RUN) break;
+      processed.add(issue.number);
+      if (!isStaleCandidate(issue, cutoff, STALE_UPVOTE_THRESHOLD)) continue;
 
       const base = `/repos/${owner}/${repo}/issues/${issue.number}`;
 
       if (DRY_RUN) {
+        const updatedAt = new Date(issue.updated_at);
         const age = Math.floor((Date.now() - updatedAt.getTime()) / 86400000);
         console.log(`#${issue.number}: would label stale (${age}d inactive) — ${issue.title}`);
       } else {
         await githubRequest(`${base}/labels`, "POST", { labels: ["stale"] });
         console.log(`#${issue.number}: labeled stale — ${issue.title}`);
+        await sleep(1000);
       }
       labeled++;
     }
@@ -97,56 +115,61 @@ async function closeExpired(owner: string, repo: string) {
     cutoff.setDate(cutoff.getDate() - days);
     console.log(`\n=== ${label} (${days}d timeout) ===`);
 
-    for (let page = 1; page <= 10; page++) {
-      const issues = await githubRequest<any[]>(
-        `/repos/${owner}/${repo}/issues?state=open&labels=${label}&sort=updated&direction=asc&per_page=100&page=${page}`
+    // Snapshot the listing before closing anything: closing an issue removes
+    // it from this filtered listing, which shifts the offset pages underneath
+    // the walk and skips one issue per close at every page boundary. The
+    // stale listing alone also outgrew the old fixed cap of 10 pages.
+    const issues = await collectPages<any>(
+      (page) =>
+        githubRequest<any[]>(
+          `/repos/${owner}/${repo}/issues?state=open&labels=${label}&sort=updated&direction=asc&per_page=100&page=${page}`
+        ).then((items) => (Array.isArray(items) ? items : [])),
+      { maxPages: 30 }
+    );
+
+    for (const issue of issues) {
+      if (issue.pull_request) continue;
+      if (issue.locked) continue;
+
+      const thumbsUp = issue.reactions?.["+1"] ?? 0;
+      if (thumbsUp >= STALE_UPVOTE_THRESHOLD) continue;
+
+      const base = `/repos/${owner}/${repo}/issues/${issue.number}`;
+
+      const events = await githubRequest<any[]>(`${base}/events?per_page=100`);
+
+      const labeledAt = events
+        .filter((e) => e.event === "labeled" && e.label?.name === label)
+        .map((e) => new Date(e.created_at))
+        .pop();
+
+      if (!labeledAt || labeledAt > cutoff) continue;
+
+      // Skip if a non-bot user commented after the label was applied.
+      // The triage workflow should remove lifecycle labels on human
+      // activity, but check here too as a safety net.
+      const comments = await githubRequest<any[]>(
+        `${base}/comments?since=${labeledAt.toISOString()}&per_page=100`
       );
-      if (issues.length === 0) break;
-
-      for (const issue of issues) {
-        if (issue.pull_request) continue;
-        if (issue.locked) continue;
-
-        const thumbsUp = issue.reactions?.["+1"] ?? 0;
-        if (thumbsUp >= STALE_UPVOTE_THRESHOLD) continue;
-
-        const base = `/repos/${owner}/${repo}/issues/${issue.number}`;
-
-        const events = await githubRequest<any[]>(`${base}/events?per_page=100`);
-
-        const labeledAt = events
-          .filter((e) => e.event === "labeled" && e.label?.name === label)
-          .map((e) => new Date(e.created_at))
-          .pop();
-
-        if (!labeledAt || labeledAt > cutoff) continue;
-
-        // Skip if a non-bot user commented after the label was applied.
-        // The triage workflow should remove lifecycle labels on human
-        // activity, but check here too as a safety net.
-        const comments = await githubRequest<any[]>(
-          `${base}/comments?since=${labeledAt.toISOString()}&per_page=100`
+      const hasHumanComment = comments.some(
+        (c) => c.user && c.user.type !== "Bot"
+      );
+      if (hasHumanComment) {
+        console.log(
+          `#${issue.number}: skipping (human activity after ${label} label)`
         );
-        const hasHumanComment = comments.some(
-          (c) => c.user && c.user.type !== "Bot"
-        );
-        if (hasHumanComment) {
-          console.log(
-            `#${issue.number}: skipping (human activity after ${label} label)`
-          );
-          continue;
-        }
-
-        if (DRY_RUN) {
-          const age = Math.floor((Date.now() - labeledAt.getTime()) / 86400000);
-          console.log(`#${issue.number}: would close (${label}, ${age}d old) — ${issue.title}`);
-        } else {
-          await githubRequest(`${base}/comments`, "POST", { body: CLOSE_MESSAGE(reason) });
-          await githubRequest(base, "PATCH", { state: "closed", state_reason: "not_planned" });
-          console.log(`#${issue.number}: closed (${label})`);
-        }
-        closed++;
+        continue;
       }
+
+      if (DRY_RUN) {
+        const age = Math.floor((Date.now() - labeledAt.getTime()) / 86400000);
+        console.log(`#${issue.number}: would close (${label}, ${age}d old) — ${issue.title}`);
+      } else {
+        await githubRequest(`${base}/comments`, "POST", { body: CLOSE_MESSAGE(reason) });
+        await githubRequest(base, "PATCH", { state: "closed", state_reason: "not_planned" });
+        console.log(`#${issue.number}: closed (${label})`);
+      }
+      closed++;
     }
   }
 


### PR DESCRIPTION
## Problem

**`markStale` currently labels nothing.** It walks `/repos/{owner}/{repo}/issues?state=open&sort=updated&direction=asc` with a fixed budget of 10×100, but that listing interleaves the issues it can label with items it can only skip — and the skips are *permanent* residents of the oldest-updated-first window, so they accumulate at the front until no candidate is reachable.

Replaying the script's exact ten listing calls against this repo (2026-07-08), the full 1,000-item window contained:

| category | count | leaves the window? |
|---|---|---|
| open pull requests | 469 | never (PRs aren't swept) |
| issues with ≥10 👍 (`STALE_UPVOTE_THRESHOLD`) | 434 | never |
| already `stale`/`autoclose` | 114 | only when closed |
| assigned | 53 | rarely |
| locked | 2 | never |
| **labelable candidates** | **0** | — |

The newest item in the window was updated **2026-05-07 — seven weeks short of the 14-day cutoff**. Meanwhile `is:issue is:open updated:<2026-06-25 -label:stale -label:autoclose no:assignee` matches **3,002 issues** the sweep should be nudging but can never reach. Since `markStale` feeds `closeExpired` (stale → 14 d → close), the lifecycle pipeline is stalled for new issues, and the window only grows more clogged as more PRs and popular issues age into it.

Two smaller defects in the same pattern:

- **Mutating while offset-paginating.** Labeling an issue (plus the nudge comment `issue-lifecycle-comment.yml` posts in response) bumps `updated_at`, reordering the ascending-sorted listing mid-walk; in `closeExpired`, closing an issue *removes* it from the `labels=`-filtered listing. Either way, each mutation on page N shifts the remaining pages left, so the `page=N+1` fetch skips one issue per mutation. Same bug class #69470 fixed in `lock-closed-issues.yml`.
- **`closeExpired`'s 10-page cap is too small**: `label:stale` alone currently lists ~1,490 open issues (15 pages), so the oldest ~500 are never even examined.

## Fix

- **`markStale` asks the search API for exactly the labelable set** (`is:issue is:open updated:<cutoff -label:stale -label:autoclose no:assignee`, oldest-updated first) — the same approach as #69470. PRs, upvoted, assigned, and already-labeled issues no longer occupy the window. A client-side predicate re-checks every condition (the search index can lag) plus the two search can't express: the exact cutoff time (search's `updated:` is date-granular) and the 👍-specific threshold (search's `reactions:` counts all reaction kinds).
- **Per-run write cap (250) with 1 s pacing**, matching `lock-closed-issues.yml`, so the backlog drains across scheduled runs without tripping secondary rate limits. Search fetches are paced (2 s) and retried with backoff on 403/429 — search's secondary limit is burst-sensitive.
- **`closeExpired` snapshots the full listing before closing anything** (up to 30 pages), so closes can't shift pages underneath the walk, and the current stale backlog fits.
- Decision logic lives in `scripts/sweep-lib.ts` with unit tests (`bun test scripts/sweep-lib.test.ts`, no network), following the `issue-lifecycle.ts` shared-module pattern.

The per-issue close logic (events → `labeledAt`, human-comment safety net) is deliberately untouched: #75541 is improving events handling there, and this PR stays out of its way — the two compose.

## Verification

- `bun test scripts/sweep-lib.test.ts` — 18 pass, no network.
- The measurement above **is** the old `markStale`'s exact walk (same endpoint, same filters, same page budget): deterministically 0 labels per run.
- Live read-only `--dry-run` of the new code against this repo immediately surfaces real candidates and stops at the per-run cap:

```
=== marking stale (14d inactive) ===
#67586: would label stale (26d inactive) — [BUG] Claude Code installer places `claude.exe` in bin/ on Linux, install script does not create working symlink
#67728: would label stale (26d inactive) — [BUG] + [RFC] Tasks run forever: 7-layer architectural root cause + permanent fix proposal (PALMS)
#61927: would label stale (26d inactive) — [BUG] "Pull request status couldn't be checked" banner persistently appears on every session in worktree branches without an associated PR
...
(250 candidates — stopped at the per-run cap)
```

The `closeExpired` phase of the same dry-run walks the snapshot listing and surfaces real work as well (`#57930: would close (stale, 14d old)`, `#23012: skipping (human activity after stale label)`, …). The run also happened to exercise the retry path end-to-end: the token had a hot secondary rate limit, and the search fetches backed off and completed instead of killing the run.

With the cap at 250 and the sweep scheduled twice daily, the ~3,000-issue backlog drains in about six days, then the sweep returns to a steady trickle.


