### PR TITLE
fix: detect GitHub Actions CI using directory test in load-context ex…

### DIFF
--- a/plugins/plugin-dev/skills/hook-development/examples/load-context.sh
+++ b/plugins/plugin-dev/skills/hook-development/examples/load-context.sh
@@ -47,7 +47,7 @@ else
 fi
 
 # Check for CI configuration
-if [ -f ".github/workflows" ] || [ -f ".gitlab-ci.yml" ] || [ -f ".circleci/config.yml" ]; then
+if [ -d ".github/workflows" ] || [ -f ".gitlab-ci.yml" ] || [ -f ".circleci/config.yml" ]; then
   echo "export HAS_CI=true" >> "$CLAUDE_ENV_FILE"
 fi
 


### PR DESCRIPTION
…ample

The SessionStart hook example tested `.github/workflows` with `-f` (regular file), but it is always a directory. As a result the GitHub Actions branch of the CI-detection check could never be true, so HAS_CI was not set for GitHub-based projects.

Use `-d` for the `.github/workflows` directory. The GitLab and CircleCI checks remain `-f` since those are files.