### PR TITLE
docs(plugin-dev): fix stale marketplace name in README install instructions

### DIFF
--- a/plugins/plugin-dev/README.md
+++ b/plugins/plugin-dev/README.md
@@ -195,10 +195,10 @@ Use this workflow for structured, high-quality plugin development from concept t
 
 ## Installation
 
-Install from claude-code-marketplace:
+Install from the official marketplace:
 
 ```bash
-/plugin install plugin-dev@claude-code-marketplace
+/plugin install plugin-dev@claude-plugins-official
 ```
 
 Or for development, use directly:
@@ -378,7 +378,7 @@ All skills emphasize:
 
 ## Contributing
 
-This plugin is part of the claude-code-marketplace. To contribute improvements:
+This plugin is part of the official Claude Code plugins marketplace. To contribute improvements:
 
 1. Fork the marketplace repository
 2. Make changes to plugin-dev/


### PR DESCRIPTION
## Summary

Fixes #70064.

`plugins/plugin-dev/README.md` told users to install from `plugin-dev@claude-code-marketplace`, which does not match the marketplace naming used elsewhere in the bundled plugin docs. For example, `plugins/security-guidance/README.md` documents installation as `security-guidance@claude-plugins-official`. A user following the plugin-dev README would try a marketplace name that is inconsistent with the rest of the repo.

## Changes

Docs-only, limited to `plugins/plugin-dev/README.md`:

```diff
-Install from claude-code-marketplace:
+Install from the official marketplace:

-/plugin install plugin-dev@claude-code-marketplace
+/plugin install plugin-dev@claude-plugins-official
```

Also updated the "Contributing" line that referenced `claude-code-marketplace` to describe the official marketplace in prose.

## Verification

- `grep` confirms no `claude-code-marketplace` references remain in the file.
- The install command now matches the existing `@claude-plugins-official` convention already used by `plugins/security-guidance/README.md`.