### PR TITLE
docs(plugin-dev): use flat format in .mcp.json example

### DIFF
--- a/plugins/plugin-dev/skills/plugin-structure/examples/advanced-plugin.md
+++ b/plugins/plugin-dev/skills/plugin-structure/examples/advanced-plugin.md
@@ -146,30 +146,28 @@ enterprise-devops/
 
 ```json
 {
-  "mcpServers": {
-    "kubernetes": {
-      "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/servers/kubernetes-mcp/index.js"],
-      "env": {
-        "KUBECONFIG": "${KUBECONFIG}",
-        "K8S_NAMESPACE": "${K8S_NAMESPACE:-default}"
-      }
-    },
-    "terraform": {
-      "command": "python",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/servers/terraform-mcp/main.py"],
-      "env": {
-        "TF_STATE_BUCKET": "${TF_STATE_BUCKET}",
-        "AWS_REGION": "${AWS_REGION}"
-      }
-    },
-    "github-actions": {
-      "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/servers/github-actions-mcp/server.js"],
-      "env": {
-        "GITHUB_TOKEN": "${GITHUB_TOKEN}",
-        "GITHUB_ORG": "${GITHUB_ORG}"
-      }
+  "kubernetes": {
+    "command": "node",
+    "args": ["${CLAUDE_PLUGIN_ROOT}/servers/kubernetes-mcp/index.js"],
+    "env": {
+      "KUBECONFIG": "${KUBECONFIG}",
+      "K8S_NAMESPACE": "${K8S_NAMESPACE:-default}"
+    }
+  },
+  "terraform": {
+    "command": "python",
+    "args": ["${CLAUDE_PLUGIN_ROOT}/servers/terraform-mcp/main.py"],
+    "env": {
+      "TF_STATE_BUCKET": "${TF_STATE_BUCKET}",
+      "AWS_REGION": "${AWS_REGION}"
+    }
+  },
+  "github-actions": {
+    "command": "node",
+    "args": ["${CLAUDE_PLUGIN_ROOT}/servers/github-actions-mcp/server.js"],
+    "env": {
+      "GITHUB_TOKEN": "${GITHUB_TOKEN}",
+      "GITHUB_ORG": "${GITHUB_ORG}"
     }
   }
 }


### PR DESCRIPTION
## Summary

Related to #63694.

The `advanced-plugin` example in the plugin-dev skill showed a plugin's `.mcp.json` file wrapped in an `mcpServers` object:

```json
{
  "mcpServers": {
    "kubernetes": { ... }
  }
}
```

That `mcpServers` envelope is a **`plugin.json`** concept (it can be a path string or an inline object). The standalone **`.mcp.json`** file uses the **flat** format, where each server name is a top-level key. The wrapped example was inconsistent with:

- This repo's own `plugins/plugin-dev/skills/mcp-integration/SKILL.md`, which already shows `.mcp.json` in flat format, and
- All official plugins in `anthropics/claude-plugins-official`.

This is the same conflation reported for the hosted docs in #63694, present here in the bundled skill content.

## Change

Docs-only, limited to `plugins/plugin-dev/skills/plugin-structure/examples/advanced-plugin.md` — the `### .mcp.json` block is unwrapped so each server is a top-level key.

## Verification

- The corrected block parses as valid JSON with top-level keys `kubernetes`, `terraform`, `github-actions` and no `mcpServers` wrapper.
- Now matches the flat `.mcp.json` format shown in `skills/mcp-integration/SKILL.md`.