### PR TITLE
Flag innerHTML/outerHTML += append sink in security-guidance

### DIFF
--- a/plugins/security-guidance/hooks/patterns.py
+++ b/plugins/security-guidance/hooks/patterns.py
@@ -117,7 +117,10 @@ Only use exec() if you absolutely need shell features and the input is guarantee
     },
     {
         "ruleName": "innerHTML_xss",
-        "substrings": [".innerHTML =", ".innerHTML="],
+        # Flag assignment and the `+=` append sink (the most common innerHTML XSS
+        # pattern), tolerating any whitespace; the `(?!=)` lookahead avoids firing
+        # on `==`/`===` comparisons.
+        "regex": r"\.innerHTML\s*\+?=(?!=)",
         "reminder": "⚠️ Security Warning: Setting innerHTML with untrusted content can lead to XSS vulnerabilities. Use textContent for plain text or safe DOM methods for HTML content. If you need HTML support, consider using an HTML sanitizer library such as DOMPurify.",
     },
     {
@@ -217,7 +220,7 @@ Additionally, validate user inputs:
     },
     {
         "ruleName": "outerHTML_xss",
-        "substrings": [".outerHTML =", ".outerHTML="],
+        "regex": r"\.outerHTML\s*\+?=(?!=)",
         "reminder": "⚠️ Security Warning: Use textContent or sanitize with DOMPurify. outerHTML assignment is an XSS sink equivalent to innerHTML.",
     },
     {

--- a/plugins/security-guidance/hooks/tests/test_innerhtml_patterns.py
+++ b/plugins/security-guidance/hooks/tests/test_innerhtml_patterns.py
@@ -1,0 +1,56 @@
+"""Regression tests for the innerHTML/outerHTML XSS warning patterns.
+
+Both `innerHTML_xss` and `outerHTML_xss` guard the same class of DOM sink -
+assigning untrusted HTML to `.innerHTML` / `.outerHTML` - so they are tested
+symmetrically here across every assignment/append/whitespace variant, plus the
+comparisons and reads that must NOT fire.
+
+Run with: python -m pytest plugins/security-guidance/hooks/tests
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from security_reminder_hook import check_patterns
+
+
+def _rules(content):
+    return {rule for rule, _ in check_patterns("a.js", content)}
+
+
+# (property, ruleName) - both sinks are handled identically.
+SINKS = [("innerHTML", "innerHTML_xss"), ("outerHTML", "outerHTML_xss")]
+
+# Assignment forms that ARE an HTML sink and must be flagged.
+SINK_EXPRS = [
+    "el.{p} = userInput",  # plain assignment
+    "el.{p} += userInput",  # append sink (the main gap)
+    "el.{p}+=userInput",  # append, no surrounding spaces
+    "el.{p}  =  userInput",  # multiple spaces
+    "el.{p}\t= userInput",  # tab
+    "obj?.{p} = userInput",  # optional chaining still assigns
+]
+
+# Forms that are NOT a sink (reads / comparisons) and must NOT be flagged.
+NON_SINK_EXPRS = [
+    "if (el.{p} == other) {{}}",  # loose comparison
+    "if (el.{p} === '') {{}}",  # strict comparison
+    "const html = el.{p};",  # read-only access
+    "return el.{p};",  # read-only access
+]
+
+
+@pytest.mark.parametrize("prop,rule", SINKS)
+@pytest.mark.parametrize("expr", SINK_EXPRS)
+def test_assignment_sinks_are_flagged(prop, rule, expr):
+    assert rule in _rules(expr.format(p=prop))
+
+
+@pytest.mark.parametrize("prop,rule", SINKS)
+@pytest.mark.parametrize("expr", NON_SINK_EXPRS)
+def test_non_sinks_are_not_flagged(prop, rule, expr):
+    assert rule not in _rules(expr.format(p=prop))


### PR DESCRIPTION
No linked issue — found while reading the security-guidance patterns.

## Summary

The `innerHTML_xss` and `outerHTML_xss` rules in `plugins/security-guidance/hooks/patterns.py` match by substring:

```python
"substrings": [".innerHTML =", ".innerHTML="],
```

This misses `el.innerHTML += userInput` — the most common DOM-XSS *append* sink. `+=` desugars to `x = x + …`, which re-parses the whole value as HTML, so it's an innerHTML assignment and squarely within the rule's stated scope (*"Setting innerHTML with untrusted content can lead to XSS"*). Tab- and multi-space-separated assignments (`el.innerHTML  =  x`) are missed too. Separately, the substring `.innerHTML =` also matches `.innerHTML ==` / `=== ` comparisons, which are reads rather than sinks — a false positive.

Observed through the shipped `check_patterns`:

```
el.innerHTML = x            -> innerHTML_xss   (ok)
el.innerHTML += x           -> (nothing)       <- missed sink
container.outerHTML += x    -> (nothing)       <- missed sink
node.innerHTML  =  x        -> (nothing)       <- missed sink
if (el.innerHTML === '')    -> innerHTML_xss   <- false positive
```

## Fix

Replace the two substring lists with a regex, matching the plugin's own regex-rule style (used by ~20 other rules):

```python
"regex": r"\.innerHTML\s*\+?=(?!=)",
```

`\s*` absorbs tabs/extra spaces, `\+?` catches `+=`, and the `(?!=)` lookahead skips `==`/`===` comparisons (fixing the false positive too). After the change all five cases above behave correctly, and read-only access (`const x = el.innerHTML`) is still not flagged.

`innerHTML_xss` and `outerHTML_xss` were the only two rules using the assignment-substring form `[".X =", ".X="]`, so both are covered here. I also checked the other `regex` rules that match `=` (`verify=False`, `shell=True`, `weights_only=True`, …): those are boolean/kwarg flags with no meaningful `+=` form, so they don't share this gap.

## Test

Adds `plugins/security-guidance/hooks/tests/test_innerhtml_patterns.py` (the plugin previously shipped no tests). It parametrizes **both** rules across every sink form — plain `=`, `+=`, no-space `+=`, multi-space, tab, and optional chaining (`obj?.innerHTML =`) — and every non-sink form that must stay quiet — `==`, `===`, and read-only access. 20 cases; it fails on the current code (12 of 20) and passes with the fix.
