### PR TITLE
fix(plugins): harden YAML, path, and symlink handling in scripts

### DIFF
--- a/plugins/plugin-dev/skills/hook-development/examples/load-context.sh
+++ b/plugins/plugin-dev/skills/hook-development/examples/load-context.sh
@@ -7,6 +7,17 @@ set -euo pipefail
 # Navigate to project directory
 cd "$CLAUDE_PROJECT_DIR" || exit 1
 
+# SessionStart hooks persist env via CLAUDE_ENV_FILE. Require a real path and
+# refuse symlinks so a planted link cannot redirect writes into credential files.
+if [[ -z "${CLAUDE_ENV_FILE:-}" ]]; then
+  echo "CLAUDE_ENV_FILE is not set; skipping env persistence" >&2
+  exit 0
+fi
+if [[ -L "$CLAUDE_ENV_FILE" ]]; then
+  echo "Refusing to write through symlink CLAUDE_ENV_FILE=$CLAUDE_ENV_FILE" >&2
+  exit 1
+fi
+
 echo "Loading project context..."
 
 # Detect project type and set environment

--- a/plugins/plugin-dev/skills/hook-development/references/patterns.md
+++ b/plugins/plugin-dev/skills/hook-development/references/patterns.md
@@ -71,6 +71,11 @@ Load project-specific context at session start:
 #!/bin/bash
 cd "$CLAUDE_PROJECT_DIR" || exit 1
 
+# Require a real CLAUDE_ENV_FILE path; refuse symlink redirect (credential overwrite).
+if [[ -z "${CLAUDE_ENV_FILE:-}" || -L "$CLAUDE_ENV_FILE" ]]; then
+  exit 1
+fi
+
 # Detect project type
 if [ -f "package.json" ]; then
   echo "📦 Node.js project detected"

--- a/plugins/plugin-dev/skills/plugin-settings/scripts/parse-frontmatter.sh
+++ b/plugins/plugin-dev/skills/plugin-settings/scripts/parse-frontmatter.sh
@@ -27,7 +27,11 @@ fi
 FILE="$1"
 FIELD="${2:-}"
 
-# Validate file
+# Validate file (do not follow/operate on symlinks for credential-adjacent settings)
+if [ -L "$FILE" ]; then
+  echo "Error: Refusing to read symlink settings file: $FILE" >&2
+  exit 1
+fi
 if [ ! -f "$FILE" ]; then
   echo "Error: File not found: $FILE" >&2
   exit 1
@@ -45,6 +49,13 @@ fi
 if [ -z "$FIELD" ]; then
   echo "$FRONTMATTER"
   exit 0
+fi
+
+# Field is used in grep/sed patterns — allow only safe identifiers to prevent
+# regex metacharacter injection (e.g. FIELD='.*|evil').
+if ! [[ "$FIELD" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+  echo "Error: Field name must be a simple identifier (got: $FIELD)" >&2
+  exit 1
 fi
 
 # Extract specific field

--- a/plugins/ralph-wiggum/hooks/stop-hook.sh
+++ b/plugins/ralph-wiggum/hooks/stop-hook.sh
@@ -55,14 +55,39 @@ if [[ $MAX_ITERATIONS -gt 0 ]] && [[ $ITERATION -ge $MAX_ITERATIONS ]]; then
 fi
 
 # Get transcript path from hook input
-TRANSCRIPT_PATH=$(echo "$HOOK_INPUT" | jq -r '.transcript_path')
+TRANSCRIPT_PATH=$(echo "$HOOK_INPUT" | jq -r '.transcript_path // empty')
+
+# Validate transcript path before reading. A missing/null path, path traversal,
+# or symlink to an unintended target must not be followed as a data source.
+if [[ -z "$TRANSCRIPT_PATH" || "$TRANSCRIPT_PATH" == "null" ]]; then
+  echo "⚠️  Ralph loop: Transcript path missing from hook input" >&2
+  echo "   Ralph loop is stopping." >&2
+  rm -f "$RALPH_STATE_FILE"
+  exit 0
+fi
+
+if [[ "$TRANSCRIPT_PATH" == *'..'* ]]; then
+  echo "⚠️  Ralph loop: Transcript path contains '..' — refusing to read" >&2
+  echo "   Path: $TRANSCRIPT_PATH" >&2
+  echo "   Ralph loop is stopping." >&2
+  rm -f "$RALPH_STATE_FILE"
+  exit 0
+fi
+
+if [[ -L "$TRANSCRIPT_PATH" ]]; then
+  echo "⚠️  Ralph loop: Transcript path is a symlink — refusing to follow" >&2
+  echo "   Path: $TRANSCRIPT_PATH" >&2
+  echo "   Ralph loop is stopping." >&2
+  rm -f "$RALPH_STATE_FILE"
+  exit 0
+fi
 
 if [[ ! -f "$TRANSCRIPT_PATH" ]]; then
   echo "⚠️  Ralph loop: Transcript file not found" >&2
   echo "   Expected: $TRANSCRIPT_PATH" >&2
   echo "   This is unusual and may indicate a Claude Code internal issue." >&2
   echo "   Ralph loop is stopping." >&2
-  rm "$RALPH_STATE_FILE"
+  rm -f "$RALPH_STATE_FILE"
   exit 0
 fi
 
@@ -150,9 +175,20 @@ if [[ -z "$PROMPT_TEXT" ]]; then
 fi
 
 # Update iteration in frontmatter (portable across macOS and Linux)
-# Create temp file, then atomically replace
+# Create temp file, then atomically replace. Refuse symlink destinations so a
+# planted link cannot redirect the state write outside the project.
+if [[ -L "$RALPH_STATE_FILE" ]]; then
+  echo "⚠️  Ralph loop: State file is a symlink — refusing to update" >&2
+  rm -f "$RALPH_STATE_FILE"
+  exit 0
+fi
 TEMP_FILE="${RALPH_STATE_FILE}.tmp.$$"
 sed "s/^iteration: .*/iteration: $NEXT_ITERATION/" "$RALPH_STATE_FILE" > "$TEMP_FILE"
+if [[ -L "$RALPH_STATE_FILE" ]]; then
+  rm -f "$TEMP_FILE"
+  echo "⚠️  Ralph loop: State file became a symlink during update — aborting" >&2
+  exit 0
+fi
 mv "$TEMP_FILE" "$RALPH_STATE_FILE"
 
 # Build system message with iteration count and completion promise info

--- a/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
+++ b/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
@@ -130,14 +130,29 @@ fi
 # Create state file for stop hook (markdown with YAML frontmatter)
 mkdir -p .claude
 
-# Quote completion promise for YAML if it contains special chars or is not null
+# Quote completion promise for YAML if it contains special chars or is not null.
+# Escape backslashes and double quotes so untrusted promise text cannot break out
+# of the YAML string and inject extra frontmatter keys (e.g. active: false).
 if [[ -n "$COMPLETION_PROMISE" ]] && [[ "$COMPLETION_PROMISE" != "null" ]]; then
-  COMPLETION_PROMISE_YAML="\"$COMPLETION_PROMISE\""
+  COMPLETION_PROMISE_ESCAPED=${COMPLETION_PROMISE//\\/\\\\}
+  COMPLETION_PROMISE_ESCAPED=${COMPLETION_PROMISE_ESCAPED//\"/\\\"}
+  # Newlines would still break scalar YAML; flatten to spaces.
+  COMPLETION_PROMISE_ESCAPED=${COMPLETION_PROMISE_ESCAPED//$'\n'/ }
+  COMPLETION_PROMISE_ESCAPED=${COMPLETION_PROMISE_ESCAPED//$'\r'/ }
+  COMPLETION_PROMISE_YAML="\"$COMPLETION_PROMISE_ESCAPED\""
 else
   COMPLETION_PROMISE_YAML="null"
 fi
 
-cat > .claude/ralph-loop.local.md <<EOF
+# Refuse to write through a symlink — a planted link could redirect state into
+# an attacker-chosen path (credential overwrite / arbitrary file write).
+STATE_FILE=".claude/ralph-loop.local.md"
+if [[ -L "$STATE_FILE" ]]; then
+  echo "❌ Error: $STATE_FILE is a symlink; refusing to write for safety" >&2
+  exit 1
+fi
+
+cat > "$STATE_FILE" <<EOF
 ---
 active: true
 iteration: 1

--- a/plugins/security-guidance/hooks/session_state.py
+++ b/plugins/security-guidance/hooks/session_state.py
@@ -109,8 +109,23 @@ def save_state(session_id, state):
         if state_dir:
             os.makedirs(state_dir, exist_ok=True)
 
-        with open(state_file, "w") as f:
-            json.dump(state, f)
+        # Refuse to write through a symlink — a planted link under the state
+        # dir could redirect credential-adjacent session state into another file.
+        if os.path.islink(state_file):
+            debug_log(f"Refusing to write through symlink state file {state_file}")
+            return
+
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(state_file, flags, 0o600)
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(state, f)
+                fd = None  # fdopen owns the descriptor
+        finally:
+            if fd is not None:
+                os.close(fd)
     except (IOError, OSError) as e:
         debug_log(f"Failed to save state file {state_file}: {e}")
 


### PR DESCRIPTION
### Summary

Hardens official plugin scripts/examples against YAML frontmatter breakout, path traversal, and **symlink-based credential overwrite** patterns.

### Changes

| Area | Risk | Fix |
|------|------|-----|
| `ralph-wiggum` setup | YAML injection via `completion_promise` | Escape `\`/`\"`, flatten newlines; refuse symlink state file |
| `ralph-wiggum` stop-hook | Unvalidated `transcript_path` read | Reject empty/null, `..`, and symlinks; refuse symlink state updates |
| plugin-dev `load-context` example + docs | `CLAUDE_ENV_FILE` symlink redirect | Require set path; refuse if symlink |
| `parse-frontmatter.sh` | Field name → grep/sed metachar injection | Allow only `[A-Za-z_][A-Za-z0-9_]*`; refuse symlink settings files |
| security-guidance `session_state.py` | Symlink follow on state write | `O_NOFOLLOW` + mode `0600`; skip if target is symlink |

### Why this matters

These files are copy-pasted as reference implementations. Leaving symlink/YAML gaps teaches insecure defaults (and can overwrite secrets when a state/env path is a planted link). Related real-world pattern: credential writes through symlinks (#76561).

### Test plan

- [x] `bash -n` on all modified shell scripts
- [x] Manual demo: promise containing quotes/newlines no longer injects frontmatter keys
- [x] Symlink checks for state / env / settings paths

Fixes #76580