### PR TITLE
fix(plugin-dev): read full multi-line description in validate-agent.sh

### DIFF
--- a/plugins/plugin-dev/skills/agent-development/scripts/validate-agent.sh
+++ b/plugins/plugin-dev/skills/agent-development/scripts/validate-agent.sh
@@ -88,7 +88,15 @@ else
 fi
 
 # Check description field
-DESCRIPTION=$(echo "$FRONTMATTER" | grep '^description:' | sed 's/description: *//')
+# Extract the full (possibly multi-line) description block: from the
+# `description:` line up to the next known frontmatter key. A plain
+# `grep '^description:'` would capture only the first line, hiding the
+# <example> blocks that live on the continuation lines.
+DESCRIPTION=$(echo "$FRONTMATTER" | awk '
+  /^description:/ { found = 1; sub(/^description: */, ""); print; next }
+  found && /^(name|model|color|tools):/ { found = 0 }
+  found { print }
+')
 
 if [ -z "$DESCRIPTION" ]; then
   echo "❌ Missing required field: description"


### PR DESCRIPTION
## What

`plugins/plugin-dev/skills/agent-development/scripts/validate-agent.sh` extracts the agent's `description` frontmatter with:

```sh
DESCRIPTION=$(echo "$FRONTMATTER" | grep '^description:' | sed 's/description: *//')
```

`grep` is line-oriented, so this keeps only the **first physical line** of a multi-line YAML description and drops the continuation lines — which is exactly where the `<example>` blocks live. Two checks then misfire:

- `desc_length` is computed on the truncated first line.
- the `<example>` check (`grep -q '<example>'`) always fails.

So every agent with a multi-line description gets a bogus `⚠️  description should include <example> blocks for triggering` — including the repo's own `plugin-dev` agents (`agent-creator`, `plugin-validator`, `skill-reviewer`).

## Why it's more than cosmetic (Linux)

On Linux with bash ≥ 4.1, under the script's `set -euo pipefail`, the `((warning_count++))` that the false warning triggers evaluates to `0` on the first increment, returns exit status 1, and **aborts the script**. Running the shipped validator on the repo's own `agent-creator.md` in `bash:5.2`:

**before** — dies right after the false warning, no summary, exit 1:
```
✅ description: 244 characters
⚠️  description should include <example> blocks for triggering
# (script aborts here; exit code 1)
```
**after** — runs to completion, exit 0:
```
✅ All checks passed!
```

(On macOS bash 3.2 the script doesn't errexit on `(( ))`, so there the same bug surfaces as just the false warning.)

## The fix

Extract the full description block — from the `description:` line up to the next **known** frontmatter key — so the length and `<example>` checks run on the complete value:

```sh
DESCRIPTION=$(echo "$FRONTMATTER" | awk '
  /^description:/ { found = 1; sub(/^description: */, ""); print; next }
  found && /^(name|model|color|tools):/ { found = 0 }
  found { print }
')
```

It stops only at `name`/`model`/`color`/`tools`, **not** at generic `word:` lines, because `<example>` blocks contain column-0 `Context:` / `user:` / `assistant:` lines that a naive next-key match would trip on.

## Verification

Before/after on all 15 `plugins/**/agents/*.md`:

- **3** false warnings removed (`agent-creator`, `plugin-validator`, `skill-reviewer`)
- `code-simplifier` — reported character count corrected (no warning or exit-code change)
- **11** files produce byte-identical output; **no exit-code changes** anywhere
- `bash -n` clean; the `awk` program works on BSD awk (macOS) and busybox awk (Alpine)

## Out of scope (noted, not fixed here)

The same script has a separate, pre-existing fragility: under `set -euo pipefail`, `grep '^field:'` for a missing field and `((count++))` from `0` can each abort the script independently of this bug. Fixing that touches ~12 sites and is a larger change, so I've kept this PR focused. Happy to follow up if that would be useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
