### PR TITLE
fix(scripts): preserve existing labels when auto-closing duplicate issues

### DIFF
--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -70,14 +70,26 @@ async function closeIssueAsDuplicate(
   duplicateOfNumber: number,
   token: string
 ): Promise<void> {
+  // Add the `duplicate` label WITHOUT clobbering the issue's existing labels.
+  // The "Update an issue" endpoint's `labels` field *replaces* the whole label
+  // set, so passing it in the PATCH below would wipe every triage label
+  // (bug, area:*, platform:*, priority, ...). "Add labels to an issue" appends.
+  await githubRequest(
+    `/repos/${owner}/${repo}/issues/${issueNumber}/labels`,
+    token,
+    'POST',
+    {
+      labels: ['duplicate']
+    }
+  );
+
   await githubRequest(
     `/repos/${owner}/${repo}/issues/${issueNumber}`,
     token,
     'PATCH',
     {
       state: 'closed',
-      state_reason: 'duplicate',
-      labels: ['duplicate']
+      state_reason: 'duplicate'
     }
   );
 


### PR DESCRIPTION
## What

`scripts/auto-close-duplicates.ts` closes each detected duplicate with a single `PATCH /repos/{owner}/{repo}/issues/{n}`:

```ts
{
  state: 'closed',
  state_reason: 'duplicate',
  labels: ['duplicate']   // replaces the issue's ENTIRE label set
}
```

Per GitHub's REST API, the **Update an issue** endpoint's `labels` field *replaces* the full label set — [docs](https://docs.github.com/en/rest/issues/issues#update-an-issue): *"Pass one or more labels to replace the set of labels on this issue."*

So every issue auto-closed as a duplicate has **all of its other labels silently wiped** (`bug`, `area:*`, `platform:*`, priority, `needs-info`, …), leaving only `duplicate`. That destroys triage/analytics metadata on closed issues. This script runs in `.github/workflows/auto-close-duplicates.yml`.

## The fix

Add the `duplicate` label with the **Add labels to an issue** endpoint (`POST /issues/{n}/labels`), which *appends* to the existing labels — [docs](https://docs.github.com/en/rest/issues/labels#add-labels-to-an-issue): *"the labels to add to the issue's existing labels"* — and drop `labels` from the `PATCH` so it only closes the issue and sets `state_reason: 'duplicate'`:

```ts
// append — preserves existing labels
POST  /repos/{owner}/{repo}/issues/{n}/labels   { labels: ['duplicate'] }
// then close
PATCH /repos/{owner}/{repo}/issues/{n}          { state: 'closed', state_reason: 'duplicate' }
```

The label is added **before** the close so a partial failure leaves the issue open and retryable, rather than closed without its triage metadata.

## Verification

- The clobber was the only `labels` reference in the file — single-site change.
- Transpiles cleanly under `bun` (the script's runtime).
- Behavior is grounded in the two official GitHub REST endpoints linked above (replace vs. append). The script mutates production issues, so it isn't run live here; the fix relies on documented endpoint semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
