### PR TITLE
Fix hookify prompt rules on Windows: utf-8 encoding + prompt field

### DIFF
--- a/plugins/hookify/core/config_loader.py
+++ b/plugins/hookify/core/config_loader.py
@@ -248,7 +248,7 @@ def load_rule_file(file_path: str) -> Optional[Rule]:
         Rule object or None if file is invalid.
     """
     try:
-        with open(file_path, 'r') as f:
+        with open(file_path, 'r', encoding='utf-8') as f:
             content = f.read()
 
         frontmatter, message = extract_frontmatter(content)

--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -209,7 +209,7 @@ class RuleEngine:
                 transcript_path = input_data.get('transcript_path')
                 if transcript_path:
                     try:
-                        with open(transcript_path, 'r') as f:
+                        with open(transcript_path, 'r', encoding='utf-8') as f:
                             return f.read()
                     except FileNotFoundError:
                         print(f"Warning: Transcript file not found: {transcript_path}", file=sys.stderr)
@@ -224,8 +224,10 @@ class RuleEngine:
                         print(f"Warning: Encoding error in transcript {transcript_path}: {e}", file=sys.stderr)
                         return ''
             elif field == 'user_prompt':
-                # For UserPromptSubmit events
-                return input_data.get('user_prompt', '')
+                # For UserPromptSubmit events. Claude Code sends the prompt under
+                # the key 'prompt'; accept 'user_prompt' too for backward compat
+                # with existing rule files that reference it.
+                return input_data.get('user_prompt') or input_data.get('prompt') or ''
 
         # Handle special cases by tool type
         if tool_name == 'Bash':


### PR DESCRIPTION
Fixes #77270

## Problem

The `hookify` plugin's `UserPromptSubmit` rules silently never fire. The hook returns `{}` and injects nothing, so user-defined prompt gates are dead. Because the exit code is 0 with valid JSON, there's no signal that a rule failed to load.

Two root causes in `plugins/hookify/core/`:

**1. Files opened without `encoding='utf-8'`**
- `config_loader.py:251` — `open(file_path, 'r')`
- `rule_engine.py:212` — `open(transcript_path, 'r')`

On Windows the default codec is cp1252. Rule `.local.md` files are UTF-8 and commonly contain arrows, emoji, and em-dashes, so decoding raises `UnicodeDecodeError`, which is caught in `load_rule_file` and the rule is silently dropped.

**2. Wrong field name — kills every prompt rule**
`rule_engine.py:228` read `input_data.get('user_prompt', '')`, but Claude Code's `UserPromptSubmit` payload puts the prompt under the key `prompt`, not `user_prompt`. So `field: user_prompt` conditions always extracted `''`, the regex never matched, and no rule fired — independent of the encoding bug.

## Fix

- Open rule files and transcript files with `encoding='utf-8'`.
- Fall back to the `prompt` key the payload actually contains, while still accepting `user_prompt` so existing rule files keep working without edits:
  ```python
  return input_data.get('user_prompt') or input_data.get('prompt') or ''
  ```

## Verification

Ran the issue's repro against the patched code with a UTF-8 rule file using `field: user_prompt` and a `prompt` payload key — the rule now fires (emits a `systemMessage`) instead of the pre-fix empty `{}`.