### PR TITLE
docs(plugins): use correct marketplace name in plugin READMEs

### DIFF
--- a/plugins/plugin-dev/README.md
+++ b/plugins/plugin-dev/README.md
@@ -195,10 +195,10 @@ Use this workflow for structured, high-quality plugin development from concept t
 
 ## Installation
 
-Install from claude-code-marketplace:
+Install from claude-code-plugins:
 
 ```bash
-/plugin install plugin-dev@claude-code-marketplace
+/plugin install plugin-dev@claude-code-plugins
 ```
 
 Or for development, use directly:
@@ -378,7 +378,7 @@ All skills emphasize:
 
 ## Contributing
 
-This plugin is part of the claude-code-marketplace. To contribute improvements:
+This plugin is part of the claude-code-plugins marketplace. To contribute improvements:
 
 1. Fork the marketplace repository
 2. Make changes to plugin-dev/

--- a/plugins/security-guidance/README.md
+++ b/plugins/security-guidance/README.md
@@ -11,7 +11,7 @@ Findings cover common web-vulnerability classes — injection, XSS, SSRF, hardco
 ## Install
 
 ```
-/plugin install security-guidance@claude-plugins-official
+/plugin install security-guidance@claude-code-plugins
 ```
 
 Marketplace ships enabled by default in Claude Code — no setup beyond having the CLI itself.


### PR DESCRIPTION
Fixes #70064

## Problem

The bundled marketplace is named **`claude-code-plugins`** in `.claude-plugin/marketplace.json`, and that is the name `/plugin install <plugin>@<marketplace>` resolves against. Two plugin READMEs documented install commands with names that don't match it, so following them fails:

| File | Documented name | Correct? |
|------|-----------------|----------|
| `.claude-plugin/marketplace.json` (`name`) | `claude-code-plugins` | ✅ authoritative |
| `plugins/plugin-dev/README.md` | `claude-code-marketplace` | ❌ |
| `plugins/security-guidance/README.md` | `claude-plugins-official` | ❌ |

The issue (#70064) reports the `plugin-dev` case and suggests matching `security-guidance`'s `claude-plugins-official`. But that name is *also* wrong — it isn't the marketplace's registered name either. This PR fixes both READMEs to the actual name in `marketplace.json`.

## Changes

- `plugins/plugin-dev/README.md`: `claude-code-marketplace` → `claude-code-plugins` (install command + contributing note)
- `plugins/security-guidance/README.md`: `claude-plugins-official` → `claude-code-plugins`

## Verification

`grep -rn "claude-code-marketplace\|claude-plugins-official" plugins/*/README.md` now returns nothing; every plugin README install command matches the `name` field in `.claude-plugin/marketplace.json`.