### PR TITLE
fix: repair issue-automation telemetry and dead days_back input

### DIFF
--- a/.github/workflows/claude-dedupe-issues.yml
+++ b/.github/workflows/claude-dedupe-issues.yml
@@ -72,7 +72,7 @@ jobs:
                   triggered_by: $triggered_by,
                   workflow_run_id: $workflow_run_id
                 },
-                time: (now | floor | tostring)
+                time: (now * 1000 | floor | tostring)
               }]
             }')
           

--- a/.github/workflows/log-issue-events.yml
+++ b/.github/workflows/log-issue-events.yml
@@ -21,20 +21,30 @@ jobs:
         run: |
           # All values are now safely passed via environment variables
           # No direct templating in the shell script to prevent injection attacks
-          
+
+          # Build the payload with jq so titles containing quotes, backslashes,
+          # or control characters can't produce invalid JSON
+          EVENT_PAYLOAD=$(jq -n \
+            --arg issue_number "$ISSUE_NUMBER" \
+            --arg repo "$REPO" \
+            --arg title "$ISSUE_TITLE" \
+            --arg author "$AUTHOR" \
+            --arg created_at "$CREATED_AT" \
+            '{
+              events: [{
+                eventName: "github_issue_created",
+                metadata: {
+                  issue_number: $issue_number,
+                  repository: $repo,
+                  title: $title,
+                  author: $author,
+                  created_at: $created_at
+                },
+                time: (now * 1000 | floor)
+              }]
+            }')
+
           curl -X POST "https://events.statsigapi.net/v1/log_event" \
             -H "Content-Type: application/json" \
             -H "statsig-api-key: $STATSIG_API_KEY" \
-            -d '{
-              "events": [{
-                "eventName": "github_issue_created",
-                "metadata": {
-                  "issue_number": "'"$ISSUE_NUMBER"'",
-                  "repository": "'"$REPO"'",
-                  "title": "'"$(echo "$ISSUE_TITLE" | sed "s/\"/\\\\\"/g")"'",
-                  "author": "'"$AUTHOR"'",
-                  "created_at": "'"$CREATED_AT"'"
-                },
-                "time": '"$(date +%s)000"'
-              }]
-            }'
+            -d "$EVENT_PAYLOAD"

--- a/scripts/backfill-duplicate-comments.ts
+++ b/scripts/backfill-duplicate-comments.ts
@@ -82,19 +82,36 @@ Usage:
 Environment Variables:
   GITHUB_TOKEN - GitHub personal access token with repo and actions permissions (required)
   DRY_RUN - Set to "false" to actually trigger workflows (default: true for safety)
-  MAX_ISSUE_NUMBER - Only process issues with numbers less than this value (default: 4050)`);
+  DAYS_BACK - Only process issues created in the last N days (default: no date filter)
+  MAX_ISSUE_NUMBER - Only process issues with numbers less than this value (default: 4050, or no cap when DAYS_BACK is set)`);
   }
   console.log("[DEBUG] GitHub token found");
 
   const owner = "anthropics";
   const repo = "claude-code";
   const dryRun = process.env.DRY_RUN !== "false";
-  const maxIssueNumber = parseInt(process.env.MAX_ISSUE_NUMBER || "4050", 10);
+
+  let cutoffTime: number | undefined;
+  if (process.env.DAYS_BACK) {
+    const daysBack = parseInt(process.env.DAYS_BACK, 10);
+    if (!Number.isInteger(daysBack) || daysBack <= 0) {
+      throw new Error(`DAYS_BACK must be a positive integer (got: "${process.env.DAYS_BACK}")`);
+    }
+    cutoffTime = Date.now() - daysBack * 24 * 60 * 60 * 1000;
+  }
+
+  // The issue-number cap is a legacy default from the original backfill run;
+  // don't apply it when the caller asked for a date window instead
+  const defaultMaxIssueNumber = cutoffTime === undefined ? "4050" : `${Number.MAX_SAFE_INTEGER}`;
+  const maxIssueNumber = parseInt(process.env.MAX_ISSUE_NUMBER || defaultMaxIssueNumber, 10);
   const minIssueNumber = parseInt(process.env.MIN_ISSUE_NUMBER || "1", 10);
-  
+
   console.log(`[DEBUG] Repository: ${owner}/${repo}`);
   console.log(`[DEBUG] Dry run mode: ${dryRun}`);
   console.log(`[DEBUG] Looking at issues between #${minIssueNumber} and #${maxIssueNumber}`);
+  if (cutoffTime !== undefined) {
+    console.log(`[DEBUG] Only processing issues created after ${new Date(cutoffTime).toISOString()} (DAYS_BACK=${process.env.DAYS_BACK})`);
+  }
 
   console.log(`[DEBUG] Fetching issues between #${minIssueNumber} and #${maxIssueNumber}...`);
   const allIssues: GitHubIssue[] = [];
@@ -110,14 +127,20 @@ Environment Variables:
     if (pageIssues.length === 0) break;
     
     // Filter to only include issues within the specified range
-    const filteredIssues = pageIssues.filter(issue => 
-      issue.number >= minIssueNumber && issue.number < maxIssueNumber
+    const filteredIssues = pageIssues.filter(issue =>
+      issue.number >= minIssueNumber && issue.number < maxIssueNumber &&
+      (cutoffTime === undefined || new Date(issue.created_at).getTime() >= cutoffTime)
     );
     allIssues.push(...filteredIssues);
-    
+
     // If the oldest issue in this page is still above our minimum, we need to continue
     // but if the oldest issue is below our minimum, we can stop
     const oldestIssueInPage = pageIssues[pageIssues.length - 1];
+    // Pages are sorted by created desc, so once we're past the date cutoff we're done
+    if (oldestIssueInPage && cutoffTime !== undefined && new Date(oldestIssueInPage.created_at).getTime() < cutoffTime) {
+      console.log(`[DEBUG] Oldest issue in page #${page} (#${oldestIssueInPage.number}) is older than the DAYS_BACK cutoff, stopping`);
+      break;
+    }
     if (oldestIssueInPage && oldestIssueInPage.number >= maxIssueNumber) {
       console.log(`[DEBUG] Oldest issue in page #${page} is #${oldestIssueInPage.number}, continuing...`);
     } else if (oldestIssueInPage && oldestIssueInPage.number < minIssueNumber) {


### PR DESCRIPTION
Three small correctness fixes in the issue-automation workflows, found by cross-checking the workflows against the scripts they invoke and against each other.

## 1. Statsig events from the dedupe workflow are timestamped in 1970

`claude-dedupe-issues.yml` builds the event with `time: (now | floor | tostring)` — Unix **seconds**. Statsig's `log_event` API expects Unix **milliseconds**, and the sibling workflow `log-issue-events.yml` already handles this correctly (`$(date +%s)000`). A seconds value interpreted as ms lands near the 1970 epoch, so every `github_duplicate_comment_added` event is mistimed or dropped as out-of-range.

Fix: `time: (now * 1000 | floor | tostring)`.

## 2. Issue titles with backslashes silently break issue-created events

`log-issue-events.yml` assembles the JSON body by shell interpolation and only escapes double quotes via `sed`. A title containing a backslash — common in this repo's bug reports (Windows paths like `C:\Users\...`, regex snippets) — produces invalid JSON escape sequences, the POST body is rejected, and the event is lost with no error surfaced.

Fix: build the payload with `jq --arg` (the same approach `claude-dedupe-issues.yml` already uses), which escapes everything correctly. Also emits `time` in ms as before.

## 3. The backfill workflow's `days_back` input does nothing

`backfill-duplicate-comments.yml` exposes a `days_back` input (default `'90'`) and passes it as `DAYS_BACK`, but `scripts/backfill-duplicate-comments.ts` never reads that variable — it selects issues by number via `MAX_ISSUE_NUMBER` (default `4050`) / `MIN_ISSUE_NUMBER`, which the workflow doesn't set. So any dispatch of the workflow ignores the operator's input and always scans issues #1–#4049, meaning recent issues can never be backfilled.

Fix: when `DAYS_BACK` is set, filter issues by `created_at` against the cutoff and stop paginating once past it (listing is sorted `created desc`). The legacy `4050` number cap now only applies when no date window was requested; explicit `MAX_ISSUE_NUMBER`/`MIN_ISSUE_NUMBER` still work as before. Invalid `DAYS_BACK` values fail fast with a clear error.

## Verification

- Both workflow files parse as valid YAML.
- `scripts/backfill-duplicate-comments.ts` passes `tsc --noEmit`.
- The jq payload construction mirrors the existing, working pattern in `claude-dedupe-issues.yml`.