### PR TITLE
fix(ralph-wiggum): make stop hook's jq error handling reachable under set -e

### DIFF
--- a/plugins/ralph-wiggum/hooks/stop-hook.sh
+++ b/plugins/ralph-wiggum/hooks/stop-hook.sh
@@ -87,15 +87,17 @@ if [[ -z "$LAST_LINE" ]]; then
 fi
 
 # Parse JSON with error handling
+# Guard the assignment so set -e doesn't abort before the error branch below
+JQ_EXIT=0
 LAST_OUTPUT=$(echo "$LAST_LINE" | jq -r '
   .message.content |
   map(select(.type == "text")) |
   map(.text) |
   join("\n")
-' 2>&1)
+' 2>&1) || JQ_EXIT=$?
 
 # Check if jq succeeded
-if [[ $? -ne 0 ]]; then
+if [[ $JQ_EXIT -ne 0 ]]; then
   echo "⚠️  Ralph loop: Failed to parse assistant message JSON" >&2
   echo "   Error: $LAST_OUTPUT" >&2
   echo "   This may indicate a transcript format issue" >&2


### PR DESCRIPTION
## Problem

`plugins/ralph-wiggum/hooks/stop-hook.sh` runs under `set -euo pipefail` and parses the last assistant transcript line with:

```bash
LAST_OUTPUT=$(echo "$LAST_LINE" | jq -r '...' 2>&1)

# Check if jq succeeded
if [[ $? -ne 0 ]]; then
  # friendly message, rm state file, exit 0
```

A plain `VAR=$(cmd)` assignment takes `cmd`'s exit status, so if jq fails to parse (malformed/truncated transcript line), `set -e` aborts the script **at the assignment** — the `$?` check and the whole recovery branch below it are unreachable. Instead of the designed graceful stop (message to the user, `.claude/ralph-loop.local.md` cleaned up, `exit 0`), the hook dies with an unhandled nonzero exit and leaves the loop state file behind.

## Fix

Guard the assignment so the failure is captured instead of fatal:

```bash
JQ_EXIT=0
LAST_OUTPUT=$(echo "$LAST_LINE" | jq -r '...' 2>&1) || JQ_EXIT=$?

if [[ $JQ_EXIT -ne 0 ]]; then
```

Behavior is otherwise identical: `2>&1` still captures jq's error text into `LAST_OUTPUT` for the diagnostic message.

## Verification

- `bash -n` passes.
- Reproduced the pattern under `set -euo pipefail`: with the guard, a failing command substitution reaches the error branch with the right exit code; without it, the shell exits at the assignment.