### PR TITLE
fix(hookify): match Write and prompt rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed Hookify file rules missing content written with Write and prompt rules missing the submitted prompt
+
 ## 2.1.207
 
 - Auto mode is now available without `CLAUDE_CODE_ENABLE_AUTO_MODE` opt-in on Bedrock, Vertex AI, and Foundry; disable via `disableAutoMode` in settings

--- a/plugins/hookify/README.md
+++ b/plugins/hookify/README.md
@@ -253,7 +253,7 @@ Use environment variables instead of hardcoded values.
 - `content`: File content (Write only)
 
 **For prompt events:**
-- `user_prompt`: The user's submitted prompt text
+- `prompt`: The user's submitted prompt text
 
 **For stop events:**
 - Use general matching on session state

--- a/plugins/hookify/core/config_loader.py
+++ b/plugins/hookify/core/config_loader.py
@@ -63,6 +63,8 @@ class Rule:
                 field = 'command'
             elif event == 'file':
                 field = 'new_text'
+            elif event == 'prompt':
+                field = 'prompt'
             else:
                 field = 'content'
 

--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -223,9 +223,9 @@ class RuleEngine:
                     except UnicodeDecodeError as e:
                         print(f"Warning: Encoding error in transcript {transcript_path}: {e}", file=sys.stderr)
                         return ''
-            elif field == 'user_prompt':
+            elif field in ('prompt', 'user_prompt'):
                 # For UserPromptSubmit events
-                return input_data.get('user_prompt', '')
+                return input_data.get('prompt') or input_data.get('user_prompt', '')
 
         # Handle special cases by tool type
         if tool_name == 'Bash':
@@ -237,7 +237,8 @@ class RuleEngine:
                 # Write uses 'content', Edit has 'new_string'
                 return tool_input.get('content') or tool_input.get('new_string', '')
             elif field == 'new_text' or field == 'new_string':
-                return tool_input.get('new_string', '')
+                # New text is supplied as content for Write and new_string for Edit.
+                return tool_input.get('new_string') or tool_input.get('content', '')
             elif field == 'old_text' or field == 'old_string':
                 return tool_input.get('old_string', '')
             elif field == 'file_path':

--- a/plugins/hookify/skills/writing-rules/SKILL.md
+++ b/plugins/hookify/skills/writing-rules/SKILL.md
@@ -208,7 +208,7 @@ Match user prompt content (advanced):
 ---
 event: prompt
 conditions:
-  - field: user_prompt
+  - field: prompt
     operator: contains
     pattern: deploy to production
 ---
@@ -368,7 +368,7 @@ Warning message
 **Field options:**
 - Bash: `command`
 - File: `file_path`, `new_text`, `old_text`, `content`
-- Prompt: `user_prompt`
+- Prompt: `prompt`
 
 **Operators:**
 - `regex_match`, `contains`, `equals`, `not_contains`, `starts_with`, `ends_with`

--- a/plugins/hookify/tests/test_rule_engine.py
+++ b/plugins/hookify/tests/test_rule_engine.py
@@ -1,0 +1,78 @@
+"""Regression tests for simple hookify rule field inference."""
+
+import sys
+from pathlib import Path
+import unittest
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from hookify.core.config_loader import Rule
+from hookify.core.rule_engine import RuleEngine
+
+
+class SimpleRuleFieldInferenceTests(unittest.TestCase):
+    def setUp(self):
+        self.engine = RuleEngine()
+
+    def test_file_pattern_matches_write_content(self):
+        rule = Rule.from_dict(
+            {"name": "warn-console-log", "event": "file", "pattern": r"console\.log\("},
+            "Console logging detected.",
+        )
+
+        result = self.engine.evaluate_rules(
+            [rule],
+            {"tool_name": "Write", "tool_input": {"content": "console.log('debug')"}},
+        )
+
+        self.assertIn("Console logging detected.", result["systemMessage"])
+
+    def test_file_pattern_continues_to_match_edit_new_string(self):
+        rule = Rule.from_dict(
+            {"name": "warn-console-log", "event": "file", "pattern": r"console\.log\("},
+            "Console logging detected.",
+        )
+
+        result = self.engine.evaluate_rules(
+            [rule],
+            {"tool_name": "Edit", "tool_input": {"new_string": "console.log('debug')"}},
+        )
+
+        self.assertIn("Console logging detected.", result["systemMessage"])
+
+    def test_prompt_pattern_matches_current_hook_payload(self):
+        rule = Rule.from_dict(
+            {"name": "warn-deploy", "event": "prompt", "pattern": "deploy"},
+            "Deployment requested.",
+        )
+
+        result = self.engine.evaluate_rules(
+            [rule],
+            {"hook_event_name": "UserPromptSubmit", "prompt": "Please deploy this service."},
+        )
+
+        self.assertIn("Deployment requested.", result["systemMessage"])
+
+    def test_legacy_prompt_field_matches_current_hook_payload(self):
+        rule = Rule.from_dict(
+            {
+                "name": "warn-deploy",
+                "event": "prompt",
+                "conditions": [
+                    {"field": "user_prompt", "operator": "contains", "pattern": "deploy"}
+                ],
+            },
+            "Deployment requested.",
+        )
+
+        result = self.engine.evaluate_rules(
+            [rule],
+            {"hook_event_name": "UserPromptSubmit", "prompt": "Please deploy this service."},
+        )
+
+        self.assertIn("Deployment requested.", result["systemMessage"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Make file rules inspect content passed to Write as new text.
- Map simple prompt rules to the current UserPromptSubmit payload and retain the legacy configured field.
- Add regression coverage for Write, Edit, and prompt rules.

## Root cause

Simple rules were inferred as fields absent from normal Write and UserPromptSubmit payloads, so documented Hookify rules silently did not match.

## Validation

- Ran the Hookify unittest discovery suite: 4 tests passed.
- Ran Python bytecode compilation for Hookify.
- Parsed the writing-rules skill frontmatter as YAML.
- Ran git diff whitespace validation.
