### PR TITLE
fix(plugin-dev): validate-hook-schema.sh handles plugin hooks.json format

### DIFF
--- a/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh
@@ -35,12 +35,24 @@ if ! jq empty "$HOOKS_FILE" 2>/dev/null; then
 fi
 echo "✅ Valid JSON"
 
+# Determine configuration format.
+# Plugin hooks.json uses a wrapper: {"description"?: ..., "hooks": {<events>}}
+# User settings.json uses events directly at the top level: {<events>}
+# H is the jq path to the object that maps event names to hook arrays.
+if [ "$(jq -r 'if (has("hooks") and (.hooks | type == "object")) then "wrapped" else "flat" end' "$HOOKS_FILE")" = "wrapped" ]; then
+  H=".hooks"
+  echo "ℹ️  Detected plugin hooks.json format (events nested under \"hooks\")"
+else
+  H="."
+  echo "ℹ️  Detected settings format (events at top level)"
+fi
+
 # Check 2: Root structure
 echo ""
 echo "Checking root structure..."
 VALID_EVENTS=("PreToolUse" "PostToolUse" "UserPromptSubmit" "Stop" "SubagentStop" "SessionStart" "SessionEnd" "PreCompact" "Notification")
 
-for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
+for event in $(jq -r "(${H}) | keys[]" "$HOOKS_FILE"); do
   found=false
   for valid_event in "${VALID_EVENTS[@]}"; do
     if [ "$event" = "$valid_event" ]; then
@@ -62,20 +74,16 @@ echo "Validating individual hooks..."
 error_count=0
 warning_count=0
 
-for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
-  hook_count=$(jq -r ".\"$event\" | length" "$HOOKS_FILE")
+for event in $(jq -r "(${H}) | keys[]" "$HOOKS_FILE"); do
+  hook_count=$(jq -r "(${H}).\"$event\" | length" "$HOOKS_FILE")
 
   for ((i=0; i<hook_count; i++)); do
-    # Check matcher exists
-    matcher=$(jq -r ".\"$event\"[$i].matcher // empty" "$HOOKS_FILE")
-    if [ -z "$matcher" ]; then
-      echo "❌ $event[$i]: Missing 'matcher' field"
-      ((error_count++))
-      continue
-    fi
+    # 'matcher' is optional. It only applies to PreToolUse/PostToolUse (to
+    # target specific tools), and even there an absent matcher means "match
+    # all". Events like Stop, SessionStart, and UserPromptSubmit never use it.
 
     # Check hooks array exists
-    hooks=$(jq -r ".\"$event\"[$i].hooks // empty" "$HOOKS_FILE")
+    hooks=$(jq -r "(${H}).\"$event\"[$i].hooks // empty" "$HOOKS_FILE")
     if [ -z "$hooks" ] || [ "$hooks" = "null" ]; then
       echo "❌ $event[$i]: Missing 'hooks' array"
       ((error_count++))
@@ -83,10 +91,10 @@ for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
     fi
 
     # Validate each hook in the array
-    hook_array_count=$(jq -r ".\"$event\"[$i].hooks | length" "$HOOKS_FILE")
+    hook_array_count=$(jq -r "(${H}).\"$event\"[$i].hooks | length" "$HOOKS_FILE")
 
     for ((j=0; j<hook_array_count; j++)); do
-      hook_type=$(jq -r ".\"$event\"[$i].hooks[$j].type // empty" "$HOOKS_FILE")
+      hook_type=$(jq -r "(${H}).\"$event\"[$i].hooks[$j].type // empty" "$HOOKS_FILE")
 
       if [ -z "$hook_type" ]; then
         echo "❌ $event[$i].hooks[$j]: Missing 'type' field"
@@ -102,7 +110,7 @@ for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
 
       # Check type-specific fields
       if [ "$hook_type" = "command" ]; then
-        command=$(jq -r ".\"$event\"[$i].hooks[$j].command // empty" "$HOOKS_FILE")
+        command=$(jq -r "(${H}).\"$event\"[$i].hooks[$j].command // empty" "$HOOKS_FILE")
         if [ -z "$command" ]; then
           echo "❌ $event[$i].hooks[$j]: Command hooks must have 'command' field"
           ((error_count++))
@@ -114,7 +122,7 @@ for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
           fi
         fi
       elif [ "$hook_type" = "prompt" ]; then
-        prompt=$(jq -r ".\"$event\"[$i].hooks[$j].prompt // empty" "$HOOKS_FILE")
+        prompt=$(jq -r "(${H}).\"$event\"[$i].hooks[$j].prompt // empty" "$HOOKS_FILE")
         if [ -z "$prompt" ]; then
           echo "❌ $event[$i].hooks[$j]: Prompt hooks must have 'prompt' field"
           ((error_count++))
@@ -128,7 +136,7 @@ for event in $(jq -r 'keys[]' "$HOOKS_FILE"); do
       fi
 
       # Check timeout
-      timeout=$(jq -r ".\"$event\"[$i].hooks[$j].timeout // empty" "$HOOKS_FILE")
+      timeout=$(jq -r "(${H}).\"$event\"[$i].hooks[$j].timeout // empty" "$HOOKS_FILE")
       if [ -n "$timeout" ] && [ "$timeout" != "null" ]; then
         if ! [[ "$timeout" =~ ^[0-9]+$ ]]; then
           echo "❌ $event[$i].hooks[$j]: Timeout must be a number"


### PR DESCRIPTION
## Problem

The hook-schema validator shipped in the **plugin-dev** plugin's Hook Development skill (`plugins/plugin-dev/skills/hook-development/scripts/validate-hook-schema.sh`) has two bugs that make it fail on valid configurations — including the exact format the skill itself documents.

**1. Crashes on plugin `hooks.json` files.**
The validator only understood the flat *settings* format, where hook events live at the top level. But plugin `hooks.json` uses a wrapper — events nested under a `"hooks"` key alongside an optional `"description"` — which is the format documented in `SKILL.md` and used by every bundled plugin (hookify, security-guidance, ralph-wiggum, …). Given a real plugin `hooks.json`, the validator treated `description` and `hooks` as event names and then crashed:

```
⚠️  Unknown event type: description
⚠️  Unknown event type: hooks
jq: error (at hooks.json:49): Cannot index string with number
```

**2. Treats `matcher` as required.**
It reported `❌ Missing 'matcher' field` for any hook entry without a matcher. But `matcher` is optional: it only applies to `PreToolUse`/`PostToolUse` (to target specific tools), and even there an absent matcher means "match all". Events like `Stop`, `SessionStart`, and `UserPromptSubmit` never carry one, so valid configs failed validation.

## Fix

- Detect the config format and unwrap the plugin `{"hooks": {...}}` wrapper (ignoring `description`); fall back to the flat settings format.
- Stop treating `matcher` as required.

No behavior change for genuinely invalid configs — missing `hooks` arrays, bad hook `type`, missing `command`/`prompt`, and non-numeric timeouts are still reported.

## Verification

| Input | Before | After |
|---|---|---|
| `plugins/hookify/hooks/hooks.json` (wrapper) | crash | ✅ passes |
| `plugins/security-guidance/hooks/hooks.json` (wrapper, matchers, timeouts) | crash | ✅ passes |
| flat settings config with a matcher-less `Stop` hook | ❌ false "Missing matcher" | ✅ passes |
| deliberately broken config (missing hooks array, bad type, missing command, bad timeout) | errors | ✅ still errors (exit 1) |