### PR TITLE
fix(plugin-dev): validate-settings.sh false-passes marker check on files with no frontmatter

### DIFF
--- a/plugins/plugin-dev/skills/plugin-settings/scripts/validate-settings.sh
+++ b/plugins/plugin-dev/skills/plugin-settings/scripts/validate-settings.sh
@@ -38,7 +38,7 @@ fi
 echo "✅ File is readable"
 
 # Check 3: Has frontmatter markers
-MARKER_COUNT=$(grep -c '^---$' "$SETTINGS_FILE" 2>/dev/null || echo "0")
+MARKER_COUNT=$(grep -c '^---$' "$SETTINGS_FILE" 2>/dev/null || true)
 
 if [ "$MARKER_COUNT" -lt 2 ]; then
   echo "❌ Invalid frontmatter: found $MARKER_COUNT '---' markers (need at least 2)"


### PR DESCRIPTION
## What's wrong

`plugins/plugin-dev/skills/plugin-settings/scripts/validate-settings.sh` has a "Check 3" that is meant to reject files without valid YAML frontmatter (fewer than two `---` markers). On a file that has **no** `---` markers it does the opposite — it emits a raw Bash error and then falsely reports the markers are present.

## Repro (macOS `/bin/bash` 3.2.57)

```sh
printf 'no markers here\njust plain text\n' > /tmp/nomark.md
bash plugins/plugin-dev/skills/plugin-settings/scripts/validate-settings.sh /tmp/nomark.md
```

Before this change:

```
✅ File exists
✅ File is readable
validate-settings.sh: line 43: [: 0
0: integer expression expected
✅ Frontmatter markers present        <-- false positive
❌ Empty frontmatter (nothing between --- markers)
```

## Root cause

```sh
MARKER_COUNT=$(grep -c '^---$' "$SETTINGS_FILE" 2>/dev/null || echo "0")
```

`grep -c` already prints the count (including `0`) **and** exits `1` when there are no matches. The `|| echo "0"` fallback therefore appends a *second* `0`, so `MARKER_COUNT` becomes `"0\n0"`. The next line

```sh
if [ "$MARKER_COUNT" -lt 2 ]; then
```

fails with `[: 0\n0: integer expression expected`; since a failed test evaluates as false, the `❌ Invalid frontmatter` branch is skipped and the script prints `✅ Frontmatter markers present`.

## Fix

Replace the redundant `|| echo "0"` with `|| true`. `grep -c` already emits the count; `|| true` only prevents `set -e` from aborting on a no-match, without adding a duplicate line.

## After

```
✅ File exists
✅ File is readable
❌ Invalid frontmatter: found 0 '---' markers (need at least 2)
```

Verified with no regression: a valid file (two markers + fields) still passes and exits `0`, and a file with a single marker correctly reports `found 1 markers`.
