### PR TITLE
Add settings example: official marketplace only

### DIFF
--- a/examples/settings/settings-official-marketplace-only.json
+++ b/examples/settings/settings-official-marketplace-only.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "disableBypassPermissionsMode": "disable",
+    "deny": ["WebSearch", "WebFetch"]
+  },
+  "allowManagedPermissionRulesOnly": true,
+  "allowManagedHooksOnly": true,
+  "strictKnownMarketplaces": [
+    {
+      "source": "github",
+      "repo": "anthropics/claude-plugins-official"
+    }
+  ],
+  "disableSideloadFlags": true
+}


### PR DESCRIPTION
Adds `settings-official-marketplace-only.json` to `examples/settings/`.

This example demonstrates how to restrict plugin marketplaces to only the official Anthropic marketplace (`claude-plugins-official`) using `strictKnownMarketplaces` with an explicit GitHub source entry.

### Motivation

The existing `settings-strict.json` uses `strictKnownMarketplaces: []`, which blocks **all** marketplaces including the official one. This is a valid configuration for complete lockdown, but many organizations want a middle ground: block third-party marketplaces while still allowing the official Anthropic marketplace.

This is a common enterprise requirement (see #34873), and the correct configuration is not immediately obvious from the current documentation or examples.

### What's included

- `strictKnownMarketplaces` with `anthropics/claude-plugins-official` as the only allowed source
- `disableSideloadFlags: true` to also block CLI-based sideloading
- Standard strict permissions baseline (managed-only permissions and hooks, bypass mode disabled)

### Related

- #34873 — `strictKnownMarketplaces: []` blocks official marketplace