### PR TITLE
docs(plugin-dev): document skipLfs marketplace sources

### DIFF
--- a/plugins/plugin-dev/skills/command-development/references/marketplace-considerations.md
+++ b/plugins/plugin-dev/skills/command-development/references/marketplace-considerations.md
@@ -293,6 +293,39 @@ For support, include the above diagnostics.
 
 ## Distribution Best Practices
 
+### Git Source Options
+
+Marketplace entries that use `github` or `git` sources can skip Git LFS downloads
+when the repository contains large optional assets that are not required at
+runtime. Set `skipLfs` alongside the source-specific location field so installs
+and updates avoid fetching those LFS objects.
+
+**GitHub source:**
+
+```json
+{
+  "name": "large-fixtures-plugin",
+  "source": {
+    "source": "github",
+    "repo": "acme-corp/claude-plugin",
+    "skipLfs": true
+  }
+}
+```
+
+**Git URL source:**
+
+```json
+{
+  "name": "large-fixtures-plugin",
+  "source": {
+    "source": "git",
+    "url": "https://git.example.com/acme/claude-plugin.git",
+    "skipLfs": true
+  }
+}
+```
+
 ### Namespace Awareness
 
 **Avoid name collisions:**


### PR DESCRIPTION
## Summary
- Document the `skipLfs` option for `github` and `git` marketplace source objects in plugin-dev marketplace guidance
- Add examples for GitHub shorthand and generic Git URL sources that skip Git LFS downloads

Refs #63035.

## Test plan
- Docs only; not run.