### PR TITLE
fix(mdm): Set-ClaudeCodePolicy.ps1 writes to Program Files (x86) when run in a 32-bit PowerShell host

### DIFF
--- a/examples/mdm/windows/Set-ClaudeCodePolicy.ps1
+++ b/examples/mdm/windows/Set-ClaudeCodePolicy.ps1
@@ -12,7 +12,9 @@ deployed settings; see https://code.claude.com/docs/en/settings for available ke
 
 $ErrorActionPreference = 'Stop'
 
-$dir = Join-Path $env:ProgramFiles 'ClaudeCode'
+# ProgramW6432, not ProgramFiles: in the 32-bit PowerShell host (Intune's default)
+# ProgramFiles is C:\Program Files (x86), a path Claude Code never reads.
+$dir = Join-Path $env:ProgramW6432 'ClaudeCode'
 New-Item -ItemType Directory -Path $dir -Force | Out-Null
 
 $json = @'


### PR DESCRIPTION
`Set-ClaudeCodePolicy.ps1` builds its destination from `$env:ProgramFiles`. Intune runs platform scripts in the 32-bit PowerShell host unless "Run script in 64 bit PowerShell Host" is set to Yes — the script's header documents that setting, but nothing enforces it. In the 32-bit host the variable resolves differently:

|  | 64-bit host | 32-bit host (Intune default) |
|---|---|---|
| `$env:ProgramFiles` | `C:\Program Files` | `C:\Program Files (x86)` |
| `$env:ProgramW6432` | `C:\Program Files` | `C:\Program Files` |

So when the toggle is missed, the script creates `C:\Program Files (x86)\ClaudeCode\managed-settings.json`, prints `Wrote ...`, and exits 0 — but Claude Code only reads `C:\Program Files\ClaudeCode\managed-settings.json` ([settings docs](https://code.claude.com/docs/en/settings#settings-files)), so the deployed policy (here `disableBypassPermissionsMode`) is silently never applied.

`ProgramW6432` resolves to the 64-bit Program Files from either host, which makes the script correct regardless of how the Intune script option is configured. The 64-bit-host guidance in the header remains the right default; this change only removes the silent failure when it's missed.

Verified on Windows 11 (PowerShell 5.1): ran the path expression in both hosts (`SysWOW64\WindowsPowerShell\v1.0\powershell.exe` for the 32-bit case) and ran the full script in the 32-bit host with `ProgramW6432` redirected to a temp directory — it writes the expected file with the expected content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
