### PR TITLE
fix(security-guidance): flag Python exec() as a code-injection sink

### DIFF
--- a/plugins/security-guidance/hooks/patterns.py
+++ b/plugins/security-guidance/hooks/patterns.py
@@ -106,6 +106,17 @@ Only use exec() if you absolutely need shell features and the input is guarantee
         "reminder": "⚠️ Security Warning: eval() executes arbitrary code and is a major security risk. Use JSON.parse() for data, ast.literal_eval() for Python literals, or a safe expression parser. If this is safe or is explicitly needed, briefly document that in a comment before continuing.",
     },
     {
+        "ruleName": "python_exec_injection",
+        # Python's exec() builtin — an RCE sink at least as dangerous as eval()
+        # (it runs statements, not just expressions). Python-only: the JS/TS
+        # exec( sinks are child_process_exec's job. Same lookbehind as that rule
+        # excludes `.exec(` method calls and `_exec(` suffixes, so the safe
+        # asyncio.create_subprocess_exec( does not match.
+        "path_filter": lambda p: p.endswith(_PY_EXTS),
+        "regex": r"(?<![a-zA-Z0-9_\.])exec\(",
+        "reminder": "⚠️ Security Warning: exec() runs arbitrary Python and is a code-injection sink — more dangerous than eval(), since it executes statements, not just a single expression. If any part of the string is attacker-influenced this is remote code execution. Prefer a data format (JSON) or an explicit dispatch table / getattr() against an allowlist instead of executing generated source. If this is safe or is explicitly needed, briefly document that in a comment before continuing.",
+    },
+    {
         "ruleName": "react_dangerously_set_html",
         "substrings": ["dangerouslySetInnerHTML"],
         "reminder": "⚠️ Security Warning: dangerouslySetInnerHTML can lead to XSS vulnerabilities if used with untrusted content. Ensure all content is properly sanitized using an HTML sanitizer library like DOMPurify, or use safe alternatives.",
@@ -295,6 +306,7 @@ class RuleId(IntEnum):
     TORCH_UNSAFE_LOAD = 23
     YAML_UNSAFE_LOAD_VARIANTS = 24
     PICKLE_WRAPPER_LOAD = 25
+    PYTHON_EXEC_INJECTION = 26
 
 
 _RULE_NAME_TO_ID = {
@@ -302,6 +314,7 @@ _RULE_NAME_TO_ID = {
     "child_process_exec": RuleId.CHILD_PROCESS_EXEC,
     "new_function_injection": RuleId.NEW_FUNCTION_INJECTION,
     "eval_injection": RuleId.EVAL_INJECTION,
+    "python_exec_injection": RuleId.PYTHON_EXEC_INJECTION,
     "react_dangerously_set_html": RuleId.REACT_DANGEROUSLY_SET_HTML,
     "document_write_xss": RuleId.DOCUMENT_WRITE_XSS,
     "innerHTML_xss": RuleId.INNERHTML_XSS,


### PR DESCRIPTION
No linked issue — found while reading the security-guidance patterns.

## Summary

`patterns.py` warns on Python `eval()` (`eval_injection`, which fires on `.py` files) but has no rule for `exec()`. The only `exec(` matcher is `child_process_exec`, and it's gated to JS/TS files:

```python
"ruleName": "child_process_exec",
# Gate to JS/TS files — bare `exec(` otherwise fires on Python's
# exec() and on prose/docstrings mentioning exec.
"path_filter": lambda p: p.endswith(_JS_EXTS),
```

So a `.py` file doing `exec(user_input)` gets no warning at all, while `eval(user_input)` on the line above does. `exec()` is the more dangerous of the two — it runs arbitrary statements, not just a single expression — so flagging `eval` but not `exec` is an asymmetric gap.

## Fix

Add a `python_exec_injection` rule: the same lookbehind `child_process_exec` uses, scoped to Python files.

```python
"path_filter": lambda p: p.endswith(_PY_EXTS),
"regex": r"(?<![a-zA-Z0-9_\.])exec\(",
```

The `(?<![a-zA-Z0-9_\.])` lookbehind means it does **not** fire on:
- `.exec(` method calls (`cursor.exec(...)`, ORM/Qt APIs)
- `asyncio.create_subprocess_exec(` — the safe, no-shell variant (the `_` before `exec` is excluded)
- `run_in_executor(` and other `exec`-substring identifiers

Python-only scope is deliberate: the JS/TS `exec(` sinks stay `child_process_exec`'s job, so the two rules don't double-fire.

## Verification

Ran the module's import-time `assert` (the `RuleId` ↔ `SECURITY_PATTERNS` sync check) and the `check_patterns` matcher against a table of cases:

| Input (`.py` unless noted) | Fires |
|---|---|
| `exec(user_input)` | `python_exec_injection` ✅ |
| `exec(compile(src, '<s>', 'exec'))` | `python_exec_injection` ✅ |
| `eval(user_input)` | `eval_injection` (unchanged) |
| `asyncio.create_subprocess_exec('ls')` | — (no false positive) |
| `obj.exec(x)` | — |
| `exec(cmd)` in a `.js` file | `child_process_exec` (unchanged) |
| `exec(x)` in a `.md` file | — |

`RuleId.PYTHON_EXEC_INJECTION = 26` is appended per the enum's "do not renumber, append new ones" contract, and `rule_names_to_mask({"python_exec_injection"})` round-trips to `1 << 26`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
