### PR TITLE
Harden ralph-wiggum plugin: bounded iterations, push/publish guard, stop-hook fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -125,17 +125,6 @@
       "category": "productivity"
     },
     {
-      "name": "ralph-wiggum",
-      "description": "Interactive self-referential AI loops for iterative development. Claude works on the same task repeatedly, seeing its previous work, until completion.",
-      "version": "1.0.0",
-      "author": {
-        "name": "Daisy Hollman",
-        "email": "daisy@anthropic.com"
-      },
-      "source": "./plugins/ralph-wiggum",
-      "category": "development"
-    },
-    {
       "name": "security-guidance",
       "description": "Security reminder hook that warns about potential security issues when editing files, including command injection, XSS, and unsafe code patterns",
       "version": "1.0.0",

--- a/.github/workflows/plugin-checks.yml
+++ b/.github/workflows/plugin-checks.yml
@@ -1,0 +1,39 @@
+name: Plugin Checks
+
+on:
+  pull_request:
+    paths:
+      - ".claude-plugin/**"
+      - ".github/workflows/plugin-checks.yml"
+      - ".gitignore"
+      - "plugins/**"
+
+permissions:
+  contents: read
+
+jobs:
+  plugin-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Validate plugin JSON
+        run: |
+          python3 -m json.tool .claude-plugin/marketplace.json >/dev/null
+          find plugins -path '*/.claude-plugin/plugin.json' -print0 \
+            | xargs -0 -n1 python3 -m json.tool >/dev/null
+          find plugins -path '*/hooks/hooks.json' -print0 \
+            | xargs -0 -n1 python3 -m json.tool >/dev/null
+
+      - name: Check shell hooks
+        run: |
+          find plugins -type f -name '*.sh' -print0 \
+            | xargs -0 -n1 bash -n
+          if command -v shellcheck >/dev/null 2>&1; then
+            find plugins/ralph-wiggum -type f -name '*.sh' -print0 \
+              | xargs -0 shellcheck
+          fi
+
+      - name: Ralph smoke tests
+        run: plugins/ralph-wiggum/tests/smoke.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
-
+.claude/ralph-loop.local.md
+.claude/ralph-loop.local.md.tmp.*

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -23,8 +23,15 @@ Learn more in the [official plugins documentation](https://docs.claude.com/en/do
 | [learning-output-style](./learning-output-style/) | Interactive learning mode that requests meaningful code contributions at decision points (mimics the unshipped Learning output style) | **Hook:** SessionStart - Encourages users to write meaningful code (5-10 lines) at decision points while receiving educational insights |
 | [plugin-dev](./plugin-dev/) | Comprehensive toolkit for developing Claude Code plugins with 7 expert skills and AI-assisted creation | **Command:** `/plugin-dev:create-plugin` - 8-phase guided workflow for building plugins<br>**Agents:** `agent-creator`, `plugin-validator`, `skill-reviewer`<br>**Skills:** Hook development, MCP integration, plugin structure, settings, commands, agents, and skill development |
 | [pr-review-toolkit](./pr-review-toolkit/) | Comprehensive PR review agents specializing in comments, tests, error handling, type design, code quality, and code simplification | **Command:** `/pr-review-toolkit:review-pr` - Run with optional review aspects (comments, tests, errors, types, code, simplify, all)<br>**Agents:** `comment-analyzer`, `pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer`, `code-reviewer`, `code-simplifier` |
-| [ralph-wiggum](./ralph-wiggum/) | Interactive self-referential AI loops for iterative development. Claude works on the same task repeatedly until completion | **Commands:** `/ralph-loop`, `/cancel-ralph` - Start/stop autonomous iteration loops<br>**Hook:** Stop - Intercepts exit attempts to continue iteration |
 | [security-guidance](./security-guidance/) | Security reminder hook that warns about potential security issues when editing files | **Hook:** PreToolUse - Monitors 9 security patterns including command injection, XSS, eval usage, dangerous HTML, pickle deserialization, and os.system calls |
+
+## Experimental Plugins
+
+These plugins are kept in-tree for reference or local experimentation, but are not listed in the bundled marketplace.
+
+| Name | Description | Status |
+|------|-------------|--------|
+| [ralph-wiggum](./ralph-wiggum/) | Self-referential development loop using Stop hooks | Experimental; not recommended for unattended work or merge decisions |
 
 ## Installation
 

--- a/plugins/ralph-wiggum/README.md
+++ b/plugins/ralph-wiggum/README.md
@@ -2,6 +2,10 @@
 
 Implementation of the Ralph Wiggum technique for iterative, self-referential AI development loops in Claude Code.
 
+> **Status:** Experimental. This plugin is kept in-tree for local experimentation
+> and is not listed in the bundled plugin marketplace. Do not use it for
+> unattended merge, publish, deploy, or production decisions.
+
 ## What is Ralph?
 
 Ralph is a development methodology based on continuous AI agent loops. As Geoffrey Huntley describes it: **"Ralph is a Bash loop"** - a simple `while true` that repeatedly feeds an AI agent a prompt file, allowing it to iteratively improve its work until completion.
@@ -35,7 +39,7 @@ This creates a **self-referential feedback loop** where:
 ## Quick Start
 
 ```bash
-/ralph-loop "Build a REST API for todos. Requirements: CRUD operations, input validation, tests. Output <promise>COMPLETE</promise> when done." --completion-promise "COMPLETE" --max-iterations 50
+/ralph-loop "Build a REST API for todos. Requirements: CRUD operations, input validation, tests. Output <promise>COMPLETE</promise> when done." --completion-promise "COMPLETE" --max-iterations 5
 ```
 
 Claude will:
@@ -57,7 +61,7 @@ Start a Ralph loop in your current session.
 ```
 
 **Options:**
-- `--max-iterations <n>` - Stop after N iterations (default: unlimited)
+- `--max-iterations <n>` - Stop after N iterations (default: 5)
 - `--completion-promise <text>` - Phrase that signals completion
 
 ### /cancel-ralph
@@ -118,10 +122,10 @@ Implement feature X following TDD:
 
 ### 4. Escape Hatches
 
-Always use `--max-iterations` as a safety net to prevent infinite loops on impossible tasks:
+Always use `--max-iterations` as a safety net to prevent runaway work on impossible tasks:
 
 ```bash
-# Recommended: Always set a reasonable iteration limit
+# Recommended: Keep iteration limits small
 /ralph-loop "Try to implement feature X" --max-iterations 20
 
 # In your prompt, include what to do if stuck:
@@ -131,7 +135,7 @@ Always use `--max-iterations` as a safety net to prevent infinite loops on impos
 #  - Suggest alternative approaches"
 ```
 
-**Note**: The `--completion-promise` uses exact string matching, so you cannot use it for multiple completion conditions (like "SUCCESS" vs "BLOCKED"). Always rely on `--max-iterations` as your primary safety mechanism.
+**Note**: The `--completion-promise` uses exact string matching, so you cannot use it for multiple completion conditions (like "SUCCESS" vs "BLOCKED"). Always rely on `--max-iterations` as your primary safety mechanism. For production workflows, prefer an external verifier that runs tests and checks the diff instead of relying on a model-written promise.
 
 ## Philosophy
 

--- a/plugins/ralph-wiggum/commands/help.md
+++ b/plugins/ralph-wiggum/commands/help.md
@@ -46,12 +46,13 @@ Start a Ralph loop in your current session.
 - `--completion-promise <text>` - Promise phrase to signal completion
 
 **How it works:**
-1. Creates `.claude/.ralph-loop.local.md` state file
+1. Creates `.claude/ralph-loop.local.md` state file
 2. You work on the task
 3. When you try to exit, stop hook intercepts
 4. Same prompt fed back
 5. You see your previous work
 6. Continues until promise detected or max iterations
+7. Blocks common push, merge, publish, and deploy commands while active
 
 ---
 
@@ -66,7 +67,7 @@ Cancel an active Ralph loop (removes the loop state file).
 
 **How it works:**
 - Checks for active loop state file
-- Removes `.claude/.ralph-loop.local.md`
+- Removes `.claude/ralph-loop.local.md`
 - Reports cancellation with iteration count
 
 ---
@@ -81,7 +82,7 @@ To signal completion, Claude must output a `<promise>` tag:
 <promise>TASK COMPLETE</promise>
 ```
 
-The stop hook looks for this specific tag. Without it (or `--max-iterations`), Ralph runs infinitely.
+The stop hook looks for this specific tag. Without it, Ralph stops at `--max-iterations`.
 
 ### Self-Reference Mechanism
 

--- a/plugins/ralph-wiggum/hooks/hooks.json
+++ b/plugins/ralph-wiggum/hooks/hooks.json
@@ -1,6 +1,17 @@
 {
   "description": "Ralph Wiggum plugin stop hook for self-referential loops",
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse-guard.sh"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/plugins/ralph-wiggum/hooks/pretooluse-guard.sh
+++ b/plugins/ralph-wiggum/hooks/pretooluse-guard.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Blocks high-blast-radius shell commands while a Ralph loop is active.
+
+set -euo pipefail
+
+RALPH_STATE_FILE=".claude/ralph-loop.local.md"
+
+if [[ ! -f "$RALPH_STATE_FILE" ]]; then
+  exit 0
+fi
+
+HOOK_INPUT=$(cat)
+COMMAND=$(echo "$HOOK_INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || true)
+
+if [[ -z "$COMMAND" ]]; then
+  exit 0
+fi
+
+BLOCK_PATTERNS=(
+  '(^|[;&|[:space:]])git[[:space:]]+push([[:space:]]|$)'
+  '(^|[;&|[:space:]])git[[:space:]]+push[[:space:]]+--force'
+  '(^|[;&|[:space:]])gh[[:space:]]+pr[[:space:]]+merge([[:space:]]|$)'
+  '(^|[;&|[:space:]])gh[[:space:]]+workflow[[:space:]]+run([[:space:]]|$)'
+  '(^|[;&|[:space:]])npm[[:space:]]+publish([[:space:]]|$)'
+  '(^|[;&|[:space:]])pnpm[[:space:]]+publish([[:space:]]|$)'
+  '(^|[;&|[:space:]])yarn[[:space:]]+publish([[:space:]]|$)'
+  '(^|[;&|[:space:]])bun[[:space:]]+publish([[:space:]]|$)'
+  '(^|[;&|[:space:]])wrangler[[:space:]]+deploy([[:space:]]|$)'
+  '(^|[;&|[:space:]])vercel([[:space:]]|$)'
+)
+
+for pattern in "${BLOCK_PATTERNS[@]}"; do
+  if [[ "$COMMAND" =~ $pattern ]]; then
+    cat >&2 <<'EOF'
+Ralph loop guard blocked this command.
+
+Ralph is an experimental local iteration loop and must not push, merge, publish,
+or deploy changes. Stop the loop with /cancel-ralph, review the work manually,
+run verification, then perform release or merge actions outside the loop.
+EOF
+    exit 2
+  fi
+done

--- a/plugins/ralph-wiggum/hooks/stop-hook.sh
+++ b/plugins/ralph-wiggum/hooks/stop-hook.sh
@@ -87,15 +87,12 @@ if [[ -z "$LAST_LINE" ]]; then
 fi
 
 # Parse JSON with error handling
-LAST_OUTPUT=$(echo "$LAST_LINE" | jq -r '
-  .message.content |
-  map(select(.type == "text")) |
-  map(.text) |
-  join("\n")
-' 2>&1)
-
-# Check if jq succeeded
-if [[ $? -ne 0 ]]; then
+if ! LAST_OUTPUT=$(echo "$LAST_LINE" | jq -r '
+    .message.content |
+    map(select(.type == "text")) |
+    map(.text) |
+    join("\n")
+  ' 2>&1); then
   echo "⚠️  Ralph loop: Failed to parse assistant message JSON" >&2
   echo "   Error: $LAST_OUTPUT" >&2
   echo "   This may indicate a transcript format issue" >&2
@@ -116,7 +113,7 @@ if [[ "$COMPLETION_PROMISE" != "null" ]] && [[ -n "$COMPLETION_PROMISE" ]]; then
   # Extract text from <promise> tags using Perl for multiline support
   # -0777 slurps entire input, s flag makes . match newlines
   # .*? is non-greedy (takes FIRST tag), whitespace normalized
-  PROMISE_TEXT=$(echo "$LAST_OUTPUT" | perl -0777 -pe 's/.*?<promise>(.*?)<\/promise>.*/$1/s; s/^\s+|\s+$//g; s/\s+/ /g' 2>/dev/null || echo "")
+  PROMISE_TEXT=$(echo "$LAST_OUTPUT" | perl -0777 -ne 'if (/<promise>(.*?)<\/promise>/s) { $x=$1; $x =~ s/^\s+|\s+$//g; $x =~ s/\s+/ /g; print $x }' 2>/dev/null || echo "")
 
   # Use = for literal string comparison (not pattern matching)
   # == in [[ ]] does glob pattern matching which breaks with *, ?, [ characters

--- a/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
+++ b/plugins/ralph-wiggum/scripts/setup-ralph-loop.sh
@@ -7,7 +7,8 @@ set -euo pipefail
 
 # Parse arguments
 PROMPT_PARTS=()
-MAX_ITERATIONS=0
+DEFAULT_MAX_ITERATIONS=5
+MAX_ITERATIONS=$DEFAULT_MAX_ITERATIONS
 COMPLETION_PROMISE="null"
 
 # Parse options and positional arguments
@@ -24,7 +25,7 @@ ARGUMENTS:
   PROMPT...    Initial prompt to start the loop (can be multiple words without quotes)
 
 OPTIONS:
-  --max-iterations <n>           Maximum iterations before auto-stop (default: unlimited)
+  --max-iterations <n>           Maximum iterations before auto-stop (default: 5)
   --completion-promise '<text>'  Promise phrase (USE QUOTES for multi-word)
   -h, --help                     Show this help message
 
@@ -42,12 +43,11 @@ DESCRIPTION:
 EXAMPLES:
   /ralph-loop Build a todo API --completion-promise 'DONE' --max-iterations 20
   /ralph-loop --max-iterations 10 Fix the auth bug
-  /ralph-loop Refactor cache layer  (runs forever)
+  /ralph-loop Refactor cache layer  (runs up to 5 iterations)
   /ralph-loop --completion-promise 'TASK COMPLETE' Create a REST API
 
 STOPPING:
-  Only by reaching --max-iterations or detecting --completion-promise
-  No manual stop - Ralph runs infinitely by default!
+  By reaching --max-iterations, detecting --completion-promise, or /cancel-ralph.
 
 MONITORING:
   # View current iteration:
@@ -65,18 +65,18 @@ HELP_EOF
         echo "   Valid examples:" >&2
         echo "     --max-iterations 10" >&2
         echo "     --max-iterations 50" >&2
-        echo "     --max-iterations 0  (unlimited)" >&2
+        echo "     --max-iterations $DEFAULT_MAX_ITERATIONS" >&2
         echo "" >&2
         echo "   You provided: --max-iterations (with no number)" >&2
         exit 1
       fi
-      if ! [[ "$2" =~ ^[0-9]+$ ]]; then
-        echo "❌ Error: --max-iterations must be a positive integer or 0, got: $2" >&2
+      if ! [[ "$2" =~ ^[1-9][0-9]*$ ]]; then
+        echo "❌ Error: --max-iterations must be a positive integer, got: $2" >&2
         echo "" >&2
         echo "   Valid examples:" >&2
         echo "     --max-iterations 10" >&2
         echo "     --max-iterations 50" >&2
-        echo "     --max-iterations 0  (unlimited)" >&2
+        echo "     --max-iterations $DEFAULT_MAX_ITERATIONS" >&2
         echo "" >&2
         echo "   Invalid: decimals (10.5), negative numbers (-5), text" >&2
         exit 1
@@ -132,7 +132,9 @@ mkdir -p .claude
 
 # Quote completion promise for YAML if it contains special chars or is not null
 if [[ -n "$COMPLETION_PROMISE" ]] && [[ "$COMPLETION_PROMISE" != "null" ]]; then
-  COMPLETION_PROMISE_YAML="\"$COMPLETION_PROMISE\""
+  COMPLETION_PROMISE_ESCAPED=${COMPLETION_PROMISE//\\/\\\\}
+  COMPLETION_PROMISE_ESCAPED=${COMPLETION_PROMISE_ESCAPED//\"/\\\"}
+  COMPLETION_PROMISE_YAML="\"$COMPLETION_PROMISE_ESCAPED\""
 else
   COMPLETION_PROMISE_YAML="null"
 fi
@@ -154,7 +156,7 @@ cat <<EOF
 🔄 Ralph loop activated in this session!
 
 Iteration: 1
-Max iterations: $(if [[ $MAX_ITERATIONS -gt 0 ]]; then echo $MAX_ITERATIONS; else echo "unlimited"; fi)
+Max iterations: $MAX_ITERATIONS
 Completion promise: $(if [[ "$COMPLETION_PROMISE" != "null" ]]; then echo "${COMPLETION_PROMISE//\"/} (ONLY output when TRUE - do not lie!)"; else echo "none (runs forever)"; fi)
 
 The stop hook is now active. When you try to exit, the SAME PROMPT will be
@@ -163,8 +165,9 @@ self-referential loop where you iteratively improve on the same task.
 
 To monitor: head -10 .claude/ralph-loop.local.md
 
-⚠️  WARNING: This loop cannot be stopped manually! It will run infinitely
-    unless you set --max-iterations or --completion-promise.
+⚠️  WARNING: Ralph is experimental. It must not be used for unattended merge,
+    publish, or deploy decisions. The loop guard blocks common high-risk
+    commands while the loop is active.
 
 🔄
 EOF

--- a/plugins/ralph-wiggum/tests/smoke.sh
+++ b/plugins/ralph-wiggum/tests/smoke.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -euo pipefail
+
+PLUGIN_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cd "$TMP_DIR"
+
+"$PLUGIN_ROOT/scripts/setup-ralph-loop.sh" Do work >/dev/null
+grep -q '^max_iterations: 5$' .claude/ralph-loop.local.md
+
+if "$PLUGIN_ROOT/scripts/setup-ralph-loop.sh" --max-iterations 0 Do work >/tmp/ralph-zero.out 2>/tmp/ralph-zero.err; then
+  echo "Expected --max-iterations 0 to fail" >&2
+  exit 1
+fi
+
+rm -rf .claude
+mkdir -p .claude
+cat > .claude/ralph-loop.local.md <<'STATE'
+---
+active: true
+iteration: 1
+max_iterations: 3
+completion_promise: "DONE"
+started_at: "2026-01-01T00:00:00Z"
+---
+Do work
+STATE
+
+cat > transcript-no-tag.jsonl <<'JSONL'
+{"message":{"role":"assistant","content":[{"type":"text","text":"DONE"}]}}
+JSONL
+
+printf '{"transcript_path":"%s/transcript-no-tag.jsonl"}' "$TMP_DIR" \
+  | CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" "$PLUGIN_ROOT/hooks/stop-hook.sh" >/tmp/ralph-no-tag.out
+grep -q '"decision": "block"' /tmp/ralph-no-tag.out
+grep -q '^iteration: 2$' .claude/ralph-loop.local.md
+
+cat > transcript-done.jsonl <<'JSONL'
+{"message":{"role":"assistant","content":[{"type":"text","text":"<promise>DONE</promise>"}]}}
+JSONL
+
+printf '{"transcript_path":"%s/transcript-done.jsonl"}' "$TMP_DIR" \
+  | CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" "$PLUGIN_ROOT/hooks/stop-hook.sh" >/tmp/ralph-done.out
+test ! -f .claude/ralph-loop.local.md
+
+cat > .claude/ralph-loop.local.md <<'STATE'
+---
+active: true
+iteration: 1
+max_iterations: 3
+completion_promise: null
+started_at: "2026-01-01T00:00:00Z"
+---
+Do work
+STATE
+
+if printf '{"tool_name":"Bash","tool_input":{"command":"git push origin HEAD"}}' \
+  | CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" "$PLUGIN_ROOT/hooks/pretooluse-guard.sh" >/tmp/ralph-guard.out 2>/tmp/ralph-guard.err; then
+  echo "Expected guard to block git push" >&2
+  exit 1
+fi
+grep -q 'Ralph loop guard blocked this command' /tmp/ralph-guard.err
+
+echo "ralph-wiggum smoke tests passed"


### PR DESCRIPTION
## Summary

Safety hardening for the `ralph-wiggum` plugin. Ralph loops are powerful but dangerous by default: they run **unlimited iterations** and nothing stops an unattended loop from pushing, merging, publishing, or deploying half-finished work. This PR keeps the plugin available for local experimentation while removing the sharpest edges, and fixes two real bugs in the stop hook.

## Changes

### Bug fixes (`hooks/stop-hook.sh`)
- **False completion-promise matching**: the previous Perl one-liner (`s/.*?<promise>(.*?)<\/promise>.*/$1/s`) returned the **entire assistant output unchanged** when no `<promise>` tag was present (no match → no substitution → full text printed). `PROMISE_TEXT` then contained the whole message, corrupting the completion comparison. Now extraction only prints on an actual match.
- **jq error handling**: `LAST_OUTPUT=$(... | jq ...)` followed by a separate `[[ $? -ne 0 ]]` check is fragile; the error branch is now tied directly to the command via `if ! LAST_OUTPUT=$(...)`.

### Safer defaults (`scripts/setup-ralph-loop.sh`)
- `--max-iterations` now defaults to **5** instead of unlimited, and `0` (infinite) is no longer accepted. Long runs remain possible by passing an explicit higher bound.
- Help text updated accordingly ("runs forever" → bounded, documents `/cancel-ralph`).

### New guard: block high-blast-radius commands while a loop is active
- `hooks/pretooluse-guard.sh` (wired via `PreToolUse`/`Bash` in `hooks.json`): while `.claude/ralph-loop.local.md` exists, `git push`, `gh pr merge`, `gh workflow run`, `npm/pnpm/yarn/bun publish`, `wrangler deploy`, and `vercel` are blocked with a message telling the user to stop the loop, review, and release outside it. No effect when no loop is active.

### Marketplace demotion
- Removed `ralph-wiggum` from `.claude-plugin/marketplace.json`; `plugins/README.md` now lists it under a new **Experimental Plugins** section ("not recommended for unattended work or merge decisions"). The plugin stays in-tree for reference and opt-in local use.

### Tests & CI
- `plugins/ralph-wiggum/tests/smoke.sh`: smoke test for the stop hook and guard.
- `.github/workflows/plugin-checks.yml`: validates plugin JSON (`marketplace.json`, `plugin.json`, `hooks.json`) and shell hooks on PRs touching `plugins/**`.
- `.gitignore`: ignore the loop's local state files.

## Verification

- `bash tests/smoke.sh` passes locally.
- `bash -n` clean on all touched shell scripts; plugin JSON validates with `python3 -m json.tool`.
