### PR TITLE
fix(code-review): require explicit user invocation

### DIFF
--- a/plugins/code-review/commands/code-review.md
+++ b/plugins/code-review/commands/code-review.md
@@ -1,6 +1,7 @@
 ---
 allowed-tools: Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*), mcp__github_inline_comment__create_inline_comment
 description: Code review a pull request
+disable-model-invocation: true
 ---
 
 Provide a code review for the given pull request.


### PR DESCRIPTION
## Summary

- mark `/code-review` as manual-only with `disable-model-invocation: true`
- preserve explicit user invocation of `/code-review` and `/code-review --comment`
- prevent models and subagents from programmatically re-entering the full multi-agent review workflow

## Motivation

The `code-review` command launches an initial gate agent, a guidance-discovery agent, a change-summary agent, four parallel reviewers, and additional validators for reported findings. Programmatic invocation from one of those descendants can recursively re-enter the complete workflow and multiply the agent tree.

`disable-model-invocation` is the documented frontmatter control for commands that require explicit user judgment: it keeps the slash command available to users while removing it from the model's programmatic command invocation surface.

This is a plugin-level mitigation related to #77414 and #68110. It cuts off recursive model-initiated re-entry into this specific multi-agent workflow, but it does not replace host-level descendant budgets, breadth limits, resource backpressure, or tree-wide cancellation.

## Behavior change

| Invocation path | Before | After |
|---|---|---|
| User types `/code-review` | Allowed | Allowed |
| User types `/code-review --comment` | Allowed | Allowed |
| Model or subagent invokes `code-review` programmatically | Allowed | Blocked |
| Subagent directly invokes `Agent` | Allowed | Unchanged |

## Test plan

- [x] Validate `plugins/code-review` with `claude plugin validate`
- [x] Validate `plugins/code-review` with `claude plugin validate --strict`
- [x] Parse the command frontmatter as YAML and confirm `disable-model-invocation` is boolean `true`
- [x] Run `git diff --check`
- [x] Confirm only `plugins/code-review/commands/code-review.md` changed
- [x] Confirm the branch is based on the latest `upstream/main`

No Agent integration test was run because `/code-review` intentionally launches multiple agents; this PR is limited to static frontmatter and plugin validation on an unrestricted workstation.

Generated with [Claude Code](https://claude.ai/code)
