### PR TITLE
fix(devcontainer script): detect native command failures via $LASTEXITCODE

### DIFF
--- a/Script/run_devcontainer_claude_code.ps1
+++ b/Script/run_devcontainer_claude_code.ps1
@@ -61,32 +61,33 @@ if ($Backend -eq 'podman') {
     Write-Host "--- Podman Backend Initialization ---"
 
     # --- Step 1a: Initialize Podman machine ---
+    # A non-zero exit here usually just means the machine already exists, so this
+    # is intentionally tolerated rather than fatal.
     Write-Host "Initializing Podman machine 'claudeVM'..."
-    try {
-        & podman machine init claudeVM
-        Write-Host "Podman machine 'claudeVM' initialized or already exists."
-    } catch {
-        Write-Error "Failed to initialize Podman machine: $($_.Exception.Message)"
-        exit 1 # Exit script on error
+    & podman machine init claudeVM
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "'podman machine init claudeVM' exited with code $LASTEXITCODE (the machine may already exist). Continuing."
+    } else {
+        Write-Host "Podman machine 'claudeVM' initialized."
     }
 
     # --- Step 1b: Start Podman machine ---
+    # Likewise tolerated: starting an already-running machine exits non-zero.
     Write-Host "Starting Podman machine 'claudeVM'..."
-    try {
-        & podman machine start claudeVM -q
-        Write-Host "Podman machine started or already running."
-    } catch {
-        Write-Error "Failed to start Podman machine: $($_.Exception.Message)"
-        exit 1
+    & podman machine start claudeVM -q
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "'podman machine start claudeVM' exited with code $LASTEXITCODE (the machine may already be running). Continuing."
+    } else {
+        Write-Host "Podman machine started."
     }
 
     # --- Step 2: Set default connection ---
     Write-Host "Setting default Podman connection to 'claudeVM'..."
-    try {
-        & podman system connection default claudeVM
+    & podman system connection default claudeVM
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Failed to set default Podman connection (exit code $LASTEXITCODE); it may already be set."
+    } else {
         Write-Host "Default connection set."
-    } catch {
-        Write-Warning "Failed to set default Podman connection (may be already set or machine issue): $($_.Exception.Message)"
     }
 
 } elseif ($Backend -eq 'docker') {
@@ -94,59 +95,60 @@ if ($Backend -eq 'podman') {
 
     # --- Step 1 & 2: Check Docker Desktop ---
     Write-Host "Checking if Docker Desktop is running and docker command is available..."
-    try {
-        docker info | Out-Null
-        Write-Host "Docker Desktop (daemon) is running."
-    } catch {
-        Write-Error "Docker Desktop is not running or docker command not found."
+    & docker info | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Docker Desktop is not running or docker command not found (exit code $LASTEXITCODE)."
         Write-Error "Please ensure Docker Desktop is running."
         exit 1
     }
+    Write-Host "Docker Desktop (daemon) is running."
 }
 
 # --- Step 3: Bring up DevContainer ---
 Write-Host "Bringing up DevContainer in the current folder..."
-try {
-    $arguments = @('up', '--workspace-folder', '.')
-    if ($Backend -eq 'podman') {
-        $arguments += '--docker-path', 'podman'
-    }
-    & devcontainer @arguments
-    Write-Host "DevContainer startup process completed."
-} catch {
-    Write-Error "Failed to bring up DevContainer: $($_.Exception.Message)"
+$arguments = @('up', '--workspace-folder', '.')
+if ($Backend -eq 'podman') {
+    $arguments += '--docker-path', 'podman'
+}
+& devcontainer @arguments
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to bring up DevContainer (Command: devcontainer $($arguments -join ' ') - exit code $LASTEXITCODE)."
     exit 1
 }
+Write-Host "DevContainer startup process completed."
 
 # --- Step 4: Get DevContainer ID ---
 Write-Host "Finding the DevContainer ID..."
 $currentFolder = (Get-Location).Path
+$displayCommand = "$Backend ps --filter `"label=devcontainer.local_folder=$currentFolder`" --format '{{.ID}}'"
 
-try {
-    $containerId = (& $Backend ps --filter "label=devcontainer.local_folder=$currentFolder" --format '{{.ID}}').Trim()
-} catch {
-    $displayCommand = "$Backend ps --filter `"label=devcontainer.local_folder=$currentFolder`" --format '{{.ID}}'"
-    Write-Error "Failed to get container ID (Command: $displayCommand): $($_.Exception.Message)"
+# Note: no .Trim() here - when nothing matches, the command emits no output and
+# calling a method on the resulting $null would throw before the check below.
+$containerId = & $Backend ps --filter "label=devcontainer.local_folder=$currentFolder" --format '{{.ID}}'
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to get container ID (Command: $displayCommand - exit code $LASTEXITCODE)."
     exit 1
 }
 
-if (-not $containerId) {
+# Multiple matches would otherwise be passed on as an array and break 'exec'.
+$containerId = ($containerId | Select-Object -First 1)
+if ([string]::IsNullOrWhiteSpace($containerId)) {
     Write-Error "Could not find DevContainer ID for the current folder ('$currentFolder')."
     Write-Error "Please check if 'devcontainer up' was successful and the container is running."
     exit 1
 }
+$containerId = $containerId.Trim()
 Write-Host "Found container ID: $containerId"
 
 # --- Step 5 & 6: Execute command and enter interactive shell inside container ---
 Write-Host "Executing 'claude' command and then starting zsh session inside container $($containerId)..."
-try {
-    & $Backend exec -it $containerId zsh -c 'claude; exec zsh'
-    Write-Host "Interactive session ended."
-} catch {
+& $Backend exec -it $containerId zsh -c 'claude; exec zsh'
+if ($LASTEXITCODE -ne 0) {
     $displayCommand = "$Backend exec -it $containerId zsh -c 'claude; exec zsh'"
-    Write-Error "Failed to execute command inside container (Command: $displayCommand): $($_.Exception.Message)"
+    Write-Error "Failed to execute command inside container (Command: $displayCommand - exit code $LASTEXITCODE)."
     exit 1
 }
+Write-Host "Interactive session ended."
 
 # Notify script completion
 Write-Host "--- Script completed ---"


### PR DESCRIPTION
### Problem

`Script/run_devcontainer_claude_code.ps1` wraps every backend call (`docker`, `podman`, `devcontainer`) in `try`/`catch`. In PowerShell a **native executable exiting non-zero does not raise a terminating error**, so none of those `catch` blocks can ever run. Every failure path in the script is unreachable.

The most visible consequence is the Docker prerequisite check:

```powershell
try {
    docker info | Out-Null
    Write-Host "Docker Desktop (daemon) is running."
} catch {
    Write-Error "Docker Desktop is not running or docker command not found."
    exit 1
}
```

When Docker Desktop is stopped, `docker info` exits 1 — the `catch` is skipped and the script prints **"Docker Desktop (daemon) is running."**, i.e. the exact opposite of the truth, then continues.

### Reproduction

With a `docker` on PATH that exits non-zero (a stopped daemon), running `.\Script\run_devcontainer_claude_code.ps1 -Backend docker` on the current script gives:

```
Checking if Docker Desktop is running and docker command is available...
Docker Desktop (daemon) is running.          <- daemon is NOT running
Bringing up DevContainer in the current folder...
DevContainer startup process completed.      <- it did not
Finding the DevContainer ID...
Failed to get container ID (Command: docker ps --filter "label=devcontainer.local_folder=..." ...)
```

The user is told everything succeeded, then hits an unrelated-looking error two steps later. The intended clear message ("Please ensure Docker Desktop is running") is never printed.

The same dead-`catch` pattern is at lines 65-71 (`podman machine init`), 75-81 (`podman machine start`), 85-90 (`podman system connection default`), 109-119 (`devcontainer up`) and 142-149 (`exec -it`).

There is also a latent bug at the container-ID lookup:

```powershell
$containerId = (& $Backend ps --filter "label=..." --format '{{.ID}}').Trim()
```

When no container matches, the command emits nothing, so `.Trim()` is called on `$null` and throws *"You cannot call a method on a null-valued expression"*. That surfaces as `Failed to get container ID` — and makes the friendly `Could not find DevContainer ID for the current folder` branch below it unreachable dead code.

### Fix

Check `$LASTEXITCODE` after each native call instead of relying on `try`/`catch`.

Failure handling is kept faithful to each call's original intent rather than made uniformly fatal:

- **`podman machine init` / `machine start` / `system connection default`** — tolerated with a `Write-Warning`, because a non-zero exit here normally just means *"already exists"* / *"already running"* / *"already set"*. The existing messages ("initialized or already exists", "started or already running") show this was the intent; making them fatal would break every re-run.
- **`docker info`, `devcontainer up`, `ps`, `exec`** — fatal, as originally intended.

Also made the container-ID lookup null-safe so the existing "could not find" message is reachable, and `Select-Object -First 1` so multiple matching containers don't get passed to `exec` as an array.

### Verification

With the same stopped-daemon `docker` stub, the patched script now stops at the right place with the intended message:

```
Checking if Docker Desktop is running and docker command is available...
Docker Desktop is not running or docker command not found (exit code 1).
Please ensure Docker Desktop is running.
```

Exits 1. Script parses clean (`[Parser]::ParseFile`, no errors). No behaviour change on the success path.
