### PR TITLE
fix(plugin-dev): add the missing .claude-plugin/plugin.json manifest

### DIFF
--- a/plugins/plugin-dev/.claude-plugin/plugin.json
+++ b/plugins/plugin-dev/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "plugin-dev",
+  "description": "Comprehensive toolkit for developing Claude Code plugins. Includes 7 expert skills covering hooks, MCP integration, commands, agents, and best practices. AI-assisted plugin creation and validation.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Daisy Hollman",
+    "email": "daisy@anthropic.com"
+  }
+}


### PR DESCRIPTION
### Problem

`plugins/plugin-dev/` has no `.claude-plugin/plugin.json`. It is the only plugin in the repo without a manifest — the other 12 all have one:

```
OK      agent-sdk-dev
OK      claude-opus-4-5-migration
OK      code-review
OK      commit-commands
OK      explanatory-output-style
OK      feature-dev
OK      frontend-design
OK      hookify
OK      learning-output-style
MISSING plugin-dev          <-- no manifest
OK      pr-review-toolkit
OK      ralph-wiggum
OK      security-guidance
```

It is nevertheless published as an installable plugin in `.claude-plugin/marketplace.json` (`"source": "./plugins/plugin-dev"`), so depending on install-time validation this either fails or installs with no manifest metadata.

There's some irony here: `plugin-dev` is the plugin whose job is teaching plugin structure, and its own `skills/plugin-structure/SKILL.md:27` documents this exact file as mandatory:

```
plugin-name/
├── .claude-plugin/
│   └── plugin.json          # Required: Plugin manifest
```

`plugins/README.md:69` ("Add plugin metadata in `.claude-plugin/plugin.json`") says the same.

### Fix

Adds the missing manifest. Every value is copied verbatim from the existing `plugin-dev` entry in `.claude-plugin/marketplace.json` — nothing is invented:

| field | source |
|---|---|
| `name` | `marketplace.json` → `plugin-dev` |
| `description` | `marketplace.json` (verbatim) |
| `version` | `marketplace.json` → `0.1.0` |
| `author` | `marketplace.json` → Daisy Hollman |

`source` and `category` are deliberately omitted: they're marketplace-entry fields, and no existing `plugin.json` in this repo carries them (the union of keys across all 12 is `name`, `description`, `version`, `author`, `homepage`).

### Verification

- New file parses as valid JSON.
- Uses no key that doesn't already appear in the other manifests.
- `name` / `description` / `version` / `author` all compare equal to the `marketplace.json` entry, so the two can't drift.
- All 13 plugins now have a manifest.
- The description's claim of "7 expert skills" checks out: `skills/` contains exactly 7, each with a `SKILL.md`.

No functional change — this only adds metadata that was expected to be there.
