### PR TITLE
feat(hookify): add regex_not_match / not_regex_match operator

### DIFF
--- a/plugins/hookify/README.md
+++ b/plugins/hookify/README.md
@@ -235,6 +235,7 @@ Use environment variables instead of hardcoded values.
 ### Operators Reference
 
 - `regex_match`: Pattern must match (most common)
+- `regex_not_match` (alias `not_regex_match`): Regex pattern must NOT match
 - `contains`: String must contain pattern
 - `equals`: Exact string match
 - `not_contains`: String must NOT contain pattern

--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -165,6 +165,10 @@ class RuleEngine:
 
         if operator == 'regex_match':
             return self._regex_match(pattern, field_value)
+        elif operator in ('regex_not_match', 'not_regex_match'):
+            # Negated regex: True when the pattern does NOT match the field.
+            # Both spellings are accepted (not_regex_match mirrors not_contains).
+            return not self._regex_match(pattern, field_value)
         elif operator == 'contains':
             return pattern in field_value
         elif operator == 'equals':

--- a/plugins/hookify/skills/writing-rules/SKILL.md
+++ b/plugins/hookify/skills/writing-rules/SKILL.md
@@ -88,6 +88,7 @@ You're adding an API key to a .env file. Ensure this file is in .gitignore!
   - For file: `file_path`, `new_text`, `old_text`, `content`
 - `operator`: How to match
   - `regex_match`: Regex pattern matching
+  - `regex_not_match`: Regex must NOT match (alias: `not_regex_match`)
   - `contains`: Substring check
   - `equals`: Exact match
   - `not_contains`: Substring must NOT be present
@@ -371,4 +372,4 @@ Warning message
 - Prompt: `user_prompt`
 
 **Operators:**
-- `regex_match`, `contains`, `equals`, `not_contains`, `starts_with`, `ends_with`
+- `regex_match`, `regex_not_match`, `contains`, `equals`, `not_contains`, `starts_with`, `ends_with`


### PR DESCRIPTION
## Summary

The hookify rule engine supports `regex_match`, `contains`, `equals`, `not_contains`, `starts_with`, and `ends_with`, but there is no operator for "this regex must **NOT** match." A rule authored with `operator: regex_not_match` hits the unknown-operator branch in `_check_condition`, returns `False`, and therefore **silently never fires** — the rule loads fine and just does nothing, which is easy to ship by accident.

This adds `regex_not_match`, plus the alias `not_regex_match` (which mirrors the existing `not_contains` naming), as the negation of `regex_match`.

## Changes

- `core/rule_engine.py` — `_check_condition` handles `regex_not_match` / `not_regex_match` as `not self._regex_match(...)`.
- `README.md` and `skills/writing-rules/SKILL.md` — operator reference lists updated.

## Behavior notes

- Negates `re.search` over the whole field value, so it fires only when the pattern matches **nowhere** in the field.
- An invalid regex makes `_regex_match` return `False`, so the negated operator **fires** on a malformed pattern rather than silently passing (the safer default for a guard).
- Existing operators are untouched; unknown operators still return `False`.

## Verification

Exercised the patched engine's `_check_condition` directly across fire / no-fire / alias / whole-field / invalid-regex / regression cases — 13 assertions, all passing:

```
PASS  regex_not_match: pattern ABSENT  -> fires
PASS  regex_not_match: pattern PRESENT -> silent
PASS  not_regex_match (alias): ABSENT  -> fires
PASS  not_regex_match (alias): PRESENT -> silent
PASS  content-is-not-a-complete-JSON-object: valid -> silent, malformed -> fires, empty -> fires
PASS  invalid regex + regex_not_match  -> fires
PASS  regression: regex_match / contains / not_contains unchanged
PASS  unknown operator still           -> silent
```

`python3 -m py_compile core/rule_engine.py` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
