### PR TITLE
fix(hookify): hook scripts break when plugin is installed under a version-numbered directory

### DIFF
--- a/plugins/hookify/hooks/_bootstrap.py
+++ b/plugins/hookify/hooks/_bootstrap.py
@@ -1,0 +1,32 @@
+"""Shared bootstrap for hookify's hook entry points.
+
+Registers this plugin's own directory as the "hookify" package regardless of
+its on-disk directory name. Claude Code may install or cache a plugin under
+a version-numbered directory (e.g. ".../hookify/0.1.0/") rather than one
+literally named "hookify". A plain sys.path-based ``import hookify.xxx``
+only works if some directory *named* "hookify" is on sys.path - it silently
+breaks the moment the install layout changes, with every hook failing with
+``No module named 'hookify'``. Building the module directly from
+CLAUDE_PLUGIN_ROOT removes that assumption entirely.
+"""
+import importlib.util
+import os
+import sys
+
+
+def ensure_hookify_importable() -> None:
+    """Make ``import hookify.xxx`` work no matter what CLAUDE_PLUGIN_ROOT is named."""
+    if "hookify" in sys.modules:
+        return
+    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if not plugin_root:
+        return
+    init_path = os.path.join(plugin_root, "__init__.py")
+    spec = importlib.util.spec_from_file_location(
+        "hookify", init_path, submodule_search_locations=[plugin_root]
+    )
+    if spec is None or spec.loader is None:
+        return
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["hookify"] = module
+    spec.loader.exec_module(module)

--- a/plugins/hookify/hooks/posttooluse.py
+++ b/plugins/hookify/hooks/posttooluse.py
@@ -9,14 +9,9 @@ import os
 import sys
 import json
 
-# CRITICAL: Add plugin root to Python path for imports
-PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+from _bootstrap import ensure_hookify_importable
+
+ensure_hookify_importable()
 
 try:
     from hookify.core.config_loader import load_rules

--- a/plugins/hookify/hooks/pretooluse.py
+++ b/plugins/hookify/hooks/pretooluse.py
@@ -9,18 +9,9 @@ import os
 import sys
 import json
 
-# CRITICAL: Add plugin root to Python path for imports
-# We need to add the parent of the plugin directory so Python can find "hookify" package
-PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    # Add the parent directory of the plugin
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
+from _bootstrap import ensure_hookify_importable
 
-    # Also add PLUGIN_ROOT itself in case we have other scripts
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+ensure_hookify_importable()
 
 try:
     from hookify.core.config_loader import load_rules

--- a/plugins/hookify/hooks/stop.py
+++ b/plugins/hookify/hooks/stop.py
@@ -9,14 +9,9 @@ import os
 import sys
 import json
 
-# CRITICAL: Add plugin root to Python path for imports
-PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+from _bootstrap import ensure_hookify_importable
+
+ensure_hookify_importable()
 
 try:
     from hookify.core.config_loader import load_rules

--- a/plugins/hookify/hooks/userpromptsubmit.py
+++ b/plugins/hookify/hooks/userpromptsubmit.py
@@ -9,14 +9,9 @@ import os
 import sys
 import json
 
-# CRITICAL: Add plugin root to Python path for imports
-PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+from _bootstrap import ensure_hookify_importable
+
+ensure_hookify_importable()
 
 try:
     from hookify.core.config_loader import load_rules


### PR DESCRIPTION
## Summary
- Every hookify hook script (`pretooluse.py`, `posttooluse.py`, `stop.py`, `userpromptsubmit.py`) bootstraps its imports by adding `dirname(CLAUDE_PLUGIN_ROOT)` to `sys.path` and doing `from hookify.core... import ...`. That only resolves if some directory literally named `hookify` is on `sys.path` - i.e. `CLAUDE_PLUGIN_ROOT`'s own basename must be `hookify`.
- When the plugin is installed/cached under a version-numbered directory (e.g. `.../hookify/0.1.0/`), `CLAUDE_PLUGIN_ROOT`'s basename is `0.1.0`, so `dirname(CLAUDE_PLUGIN_ROOT)/hookify` never exists. Every hook then fails with `No module named 'hookify'` and hookify silently stops evaluating any rules (surfaced only as a `systemMessage`, tool calls proceed as if no hook ran).
- Hit this live: `hookify` was cached at `~/.claude/plugins/cache/claude-code-plugins/hookify/0.1.0/`, and `PreToolUse` was failing with exactly `Hookify import error: No module named 'hookify'` on every tool call.

## Fix
Added `plugins/hookify/hooks/_bootstrap.py`, which registers `CLAUDE_PLUGIN_ROOT` itself as the `hookify` module via `importlib.util.spec_from_file_location`, independent of what the directory is actually named on disk. All four hook scripts now call `ensure_hookify_importable()` instead of hand-rolling `sys.path` manipulation. Also added `plugins/hookify/__init__.py` (the top-level package file this approach needs - previously only the `core`/`matchers`/`utils` subpackages had one, not the plugin root itself).

This removes the implicit assumption that a plugin's install path preserves its declared name, which isn't guaranteed across install/cache mechanisms.

## Test plan
- [x] Reproduced the exact failure: copied `plugins/hookify` into a synthetic `.../hookify/0.1.0/` layout and ran each hook script against it with `CLAUDE_PLUGIN_ROOT` pointed at the version-numbered path - confirmed `No module named 'hookify'` on `main`.
- [x] Same repro, same synthetic layout, this branch: all four hook scripts (`pretooluse.py`, `posttooluse.py`, `stop.py`, `userpromptsubmit.py`) run cleanly and return valid JSON (exit 0).
- [x] Also verified against the original (non-version-numbered) `PLUGIN_ROOT` layout to confirm no regression there.