### PR TITLE
fix: guard empty FLAGS array expansion in gh.sh for bash < 4.4

### DIFF
--- a/scripts/gh.sh
+++ b/scripts/gh.sh
@@ -80,17 +80,17 @@ if [[ "$CMD" == "search issues" ]]; then
     echo "Error: search query must not contain repo:, org:, or user: qualifiers (e.g., ./scripts/gh.sh search issues \"bug report\" --limit 10)" >&2
     exit 1
   fi
-  gh "$SUB1" "$SUB2" "$QUERY" --repo "$REPO" "${FLAGS[@]}"
+  gh "$SUB1" "$SUB2" "$QUERY" --repo "$REPO" ${FLAGS[@]+"${FLAGS[@]}"}
 elif [[ "$CMD" == "issue view" ]]; then
   if [[ ${#POSITIONAL[@]} -ne 1 ]] || ! [[ "${POSITIONAL[0]}" =~ ^[0-9]+$ ]]; then
     echo "Error: issue view requires exactly one numeric issue number (e.g., ./scripts/gh.sh issue view 123)" >&2
     exit 1
   fi
-  gh "$SUB1" "$SUB2" "${POSITIONAL[0]}" "${FLAGS[@]}"
+  gh "$SUB1" "$SUB2" "${POSITIONAL[0]}" ${FLAGS[@]+"${FLAGS[@]}"}
 else
   if [[ ${#POSITIONAL[@]} -ne 0 ]]; then
     echo "Error: issue list and label list do not accept positional arguments (e.g., ./scripts/gh.sh issue list --state open, ./scripts/gh.sh label list --limit 100)" >&2
     exit 1
   fi
-  gh "$SUB1" "$SUB2" "${FLAGS[@]}"
+  gh "$SUB1" "$SUB2" ${FLAGS[@]+"${FLAGS[@]}"}
 fi


### PR DESCRIPTION
## Summary

`scripts/gh.sh` crashes with `FLAGS[@]: unbound variable` on any flagless invocation under bash < 4.4 (macOS stock /bin/bash 3.2), including its own usage example `issue view 123`. Under `set -u`, expanding an empty array with `"${FLAGS[@]}"` is fatal on older bash. This PR applies the standard `${FLAGS[@]+"${FLAGS[@]}"}` guard at the three call sites.

## Files changed

* `scripts/gh.sh` (lines 83, 89, 95: same one-token guard at each `gh` invocation)

## Verification

**Setup**: repro script that runs the wrapper under stock macOS `/bin/bash` 3.2.57 with a fake `gh` shim on PATH that prints its argv (no network), covering all four subcommands with and without flags plus the error paths.

**Details**: ran the script against the unfixed and fixed file on macOS (bash 3.2.57). CI runs on ubuntu bash 5 where empty-array expansion is already safe, so no behavior change there; the guard expands to the same argv, as the shim output confirms. Not re-run under bash >= 4.4 locally (none installed), but `${arr[@]+...}` expands identically to the unguarded form when the array is non-empty and to nothing when empty.

**Comparisons**

| Invocation (bash 3.2) | Unfixed | Fixed |
|---|---|---|
| `issue view 123` (documented example) | exit 1, `line 89: FLAGS[@]: unbound variable` | exit 0, gh called with `issue view 123` |
| `issue list` / `label list` / `search issues "q"` | exit 1, unbound variable | exit 0, correct argv |
| `issue view 123 --comments` (regression) | exit 0 | exit 0, identical argv |
| `issue list --state open --limit 20` (regression) | exit 0 | exit 0, identical argv |
| `issue list --json` (still rejected) | exit 1, flag error | exit 1, flag error |
| missing GH_REPO (guard intact) | exit 1, repo error | exit 1, repo error |

## Refs

Fixes #79128
