### PR TITLE
fix: do not abort validate-settings.sh when no lowercase frontmatter keys match

### DIFF
--- a/plugins/plugin-dev/skills/plugin-settings/scripts/validate-settings.sh
+++ b/plugins/plugin-dev/skills/plugin-settings/scripts/validate-settings.sh
@@ -68,7 +68,7 @@ fi
 # Check 6: Look for common fields
 echo ""
 echo "Detected fields:"
-echo "$FRONTMATTER" | grep '^[a-z_][a-z0-9_]*:' | while IFS=':' read -r key value; do
+echo "$FRONTMATTER" | { grep '^[a-z_][a-z0-9_]*:' || true; } | while IFS=':' read -r key value; do
   echo "  - $key: ${value:0:50}"
 done
 

--- a/plugins/plugin-dev/skills/plugin-settings/scripts/validate-settings.sh
+++ b/plugins/plugin-dev/skills/plugin-settings/scripts/validate-settings.sh
@@ -72,6 +72,21 @@ echo "$FRONTMATTER" | { grep '^[a-z_][a-z0-9_]*:' || true; } | while IFS=':' rea
   echo "  - $key: ${value:0:50}"
 done
 
+# Check 6b: Report keys the detector above skipped, so they are not invisible
+SKIPPED_KEYS=$(echo "$FRONTMATTER" \
+  | { grep '^[A-Za-z_][A-Za-z0-9_-]*:' || true; } \
+  | { grep -v '^[a-z_][a-z0-9_]*:' || true; } \
+  | cut -d: -f1)
+
+if [ -n "$SKIPPED_KEYS" ]; then
+  echo ""
+  echo "⚠️  Keys not listed above in $SETTINGS_FILE:"
+  echo "$SKIPPED_KEYS" | while IFS= read -r key; do
+    echo "  - $key"
+  done
+  echo "   Field names must be lowercase letters, digits or underscore."
+fi
+
 # Check 7: Validate common boolean fields
 for field in enabled strict_mode; do
   VALUE=$(echo "$FRONTMATTER" | grep "^${field}:" | sed "s/${field}: *//" || true)


### PR DESCRIPTION
## Summary

`validate-settings.sh` dies with exit 1 and no diagnostic when no frontmatter key matches its lowercase field pattern: `grep` returns 1, and `set -euo pipefail` aborts the script before any message prints. Keys that the pattern skips are also never reported, so a mixed-case or hyphenated key is invisible whether the script aborts or passes. This guards the `grep` so the run continues, and adds a check that names the file and every skipped key.

## Files changed

* `plugins/plugin-dev/skills/plugin-settings/scripts/validate-settings.sh` (guard on the check-6 `grep`; new check 6b listing skipped keys)

## Verification

**Setup** — `notes/repro-validate-settings/repro.sh` in the reproduction branch builds six fixture settings files in a temp dir and runs a target copy of the script against each, recording exit code and whether the skipped-key warning appeared. Fixtures: uppercase-only key, lowercase plus uppercase key, hyphenated key, all-lowercase keys, missing closing marker, non-boolean `enabled`.

**Details** — ran the harness twice on macOS with the system `/bin/bash` 3.2.57: once against `validate-settings.sh` as it stands on main, once against the patched file. Full script output was inspected by hand for the mixed-key fixture to confirm the warning text names the file and both offending keys.

**Comparisons**

| Fixture | On main | With this patch |
|---|---|---|
| `Enabled: true` only | exit 1, output stops at "Detected fields:" | exit 0, warns `- Enabled` |
| `enabled` + `Description` | exit 0, `Description` never mentioned | exit 0, warns `- Description` |
| `strict-mode: false` only | exit 1, silent abort | exit 0, warns `- strict-mode` |
| all-lowercase keys (regression) | exit 0, fields listed | exit 0, unchanged, no warning |
| missing `---` marker (regression) | exit 1 with the marker error | exit 1, same error |
| `enabled: maybe` (regression) | exit 0 with the boolean warning | exit 0, same warning |

The hyphenated-key row was not in the original report. It aborts on main for the same reason, since the check-6 pattern allows underscore but not hyphen.

The new check warns and leaves the exit code alone, matching how check 7 already reports a bad boolean value. Nothing here turns a previously passing file into a failing one.

## Refs

Fixes #79130
