### PR TITLE
docs: point pr-review-toolkit Contributing section at the in-repo agents directory

### DIFF
--- a/plugins/pr-review-toolkit/README.md
+++ b/plugins/pr-review-toolkit/README.md
@@ -296,9 +296,9 @@ This plugin works great with:
 
 ## Contributing
 
-Found issues or have suggestions? These agents are maintained in:
-- User agents: `~/.claude/agents/`
-- Project agents: `.claude/agents/` in claude-cli-internal
+Found issues or have suggestions? These agents are maintained in
+[`plugins/pr-review-toolkit/agents/`](https://github.com/anthropics/claude-code/tree/main/plugins/pr-review-toolkit/agents)
+in this repository.
 
 ## License
 


### PR DESCRIPTION
## Summary

The Contributing section of the pr-review-toolkit README directs contributors to `~/.claude/agents/` and to `.claude/agents/` in `claude-cli-internal`, a private repo that public contributors cannot reach. Leftover from before the plugin was open-sourced. The agents live in `plugins/pr-review-toolkit/agents/` in this repository, so the section now points there.

## Files changed

* `plugins/pr-review-toolkit/README.md` (Contributing section only, lines 299-301)

## Verification

**Setup**: fresh checkout of main.

**Details**: confirmed the six agent files exist at the new target with `ls plugins/pr-review-toolkit/agents/` (code-reviewer, code-simplifier, comment-analyzer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer). Confirmed the removed reference was the only one with `grep -rn 'claude-cli-internal' plugins/`, which matches nothing after the change. Link target verified against the live repo tree.

**Comparisons**

| Check | Before | After |
|---|---|---|
| `grep -rn claude-cli-internal plugins/` | 1 match (this README) | 0 matches |
| Contributing section target | private repo, unreachable | `plugins/pr-review-toolkit/agents/`, exists on main |
| Rest of README | n/a | untouched, no other section changed |

## Refs

Fixes #79137
