### PR TITLE
fix: use disable-model-invocation to hide ralph-wiggum commands from model invocation

### DIFF
--- a/plugins/ralph-wiggum/commands/cancel-ralph.md
+++ b/plugins/ralph-wiggum/commands/cancel-ralph.md
@@ -1,7 +1,7 @@
 ---
 description: "Cancel active Ralph Wiggum loop"
 allowed-tools: ["Bash(test -f .claude/ralph-loop.local.md:*)", "Bash(rm .claude/ralph-loop.local.md)", "Read(.claude/ralph-loop.local.md)"]
-hide-from-slash-command-tool: "true"
+disable-model-invocation: true
 ---
 
 # Cancel Ralph

--- a/plugins/ralph-wiggum/commands/ralph-loop.md
+++ b/plugins/ralph-wiggum/commands/ralph-loop.md
@@ -2,7 +2,7 @@
 description: "Start Ralph Wiggum loop in current session"
 argument-hint: "PROMPT [--max-iterations N] [--completion-promise TEXT]"
 allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh:*)"]
-hide-from-slash-command-tool: "true"
+disable-model-invocation: true
 ---
 
 # Ralph Loop Command


### PR DESCRIPTION
## Summary

Both ralph-wiggum commands set `hide-from-slash-command-tool: "true"`, a key the CLI tolerates but never reads, so the model can invoke `/ralph-loop` via the Skill tool even though the author clearly intended it to be user-only (a self-invoked Ralph loop starts an infinite loop). The documented key for this is `disable-model-invocation` (see `plugins/plugin-dev/skills/command-development/references/frontmatter-reference.md`). This PR replaces the key in both files.

## Files changed

* `plugins/ralph-wiggum/commands/ralph-loop.md`
* `plugins/ralph-wiggum/commands/cancel-ralph.md`

## Verification

**Setup**: scratch project with two test commands identical except for the frontmatter key, one with `hide-from-slash-command-tool: "true"` and one with `disable-model-invocation: true`. Probed each with a headless session (`claude -p ... --allowedTools "Skill"`, Claude Code v2.1.215) instructed to invoke the command via the Skill tool and report the outcome.

**Details**: the old-key command was invoked successfully by the model (its output came back verbatim), demonstrating the key does not hide anything. The new-key command was reported as not present in the model's available skills. A third run typed the new-key command as a user prompt (`claude -p "/test-cmd"`) and it executed normally, confirming the user-facing path is unaffected.

**Comparisons**

| Probe (v2.1.215) | `hide-from-slash-command-tool: "true"` | `disable-model-invocation: true` |
|---|---|---|
| Model invokes via Skill tool | invoked, output returned (bug) | not in available skills (hidden) |
| User types the slash command | works | works |

## Refs

Fixes #79138
