### PR TITLE
docs: align commit-push-pr README claims with what the command actually does

### DIFF
--- a/plugins/commit-commands/README.md
+++ b/plugins/commit-commands/README.md
@@ -70,15 +70,14 @@ Complete workflow command that commits, pushes, and creates a pull request in on
 # - Create a feature branch (if needed)
 # - Commit your changes
 # - Push to remote
-# - Open a PR with summary and test plan
+# - Open a PR with a summary of the changes
 # - Give you the PR URL to review
 ```
 
 **Features:**
-- Analyzes all commits in the branch (not just the latest)
-- Creates comprehensive PR descriptions with:
+- Generates the PR from your uncommitted changes (`git status` and `git diff HEAD`)
+- Creates PR descriptions with:
   - Summary of changes (1-3 bullet points)
-  - Test plan checklist
   - Claude Code attribution
 - Handles branch creation automatically
 - Uses GitHub CLI (`gh`) for PR creation
@@ -140,7 +139,7 @@ This plugin is included in the Claude Code repository. The commands are automati
 ### Using `/commit-push-pr`
 - Use when you're ready to create a PR
 - Ensure all your changes are complete and tested
-- Claude will analyze the full branch history for the PR description
+- Claude generates the PR description from the current uncommitted diff, not the branch's commit history
 - Review the PR description and edit if needed
 - Use when you want to minimize context switching
 


### PR DESCRIPTION
## Summary

The commit-commands README claims `/commit-push-pr` "analyzes all commits in the branch", "will analyze the full branch history", and produces a "test plan checklist". The command file injects only `git status`, `git diff HEAD`, and the current branch name, has no `git log` in `allowed-tools`, and forbids other tool use, so none of those claims hold. This PR rewords the three claims to describe what the command actually does: generate the PR from the uncommitted diff.

## Files changed

* `plugins/commit-commands/README.md` (lines 73, 78-82, 143)

## Verification

**Setup**: fresh checkout of main; claim-by-claim comparison against `commands/commit-push-pr.md`.

**Details**: for each README claim, checked whether the command's context injection (`git status`, `git diff HEAD`, `git branch --show-current`), `allowed-tools`, and prompt support it. Confirmed the `/commit` section's "examines recent commit messages" claim is backed by `git log --oneline -10` in `commit.md` and left it untouched.

**Comparisons**

| README claim | Backing in command | Action |
|---|---|---|
| "Analyzes all commits in the branch" | none (no git log, diff only) | reworded to uncommitted-diff behavior |
| "analyze the full branch history" | none | reworded |
| "Test plan checklist" | not specified by the command | removed |
| `/commit` "examines recent commit messages" (regression) | `git log --oneline -10` in commit.md | unchanged |

## Refs

Fixes #79144
