### PR TITLE
fix: honor thumbs-down from any user when skipping duplicate auto-close

### DIFF
--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -225,17 +225,16 @@ async function autoCloseDuplicates(): Promise<void> {
       `[DEBUG] Issue #${issue.number} - duplicate comment has ${reactions.length} reactions`
     );
 
-    const authorThumbsDown = reactions.some(
-      (reaction) =>
-        reaction.user.id === issue.user.id && reaction.content === "-1"
+    const thumbsDown = reactions.some(
+      (reaction) => reaction.content === "-1"
     );
     console.log(
-      `[DEBUG] Issue #${issue.number} - author thumbs down reaction: ${authorThumbsDown}`
+      `[DEBUG] Issue #${issue.number} - thumbs down reaction: ${thumbsDown}`
     );
 
-    if (authorThumbsDown) {
+    if (thumbsDown) {
       console.log(
-        `[DEBUG] Issue #${issue.number} - author disagreed with duplicate detection, skipping`
+        `[DEBUG] Issue #${issue.number} - a user disagreed with duplicate detection, skipping`
       );
       continue;
     }


### PR DESCRIPTION
## Summary

The dedupe bot comment promises "To prevent auto-closure, add a comment or 👎 this comment" with no author qualifier (`scripts/comment-on-duplicates.sh:89`), but `auto-close-duplicates.ts` only counts a `-1` reaction from the issue author, so anyone else's thumbs-down is ignored and the issue still auto-closes. The comment path already blocks on activity from any user, so this PR makes the reaction path consistent: any user's `-1` on the dupe comment skips auto-closure. No new abuse surface, since anyone can already block closure by commenting.

## Files changed

* `scripts/auto-close-duplicates.ts` (reaction predicate and its debug logs, lines 228-241)

## Verification

**Setup**: repro script that slices the actual `.some(...)` predicate out of a given copy of the file and evaluates it against fixture reaction sets (author `-1`, non-author `-1`, non-author `+1`, none). Typecheck with tsc 7.0.2 (`--strict`, es2022+dom libs) on both versions.

**Details**: ran the predicate harness and typecheck against upstream main and this branch on macOS/node. Both versions typecheck clean; behavior differs only in the non-author `-1` case.

**Comparisons**

| Reactions on dupe comment | Unfixed | Fixed |
|---|---|---|
| author 👎 | blocks auto-close | blocks auto-close |
| non-author 👎 | auto-closes anyway (bug) | blocks auto-close |
| non-author 👍 only | proceeds | proceeds |
| none | proceeds | proceeds |

If author-only was intentional, the alternative is rewording the bot comment; happy to switch to that if preferred.

## Refs

Fixes #79146
