### PR TITLE
fix: only log the Statsig duplicate-comment metric when a duplicate comment was posted

### DIFF
--- a/.github/workflows/claude-dedupe-issues.yml
+++ b/.github/workflows/claude-dedupe-issues.yml
@@ -43,9 +43,9 @@ jobs:
           claude_args: "--model claude-sonnet-4-5-20250929"
 
       - name: Log duplicate comment event to Statsig
-        if: always()
         env:
           STATSIG_API_KEY: ${{ secrets.STATSIG_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
           REPO: ${{ github.repository }}
           TRIGGERED_BY: ${{ github.event_name }}
@@ -55,7 +55,18 @@ jobs:
             echo "STATSIG_API_KEY not found, skipping Statsig logging"
             exit 0
           fi
-          
+
+          # Only log the event if this run actually posted a duplicate comment.
+          # The /dedupe command bails without commenting when the issue is
+          # closed, already deduped, or has no surviving duplicates.
+          RUN_STARTED_AT=$(gh run view "$WORKFLOW_RUN_ID" --repo "$REPO" --json createdAt --jq .createdAt)
+          MARKER_COUNT=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments?since=${RUN_STARTED_AT}&per_page=100" \
+            --jq '[.[] | select(.user.type == "Bot" and (.body | contains("possible duplicate")))] | length')
+          if [ "$MARKER_COUNT" -eq 0 ]; then
+            echo "No duplicate comment posted by this run, skipping Statsig logging"
+            exit 0
+          fi
+
           # Prepare the event payload
           EVENT_PAYLOAD=$(jq -n \
             --arg issue_number "$ISSUE_NUMBER" \


### PR DESCRIPTION
## Summary

The "Log duplicate comment event to Statsig" step runs with `if: always()` and unconditionally emits `github_duplicate_comment_added` with value 1, even though the `/dedupe` command bails without commenting when the issue is closed, already deduped, or has no surviving duplicates, and even when the action step fails. The metric therefore counts workflow runs, not duplicate comments. This PR drops `if: always()` and skips the emission unless a bot comment containing the duplicate marker was created on the issue after the run started.

## Files changed

* `.github/workflows/claude-dedupe-issues.yml` (Statsig step: removed `if: always()`, added `GH_TOKEN` env and a marker-comment gate before the payload; the `time:` line and HTTP status check are untouched to stay clear of #69716, #77442, and #68682)

## Verification

**Setup**: YAML parse of the workflow, bash syntax check of the extracted run block, and a live test of the gate query against real repo data (issue #77821, which has a dedupe marker comment from 2026-07-15, and a real run id of this workflow for `gh run view --json createdAt`).

**Details**: workflows cannot be executed from a fork with repo secrets, so the gate logic was exercised directly with the gh CLI using the exact commands from the step. `since=` before the marker's timestamp simulates a run that just posted a comment; `since=` at a later run's start time simulates a run that posted nothing.

**Comparisons**

| Case | Gate result | Step outcome |
|---|---|---|
| marker comment created after run start (since=2026-01-01 vs 2026-07-15 marker) | count 1 | logs event |
| no marker since run start (since=2026-07-19 run createdAt) | count 0 | skips, exit 0 |
| STATSIG_API_KEY absent (regression) | unchanged early exit | skips, exit 0 |
| action step fails | step no longer runs (`if: always()` removed) | no false metric |

Re-runs via workflow_dispatch on an already-deduped issue no longer double-count: the pre-existing marker predates the new run's start, so the gate skips it.

## Refs

Fixes #79147
