### PR TITLE
Mobile app issue triage: ranked report for July 12–19

### DIFF
--- a/triage/mobile-issues-2026-07-12-to-2026-07-19.md
+++ b/triage/mobile-issues-2026-07-12-to-2026-07-19.md
@@ -1,0 +1,73 @@
+# Mobile app issue triage — July 12–19, 2026
+
+Scope: open issues filed against this repo between 2026-07-12 and 2026-07-19 that affect the
+Claude mobile apps (iOS / Android), including Remote Control and Dispatch flows where the
+mobile app is the affected surface. Sources: keyword search for "mobile" (96 open issues) plus
+label searches for `platform:ios` (19) and `platform:android` (5). Issues already labeled
+`duplicate` or `invalid` are folded into their clusters or dropped.
+
+Ranking criteria, in order: (1) user lockout or data/billing loss, (2) core flow broken with
+no workaround, (3) report frequency (duplicate clusters), (4) has a reproduction, (5) degraded
+UX / polish, (6) feature requests.
+
+## P0 — critical
+
+| Rank | Issue | Summary | Why it ranks here |
+|---|---|---|---|
+| 1 | [#78452](https://github.com/anthropics/claude-code/issues/78452) | Mobile app has no Bypass Permissions mode; with the fail-closed auto-mode classifier outage, remote users are completely locked out — no prompt fallback, and settings.json edits are themselves gated | Total lockout with zero workaround from the phone. A server-side outage in one component (permission classifier) cascades into every remote session being unusable. Needs both an incident-side fix and a client-side fallback (fail open to a manual prompt). |
+| 2 | [#77157](https://github.com/anthropics/claude-code/issues/77157) | Single prompt on iOS/iPadOS spawns multiple sessions that all execute independently, multiplying quota consumption | Direct billing/quota damage. Duplicate-session spawn means users pay several times for one request, silently. |
+| 3 | [#77915](https://github.com/anthropics/claude-code/issues/77915) | Remote Control disconnect always crashes with `Cannot read properties of undefined (reading 'session_url')` — missing null guard on the toggle-off path | The most-reported crash of the week: duplicates/variants include [#78786](https://github.com/anthropics/claude-code/issues/78786), [#78933](https://github.com/anthropics/claude-code/issues/78933), [#78336](https://github.com/anthropics/claude-code/issues/78336), [#78482](https://github.com/anthropics/claude-code/issues/78482) (crash on `/compact`), and [#78484](https://github.com/anthropics/claude-code/issues/78484) (toggle permanently stuck afterwards). Has repro; likely a small, well-localized null-guard fix with outsized impact on mobile connectivity. |
+
+## P1 — core mobile flows broken
+
+| Rank | Issue | Summary | Why it ranks here |
+|---|---|---|---|
+| 4 | [#77369](https://github.com/anthropics/claude-code/issues/77369) | Messages sent from phone/web show as sent but never arrive in the CLI session | Silent message loss — the worst failure mode for a remote UI. Related silent-loss reports: [#77252](https://github.com/anthropics/claude-code/issues/77252) (long-idle sessions go stale, prompts vanish after ~60s while mobile still shows "Connected") and [#77103](https://github.com/anthropics/claude-code/issues/77103) (bridge answer dropped when a Stop-hook turn supersedes the state being answered). |
+| 5 | [#78302](https://github.com/anthropics/claude-code/issues/78302) | Repo picker empty on iOS ("Repositories not showing") despite working on web | Blocks first-run/session creation entirely. Android twin [#78292](https://github.com/anthropics/claude-code/issues/78292) is already marked duplicate of the long-running backend repo-index cluster (#34523 et al.). High frequency across the tracker. |
+| 6 | [#78987](https://github.com/anthropics/claude-code/issues/78987) | Sessions show "Disconnected" on mobile while the local `claude.exe` process is alive; presence tracks recent mobile chat activity, not process liveness | Presence layer is wrong in both directions — see also [#77881](https://github.com/anthropics/claude-code/issues/77881) (Devices row stays "Active" after session end and machine power-off). Users can't trust the session list, which is the mobile app's home screen. |
+| 7 | [#76843](https://github.com/anthropics/claude-code/issues/76843) | iOS app blocks session initialization with a "GitHub app is not installed" modal for non-admin repos authorized via /web-setup | Hard block on session creation for org members who aren't repo admins; works on web, so it's a mobile-side gating bug. |
+| 8 | [#77387](https://github.com/anthropics/claude-code/issues/77387) | Continuing a Mac-created session from iOS intermittently fails — "active worker" contention (close code 4090) plus 15-min warm idle timeout | Has repro and a solid protocol-level diagnosis in the report; breaks the flagship "start on desktop, continue on phone" flow. |
+| 9 | [#78358](https://github.com/anthropics/claude-code/issues/78358) | Image-only paste from the mobile app uploads the attachment but never submits the prompt | Has repro. Sibling report [#77365](https://github.com/anthropics/claude-code/issues/77365) (cannot add pictures to a Claude Code chat from the app) suggests image input on mobile is broadly unreliable. |
+| 10 | [#79142](https://github.com/anthropics/claude-code/issues/79142) | Desktop machine no longer offered as a target for new local sessions from the mobile app (cloud only) | Recent regression that removes a whole entry point; also see [#76821](https://github.com/anthropics/claude-code/issues/76821) (project/folder selection step disappeared — sessions always start at `$HOME`). |
+| 11 | [#78565](https://github.com/anthropics/claude-code/issues/78565) | iOS Code tab stuck at "Setting up a cloud container" on every new instruction while the session is actually running | Display-only stall, but it makes the app look broken and hides real progress. Related: [#78669](https://github.com/anthropics/claude-code/issues/78669) (infinite spinner instead of an error when the session runner has died). |
+| 12 | [#79198](https://github.com/anthropics/claude-code/issues/79198) | Remote Control sessions auto-archive on iOS but not on desktop, despite the auto-archive setting being disabled | Sessions disappear from the phone; data isn't lost but users can't find their work. |
+| 13 | [#78792](https://github.com/anthropics/claude-code/issues/78792) | Published Claude Code artifacts do not appear in the mobile app (they show on web and desktop) | Feature-parity gap that breaks artifact hand-off to the device where viewing matters most. |
+| 14 | [#76900](https://github.com/anthropics/claude-code/issues/76900) | Mobile push notifications are never revoked after the session is answered on another device | Has repro. Notification noise trains users to ignore real prompts. |
+| 15 | [#77056](https://github.com/anthropics/claude-code/issues/77056) | Silent model downgrade on guardrail trigger — no iOS notification, and the model itself is unaware of the switch | Trust/transparency issue: users pay for and expect a specific model. |
+| 16 | [#78684](https://github.com/anthropics/claude-code/issues/78684) | Code sessions started via Dispatch don't appear in the mobile Dispatch list | Dispatch-on-mobile gap; see also [#76840](https://github.com/anthropics/claude-code/issues/76840) (AskUserQuestion dialogs never appear on the synced mobile app, blocking remote sessions) and [#76841](https://github.com/anthropics/claude-code/issues/76841) (no way to reopen a routine's session after the notification is gone). |
+| 17 | [#78400](https://github.com/anthropics/claude-code/issues/78400) | `/goal` issued from the phone doesn't start working until an extra nudge prompt is sent | Workaround exists (send a follow-up), so lower than the silent-loss bugs. |
+
+Desktop-side bridge bugs whose visible symptom is "my session never shows up on my phone" —
+worth tracking as one registration-lifecycle cluster: [#78001](https://github.com/anthropics/claude-code/issues/78001)
+(reused window never re-registers), [#78563](https://github.com/anthropics/claude-code/issues/78563)
+(forked sessions never enable Remote Control), [#78564](https://github.com/anthropics/claude-code/issues/78564)
+(resumed sessions don't re-mint a bridge), [#78667](https://github.com/anthropics/claude-code/issues/78667)
+(auto-registration stops after app update), [#78366](https://github.com/anthropics/claude-code/issues/78366)
+(presence pulses get unretried 401s), [#78428](https://github.com/anthropics/claude-code/issues/78428)
+(orphans on OAuth token rotation), [#79108](https://github.com/anthropics/claude-code/issues/79108)
+(orphaned when the worker dies), [#78741](https://github.com/anthropics/claude-code/issues/78741)
+(push registration dies silently while the socket stays connected).
+
+## P2 — enhancements and paper cuts
+
+| Issue | Summary |
+|---|---|
+| [#78784](https://github.com/anthropics/claude-code/issues/78784) | Failure-resistant Remote Control session model: survive hibernation, auto-reattach, mobile-side recovery — the umbrella request that would resolve much of the P1 bridge cluster |
+| [#78731](https://github.com/anthropics/claude-code/issues/78731) | Queue messages while the app is minimized; improve approval-request visibility on mobile |
+| [#78883](https://github.com/anthropics/claude-code/issues/78883) | Widget/visual tool output doesn't render in mobile remote-control sessions |
+| [#78679](https://github.com/anthropics/claude-code/issues/78679) | Mobile Code tab has no Pinned sessions section; desktop/web pins never surface |
+| [#76898](https://github.com/anthropics/claude-code/issues/76898) | Session list should surface hostname and cwd — multi-machine fleets are indistinguishable |
+| [#76794](https://github.com/anthropics/claude-code/issues/76794) | Always-on context-window usage indicator on mobile |
+| [#76896](https://github.com/anthropics/claude-code/issues/76896) | iOS web app paper cuts: input auto-zoom and sticky `:hover` on touch |
+| [#77134](https://github.com/anthropics/claude-code/issues/77134) | Surface just-authored text for approval without a second model pass (token cost on remote/mobile) |
+
+## Why there are no per-issue fix PRs
+
+Every issue above lives in closed-source surfaces — the iOS/Android apps, the desktop app,
+the CLI, or the Remote Control / session backend. This repository contains only the public
+changelog, docs examples, plugins, and issue-tracker automation, so none of the affected code
+can be patched here. Suggested next step for the highest-leverage internal fixes:
+
+1. Null-guard the Remote Control disconnect path (`session_url` crash family, rank 3) — small fix, five reports this week.
+2. Give the mobile app a permission-prompt fallback when the auto-mode classifier is unavailable (rank 1).
+3. Reconcile server-side presence with process liveness in both directions (ranks 6 and the registration cluster).


### PR DESCRIPTION
## Summary

Adds a ranked triage report covering all open mobile-related issues (iOS/Android apps, Remote Control, Dispatch) filed between 2026-07-12 and 2026-07-19.

- Sources: keyword search for "mobile" (96 open issues) plus `platform:ios` (19) and `platform:android` (5) label searches; `duplicate`/`invalid` issues folded into clusters.
- Issues are ranked P0/P1/P2 by lockout/billing impact, broken core flows, report frequency, and repro availability.
- Top findings: the remote-user permission lockout (#78452), duplicate session spawn multiplying quota on iOS (#77157), and the `session_url` disconnect-crash family (#77915 + 4 duplicates this week).
- Identifies two recurring clusters worth fixing as units: the desktop bridge registration lifecycle (8 issues) and server-side presence reconciliation (2 issues).

## Notes

The affected code (mobile apps, desktop app, CLI, Remote Control backend) is not in this repository, so no per-issue fix PRs are possible here; this PR carries the triage document only and is intentionally a draft.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UhUHGiupKBXCNVXNiZztc7)_