### PR TITLE
docs(pr-review-toolkit): point Contributing section to in-repo agents

### DIFF
--- a/plugins/pr-review-toolkit/README.md
+++ b/plugins/pr-review-toolkit/README.md
@@ -296,9 +296,7 @@ This plugin works great with:
 
 ## Contributing
 
-Found issues or have suggestions? These agents are maintained in:
-- User agents: `~/.claude/agents/`
-- Project agents: `.claude/agents/` in claude-cli-internal
+Found issues or have suggestions? These agents are maintained in `plugins/pr-review-toolkit/agents/` in this repository.
 
 ## License
 


### PR DESCRIPTION
Fixes #79137

The Contributing section of `plugins/pr-review-toolkit/README.md` pointed readers to `.claude/agents/` in `claude-cli-internal`, a private repository that users of this repo cannot access.

The six review agents actually live in `plugins/pr-review-toolkit/agents/` in this repository, so the section now points there.

`grep -rn 'claude-cli-internal' plugins/` confirms this was the only such reference.