### PR TITLE
fix(ralph-wiggum): use disable-model-invocation to keep commands user-only

### DIFF
--- a/plugins/ralph-wiggum/commands/cancel-ralph.md
+++ b/plugins/ralph-wiggum/commands/cancel-ralph.md
@@ -1,7 +1,7 @@
 ---
 description: "Cancel active Ralph Wiggum loop"
 allowed-tools: ["Bash(test -f .claude/ralph-loop.local.md:*)", "Bash(rm .claude/ralph-loop.local.md)", "Read(.claude/ralph-loop.local.md)"]
-hide-from-slash-command-tool: "true"
+disable-model-invocation: true
 ---
 
 # Cancel Ralph

--- a/plugins/ralph-wiggum/commands/ralph-loop.md
+++ b/plugins/ralph-wiggum/commands/ralph-loop.md
@@ -2,7 +2,7 @@
 description: "Start Ralph Wiggum loop in current session"
 argument-hint: "PROMPT [--max-iterations N] [--completion-promise TEXT]"
 allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh:*)"]
-hide-from-slash-command-tool: "true"
+disable-model-invocation: true
 ---
 
 # Ralph Loop Command


### PR DESCRIPTION
Fixes #79138

`commands/ralph-loop.md` and `commands/cancel-ralph.md` set `hide-from-slash-command-tool: "true"`. That key is not recognized — the repo's own frontmatter reference (`plugins/plugin-dev/skills/command-development/references/frontmatter-reference.md`) documents `disable-model-invocation` as the key that removes a command from the SlashCommand tool.

As a result the model can invoke `/ralph-loop` itself, which starts an unattended loop — the one command clearly meant to stay user-only.

This switches both files to `disable-model-invocation: true`.