### PR TITLE
docs(plugin-dev): correct marketplace name to claude-code-plugins

### DIFF
--- a/plugins/plugin-dev/README.md
+++ b/plugins/plugin-dev/README.md
@@ -195,10 +195,10 @@ Use this workflow for structured, high-quality plugin development from concept t
 
 ## Installation
 
-Install from claude-code-marketplace:
+Install from claude-code-plugins:
 
 ```bash
-/plugin install plugin-dev@claude-code-marketplace
+/plugin install plugin-dev@claude-code-plugins
 ```
 
 Or for development, use directly:
@@ -378,7 +378,7 @@ All skills emphasize:
 
 ## Contributing
 
-This plugin is part of the claude-code-marketplace. To contribute improvements:
+This plugin is part of the claude-code-plugins. To contribute improvements:
 
 1. Fork the marketplace repository
 2. Make changes to plugin-dev/


### PR DESCRIPTION
Fixes #70064

`plugins/plugin-dev/README.md` tells users to install from `claude-code-marketplace`, but the bundled marketplace is named `claude-code-plugins` in `.claude-plugin/marketplace.json` (and referenced as such in `security-guidance`'s code). The documented `/plugin install plugin-dev@claude-code-marketplace` therefore does not resolve.

This updates the three `claude-code-marketplace` references in the README to the actual name.