### PR TITLE
fix: quote ${CLAUDE_PLUGIN_ROOT} in plugin hook commands

### DIFF
--- a/plugins/explanatory-output-style/hooks/hooks.json
+++ b/plugins/explanatory-output-style/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks-handlers/session-start.sh"
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks-handlers/session-start.sh\""
           }
         ]
       }

--- a/plugins/hookify/hooks/hooks.json
+++ b/plugins/hookify/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse.py",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse.py\"",
             "timeout": 10
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/posttooluse.py",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/posttooluse.py\"",
             "timeout": 10
           }
         ]
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/stop.py",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/stop.py\"",
             "timeout": 10
           }
         ]
@@ -39,7 +39,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/userpromptsubmit.py",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/userpromptsubmit.py\"",
             "timeout": 10
           }
         ]

--- a/plugins/learning-output-style/hooks/hooks.json
+++ b/plugins/learning-output-style/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks-handlers/session-start.sh"
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks-handlers/session-start.sh\""
           }
         ]
       }

--- a/plugins/ralph-wiggum/hooks/hooks.json
+++ b/plugins/ralph-wiggum/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.sh"
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.sh\""
           }
         ]
       }


### PR DESCRIPTION
Fixes #78490

On macOS the plugin root resolves under `~/Library/Application Support/…`, which contains a space. Several bundled plugins interpolate `${CLAUDE_PLUGIN_ROOT}` **unquoted** into their `hooks.json` commands, so the shell word-splits on the space, never finds the script, and the hook fails:

- `hookify` — the broken command is on `PreToolUse`, which blocks **every** tool call.
- `learning-output-style`, `explanatory-output-style` (`SessionStart`) and `ralph-wiggum` (`Stop`) fail **silently**.

This quotes the interpolated path in all four `hooks.json` files, matching the pattern `security-guidance` already uses (`bash "${CLAUDE_PLUGIN_ROOT}/…"`). JSON validity confirmed after the change.

Reproduced with a space in the path: unquoted exits 127 (`No such file or directory`); quoted runs the script.