### PR TITLE
fix(hookify): read rule and transcript files as UTF-8

### DIFF
--- a/plugins/hookify/core/config_loader.py
+++ b/plugins/hookify/core/config_loader.py
@@ -248,7 +248,7 @@ def load_rule_file(file_path: str) -> Optional[Rule]:
         Rule object or None if file is invalid.
     """
     try:
-        with open(file_path, 'r') as f:
+        with open(file_path, 'r', encoding='utf-8') as f:
             content = f.read()
 
         frontmatter, message = extract_frontmatter(content)

--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -209,7 +209,7 @@ class RuleEngine:
                 transcript_path = input_data.get('transcript_path')
                 if transcript_path:
                     try:
-                        with open(transcript_path, 'r') as f:
+                        with open(transcript_path, 'r', encoding='utf-8') as f:
                             return f.read()
                     except FileNotFoundError:
                         print(f"Warning: Transcript file not found: {transcript_path}", file=sys.stderr)


### PR DESCRIPTION
Addresses the encoding root cause in #77270.

`config_loader.py` and `rule_engine.py` opened files with no explicit encoding, so they used the platform default. On Windows that is cp1252, which cannot decode the UTF-8 rule files (the shipped examples contain arrows, warning emoji, and em-dashes). `load_rule_file` catches the `UnicodeDecodeError` and drops the rule silently, so prompt/tool rules never fire and nothing signals the failure.

This opens both reads with `encoding='utf-8'`.

Verified: decoding `examples/hookify.dangerous-rm.local.md` (which contains ⚠️) with cp1252 raises `UnicodeDecodeError`; with utf-8 it succeeds.

Note: this fixes only the encoding half of #77270. The report's second point (the `user_prompt` vs `prompt` payload field) is left out, since the `user_prompt` field name is used consistently across the plugin and the plugin-dev hook docs, and I could not verify the live payload key.