### PR TITLE
fix(hookify): event: prompt rules never fire (payload key is `prompt`)

### DIFF
--- a/plugins/hookify/README.md
+++ b/plugins/hookify/README.md
@@ -253,7 +253,7 @@ Use environment variables instead of hardcoded values.
 - `content`: File content (Write only)
 
 **For prompt events:**
-- `user_prompt`: The user's submitted prompt text
+- `user_prompt` (alias `prompt`): The user's submitted prompt text
 
 **For stop events:**
 - Use general matching on session state

--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -223,9 +223,11 @@ class RuleEngine:
                     except UnicodeDecodeError as e:
                         print(f"Warning: Encoding error in transcript {transcript_path}: {e}", file=sys.stderr)
                         return ''
-            elif field == 'user_prompt':
-                # For UserPromptSubmit events
-                return input_data.get('user_prompt', '')
+            elif field in ('user_prompt', 'prompt'):
+                # For UserPromptSubmit events. Claude Code sends the submitted
+                # text under the key `prompt`, so read that first and fall back
+                # to `user_prompt`. Both field spellings are accepted.
+                return input_data.get('prompt') or input_data.get('user_prompt', '')
 
         # Handle special cases by tool type
         if tool_name == 'Bash':


### PR DESCRIPTION
## Summary

`event: prompt` (UserPromptSubmit) rules **never fire**, for both field spellings.

Claude Code sends the submitted text under the payload key **`prompt`**, but `_extract_field` only handled `field == 'user_prompt'` and read `input_data.get('user_prompt', '')` — a key that is never present. `hooks/userpromptsubmit.py` passes raw stdin straight to the engine, so nothing normalizes it. The rule loads fine and silently does nothing, which is easy to ship by accident.

The README currently documents `user_prompt` as the prompt-event field, so following the docs exactly still produces a dead rule.

## Fix

Accept both field spellings and read `prompt` first, falling back to `user_prompt` for compatibility:

```python
elif field in ('user_prompt', 'prompt'):
    return input_data.get('prompt') or input_data.get('user_prompt', '')
```

## Verification

End-to-end through the real `hooks/userpromptsubmit.py` entrypoint, same rules, same payload
(`{"hook_event_name":"UserPromptSubmit","prompt":"please rotate the secret"}`):

| build | `field: prompt` | `field: user_prompt` |
|---|---|---|
| official (unpatched) | dead (`{}`) | dead (`{}`) |
| patched (this PR) | **fires** | **fires** |

Regression check: a `event: bash` rule still fires on the patched build. `python3 -m py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
