### PR TITLE
fix(hookify): make hook entrypoints runnable without CLAUDE_PLUGIN_ROOT

### DIFF
--- a/plugins/hookify/hooks/posttooluse.py
+++ b/plugins/hookify/hooks/posttooluse.py
@@ -10,13 +10,17 @@ import sys
 import json
 
 # CRITICAL: Add plugin root to Python path for imports
-PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+# Falls back to this file's own location so the hook is runnable outside the
+# plugin harness (direct invocation, local testing) where CLAUDE_PLUGIN_ROOT is
+# not set. Unchanged behavior when the variable IS set.
+PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT') or os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__))
+)
+parent_dir = os.path.dirname(PLUGIN_ROOT)
+if parent_dir not in sys.path:
+    sys.path.insert(0, parent_dir)
+if PLUGIN_ROOT not in sys.path:
+    sys.path.insert(0, PLUGIN_ROOT)
 
 try:
     from hookify.core.config_loader import load_rules

--- a/plugins/hookify/hooks/pretooluse.py
+++ b/plugins/hookify/hooks/pretooluse.py
@@ -11,16 +11,20 @@ import json
 
 # CRITICAL: Add plugin root to Python path for imports
 # We need to add the parent of the plugin directory so Python can find "hookify" package
-PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    # Add the parent directory of the plugin
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
+# Falls back to this file's own location so the hook is runnable outside the
+# plugin harness (direct invocation, local testing) where CLAUDE_PLUGIN_ROOT is
+# not set. Unchanged behavior when the variable IS set.
+PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT') or os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__))
+)
+# Add the parent directory of the plugin
+parent_dir = os.path.dirname(PLUGIN_ROOT)
+if parent_dir not in sys.path:
+    sys.path.insert(0, parent_dir)
 
-    # Also add PLUGIN_ROOT itself in case we have other scripts
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+# Also add PLUGIN_ROOT itself in case we have other scripts
+if PLUGIN_ROOT not in sys.path:
+    sys.path.insert(0, PLUGIN_ROOT)
 
 try:
     from hookify.core.config_loader import load_rules

--- a/plugins/hookify/hooks/stop.py
+++ b/plugins/hookify/hooks/stop.py
@@ -10,13 +10,17 @@ import sys
 import json
 
 # CRITICAL: Add plugin root to Python path for imports
-PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+# Falls back to this file's own location so the hook is runnable outside the
+# plugin harness (direct invocation, local testing) where CLAUDE_PLUGIN_ROOT is
+# not set. Unchanged behavior when the variable IS set.
+PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT') or os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__))
+)
+parent_dir = os.path.dirname(PLUGIN_ROOT)
+if parent_dir not in sys.path:
+    sys.path.insert(0, parent_dir)
+if PLUGIN_ROOT not in sys.path:
+    sys.path.insert(0, PLUGIN_ROOT)
 
 try:
     from hookify.core.config_loader import load_rules

--- a/plugins/hookify/hooks/userpromptsubmit.py
+++ b/plugins/hookify/hooks/userpromptsubmit.py
@@ -10,13 +10,17 @@ import sys
 import json
 
 # CRITICAL: Add plugin root to Python path for imports
-PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+# Falls back to this file's own location so the hook is runnable outside the
+# plugin harness (direct invocation, local testing) where CLAUDE_PLUGIN_ROOT is
+# not set. Unchanged behavior when the variable IS set.
+PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT') or os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__))
+)
+parent_dir = os.path.dirname(PLUGIN_ROOT)
+if parent_dir not in sys.path:
+    sys.path.insert(0, parent_dir)
+if PLUGIN_ROOT not in sys.path:
+    sys.path.insert(0, PLUGIN_ROOT)
 
 try:
     from hookify.core.config_loader import load_rules


### PR DESCRIPTION
## Summary

All four hook entrypoints add the plugin to `sys.path` **only** when `CLAUDE_PLUGIN_ROOT` is set:

```python
PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
if PLUGIN_ROOT:
    ... sys.path.insert(...)
```

When the variable is absent the guard silently skips path setup, the following `from hookify.core...` import fails, and the hook prints `{"systemMessage": "Hookify import error: No module named 'hookify'"}` and exits 0 — every rule for that event is inert.

The practical consequence is that **the hooks are not runnable outside the plugin harness**. Piping a payload into `pretooluse.py` to test a rule fails unless the caller happens to know to set the variable first, which makes local rule development and debugging harder than it needs to be. (I hit this twice while testing rules against this plugin, and it silently masked an unrelated result until I noticed the `import error` string in the output.)

## Fix

Fall back to the file's own location:

```python
PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT') or os.path.dirname(
    os.path.dirname(os.path.abspath(__file__))
)
```

The `if PLUGIN_ROOT:` guard becomes unnecessary (the value is now always resolvable), so its body is dedented. **Behavior is unchanged when `CLAUDE_PLUGIN_ROOT` is set** — the env var still wins.

Applied identically to `pretooluse.py`, `posttooluse.py`, `stop.py`, and `userpromptsubmit.py`.

## Verification

Real payload (`rm -rf` against a `event: bash` rule), official vs patched, with and without the variable:

| build | `CLAUDE_PLUGIN_ROOT` set | result |
|---|---|---|
| official | yes | rule fires |
| official | **no** | **import error** (all rules inert) |
| patched | yes | rule fires |
| patched | **no** | **rule fires** |

The other three entrypoints were each driven with their own payload without the variable set and returned clean `{}` instead of an import error. `python3 -m py_compile` clean on all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
