### PR TITLE
Make devcontainer firewall init resilient to DNS resolution failures

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -76,8 +76,8 @@ for domain in \
     echo "Resolving $domain..."
     ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}')
     if [ -z "$ips" ]; then
-        echo "ERROR: Failed to resolve $domain"
-        exit 1
+        echo "WARNING: Failed to resolve $domain, skipping"
+        continue
     fi
     
     while read -r ip; do
@@ -86,7 +86,7 @@ for domain in \
             exit 1
         fi
         echo "Adding $ip for $domain"
-        ipset add allowed-domains "$ip"
+        ipset add allowed-domains "$ip" -exist
     done < <(echo "$ips")
 done
 


### PR DESCRIPTION
## Summary

Hardens `.devcontainer/init-firewall.sh` so a transient DNS failure while resolving one allowed domain no longer aborts the entire firewall setup.

## Problem

The domain-resolution loop ran `exit 1` if any single domain failed to resolve. Under `set -euo pipefail`, one flaky lookup (e.g. `sentry.io`) would kill the whole script — leaving the container with default-DROP policies but no allow rules, i.e. no working egress at all.

## Changes

- Replace `exit 1` on resolution failure with a `WARNING` + `continue`, so unresolvable domains are skipped and the rest of the allowlist is still applied.
- Add `-exist` to `ipset add` so duplicate IPs (common when allowed domains share CDN ranges) don't fail under `set -e`.

## Testing

Verified inside the devcontainer that the firewall still enforces the allowlist correctly: whitelisted hosts (GitHub API, api.anthropic.com, registry.npmjs.org) are reachable while non-allowlisted hosts (example.com, pypi.org, google.com) are rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)