### PR TITLE
Add account profiles plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -145,6 +145,16 @@
       },
       "source": "./plugins/security-guidance",
       "category": "security"
+    },
+    {
+      "name": "account-profiles",
+      "description": "Manage isolated Claude Code launch profiles for personal, work, and client accounts without copying credentials",
+      "version": "0.1.0",
+      "author": {
+        "name": "Osalumense"
+      },
+      "source": "./plugins/account-profiles",
+      "category": "productivity"
     }
   ]
 }

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -12,6 +12,7 @@ Learn more in the [official plugins documentation](https://docs.claude.com/en/do
 
 | Name | Description | Contents |
 |------|-------------|----------|
+| [account-profiles](./account-profiles/) | Manage isolated launch profiles for personal, work, and client Claude accounts | **Commands:** `/account-profiles:add`, `/account-profiles:list`, `/account-profiles:status`, `/account-profiles:launch`, `/account-profiles:assign`, `/account-profiles:doctor`, `/account-profiles:remove` |
 | [agent-sdk-dev](./agent-sdk-dev/) | Development kit for working with the Claude Agent SDK | **Command:** `/new-sdk-app` - Interactive setup for new Agent SDK projects<br>**Agents:** `agent-sdk-verifier-py`, `agent-sdk-verifier-ts` - Validate SDK applications against best practices |
 | [claude-opus-4-5-migration](./claude-opus-4-5-migration/) | Migrate code and prompts from Sonnet 4.x and Opus 4.1 to Opus 4.5 | **Skill:** `claude-opus-4-5-migration` - Automated migration of model strings, beta headers, and prompt adjustments |
 | [code-review](./code-review/) | Automated PR code review using multiple specialized agents with confidence-based scoring to filter false positives | **Command:** `/code-review` - Automated PR review workflow<br>**Agents:** 5 parallel Sonnet agents for CLAUDE.md compliance, bug detection, historical context, PR history, and code comments |

--- a/plugins/account-profiles/.claude-plugin/plugin.json
+++ b/plugins/account-profiles/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "account-profiles",
+  "version": "0.1.0",
+  "description": "Manage isolated Claude Code launch profiles for personal, work, and client accounts without copying credentials",
+  "author": {
+    "name": "Osalumense"
+  }
+}

--- a/plugins/account-profiles/README.md
+++ b/plugins/account-profiles/README.md
@@ -1,0 +1,58 @@
+# Account Profiles
+
+Account Profiles manages isolated `CLAUDE_CONFIG_DIR` launch environments for people who use personal, work, or client Claude accounts on one computer.
+
+It packages the existing configuration-directory workaround into validated profile creation, launch instructions, project safeguards, and diagnostics. It **does not** modify or copy OAuth credentials, switch the currently running Claude Code process, or guarantee that operating-system credential storage is isolated.
+
+## Commands
+
+- `/account-profiles:add <name>` creates an empty profile directory.
+- `/account-profiles:list` lists registered profiles.
+- `/account-profiles:status` identifies the selected local launch profile.
+- `/account-profiles:launch <name>` prints PowerShell and POSIX launch commands.
+- `/account-profiles:assign <name>` adds a local expected-profile marker to the current project.
+- `/account-profiles:doctor` validates directories and registry data.
+- `/account-profiles:remove <name>` removes a profile after explicit confirmation.
+
+## Workflow
+
+```text
+/account-profiles:add personal
+/account-profiles:add work
+/account-profiles:launch work
+```
+
+Run the printed command in a new terminal and authenticate once using `/login`. Later launches reuse whatever authentication Claude Code itself associates with that configuration environment.
+
+Always verify the actual account with `/status`. A profile name is local metadata and is not proof of the authenticated or billed identity.
+
+## Development
+
+Load the plugin directly:
+
+```bash
+claude --plugin-dir /path/to/claude-code/plugins/account-profiles
+```
+
+Run automated tests:
+
+```bash
+node --test plugins/account-profiles/tests/profile-manager.test.mjs
+```
+
+Use a temporary profiles home for non-destructive testing:
+
+```bash
+CLAUDE_PROFILES_HOME=/tmp/account-profiles-test node plugins/account-profiles/scripts/profile-manager.mjs add work
+```
+
+## Security and limitations
+
+- Credentials are handled only by Claude Code's existing `/login` flow.
+- The plugin never reads, copies, exports, or displays tokens.
+- Profile removal deletes local settings and sessions but does not revoke OAuth access.
+- A plugin cannot mutate the parent process environment; switching requires a new process.
+- Some Claude Code surfaces and OS credential stores may not fully honor `CLAUDE_CONFIG_DIR`. Test two real accounts concurrently before relying on isolation.
+- Keep `.claude/account-profile.local.json` out of version control when project assignments reveal internal account or organization names.
+
+This is an interim workflow related to [#20131](https://github.com/anthropics/claude-code/issues/20131), not native multi-account authentication.

--- a/plugins/account-profiles/commands/add.md
+++ b/plugins/account-profiles/commands/add.md
@@ -1,0 +1,13 @@
+---
+description: Create an isolated Claude Code account profile
+argument-hint: <profile-name>
+allowed-tools: ["Bash(node:*)"]
+---
+
+Create an account profile named `$ARGUMENTS` by running:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/profile-manager.mjs" add "$ARGUMENTS"
+```
+
+Report the generated launch command. Explain that the user authenticates once with `/login` in the newly launched process. Never read, copy, or display credential files.

--- a/plugins/account-profiles/commands/assign.md
+++ b/plugins/account-profiles/commands/assign.md
@@ -1,0 +1,7 @@
+---
+description: Assign the current project to an expected account profile
+argument-hint: <profile-name>
+allowed-tools: ["Bash(node:*)"]
+---
+
+Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/profile-manager.mjs" assign "$ARGUMENTS"`. Ensure `.claude/account-profile.local.json` is ignored locally before suggesting it is safe from version control.

--- a/plugins/account-profiles/commands/doctor.md
+++ b/plugins/account-profiles/commands/doctor.md
@@ -1,0 +1,6 @@
+---
+description: Diagnose local Claude Code account profile configuration
+allowed-tools: ["Bash(node:*)"]
+---
+
+Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/profile-manager.mjs" doctor`. Then remind the user to launch every profile and check `/status`; directory validation cannot prove OAuth credential isolation.

--- a/plugins/account-profiles/commands/launch.md
+++ b/plugins/account-profiles/commands/launch.md
@@ -1,0 +1,7 @@
+---
+description: Print the command to launch Claude Code with an account profile
+argument-hint: <profile-name>
+allowed-tools: ["Bash(node:*)"]
+---
+
+Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/profile-manager.mjs" launch "$ARGUMENTS"`. Explain that the command must be used in a new terminal because a plugin cannot replace authentication in the running Claude Code process.

--- a/plugins/account-profiles/commands/list.md
+++ b/plugins/account-profiles/commands/list.md
@@ -1,0 +1,6 @@
+---
+description: List configured Claude Code account profiles
+allowed-tools: ["Bash(node:*)"]
+---
+
+Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/profile-manager.mjs" list` and show the result. Do not infer authentication status; tell the user to verify identity with `/status` after launching a profile.

--- a/plugins/account-profiles/commands/remove.md
+++ b/plugins/account-profiles/commands/remove.md
@@ -1,0 +1,7 @@
+---
+description: Remove a disposable Claude Code account profile after confirmation
+argument-hint: <profile-name>
+allowed-tools: ["Bash(node:*)"]
+---
+
+Explain that removal permanently deletes the selected profile's local settings and sessions but does not revoke OAuth access. Ask for explicit confirmation, then and only then run `node "${CLAUDE_PLUGIN_ROOT}/scripts/profile-manager.mjs" remove "$ARGUMENTS" --confirm`. Never remove the active profile.

--- a/plugins/account-profiles/commands/status.md
+++ b/plugins/account-profiles/commands/status.md
@@ -1,0 +1,6 @@
+---
+description: Show the active Claude Code launch profile
+allowed-tools: ["Bash(node:*)"]
+---
+
+Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/profile-manager.mjs" status`. Clearly distinguish the selected local profile from the authenticated Claude account; `/status` is authoritative for account identity.

--- a/plugins/account-profiles/hooks/hooks.json
+++ b/plugins/account-profiles/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Warn when a project is opened with a different account profile than its local assignment",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/profile-manager.mjs\" check-project --hook",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/account-profiles/scripts/profile-manager.mjs
+++ b/plugins/account-profiles/scripts/profile-manager.mjs
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import process from "node:process";
+
+const PROFILE_RE = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
+const RESERVED_WINDOWS_NAMES = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i;
+
+function profilesRoot(env = process.env) {
+  return resolve(env.CLAUDE_PROFILES_HOME || join(homedir(), ".claude-profiles"));
+}
+
+function registryPath(root) {
+  return join(root, "profiles.json");
+}
+
+function markerPath(root) {
+  return join(root, ".account-profiles-root");
+}
+
+function ensureSafeRoot(root) {
+  if (root === dirname(root) || root === resolve(homedir())) {
+    throw new Error("CLAUDE_PROFILES_HOME must be a dedicated subdirectory, not a filesystem root or home directory.");
+  }
+}
+
+function loadRegistry(root) {
+  const path = registryPath(root);
+  if (!existsSync(path)) return { version: 1, profiles: {} };
+  const registry = JSON.parse(readFileSync(path, "utf8"));
+  if (registry.version !== 1 || !registry.profiles || Array.isArray(registry.profiles)) {
+    throw new Error(`Invalid profile registry: ${path}`);
+  }
+  return registry;
+}
+
+function saveRegistry(root, registry) {
+  ensureSafeRoot(root);
+  mkdirSync(root, { recursive: true });
+  if (!existsSync(markerPath(root))) writeFileSync(markerPath(root), "Managed by the Claude Code account-profiles plugin.\n", { mode: 0o600 });
+  const path = registryPath(root);
+  const temporary = `${path}.${process.pid}.tmp`;
+  writeFileSync(temporary, `${JSON.stringify(registry, null, 2)}\n`, { mode: 0o600 });
+  renameSync(temporary, path);
+}
+
+function validateName(name) {
+  if (!name || !PROFILE_RE.test(name) || RESERVED_WINDOWS_NAMES.test(name)) {
+    throw new Error("Profile names must be 1-64 lowercase letters, numbers, or hyphens; reserved device names are not allowed.");
+  }
+  return name;
+}
+
+function profilePath(root, name) {
+  const path = resolve(root, name);
+  if (dirname(path) !== root) throw new Error("Profile path escaped the profiles directory.");
+  return path;
+}
+
+function quotePowerShell(value) {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function quotePosix(value) {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function launchInstructions(path) {
+  return [
+    "PowerShell:",
+    `  $env:CLAUDE_CONFIG_DIR=${quotePowerShell(path)}; claude`,
+    "",
+    "macOS/Linux:",
+    `  CLAUDE_CONFIG_DIR=${quotePosix(path)} claude`,
+  ].join("\n");
+}
+
+function activeProfile(root, registry, env = process.env) {
+  if (!env.CLAUDE_CONFIG_DIR) return null;
+  const activePath = resolve(env.CLAUDE_CONFIG_DIR);
+  return Object.entries(registry.profiles).find(([, profile]) => resolve(profile.configDir) === activePath)?.[0] || null;
+}
+
+function commandAdd(root, name) {
+  ensureSafeRoot(root);
+  validateName(name);
+  const registry = loadRegistry(root);
+  if (registry.profiles[name]) throw new Error(`Profile already exists: ${name}`);
+  const configDir = profilePath(root, name);
+  mkdirSync(root, { recursive: true });
+  mkdirSync(configDir, { recursive: false });
+  registry.profiles[name] = { configDir, createdAt: new Date().toISOString() };
+  saveRegistry(root, registry);
+  console.log(`Created profile: ${name}\nConfig directory: ${configDir}\n\n${launchInstructions(configDir)}\n\nAuthenticate once with /login after launching this profile.`);
+}
+
+function commandList(root) {
+  const registry = loadRegistry(root);
+  const active = activeProfile(root, registry);
+  const names = Object.keys(registry.profiles).sort();
+  if (!names.length) return console.log("No account profiles configured.");
+  for (const name of names) {
+    const marker = name === active ? "*" : " ";
+    const present = existsSync(registry.profiles[name].configDir) ? "ready" : "missing directory";
+    console.log(`${marker} ${name.padEnd(20)} ${present.padEnd(18)} ${registry.profiles[name].configDir}`);
+  }
+}
+
+function commandStatus(root) {
+  const registry = loadRegistry(root);
+  const active = activeProfile(root, registry);
+  if (!process.env.CLAUDE_CONFIG_DIR) {
+    console.log("No CLAUDE_CONFIG_DIR is set. Claude Code is using its default profile.");
+  } else if (active) {
+    console.log(`Active profile: ${active}\nConfig directory: ${resolve(process.env.CLAUDE_CONFIG_DIR)}`);
+  } else {
+    console.log(`CLAUDE_CONFIG_DIR is not a registered profile: ${resolve(process.env.CLAUDE_CONFIG_DIR)}`);
+  }
+}
+
+function commandLaunch(root, name) {
+  validateName(name);
+  const registry = loadRegistry(root);
+  const profile = registry.profiles[name];
+  if (!profile) throw new Error(`Unknown profile: ${name}`);
+  console.log(`Launch ${name} in a new terminal. The current Claude Code process cannot change its own authentication environment.\n\n${launchInstructions(profile.configDir)}`);
+}
+
+function commandRemove(root, name, confirmed) {
+  ensureSafeRoot(root);
+  validateName(name);
+  if (!confirmed) throw new Error("Removal requires --confirm. This deletes the profile's local settings and sessions.");
+  const registry = loadRegistry(root);
+  const profile = registry.profiles[name];
+  if (!profile) throw new Error(`Unknown profile: ${name}`);
+  if (activeProfile(root, registry) === name) throw new Error("Refusing to remove the active profile.");
+  if (!existsSync(markerPath(root))) throw new Error("Refusing to remove files because the profiles-root safety marker is missing.");
+  const expected = profilePath(root, name);
+  if (resolve(profile.configDir) !== expected) throw new Error("Refusing to remove a profile with an unexpected path.");
+  rmSync(expected, { recursive: true, force: true });
+  delete registry.profiles[name];
+  saveRegistry(root, registry);
+  console.log(`Removed profile: ${name}\nOAuth access was not revoked server-side.`);
+}
+
+function assignmentPath(cwd = process.cwd()) {
+  return join(cwd, ".claude", "account-profile.local.json");
+}
+
+function commandAssign(root, name) {
+  validateName(name);
+  const registry = loadRegistry(root);
+  if (!registry.profiles[name]) throw new Error(`Unknown profile: ${name}`);
+  const path = assignmentPath();
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify({ profile: name }, null, 2)}\n`, { flag: "w" });
+  console.log(`Assigned this project to profile: ${name}\nSaved: ${path}\nKeep this local file out of version control.`);
+}
+
+function projectExpectation() {
+  const path = assignmentPath();
+  if (!existsSync(path)) return null;
+  const assignment = JSON.parse(readFileSync(path, "utf8"));
+  validateName(assignment.profile);
+  return { ...assignment, path };
+}
+
+function commandCheckProject(root, hookMode) {
+  const expected = projectExpectation();
+  if (!expected) return;
+  const registry = loadRegistry(root);
+  const active = activeProfile(root, registry);
+  if (active === expected.profile) return;
+  const message = `Account profile mismatch: this project expects "${expected.profile}", but the active profile is ${active ? `"${active}"` : "the default or an unregistered profile"}. Run /account-profiles:launch ${expected.profile} and restart in the new terminal.`;
+  console.log(hookMode ? JSON.stringify({ hookSpecificOutput: { hookEventName: "SessionStart", additionalContext: message } }) : message);
+}
+
+function commandDoctor(root) {
+  const registry = loadRegistry(root);
+  const issues = [];
+  for (const [name, profile] of Object.entries(registry.profiles)) {
+    try {
+      validateName(name);
+      if (resolve(profile.configDir) !== profilePath(root, name)) issues.push(`${name}: unexpected config path`);
+      else if (!existsSync(profile.configDir)) issues.push(`${name}: config directory is missing`);
+    } catch (error) {
+      issues.push(`${name}: ${error.message}`);
+    }
+  }
+  const duplicatePaths = Object.values(registry.profiles).map((profile) => resolve(profile.configDir));
+  if (new Set(duplicatePaths).size !== duplicatePaths.length) issues.push("Multiple profiles share the same config directory");
+  console.log(`Profiles home: ${root}`);
+  console.log(`Registered profiles: ${Object.keys(registry.profiles).length}`);
+  console.log(process.env.CLAUDE_CONFIG_DIR ? `Current CLAUDE_CONFIG_DIR: ${resolve(process.env.CLAUDE_CONFIG_DIR)}` : "Current CLAUDE_CONFIG_DIR: not set");
+  if (issues.length) {
+    for (const issue of issues) console.log(`ERROR: ${issue}`);
+    process.exitCode = 1;
+  } else {
+    console.log("Profile directory checks passed. Confirm account identity separately with /status in each launched profile.");
+  }
+}
+
+function usage() {
+  console.log("Usage: profile-manager.mjs <add|list|status|launch|assign|check-project|doctor|remove> [profile] [--confirm|--hook]");
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const [command, name, ...flags] = argv;
+  const root = profilesRoot();
+  switch (command) {
+    case "add": return commandAdd(root, name);
+    case "list": return commandList(root);
+    case "status": return commandStatus(root);
+    case "launch": return commandLaunch(root, name);
+    case "assign": return commandAssign(root, name);
+    case "check-project": return commandCheckProject(root, flags.includes("--hook") || name === "--hook");
+    case "doctor": return commandDoctor(root);
+    case "remove": return commandRemove(root, name, flags.includes("--confirm"));
+    default: usage(); process.exitCode = 2;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
+    process.exitCode = 1;
+  }
+}
+
+export { activeProfile, launchInstructions, loadRegistry, profilePath, profilesRoot, validateName };

--- a/plugins/account-profiles/tests/profile-manager.test.mjs
+++ b/plugins/account-profiles/tests/profile-manager.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { activeProfile, launchInstructions, loadRegistry, profilePath, profilesRoot, validateName } from "../scripts/profile-manager.mjs";
+
+test("accepts safe profile names", () => {
+  for (const name of ["work", "personal-2", "a", "a1-b2"]) assert.equal(validateName(name), name);
+});
+
+test("rejects unsafe and reserved profile names", () => {
+  for (const name of ["", "../work", "work/user", "Work", "work_user", "con", "LPT1", `a${"b".repeat(64)}`]) {
+    assert.throws(() => validateName(name));
+  }
+});
+
+test("profile paths stay directly under the profiles root", () => {
+  const root = resolve(join(tmpdir(), "profiles-root"));
+  assert.equal(profilePath(root, "work"), join(root, "work"));
+});
+
+test("resolves an explicit dedicated profiles home", () => {
+  const root = resolve(join(tmpdir(), "explicit-profiles-root"));
+  assert.equal(profilesRoot({ CLAUDE_PROFILES_HOME: root }), root);
+});
+
+test("detects the active registered profile by config directory", () => {
+  const root = resolve(join(tmpdir(), "profiles-root"));
+  const registry = { profiles: { work: { configDir: join(root, "work") } } };
+  assert.equal(activeProfile(root, registry, { CLAUDE_CONFIG_DIR: join(root, "work") }), "work");
+  assert.equal(activeProfile(root, registry, { CLAUDE_CONFIG_DIR: join(root, "other") }), null);
+});
+
+test("launch instructions include both supported shell forms", () => {
+  const output = launchInstructions("C:\\Profiles\\work");
+  assert.match(output, /PowerShell:/);
+  assert.match(output, /CLAUDE_CONFIG_DIR/);
+  assert.match(output, /macOS\/Linux:/);
+});
+
+test("loads a valid registry and rejects malformed registries", () => {
+  const root = mkdtempSync(join(tmpdir(), "account-profiles-test-"));
+  try {
+    assert.deepEqual(loadRegistry(root), { version: 1, profiles: {} });
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, "profiles.json"), JSON.stringify({ version: 1, profiles: { work: { configDir: join(root, "work") } } }));
+    assert.ok(loadRegistry(root).profiles.work);
+    writeFileSync(join(root, "profiles.json"), JSON.stringify({ version: 2, profiles: {} }));
+    assert.throws(() => loadRegistry(root), /Invalid profile registry/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("creates, lists, diagnoses, and safely removes profiles", () => {
+  const root = mkdtempSync(join(tmpdir(), "account-profiles-e2e-"));
+  const script = fileURLToPath(new URL("../scripts/profile-manager.mjs", import.meta.url));
+  const run = (...args) => spawnSync(process.execPath, [script, ...args], {
+    env: { ...process.env, CLAUDE_PROFILES_HOME: root },
+    encoding: "utf8",
+  });
+  try {
+    assert.equal(run("add", "work").status, 0);
+    assert.match(run("list").stdout, /work\s+ready/);
+    assert.equal(run("doctor").status, 0);
+    assert.notEqual(run("remove", "work").status, 0);
+    assert.equal(run("remove", "work", "--confirm").status, 0);
+    assert.match(run("list").stdout, /No account profiles configured/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Adds an experimental `account-profiles` plugin that manages isolated `CLAUDE_CONFIG_DIR` launch environments for people using personal, work, or client Claude accounts on one computer.

The plugin provides commands to create, list, inspect, launch, assign, diagnose, and safely remove named profiles. It never reads, copies, exports, or displays OAuth credentials; authentication remains entirely within Claude Code's existing `/login` flow.

Related to #20131. This is an interim CLI workflow, not native in-process or Claude Desktop GUI account switching.

## User impact

Users can authenticate separate profiles once, launch independent Claude Code processes, and keep those processes tied to different accounts without repeatedly logging out and back in. A project-local assignment can warn when a repository is opened with the wrong profile.

Because plugins cannot mutate the parent process environment, switching requires launching a new Claude Code process. `/status` remains authoritative for the authenticated and billed identity.

## Security

- Validates profile names and prevents path traversal.
- Rejects filesystem roots and home directories as profile roots.
- Requires a managed-root marker and explicit confirmation before recursive profile removal.
- Refuses to remove the active profile or profiles with unexpected paths.
- Stores only non-secret profile metadata.
- Documents OS credential-store and `CLAUDE_CONFIG_DIR` isolation limitations.

## Validation

- `node --test plugins/account-profiles/tests/profile-manager.test.mjs` — 8 tests pass.
- `claude plugin validate plugins/account-profiles` — passes.
- Windows lifecycle test: create, list, launch instructions, doctor, confirmed removal.
- Real-account isolation test with Claude Code 2.1.197:
  - Claude Pro and Claude Team accounts remained independently authenticated in separate profile directories.
  - Alternating fresh `claude auth status` processes returned the correct identity for each profile without another login.
- Marketplace and hook JSON parse successfully.
- `git diff --check` passes.