### PR TITLE
fix(scripts): paginate comments and reactions in auto-close-duplicates

### DIFF
--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -46,6 +46,28 @@ async function githubRequest<T>(endpoint: string, token: string, method: string 
   return response.json();
 }
 
+// List endpoints return at most 100 items per page (30 by default), so
+// follow pagination until a short page signals the end of the collection.
+async function githubRequestAllPages<T>(
+  endpoint: string,
+  token: string
+): Promise<T[]> {
+  const results: T[] = [];
+  const perPage = 100;
+  const separator = endpoint.includes("?") ? "&" : "?";
+
+  for (let page = 1; page <= 20; page++) {
+    const pageItems: T[] = await githubRequest(
+      `${endpoint}${separator}per_page=${perPage}&page=${page}`,
+      token
+    );
+    results.push(...pageItems);
+    if (pageItems.length < perPage) break;
+  }
+
+  return results;
+}
+
 function extractDuplicateIssueNumber(commentBody: string): number | null {
   // Try to match #123 format first
   let match = commentBody.match(/#(\d+)/);
@@ -153,7 +175,7 @@ async function autoCloseDuplicates(): Promise<void> {
     );
 
     console.log(`[DEBUG] Fetching comments for issue #${issue.number}...`);
-    const comments: GitHubComment[] = await githubRequest(
+    const comments: GitHubComment[] = await githubRequestAllPages(
       `/repos/${owner}/${repo}/issues/${issue.number}/comments`,
       token
     );
@@ -217,7 +239,7 @@ async function autoCloseDuplicates(): Promise<void> {
     console.log(
       `[DEBUG] Issue #${issue.number} - checking reactions on duplicate comment...`
     );
-    const reactions: GitHubReaction[] = await githubRequest(
+    const reactions: GitHubReaction[] = await githubRequestAllPages(
       `/repos/${owner}/${repo}/issues/comments/${lastDupeComment.id}/reactions`,
       token
     );


### PR DESCRIPTION
Fixes #80506

## Problem

`auto-close-duplicates.ts` paginates the issues list, but its other two list reads rely on GitHub's default page size of **30** and never follow pagination:

- the comments read feeding both the dupe-notice lookup and the `commentsAfterDupe` activity guard
- the reactions read feeding the 👎 objection guard

`sweep.ts` in the same directory passes `per_page=100` on every list call, so this is an outlier. The result is that the two guards protecting reporters from wrongful auto-close degrade exactly on high-engagement issues: a 👎 past the first 30 reactions is ignored (real dupe notices are already at 23 👎 — see the notice on #44252), and human objections after a dupe notice sitting at comment position 30 are invisible (notices deep in threads are a supported path via `backfill-duplicate-comments.ts` dispatch). This also composes with #79146/#79151 — counting any user's 👎 doesn't help if that 👎 is on page 2.

## Fix

Add a `githubRequestAllPages` helper (`per_page=100`, follows pages until a short page, same 20-page safety cap as the existing issues loop) and use it for the comments and reactions reads. No behavior change for issues with ≤30 comments/reactions.

## Testing

Mock-fetch harness emulating GitHub pagination semantics (30 items when `per_page` is absent), three fixture issues: author's `-1` at reaction position 33 (#101), five human objections after a dupe notice at comment position 30 (#102), and a clean candidate (#103).

- Script on `main`: `closed: [101, 102, 103]` — two wrongful closes
- This branch: `closed: [103]` — objections honored, legitimate close still happens

This PR was written with the assistance of Claude Code; all changes were reviewed and the tests run by me.
