### PR TITLE
Log closed issues as closure events in Statsig

### DIFF
--- a/.github/workflows/log-issue-events.yml
+++ b/.github/workflows/log-issue-events.yml
@@ -10,14 +10,16 @@ jobs:
     permissions:
       issues: read
     steps:
-      - name: Log issue creation to Statsig
+      - name: Log issue event to Statsig
         env:
           STATSIG_API_KEY: ${{ secrets.STATSIG_API_KEY }}
+          EVENT_NAME: ${{ github.event.action == 'closed' && 'github_issue_closed' || 'github_issue_created' }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           AUTHOR: ${{ github.event.issue.user.login }}
           CREATED_AT: ${{ github.event.issue.created_at }}
+          CLOSED_AT: ${{ github.event.issue.closed_at }}
         run: |
           # All values are now safely passed via environment variables
           # No direct templating in the shell script to prevent injection attacks
@@ -27,13 +29,14 @@ jobs:
             -H "statsig-api-key: $STATSIG_API_KEY" \
             -d '{
               "events": [{
-                "eventName": "github_issue_created",
+                "eventName": "'"$EVENT_NAME"'",
                 "metadata": {
                   "issue_number": "'"$ISSUE_NUMBER"'",
                   "repository": "'"$REPO"'",
                   "title": "'"$(echo "$ISSUE_TITLE" | sed "s/\"/\\\\\"/g")"'",
                   "author": "'"$AUTHOR"'",
-                  "created_at": "'"$CREATED_AT"'"
+                  "created_at": "'"$CREATED_AT"'",
+                  "closed_at": "'"$CLOSED_AT"'"
                 },
                 "time": '"$(date +%s)000"'
               }]


### PR DESCRIPTION
## What this does

The issue event workflow listens for both opened and closed actions, but currently sends `github_issue_created` for both. As a result, closing an issue is recorded as another creation event.

This keeps the existing `github_issue_created` name for opened issues, emits `github_issue_closed` for closed issues, and includes `closed_at` alongside the existing `created_at` metadata.

The closed trigger was added specifically to expand event tracking beyond creation, so distinguishing the event preserves that intent without changing the existing creation event schema.

## How we know it works

- Parsed the workflow as YAML.
- Checked the embedded script with `bash -n`.
- Generated mocked payloads for both actions and parsed them as JSON.
- Verified opened actions emit `github_issue_created` with an empty `closed_at`.
- Verified closed actions emit `github_issue_closed` with both lifecycle timestamps.
- Ran `git diff --check`.

<!-- NO CHANGELOG -->