### PR TITLE
fix(examples/settings): make bash-sandbox example fail closed when sandbox unavailable

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -25,6 +25,7 @@ These may be applied at any level of the [settings hierarchy](https://code.claud
 - Settings files must be valid JSON
 - Before deploying configuration files to your organization, test them locally by applying to `managed-settings.json`, `settings.json` or `settings.local.json`
 - The `sandbox` property only applies to the `Bash` tool; it does not apply to other tools (like Read, Write, WebSearch, WebFetch, MCPs), hooks, or internal commands
+- The sandbox is available on macOS, Linux, and WSL2 only. When it cannot initialize (e.g. native Windows, or Linux hosts without bubblewrap), Claude Code warns and runs Bash commands unsandboxed unless `failIfUnavailable` is set to `true` — [`settings-bash-sandbox.json`](./settings-bash-sandbox.json) sets it so the sandbox requirement fails closed
 
 ## Deploying via MDM
 

--- a/examples/settings/settings-bash-sandbox.json
+++ b/examples/settings/settings-bash-sandbox.json
@@ -2,6 +2,7 @@
   "allowManagedPermissionRulesOnly": true,
   "sandbox": {
     "enabled": true,
+    "failIfUnavailable": true,
     "autoAllowBashIfSandboxed": false,
     "allowUnsandboxedCommands": false,
     "excludedCommands": [],


### PR DESCRIPTION
## Problem

`examples/settings/settings-bash-sandbox.json` is documented in the README table as **"Bash tool must run inside of sandbox"**, but the config omits `failIfUnavailable`. Per the [sandboxing docs](https://code.claude.com/docs/en/sandboxing), when the sandbox cannot initialize, Claude Code shows a warning and **runs commands without sandboxing** — and the sandbox does not run on native Windows at all, nor on Linux hosts missing bubblewrap.

So as written, the enforcement example silently fails open exactly where enforcement matters most: an organization deploying this file as managed policy across a mixed fleet gets unsandboxed Bash on every Windows machine, with no policy violation surfaced.

## Fix

- Add `"failIfUnavailable": true` to the `sandbox` block. This matches the managed-enforcement snippet recommended in the sandboxing docs (`enabled` + `failIfUnavailable` + `allowUnsandboxedCommands: false`).
- Add a Tips bullet to `examples/settings/README.md` documenting the macOS/Linux/WSL2 platform constraint and the fail-open default, so admins merging these snippets understand the behavior.

## Notes

- These examples carry the README's community-maintained banner; this change only strengthens the guarantee the table already claims for this file.
- JSON validated after the edit.
- Searched open PRs for `failIfUnavailable` and for changes to this example before filing — found none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)