### PR TITLE
fix(devcontainer): block IPv6 egress to close firewall allowlist bypass

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -13,6 +13,22 @@ iptables -t nat -X
 iptables -t mangle -F
 iptables -t mangle -X
 ipset destroy allowed-domains 2>/dev/null || true
+ipset destroy allowed-domains-v6 2>/dev/null || true
+
+# Detect IPv6 support. Without matching ip6tables rules, dual-stack networks
+# let IPv6 egress bypass the allowlist below entirely. On hosts where IPv6 is
+# disabled (e.g. ipv6.disable=1), ip6tables cannot operate - there is no IPv6
+# traffic to filter, so skip IPv6 rules rather than fail container startup.
+if ip6tables -L -n >/dev/null 2>&1; then
+    IPV6_ENABLED=true
+    ip6tables -F
+    ip6tables -X
+    ip6tables -t mangle -F 2>/dev/null || true
+    ip6tables -t mangle -X 2>/dev/null || true
+else
+    IPV6_ENABLED=false
+    echo "WARNING: ip6tables unavailable - skipping IPv6 firewall rules"
+fi
 
 # 2. Selectively restore ONLY internal Docker DNS resolution
 if [ -n "$DOCKER_DNS_RULES" ]; then
@@ -37,8 +53,21 @@ iptables -A INPUT -p tcp --sport 22 -m state --state ESTABLISHED -j ACCEPT
 iptables -A INPUT -i lo -j ACCEPT
 iptables -A OUTPUT -o lo -j ACCEPT
 
+# Same DNS/SSH/localhost allowances for IPv6
+if [ "$IPV6_ENABLED" = true ]; then
+    ip6tables -A OUTPUT -p udp --dport 53 -j ACCEPT
+    ip6tables -A INPUT -p udp --sport 53 -j ACCEPT
+    ip6tables -A OUTPUT -p tcp --dport 22 -j ACCEPT
+    ip6tables -A INPUT -p tcp --sport 22 -m state --state ESTABLISHED -j ACCEPT
+    ip6tables -A INPUT -i lo -j ACCEPT
+    ip6tables -A OUTPUT -o lo -j ACCEPT
+fi
+
 # Create ipset with CIDR support
 ipset create allowed-domains hash:net
+if [ "$IPV6_ENABLED" = true ]; then
+    ipset create allowed-domains-v6 hash:net family inet6
+fi
 
 # Fetch GitHub meta information and aggregate + add their IP ranges
 echo "Fetching GitHub IP ranges..."
@@ -61,7 +90,19 @@ while read -r cidr; do
     fi
     echo "Adding GitHub range $cidr"
     ipset add allowed-domains "$cidr"
-done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
+done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | grep -v ':' | aggregate -q)
+
+if [ "$IPV6_ENABLED" = true ]; then
+    echo "Processing GitHub IPv6 ranges..."
+    while read -r cidr; do
+        if [[ ! "$cidr" =~ ^[0-9a-fA-F:]+/[0-9]{1,3}$ ]]; then
+            echo "ERROR: Invalid IPv6 CIDR range from GitHub meta: $cidr"
+            exit 1
+        fi
+        echo "Adding GitHub IPv6 range $cidr"
+        ipset add allowed-domains-v6 "$cidr"
+    done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | grep ':' | sort -u)
+fi
 
 # Resolve and add other allowed domains
 for domain in \
@@ -88,6 +129,23 @@ for domain in \
         echo "Adding $ip for $domain"
         ipset add allowed-domains "$ip"
     done < <(echo "$ips")
+
+    # Also add AAAA records so allowed domains work first-class over IPv6.
+    # A missing AAAA record is not an error: IPv6 attempts are rejected fast
+    # below and clients fall back to IPv4.
+    if [ "$IPV6_ENABLED" = true ]; then
+        ipv6s=$(dig +noall +answer AAAA "$domain" | awk '$4 == "AAAA" {print $5}')
+        while read -r ip; do
+            if [ -n "$ip" ]; then
+                if [[ ! "$ip" =~ ^[0-9a-fA-F:]+$ ]]; then
+                    echo "ERROR: Invalid IPv6 from DNS for $domain: $ip"
+                    exit 1
+                fi
+                echo "Adding $ip for $domain (IPv6)"
+                ipset add allowed-domains-v6 "$ip"
+            fi
+        done < <(echo "$ipv6s")
+    fi
 done
 
 # Get host IP from default route
@@ -119,6 +177,32 @@ iptables -A OUTPUT -m set --match-set allowed-domains dst -j ACCEPT
 # Explicitly REJECT all other outbound traffic for immediate feedback
 iptables -A OUTPUT -j REJECT --reject-with icmp-admin-prohibited
 
+# IPv6: same default-deny posture, so IPv6 cannot bypass the IPv4 allowlist
+if [ "$IPV6_ENABLED" = true ]; then
+    # Link-local and ICMPv6 are required for neighbor discovery; without
+    # them IPv6 breaks entirely, even for allowed destinations
+    ip6tables -A INPUT -s fe80::/10 -j ACCEPT
+    ip6tables -A OUTPUT -d fe80::/10 -j ACCEPT
+    ip6tables -A INPUT -p ipv6-icmp -j ACCEPT
+    ip6tables -A OUTPUT -p ipv6-icmp -j ACCEPT
+
+    # Set default policies to DROP
+    ip6tables -P INPUT DROP
+    ip6tables -P FORWARD DROP
+    ip6tables -P OUTPUT DROP
+
+    # Allow established connections for already approved traffic
+    ip6tables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+    ip6tables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+    # Then allow only specific outbound traffic to allowed domains
+    ip6tables -A OUTPUT -m set --match-set allowed-domains-v6 dst -j ACCEPT
+
+    # REJECT (not DROP) so blocked IPv6 attempts fail fast and clients
+    # fall back to IPv4 instead of hanging
+    ip6tables -A OUTPUT -j REJECT --reject-with icmp6-adm-prohibited
+fi
+
 echo "Firewall configuration complete"
 echo "Verifying firewall rules..."
 if curl --connect-timeout 5 https://example.com >/dev/null 2>&1; then
@@ -126,6 +210,17 @@ if curl --connect-timeout 5 https://example.com >/dev/null 2>&1; then
     exit 1
 else
     echo "Firewall verification passed - unable to reach https://example.com as expected"
+fi
+
+# Verify the block also holds over IPv6 (in IPv4-only environments curl -6
+# cannot connect at all, so this check passes there too)
+if [ "$IPV6_ENABLED" = true ]; then
+    if curl -6 --connect-timeout 5 https://example.com >/dev/null 2>&1; then
+        echo "ERROR: Firewall verification failed - was able to reach https://example.com over IPv6"
+        exit 1
+    else
+        echo "Firewall verification passed - unable to reach https://example.com over IPv6 as expected"
+    fi
 fi
 
 # Verify GitHub API access


### PR DESCRIPTION
## Problem

`.devcontainer/init-firewall.sh` configures a default-deny egress allowlist using `iptables` + an IPv4 `ipset` — but never touches `ip6tables`. On a dual-stack Docker network, **all IPv6 traffic bypasses the firewall entirely**: the `curl https://example.com` verification passes (blocked over IPv4) while the same host is freely reachable over IPv6. This undermines the script's stated purpose of constraining egress when running Claude Code with reduced supervision inside the devcontainer.

## Fix

Mirrors the existing IPv4 posture for IPv6:

- **Default-DROP** `INPUT`/`FORWARD`/`OUTPUT` policies, with the same allowances as IPv4: loopback, outbound DNS, SSH responses, plus link-local (`fe80::/10`) and ICMPv6 — required for neighbor discovery, without which IPv6 breaks even for allowed destinations.
- **`allowed-domains-v6` ipset** (`hash:net family inet6`) populated from (a) GitHub meta's IPv6 ranges — which the current pipeline silently discards via `aggregate` — and (b) AAAA records of the existing allowlist domains, so allowed domains work first-class on v6-native networks. A missing AAAA record is intentionally not an error.
- **Fast REJECT** (`icmp6-adm-prohibited`) for everything else, so blocked IPv6 attempts fail immediately and clients fall back to IPv4 instead of hanging (Happy Eyeballs).
- **Verification**: a `curl -6 https://example.com` negative check alongside the existing ones. In IPv4-only environments `curl -6` cannot connect at all, so the check passes there too.

### Why the capability probe matters

All `ip6tables` usage is gated behind `ip6tables -L -n >/dev/null 2>&1`. On hosts with IPv6 disabled in the kernel (`ipv6.disable=1`), `ip6tables` cannot operate — and under the script's `set -euo pipefail` an unguarded call would **hard-fail container startup**, the same failure class as the DNS-resolution aborts in #55623. When the probe fails there is no IPv6 traffic to filter, so skipping with a warning is both safe and correct.

## Relationship to existing PRs

- #24951 sets the three v6 DROP policies only — no loopback allowance (breaks `::1`-bound dev servers), no established/ICMPv6 rules, no verification, and unguarded `ip6tables` calls fail startup on IPv6-disabled hosts.
- #36260 (credit: much of the rule structure) adds flush/loopback/ICMPv6/GitHub-v6-ranges, but also uses unguarded `ip6tables` calls, doesn't resolve AAAA for the allowlist domains, validates v6 CIDRs only by presence of `:`, and adds no verification step.

This PR is a superset addressing those gaps; happy to close in favor of either if maintainers prefer iterating there.

## Testing

- `bash -n` passes.
- Rule structure follows the existing script conventions (same ordering: allowances → policies → established → match-set → REJECT; same validation-with-exit style, with stricter CIDR regexes than the prior PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)