### PR TITLE
fix(security-guidance): support Windows venv layout so the agentic reviewer works on win32

### DIFF
--- a/plugins/security-guidance/hooks/ensure_agent_sdk.py
+++ b/plugins/security-guidance/hooks/ensure_agent_sdk.py
@@ -28,7 +28,9 @@ NOOP_SYSTEM = 0      # claude_agent_sdk already importable in system python
 NOOP_VENV = 1        # venv already built and SDK imports from it
 BUILT = 2            # venv created + SDK pip-installed this run
 BUILD_FAILED = 3     # venv create or pip install raised/timed out
-SKIP_WIN32 = 4       # Windows; consumer glob doesn't handle Lib/ layout
+SKIP_WIN32 = 4       # No longer emitted (Windows venv layout is now
+                     # supported end-to-end); value reserved so telemetry
+                     # rows from older plugin versions keep their meaning.
 SKIP_SENTINEL = 5    # another SessionStart is currently building
 
 
@@ -60,13 +62,6 @@ def main() -> tuple[int, str, str]:
     err_phase / err_kind are non-empty only on BUILD_FAILED — they let
     telemetry split bootstrap failures by root cause.
     """
-    # Windows venv layout (Lib/site-packages, no python* subdir) isn't
-    # handled by the consumer's glob in security_reminder_hook.py; skip the
-    # bootstrap entirely rather than build a venv that's never read.
-    if sys.platform == "win32":
-        return SKIP_WIN32, "", ""
-
-
     if _sdk_on_syspath():
         return NOOP_SYSTEM, "", ""
 
@@ -75,7 +70,13 @@ def main() -> tuple[int, str, str]:
         or os.path.expanduser("~/.claude/security")
     )
     venv = state_dir / "agent-sdk-venv"
-    venv_py = venv / "bin" / "python"
+    # Windows venvs place the interpreter at Scripts/python.exe (and
+    # site-packages at Lib/site-packages — handled by the consumer glob
+    # in llm.py); POSIX venvs use bin/python.
+    if sys.platform == "win32":
+        venv_py = venv / "Scripts" / "python.exe"
+    else:
+        venv_py = venv / "bin" / "python"
 
     # Another SessionStart (concurrent CC instance, same plugin) may already
     # be building. The sentinel lives NEXT TO the venv, not inside it —

--- a/plugins/security-guidance/hooks/llm.py
+++ b/plugins/security-guidance/hooks/llm.py
@@ -298,9 +298,14 @@ def _call_claude_via_sdk(prompt, output_schema, *, max_tokens=16000, model=None)
             "SECURITY_WARNINGS_STATE_DIR",
             os.path.expanduser("~/.claude/security"),
         )
+        # POSIX venvs use lib/python*/site-packages; Windows venvs use
+        # Lib/site-packages with no python* subdir. Glob both layouts.
         for _sp in glob.glob(
             os.path.join(_state_dir, "agent-sdk-venv", "lib",
                          "python*", "site-packages")
+        ) + glob.glob(
+            os.path.join(_state_dir, "agent-sdk-venv", "Lib",
+                         "site-packages")
         ):
             if os.path.isdir(_sp) and _sp not in sys.path:
                 sys.path.insert(0, _sp)
@@ -1094,9 +1099,14 @@ def agentic_review(
             "SECURITY_WARNINGS_STATE_DIR",
             os.path.expanduser("~/.claude/security"),
         )
+        # POSIX venvs use lib/python*/site-packages; Windows venvs use
+        # Lib/site-packages with no python* subdir. Glob both layouts.
         for _sp in glob.glob(
             os.path.join(_state_dir, "agent-sdk-venv", "lib",
                          "python*", "site-packages")
+        ) + glob.glob(
+            os.path.join(_state_dir, "agent-sdk-venv", "Lib",
+                         "site-packages")
         ):
             if os.path.isdir(_sp) and _sp not in sys.path:
                 sys.path.insert(0, _sp)


### PR DESCRIPTION
## Problem

security-guidance's strongest layer — the agentic commit reviewer — is unavailable on Windows unless `claude_agent_sdk` happens to be system-installed. The SessionStart bootstrap (`hooks/ensure_agent_sdk.py`) returns `SKIP_WIN32` early, and the skip's own comment explains why: *"Windows venv layout (Lib/site-packages, no python* subdir) isn't handled by the consumer's glob."* The consumer fallbacks in `hooks/llm.py` glob only the POSIX layout (`lib/python*/site-packages`), and `venv_py` assumed `bin/python`.

This PR closes that annotated gap end-to-end rather than working around it.

## Fix

- **`llm.py`** (both SDK-fallback sites): additionally glob the Windows layout `Lib/site-packages` (no `python*` subdir). On POSIX the extra glob matches nothing; on Windows the original glob matches nothing — no behavior change on either platform beyond enabling the intended fallback.
- **`ensure_agent_sdk.py`**: select the venv interpreter as `Scripts/python.exe` on win32 (`bin/python` elsewhere) and remove the early-return. The `SKIP_WIN32` outcome code is **retained but never emitted**, so `sdk_bootstrap` telemetry rows from older plugin versions keep their meaning; new Windows rows will now report the same BUILT/NOOP/BUILD_FAILED codes as POSIX, and the existing `err_phase`/`err_kind` fingerprinting applies unchanged.

Everything else in the bootstrap is already platform-neutral (the `O_EXCL` sentinel lock, timeouts, pip invocation via the venv interpreter).

## Tested on Windows 11 (Python 3.13.14)

Bootstrap, run twice against a scratch `SECURITY_WARNINGS_STATE_DIR`:

```
--- RUN 1 ---
{"async": true, "asyncTimeout": 180000}
{"metrics": {"sdk_bootstrap": 2, "sdk_bootstrap_ms": 51440, "pv": 20000}}   # BUILT
--- RUN 2 ---
{"async": true, "asyncTimeout": 180000}
{"metrics": {"sdk_bootstrap": 1, "sdk_bootstrap_ms": 5191, "pv": 20000}}    # NOOP_VENV
```

Consumer glob, against the venv built above:

```
OLD glob matches: []
NEW glob matches: ['...\agent-sdk-venv\Lib\site-packages']
claude_agent_sdk imported OK from: ...\Lib\site-packages\claude_agent_sdk\__init__.py
```

i.e. the pre-fix glob cannot see a Windows venv at all (confirming why the skip existed), and the new glob finds it and the SDK imports through it. `py_compile` passes on both files.

## Notes

- No competing PR touches this (searched `ensure_agent_sdk`, `agent-sdk-venv`, `SKIP_WIN32`, `security-guidance windows`); the existing Windows-related PRs (#68694, #68701, #47502) address path separators, CRLF, and the launcher — not the venv bootstrap.
- `platform:windows` is one of the largest open-issue label groups; this restores the plugin's headline feature for that entire user class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)