### PR TITLE
Fix 404 walkthrough links in the AWS gateway example

### DIFF
--- a/examples/gateway/aws/README.md
+++ b/examples/gateway/aws/README.md
@@ -7,7 +7,7 @@ PostgreSQL, AWS Secrets Manager, and IAM-role auth to Bedrock.
 These files are provided as a working example rather than a supported production
 deployment. Adapt them to your own environment.
 
-- **Walkthrough**: https://code.claude.com/docs/en/claude-apps-gateway-on-aws
+- **Walkthrough**: https://code.claude.com/docs/en/claude-apps-gateway
 - **Related**: AWS-maintained samples for various customer environments at
   https://github.com/aws-samples/anthropic-on-aws/tree/main/claude-apps-gateway
 

--- a/examples/gateway/aws/gateway.yaml.example
+++ b/examples/gateway/aws/gateway.yaml.example
@@ -1,7 +1,7 @@
 # gateway.yaml.example — Claude apps gateway config template, AWS-shaped (walkthrough §4).
 #
 # Okta IdP + Bedrock upstream, following the walkthrough at
-# https://code.claude.com/docs/en/claude-apps-gateway-on-aws. The active sections
+# https://code.claude.com/docs/en/claude-apps-gateway. The active sections
 # below are a strict subset of the full configuration reference at
 # https://code.claude.com/docs/en/claude-apps-gateway-config; optional keys are
 # included commented-out.

--- a/examples/gateway/aws/setup.sh
+++ b/examples/gateway/aws/setup.sh
@@ -15,7 +15,7 @@
 # config edit triggers a rebuild on the next run.
 #
 #   Section markers (§N) below map to the walkthrough:
-#   https://code.claude.com/docs/en/claude-apps-gateway-on-aws
+#   https://code.claude.com/docs/en/claude-apps-gateway
 #
 # Covers here:  security groups (§1) -> IAM roles + Bedrock model-access note (§2)
 #               -> build & push image, config baked in (§6 + §4) -> DB subnet group
@@ -948,7 +948,7 @@ cat <<EOF
   Secrets               ${SECRET_NAME}, ${JWT_SECRET_NAME}, ${OIDC_SECRET_NAME}$( [[ -n "${OIDC_ARN}" ]] || printf ' (MISSING — create it)' )
   ECS service           ${CLUSTER}/${SERVICE} behind ${ALB_DNS:-(not deployed yet)}
 
-Next steps (see https://code.claude.com/docs/en/claude-apps-gateway-on-aws):
+Next steps (see https://code.claude.com/docs/en/claude-apps-gateway):
   - Create the one operator-provided secret (from the Okta OIDC web app). Put the
     client secret in a 0600 file first — passing it as a literal argument would
     leave it readable in the process table and in audit/EDR logs:

--- a/examples/gateway/aws/terraform/README.md
+++ b/examples/gateway/aws/terraform/README.md
@@ -1,7 +1,7 @@
 # Claude apps gateway — Terraform (ECS Fargate)
 
 Terraform equivalent of `../setup.sh`. Lets end-users provision and manage
-the gateway with `terraform apply`. Covers the same scope ([walkthrough](https://code.claude.com/docs/en/claude-apps-gateway-on-aws) §1–7,
+the gateway with `terraform apply`. Covers the same scope ([walkthrough](https://code.claude.com/docs/en/claude-apps-gateway) §1–7,
 ECS track): security groups → task + execution IAM roles → ECR repository →
 private-subnet RDS for PostgreSQL → Secrets Manager secrets → ECS Fargate
 service behind an internal ALB. The VPC and private subnets are walkthrough
@@ -29,7 +29,7 @@ created here.
    `gateway.yaml` is gitignored; the committed template is `gateway.yaml.example`.
 2. The **prebuilt linux-x64 `claude` binary at `../claude`** — the Claude Code
    release binary, which includes the `gateway` subcommand (see the
-   [walkthrough](https://code.claude.com/docs/en/claude-apps-gateway-on-aws)).
+   [walkthrough](https://code.claude.com/docs/en/claude-apps-gateway)).
    See `../setup.sh`'s `DIST_URL`/`DIST_SHA256` download path for a
    checksum-verified fetch.
 3. A **VPC with two+ private subnets** in different AZs and NAT egress, an **ACM

--- a/examples/gateway/aws/terraform/main.tf
+++ b/examples/gateway/aws/terraform/main.tf
@@ -1,6 +1,6 @@
 # Claude apps gateway on ECS Fargate — Terraform equivalent of setup.sh.
 # Section markers (§N) map to setup.sh and the walkthrough:
-# https://code.claude.com/docs/en/claude-apps-gateway-on-aws
+# https://code.claude.com/docs/en/claude-apps-gateway
 #
 # Unlike the GCP example this module does NOT create the network — the VPC and
 # private subnets are walkthrough prerequisites, passed in as variables.


### PR DESCRIPTION
Every reference to the AWS walkthrough in `examples/gateway/aws` points at `https://code.claude.com/docs/en/claude-apps-gateway-on-aws`, which currently returns **404**. There are seven of them:

| File | Line |
| --- | --- |
| `examples/gateway/aws/README.md` | 10 |
| `examples/gateway/aws/setup.sh` | 18, 951 |
| `examples/gateway/aws/gateway.yaml.example` | 4 |
| `examples/gateway/aws/terraform/README.md` | 4, 32 |
| `examples/gateway/aws/terraform/main.tf` | 3 |

Checks I ran:

- `claude-apps-gateway-on-aws` → **404**
- `claude-apps-gateway-on-gcp` → 200 (the GCP example's equivalent link is fine)
- `claude-apps-gateway`, `-config`, `-deploy`, `setup` → 200 (so the domain isn't rejecting the requests)
- The docs index at `code.claude.com/docs/llms.txt` lists gateway pages for `claude-apps-gateway`, `-config`, `-deploy`, `-on-gcp` and `-spend-limits`, but **no AWS page**

This repoints all seven at `https://code.claude.com/docs/en/claude-apps-gateway`, whose title covers Amazon Bedrock and Claude Platform on AWS and which includes a quickstart. `gateway.yaml.example` already links there for the config reference, so it is not a new destination for this example.

**One caveat, and a reason you may prefer to close this:** several of these references describe section markers (`§N`) that map to a numbered walkthrough, and `terraform/README.md` cites "§1–7". The page this PR points to isn't organised that way, so the `§N` wording is a loose fit. If the AWS walkthrough is written and simply not published yet, publishing it is the better fix and this PR should be closed in favour of that — the goal here is just to stop the example shipping seven dead links in the meantime. Happy to adjust the wording instead if you'd rather keep the section references and point somewhere else.
