### PR TITLE
fix(hookify): make package import independent of the install directory name

### DIFF
--- a/plugins/hookify/hooks/_bootstrap.py
+++ b/plugins/hookify/hooks/_bootstrap.py
@@ -1,0 +1,60 @@
+"""Import bootstrap shared by the hookify hook entry points.
+
+The hook scripts need to import the ``hookify`` package (``hookify.core.*``),
+but they run as standalone scripts, not as part of an installed package, so
+the package has to be made importable first.
+
+The previous approach put ``os.path.dirname(CLAUDE_PLUGIN_ROOT)`` on
+``sys.path`` and relied on the plugin directory being named exactly
+``hookify``. That assumption does not hold for a marketplace install, where
+the plugin lives in a versioned/namespaced directory such as
+``~/.claude/plugins/marketplaces/<marketplace>/hookify@0.1.0``. There the
+import resolves to nothing and every hook event fails with
+``No module named 'hookify'``.
+
+Registering the package explicitly under the name ``hookify`` -- with its
+search path pinned to the plugin root -- makes the import independent of both
+the directory name and of ``CLAUDE_PLUGIN_ROOT`` being set at all.
+"""
+
+import os
+import sys
+import types
+
+__all__ = ["load_hookify"]
+
+
+def _plugin_root() -> str:
+    """Return the hookify plugin root directory.
+
+    Prefers ``CLAUDE_PLUGIN_ROOT``, but falls back to a path derived from this
+    file so the hooks keep working if the variable is missing or points
+    somewhere unexpected (e.g. when a script is invoked directly for testing).
+    """
+    root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if root:
+        root = os.path.abspath(os.path.expanduser(root))
+        if os.path.isdir(os.path.join(root, "core")):
+            return root
+
+    # hooks/_bootstrap.py -> hooks/ -> <plugin root>
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def load_hookify():
+    """Make the ``hookify`` package importable and return it.
+
+    Idempotent: a second call reuses the module already in ``sys.modules``.
+    """
+    existing = sys.modules.get("hookify")
+    if existing is not None:
+        return existing
+
+    root = _plugin_root()
+
+    package = types.ModuleType("hookify")
+    package.__path__ = [root]
+    package.__package__ = "hookify"
+    package.__doc__ = "hookify plugin package (registered by hooks/_bootstrap.py)"
+    sys.modules["hookify"] = package
+    return package

--- a/plugins/hookify/hooks/posttooluse.py
+++ b/plugins/hookify/hooks/posttooluse.py
@@ -9,16 +9,15 @@ import os
 import sys
 import json
 
-# CRITICAL: Add plugin root to Python path for imports
-PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+# Make the "hookify" package importable no matter what directory name the
+# plugin was installed under (marketplace installs use e.g. "hookify@0.1.0").
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 try:
+    from _bootstrap import load_hookify
+
+    load_hookify()
+
     from hookify.core.config_loader import load_rules
     from hookify.core.rule_engine import RuleEngine
 except ImportError as e:

--- a/plugins/hookify/hooks/pretooluse.py
+++ b/plugins/hookify/hooks/pretooluse.py
@@ -9,20 +9,15 @@ import os
 import sys
 import json
 
-# CRITICAL: Add plugin root to Python path for imports
-# We need to add the parent of the plugin directory so Python can find "hookify" package
-PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    # Add the parent directory of the plugin
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-
-    # Also add PLUGIN_ROOT itself in case we have other scripts
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+# Make the "hookify" package importable no matter what directory name the
+# plugin was installed under (marketplace installs use e.g. "hookify@0.1.0").
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 try:
+    from _bootstrap import load_hookify
+
+    load_hookify()
+
     from hookify.core.config_loader import load_rules
     from hookify.core.rule_engine import RuleEngine
 except ImportError as e:

--- a/plugins/hookify/hooks/stop.py
+++ b/plugins/hookify/hooks/stop.py
@@ -9,16 +9,15 @@ import os
 import sys
 import json
 
-# CRITICAL: Add plugin root to Python path for imports
-PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+# Make the "hookify" package importable no matter what directory name the
+# plugin was installed under (marketplace installs use e.g. "hookify@0.1.0").
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 try:
+    from _bootstrap import load_hookify
+
+    load_hookify()
+
     from hookify.core.config_loader import load_rules
     from hookify.core.rule_engine import RuleEngine
 except ImportError as e:

--- a/plugins/hookify/hooks/userpromptsubmit.py
+++ b/plugins/hookify/hooks/userpromptsubmit.py
@@ -9,16 +9,15 @@ import os
 import sys
 import json
 
-# CRITICAL: Add plugin root to Python path for imports
-PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
-if PLUGIN_ROOT:
-    parent_dir = os.path.dirname(PLUGIN_ROOT)
-    if parent_dir not in sys.path:
-        sys.path.insert(0, parent_dir)
-    if PLUGIN_ROOT not in sys.path:
-        sys.path.insert(0, PLUGIN_ROOT)
+# Make the "hookify" package importable no matter what directory name the
+# plugin was installed under (marketplace installs use e.g. "hookify@0.1.0").
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 try:
+    from _bootstrap import load_hookify
+
+    load_hookify()
+
     from hookify.core.config_loader import load_rules
     from hookify.core.rule_engine import RuleEngine
 except ImportError as e:


### PR DESCRIPTION
Fixes #69665
Fixes #81448

## The problem

The hook entry points make the `hookify` package importable by putting
`os.path.dirname(CLAUDE_PLUGIN_ROOT)` on `sys.path` and relying on the plugin
directory being named exactly `hookify`.

A marketplace install does not satisfy that — the plugin is unpacked into a
versioned directory (`.../hookify@0.1.0`), so `hookify` is not a name Python can
resolve there. Every hook event hits the `ImportError` branch and the plugin emits
`Hookify import error: No module named 'hookify'` instead of evaluating any rule.
The plugin looks installed but is inert, on every single hook event.

## Repro

With a real rule at `.claude/hookify.dangerous-rm.local.md` and input
`{"tool_name":"Bash","tool_input":{"command":"rm -rf /"}}`:

```console
# plugin at .../hookify@0.1.0  (marketplace layout)
before: {"systemMessage": "Hookify import error: No module named 'hookify'"}
after:  {"systemMessage": "**[block-dangerous-rm]** ..."}
```

## The fix

Rather than inferring the package name from the directory layout, register the
package explicitly with its `__path__` pinned to the plugin root
(`hooks/_bootstrap.py`). That makes the import independent of the directory name.

It also removes the dependency on `CLAUDE_PLUGIN_ROOT` being set and correct: the
root falls back to a path derived from `__file__` when the variable is missing or
does not point at a hookify checkout.

## Testing

- All four entry points (PreToolUse, PostToolUse, Stop, UserPromptSubmit) under a
  `hookify@0.1.0` directory.
- `CLAUDE_PLUGIN_ROOT` unset — works.
- `CLAUDE_PLUGIN_ROOT` pointing at a nonexistent path — works.
- Plain `hookify/` directory layout — unchanged, still works.