### PR TITLE
Fix examples/gateway/aws/setup.sh aborting on stock macOS bash 3.2

### DIFF
--- a/examples/gateway/aws/setup.sh
+++ b/examples/gateway/aws/setup.sh
@@ -63,7 +63,8 @@ DOCKERFILE="${DOCKERFILE:-./Dockerfile}"
 CLAUDE_BINARY="${CLAUDE_BINARY:-./claude}"                 # prebuilt linux-x64 Claude Code release binary (includes the gateway subcommand)
 DIST_URL="${DIST_URL:-}"                                   # optional: download URL, used only if $CLAUDE_BINARY is missing
 DIST_SHA256="${DIST_SHA256:-}"                             # REQUIRED with DIST_URL: expected sha256 of the binary (verified fail-closed)
-DIST_SHA256="${DIST_SHA256,,}"                                # normalize to lowercase — openssl emits lowercase hex; some tools (PowerShell Get-FileHash) publish uppercase
+# normalize to lowercase — openssl emits lowercase hex; some tools (PowerShell Get-FileHash) publish uppercase
+DIST_SHA256="$(printf '%s' "${DIST_SHA256}" | LC_ALL=C tr '[:upper:]' '[:lower:]')"
 # Obtain DIST_SHA256 out-of-band — never from the server that serves DIST_URL.
 # For binaries from the standard Claude Code release channel, verify the
 # release's GPG-signed manifest.json and copy the platform checksum from it:


### PR DESCRIPTION
`setup.sh` line 66 uses `${DIST_SHA256,,}`, a bash 4 case-modification
expansion. macOS ships bash 3.2 as `/bin/bash`, so unless a newer bash is
earlier on `PATH`, `#!/usr/bin/env bash` resolves to 3.2 and the script aborts
there — before reaching its own argument checks. The line is unconditional, so
it fires whether or not `DIST_URL`/`DIST_SHA256` are set. `bash -n` passes; the
failure is runtime-only.

From the repo root on stock macOS:

```
$ /bin/bash examples/gateway/aws/setup.sh
examples/gateway/aws/setup.sh: line 66: ${DIST_SHA256,,}: bad substitution
```

The replacement lowercases the same digests with `tr`, pinned to `LC_ALL=C` so
BSD `tr` cannot fail the script on a stray non-UTF-8 byte under `set -e`. With
it, the same bash 3.2 run reaches the normal path and prints
`ERROR: AWS_REGION is not set.` The comment moves above the line to keep the
block's comment column.

This is the only bash 4 construct I found in the file; the GCP example next
door has none. Portability is already an explicit concern here — see the
`sha_of()` comment on line 127.
