### PR TITLE
Fix gcp gateway setup.sh exiting silently when gcloud is not installed

### DIFF
--- a/examples/gateway/gcp/setup.sh
+++ b/examples/gateway/gcp/setup.sh
@@ -28,7 +28,7 @@
 set -euo pipefail
 
 # ---- configuration (env-overridable) ----------------------------------------
-PROJECT_ID="${PROJECT_ID:-$(gcloud config get-value project 2>/dev/null)}"
+PROJECT_ID="${PROJECT_ID:-$(gcloud config get-value project 2>/dev/null || true)}"
 REGION="${REGION:-${CLOUDSDK_COMPUTE_REGION:-us-east5}}"   # guide §1 uses us-east5 (Agent Platform model region)
 
 SA_NAME="${SA_NAME:-claude-gateway}"                       # §2 service account


### PR DESCRIPTION
`setup.sh` seeds `PROJECT_ID` from a command substitution on line 31:

```
PROJECT_ID="${PROJECT_ID:-$(gcloud config get-value project 2>/dev/null)}"
```

Under `set -euo pipefail` (line 28), a missing `gcloud` makes that substitution exit 127 and takes the script down with it. The `2>/dev/null` already on the line swallows bash's own `command not found`, so the user gets nothing back:

```
$ ./setup.sh
$ echo $?
127
```

Zero bytes on stdout and zero on stderr, reproduced on bash 3.2.57 and 5.3.15. The script dies on line 31, so it never reaches the `PROJECT_ID` check on lines 79-83 — and that check's message, "PROJECT_ID is not set and no gcloud default project is configured", is exactly the hint that would have pointed the user somewhere useful.

Adding `|| true` lets the assignment fall through to an empty value so the existing check can do its job and exit 1. This file already uses that guard on lines 93 and 182, and the AWS gateway example, added later, uses the guarded form for both of its config substitutions (`examples/gateway/aws/setup.sh`, lines 41-42).

It is not a precise diagnosis: someone without `gcloud` is told to set `PROJECT_ID`, then meets the missing binary on line 126. But that error is visible, and the current one is not.
