### PR TITLE
fix(plugin-dev): report missing jq dependency

### DIFF
--- a/plugins/plugin-dev/skills/hook-development/scripts/test-hook.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/test-hook.sh
@@ -151,6 +151,11 @@ if [ ! -f "$TEST_INPUT" ]; then
   exit 1
 fi
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required but not installed. See https://jqlang.github.io/jq/download/"
+  exit 1
+fi
+
 # Validate test input JSON
 if ! jq empty "$TEST_INPUT" 2>/dev/null; then
   echo "❌ Error: Test input is not valid JSON"


### PR DESCRIPTION
## Summary

Fixes #83802.

`test-hook.sh` previously treated every failure from `jq empty` as invalid JSON. When `jq` was not installed, the shell error was suppressed and valid input was reported as malformed.

This change checks for `jq` before its first use and reports the missing dependency with an installation link.

## Verification

- Reproduced the original behavior with a valid JSON fixture and a `PATH` that does not contain `jq`: the script reported `Test input is not valid JSON`.
- Re-ran the same fixture after the change: the script reports `jq is required but not installed` and exits with status 1.
- Verified the normal path with `jq` available and a successful hook: the script exits with status 0.
- Ran `bash -n plugins/plugin-dev/skills/hook-development/scripts/test-hook.sh`.
- Ran `git diff --check`.

## Scope

This PR only improves dependency diagnosis. It does not change JSON validation or hook result semantics, and it does not address platform availability of the separate `timeout` command.
