### PR TITLE
fix(plugin-dev): assert expected hook decision

### DIFF
--- a/plugins/plugin-dev/skills/hook-development/scripts/README.md
+++ b/plugins/plugin-dev/skills/hook-development/scripts/README.md
@@ -38,6 +38,7 @@ Tests individual hook scripts with sample input before deploying to Claude Code.
 **Options:**
 - `-v, --verbose` - Show detailed execution information
 - `-t, --timeout N` - Set timeout in seconds (default: 60)
+- `-e, --expect D` - Require an `allow`, `deny`, or `ask` decision
 - `--create-sample <event-type>` - Generate sample test input
 
 **Example:**
@@ -50,6 +51,9 @@ Tests individual hook scripts with sample input before deploying to Claude Code.
 
 # Test with verbose output and custom timeout
 ./test-hook.sh -v -t 30 my-hook.sh test-input.json
+
+# Fail unless the hook denies the operation
+./test-hook.sh --expect deny my-hook.sh test-input.json
 ```
 
 **Features:**
@@ -57,6 +61,7 @@ Tests individual hook scripts with sample input before deploying to Claude Code.
 - Measures execution time
 - Validates output JSON
 - Shows exit codes and their meanings
+- Optionally asserts the hook decision
 - Captures environment file output
 
 ## hook-linter.sh

--- a/plugins/plugin-dev/skills/hook-development/scripts/test-hook.sh
+++ b/plugins/plugin-dev/skills/hook-development/scripts/test-hook.sh
@@ -12,10 +12,12 @@ show_usage() {
   echo "  -h, --help      Show this help message"
   echo "  -v, --verbose   Show detailed execution information"
   echo "  -t, --timeout N Set timeout in seconds (default: 60)"
+  echo "  -e, --expect D  Require decision D: allow, deny, or ask"
   echo ""
   echo "Examples:"
   echo "  $0 validate-bash.sh test-input.json"
   echo "  $0 -v -t 30 validate-write.sh write-input.json"
+  echo "  $0 --expect deny validate-write.sh write-input.json"
   echo ""
   echo "Creates sample test input with:"
   echo "  $0 --create-sample <event-type>"
@@ -102,6 +104,7 @@ EOF
 # Parse arguments
 VERBOSE=false
 TIMEOUT=60
+EXPECTED_DECISION=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -114,6 +117,22 @@ while [ $# -gt 0 ]; do
       ;;
     -t|--timeout)
       TIMEOUT="$2"
+      shift 2
+      ;;
+    -e|--expect)
+      if [ $# -lt 2 ]; then
+        echo "Error: --expect requires allow, deny, or ask"
+        exit 1
+      fi
+      case "$2" in
+        allow|deny|ask)
+          EXPECTED_DECISION="$2"
+          ;;
+        *)
+          echo "Error: Invalid expected decision '$2' (valid: allow, deny, ask)"
+          exit 1
+          ;;
+      esac
       shift 2
       ;;
     --create-sample)
@@ -194,12 +213,35 @@ set -e
 end_time=$(date +%s)
 duration=$((end_time - start_time))
 
+# Determine the hook decision. Exit code 2 means deny unless structured
+# output refines it to ask.
+permission_decision=""
+if [ -n "$output" ] && echo "$output" | jq empty 2>/dev/null; then
+  permission_decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty')
+fi
+
+case "$permission_decision" in
+  allow|deny|ask)
+    actual_decision="$permission_decision"
+    ;;
+  *)
+    case "$exit_code" in
+      0) actual_decision="allow" ;;
+      2) actual_decision="deny" ;;
+      *) actual_decision="" ;;
+    esac
+    ;;
+esac
+
 # Analyze results
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "Results:"
 echo ""
 echo "Exit Code: $exit_code"
 echo "Duration: ${duration}s"
+if [ -n "$actual_decision" ]; then
+  echo "Decision: $actual_decision"
+fi
 echo ""
 
 case $exit_code in
@@ -243,10 +285,18 @@ fi
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-if [ $exit_code -eq 0 ] || [ $exit_code -eq 2 ]; then
-  echo "✅ Test completed successfully"
-  exit 0
-else
+if [ $exit_code -ne 0 ] && [ $exit_code -ne 2 ]; then
   echo "❌ Test failed"
   exit 1
 fi
+
+if [ -n "$EXPECTED_DECISION" ]; then
+  if [ "$actual_decision" != "$EXPECTED_DECISION" ]; then
+    echo "❌ Expected decision '$EXPECTED_DECISION', got '$actual_decision'"
+    exit 1
+  fi
+  echo "✅ Decision matched expected '$EXPECTED_DECISION'"
+fi
+
+echo "✅ Test completed successfully"
+exit 0


### PR DESCRIPTION
## Summary

Fixes #83800.

`test-hook.sh` currently treats both allow and deny outcomes as successful execution. That verifies that a hook ran, but it cannot catch a hook that allows an operation it was intended to deny.

This change adds an optional `--expect allow|deny|ask` flag. When provided, the tester derives the observed decision from structured `hookSpecificOutput.permissionDecision`, falling back to the hook exit code, and fails if the result does not match.

Calls that do not use `--expect` retain the existing behavior.

## Changes

- Add and validate the `--expect` / `-e` option.
- Report the derived hook decision.
- Fail on an expected/actual decision mismatch.
- Document the option and an example in the script README.

## Verification

- Existing invocation with an allowing hook: passes.
- `--expect allow` with an allowing hook: passes.
- `--expect deny` with an allowing hook: fails with status 1.
- `--expect deny` with an exit-2 hook: passes.
- `--expect ask` with structured JSON output: passes.
- Invalid expected decision: fails with a validation error.
- `bash -n plugins/plugin-dev/skills/hook-development/scripts/test-hook.sh`
- `git diff --check`

## Scope

This PR only adds optional result assertions. It does not change hook matching, hook execution, or the legacy success criteria when no expected decision is supplied.
