### PR TITLE
fix(scripts): reject self-referential duplicates

### DIFF
--- a/scripts/comment-on-duplicates.sh
+++ b/scripts/comment-on-duplicates.sh
@@ -53,6 +53,10 @@ for dup in "${DUPLICATES[@]}"; do
     echo "Error: duplicate issue must be a number, got: $dup" >&2
     exit 1
   fi
+  if [[ "$dup" == "$BASE_ISSUE" ]]; then
+    echo "Error: issue #$BASE_ISSUE cannot be marked as a duplicate of itself" >&2
+    exit 1
+  fi
 done
 
 # Validate that base issue exists


### PR DESCRIPTION
## Summary

Prevent `comment-on-duplicates.sh` from proposing the triggering issue as a duplicate of itself.

The script previously accepted identical base and duplicate issue numbers, posted a self-referential duplicate comment, and returned success. That comment could then be consumed by the automatic duplicate closer.

## Changes

- Reject a duplicate candidate whose number equals `BASE_ISSUE`.
- Fail before making any GitHub API calls.
- Keep the existing numeric and issue-existence validation unchanged.

## Verification

- Reproduced the original behavior with `BASE_ISSUE=123` and duplicate `123`: the script posted the comment and exited 0.
- Re-ran the same fixture after the change: the script reports that issue `#123` cannot duplicate itself, exits 1, and makes no `gh` calls.
- Verified a normal `123 -> 456` case still validates both issues and posts the expected comment.
- Ran `bash -n scripts/comment-on-duplicates.sh`.
- Ran `git diff --check`.

## Scope

This PR only rejects self-references. It does not change duplicate ranking, comment wording, or automatic-close timing.
