### PR TITLE
fix(scripts): validate label option values

### DIFF
--- a/scripts/edit-issue-labels.sh
+++ b/scripts/edit-issue-labels.sh
@@ -23,10 +23,18 @@ REMOVE_LABELS=()
 while [[ $# -gt 0 ]]; do
   case $1 in
     --add-label)
+      if [[ $# -lt 2 || "$2" == --* ]]; then
+        echo "Error: --add-label requires a label name" >&2
+        exit 1
+      fi
       ADD_LABELS+=("$2")
       shift 2
       ;;
     --remove-label)
+      if [[ $# -lt 2 || "$2" == --* ]]; then
+        echo "Error: --remove-label requires a label name" >&2
+        exit 1
+      fi
       REMOVE_LABELS+=("$2")
       shift 2
       ;;


### PR DESCRIPTION
## Summary

Validate that `--add-label` and `--remove-label` each receive a label name before reading the next positional argument.

With `set -u`, invoking either option without a value previously aborted with an internal `$2: unbound variable` error. A following option could also be consumed as the missing value before failing later.

## Changes

- Report a specific error when `--add-label` has no value.
- Report a specific error when `--remove-label` has no value.
- Reject another option token where a label name is required.

## Verification

- `--add-label` without a value: exits 1 with a specific error and no unbound-variable message.
- `--remove-label` without a value: exits 1 with a specific error and no unbound-variable message.
- `--add-label --remove-label bug`: fails at `--add-label` instead of consuming the next option.
- A normal add/remove invocation still filters valid labels and calls `gh issue edit` with both operations.
- Ran `bash -n scripts/edit-issue-labels.sh`.
- Ran `git diff --check`.

## Scope

This PR only validates option values. It does not change label existence filtering or GitHub API behavior.
