### PR TITLE
fix(scripts): validate gh flag values

### DIFF
--- a/scripts/gh.sh
+++ b/scripts/gh.sh
@@ -41,10 +41,12 @@ shift 2
 POSITIONAL=()
 FLAGS=()
 skip_next=false
+pending_value_flag=""
 for arg in "$@"; do
   if [[ "$skip_next" == true ]]; then
     FLAGS+=("$arg")
     skip_next=false
+    pending_value_flag=""
   elif [[ "$arg" == -* ]]; then
     flag="${arg%%=*}"
     matched=false
@@ -64,6 +66,7 @@ for arg in "$@"; do
       for vflag in "${FLAGS_WITH_VALUES[@]}"; do
         if [[ "$flag" == "$vflag" ]]; then
           skip_next=true
+          pending_value_flag="$flag"
           break
         fi
       done
@@ -72,6 +75,11 @@ for arg in "$@"; do
     POSITIONAL+=("$arg")
   fi
 done
+
+if [[ "$skip_next" == true ]]; then
+  echo "Error: $pending_value_flag requires a value" >&2
+  exit 1
+fi
 
 if [[ "$CMD" == "search issues" ]]; then
   QUERY="${POSITIONAL[0]:-}"


### PR DESCRIPTION
## Summary

Reject value-taking flags that are missing their value in the restricted `gh` wrapper.

The parser previously left `skip_next=true` at end of input and forwarded incomplete commands such as `gh issue list --limit`. This bypassed the wrapper's argument validation and delegated the failure to `gh`.

## Changes

- Track which flag is waiting for a value.
- Fail before invoking `gh` if input ends while a value is pending.
- Name the incomplete flag in the error message.

## Verification

- Missing `--state`, `--limit`, and `--label` values each exit 1 before the `gh` shim is called.
- `issue list --state open --limit 20` preserves its original argv.
- `search issues bug --label=bug --limit=10` preserves `--flag=value` arguments.
- `issue view 123 --comments` remains valid.
- Ran `bash -n scripts/gh.sh`.
- Ran `git diff --check`.

## Scope

This PR only validates flags that require values. It does not change the allowed command or flag set.
