### PR TITLE
fix(scripts): propagate top-level failures

### DIFF
--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -3,6 +3,7 @@
 declare global {
   var process: {
     env: Record<string, string | undefined>;
+    exitCode?: number;
   };
 }
 
@@ -271,7 +272,10 @@ async function autoCloseDuplicates(): Promise<void> {
   );
 }
 
-autoCloseDuplicates().catch(console.error);
+autoCloseDuplicates().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
 
 // Make it a module
 export {};

--- a/scripts/backfill-duplicate-comments.ts
+++ b/scripts/backfill-duplicate-comments.ts
@@ -3,6 +3,7 @@
 declare global {
   var process: {
     env: Record<string, string | undefined>;
+    exitCode?: number;
   };
 }
 
@@ -207,7 +208,10 @@ Environment Variables:
   );
 }
 
-backfillDuplicateComments().catch(console.error);
+backfillDuplicateComments().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
 
 // Make it a module
 export {};


### PR DESCRIPTION
## Summary

- return a failing process status when either duplicate-maintenance script rejects at the top level
- keep logging the original error while allowing pending output to flush

## Problem

Both scripts used `.catch(console.error)`. That reports startup and API failures but resolves the rejection, so the Bun process exits successfully. In CI, a missing token or top-level GitHub API failure can therefore look like a successful maintenance run.

## Verification

- `GITHUB_TOKEN= node scripts/auto-close-duplicates.ts` returns 1
- `GITHUB_TOKEN= node scripts/backfill-duplicate-comments.ts` returns 1
- both scripts return 0 with a stubbed successful GitHub API response containing an empty result set
- `git diff --check`

## Scope

Per-issue failures in `auto-close-duplicates.ts` remain best-effort so one issue does not stop the batch. This only changes unhandled top-level failures.
