### PR TITLE
fix(plugin-dev): limit frontmatter parsing

### DIFF
--- a/plugins/plugin-dev/skills/plugin-settings/scripts/parse-frontmatter.sh
+++ b/plugins/plugin-dev/skills/plugin-settings/scripts/parse-frontmatter.sh
@@ -33,8 +33,25 @@ if [ ! -f "$FILE" ]; then
   exit 1
 fi
 
-# Extract frontmatter
-FRONTMATTER=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$FILE")
+# Extract only the opening frontmatter block. A range-based sed expression
+# restarts at later Markdown horizontal rules and can mix body text into it.
+FRONTMATTER=$(awk '
+  NR == 1 {
+    if ($0 != "---") exit 1
+    next
+  }
+  /^---$/ {
+    found_end = 1
+    exit
+  }
+  { print }
+  END {
+    if (!found_end) exit 1
+  }
+' "$FILE") || {
+  echo "Error: No frontmatter found in $FILE" >&2
+  exit 1
+}
 
 if [ -z "$FRONTMATTER" ]; then
   echo "Error: No frontmatter found in $FILE" >&2


### PR DESCRIPTION
## Summary

- parse only the opening YAML frontmatter block
- reject files without an opening or closing frontmatter marker

## Problem

The range-based `sed` expression restarts at every later `---` line. If a settings file's Markdown body contains horizontal rules, text between those rules is appended to `FRONTMATTER`. A body line such as `enabled: false` can then produce a second value for a field that is already defined in the actual frontmatter.

## Verification

Using a settings fixture with `enabled: true` in the opening frontmatter and `enabled: false` between two body horizontal rules:

- before: querying `enabled` prints both `true` and `false`
- after: querying `enabled` prints only `true`
- files missing either opening or closing `---` return 1 with `No frontmatter found`
- `bash -n plugins/plugin-dev/skills/plugin-settings/scripts/parse-frontmatter.sh`
- `git diff --check`

## Scope

This preserves the existing simple `key: value` field parsing. It only corrects which section of the file is treated as frontmatter.
