### PR TITLE
fix(plugin-dev): prevent validate-agent.sh exiting on first warning

### DIFF
--- a/plugins/plugin-dev/skills/agent-development/scripts/validate-agent.sh
+++ b/plugins/plugin-dev/skills/agent-development/scripts/validate-agent.sh
@@ -60,30 +60,30 @@ NAME=$(echo "$FRONTMATTER" | grep '^name:' | sed 's/name: *//' | sed 's/^"\(.*\)
 
 if [ -z "$NAME" ]; then
   echo "❌ Missing required field: name"
-  ((error_count++))
+  ((error_count += 1))
 else
   echo "✅ name: $NAME"
 
   # Validate name format
   if ! [[ "$NAME" =~ ^[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]$ ]]; then
     echo "❌ name must start/end with alphanumeric and contain only letters, numbers, hyphens"
-    ((error_count++))
+    ((error_count += 1))
   fi
 
   # Validate name length
   name_length=${#NAME}
   if [ $name_length -lt 3 ]; then
     echo "❌ name too short (minimum 3 characters)"
-    ((error_count++))
+    ((error_count += 1))
   elif [ $name_length -gt 50 ]; then
     echo "❌ name too long (maximum 50 characters)"
-    ((error_count++))
+    ((error_count += 1))
   fi
 
   # Check for generic names
   if [[ "$NAME" =~ ^(helper|assistant|agent|tool)$ ]]; then
     echo "⚠️  name is too generic: $NAME"
-    ((warning_count++))
+    ((warning_count += 1))
   fi
 fi
 
@@ -92,29 +92,29 @@ DESCRIPTION=$(echo "$FRONTMATTER" | grep '^description:' | sed 's/description: *
 
 if [ -z "$DESCRIPTION" ]; then
   echo "❌ Missing required field: description"
-  ((error_count++))
+  ((error_count += 1))
 else
   desc_length=${#DESCRIPTION}
   echo "✅ description: ${desc_length} characters"
 
   if [ $desc_length -lt 10 ]; then
     echo "⚠️  description too short (minimum 10 characters recommended)"
-    ((warning_count++))
+    ((warning_count += 1))
   elif [ $desc_length -gt 5000 ]; then
     echo "⚠️  description very long (over 5000 characters)"
-    ((warning_count++))
+    ((warning_count += 1))
   fi
 
   # Check for example blocks
   if ! echo "$DESCRIPTION" | grep -q '<example>'; then
     echo "⚠️  description should include <example> blocks for triggering"
-    ((warning_count++))
+    ((warning_count += 1))
   fi
 
   # Check for "Use this agent when" pattern
   if ! echo "$DESCRIPTION" | grep -qi 'use this agent when'; then
     echo "⚠️  description should start with 'Use this agent when...'"
-    ((warning_count++))
+    ((warning_count += 1))
   fi
 fi
 
@@ -123,7 +123,7 @@ MODEL=$(echo "$FRONTMATTER" | grep '^model:' | sed 's/model: *//')
 
 if [ -z "$MODEL" ]; then
   echo "❌ Missing required field: model"
-  ((error_count++))
+  ((error_count += 1))
 else
   echo "✅ model: $MODEL"
 
@@ -133,7 +133,7 @@ else
       ;;
     *)
       echo "⚠️  Unknown model: $MODEL (valid: inherit, sonnet, opus, haiku)"
-      ((warning_count++))
+      ((warning_count += 1))
       ;;
   esac
 fi
@@ -143,7 +143,7 @@ COLOR=$(echo "$FRONTMATTER" | grep '^color:' | sed 's/color: *//')
 
 if [ -z "$COLOR" ]; then
   echo "❌ Missing required field: color"
-  ((error_count++))
+  ((error_count += 1))
 else
   echo "✅ color: $COLOR"
 
@@ -153,7 +153,7 @@ else
       ;;
     *)
       echo "⚠️  Unknown color: $COLOR (valid: blue, cyan, green, yellow, magenta, red)"
-      ((warning_count++))
+      ((warning_count += 1))
       ;;
   esac
 fi
@@ -173,23 +173,23 @@ echo "Checking system prompt..."
 
 if [ -z "$SYSTEM_PROMPT" ]; then
   echo "❌ System prompt is empty"
-  ((error_count++))
+  ((error_count += 1))
 else
   prompt_length=${#SYSTEM_PROMPT}
   echo "✅ System prompt: $prompt_length characters"
 
   if [ $prompt_length -lt 20 ]; then
     echo "❌ System prompt too short (minimum 20 characters)"
-    ((error_count++))
+    ((error_count += 1))
   elif [ $prompt_length -gt 10000 ]; then
     echo "⚠️  System prompt very long (over 10,000 characters)"
-    ((warning_count++))
+    ((warning_count += 1))
   fi
 
   # Check for second person
   if ! echo "$SYSTEM_PROMPT" | grep -q "You are\|You will\|Your"; then
     echo "⚠️  System prompt should use second person (You are..., You will...)"
-    ((warning_count++))
+    ((warning_count += 1))
   fi
 
   # Check for structure


### PR DESCRIPTION
## Summary

Follow-up to #76985.

Prevent `validate-agent.sh` from terminating after the first warning or error when running under `set -e`.

## Problem

The validator increments counters using:

```bash
((error_count++))
((warning_count++))
```

In Bash these expressions return a non-zero exit status when the previous value is zero, which can trigger `errexit` and stop validation before the remaining checks and summary are reached.

PR #76985 intentionally left this issue out of scope.

## Changes

Replace postfix increments with:

```bash
((error_count += 1))
((warning_count += 1))
```

This preserves the counter values while allowing validation to continue through all validation checks.

## Verification

- Reproduced the premature exit before the fix.
- Verified the validator now reaches the final summary.
- `bash -n plugins/plugin-dev/skills/agent-development/scripts/validate-agent.sh`
- `git diff --check`

## Scope

This PR only changes counter increments to avoid unintended `errexit` behavior. No validation rules or output were modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016A6KkbNjaUq7QKa99jAcfW
