### PR TITLE
Enable frontend-design plugin at project scope

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "claude-code-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/claude-code"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "frontend-design@claude-code-plugins": true
+  }
+}


### PR DESCRIPTION
Registers the official anthropics/claude-code marketplace and enables the frontend-design skill via .claude/settings.json, so it loads automatically for anyone using Claude Code in this repo.


Claude-Session: https://claude.ai/code/session_01DXwdaBFMTY5wDNPHwA1qr4