### PR TITLE
fix(hookify): enforce proper rule evaluation scope and secure file read

### DIFF
--- a/plugins/hookify/core/config_loader.py
+++ b/plugins/hookify/core/config_loader.py
@@ -216,9 +216,12 @@ def load_rules(event: Optional[str] = None) -> List[Rule]:
             if not rule:
                 continue
 
-            # Filter by event if specified
+            # Filter by event
             if event:
                 if rule.event != 'all' and rule.event != event:
+                    continue
+            else:
+                if rule.event != 'all':
                     continue
 
             # Only include enabled rules

--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -210,8 +210,11 @@ class RuleEngine:
                 if transcript_path:
                     try:
                         import os
-                        # Read transcript defensively against symlinks
-                        fd = os.open(transcript_path, os.O_RDONLY | os.O_NOFOLLOW)
+                        # Read transcript defensively against symlinks where supported
+                        flags = os.O_RDONLY
+                        if hasattr(os, 'O_NOFOLLOW'):
+                            flags |= getattr(os, 'O_NOFOLLOW')
+                        fd = os.open(transcript_path, flags)
                         with os.fdopen(fd, 'r') as f:
                             return f.read()
                     except FileNotFoundError:

--- a/plugins/hookify/core/rule_engine.py
+++ b/plugins/hookify/core/rule_engine.py
@@ -209,7 +209,10 @@ class RuleEngine:
                 transcript_path = input_data.get('transcript_path')
                 if transcript_path:
                     try:
-                        with open(transcript_path, 'r') as f:
+                        import os
+                        # Read transcript defensively against symlinks
+                        fd = os.open(transcript_path, os.O_RDONLY | os.O_NOFOLLOW)
+                        with os.fdopen(fd, 'r') as f:
                             return f.read()
                     except FileNotFoundError:
                         print(f"Warning: Transcript file not found: {transcript_path}", file=sys.stderr)


### PR DESCRIPTION
This PR fixes two critical security logic issues in the `hookify` plugin:
1. Fixes an issue where `load_rules()` bypassed the event filter when `event` is `None`. This ensures that tools which aren't explicitly mapped to an event (like `Read` and `Browser`) only trigger `all` scoped rules instead of unconditionally executing all `bash` and `file` scoped rules. Fixes #84745.
2. Defensively updates `transcript_path` reading in `rule_engine.py` to use `os.open` with `O_NOFOLLOW` to prevent symlink and path traversal attacks. Fixes #84746.