### PR TITLE
docs: fix stale hooks documentation link in bash_command_validator_example.py

### DIFF
--- a/examples/hooks/bash_command_validator_example.py
+++ b/examples/hooks/bash_command_validator_example.py
@@ -6,7 +6,7 @@ This hook runs as a PreToolUse hook for the Bash tool.
 It validates bash commands against a set of rules before execution.
 In this case it changes grep calls to using rg.
 
-Read more about hooks here: https://docs.anthropic.com/en/docs/claude-code/hooks
+Read more about hooks here: https://code.claude.com/docs/en/hooks
 
 Make sure to change your path to your actual script.
 


### PR DESCRIPTION
## Summary
- The example hook script at `examples/hooks/bash_command_validator_example.py` links to the old `docs.anthropic.com/en/docs/claude-code/hooks` URL.
- Every other doc link in the repo (46 occurrences across 16 files, including CHANGELOG.md) already uses the current `code.claude.com/docs/en/...` domain.
- This updates the link to `https://code.claude.com/docs/en/hooks` for consistency, so the reference doesn't point to a stale/legacy path.

## Test plan
- [x] Verified via grep that `code.claude.com/docs/en/hooks` is the URL pattern already used elsewhere (e.g. CHANGELOG.md) for the hooks documentation page.
- [x] Docs-only change; no code behavior affected.