### PR TITLE
fix(skills): use spec-conformant names in the plugin-dev and hookify skills

### DIFF
--- a/plugins/hookify/skills/writing-rules/SKILL.md
+++ b/plugins/hookify/skills/writing-rules/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Writing Hookify Rules
+name: writing-rules
 description: This skill should be used when the user asks to "create a hookify rule", "write a hook rule", "configure hookify", "add a hookify rule", or needs guidance on hookify rule syntax and patterns.
 version: 0.1.0
 ---

--- a/plugins/plugin-dev/skills/agent-development/SKILL.md
+++ b/plugins/plugin-dev/skills/agent-development/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Agent Development
+name: agent-development
 description: This skill should be used when the user asks to "create an agent", "add an agent", "write a subagent", "agent frontmatter", "when to use description", "agent examples", "agent tools", "agent colors", "autonomous agent", or needs guidance on agent structure, system prompts, triggering conditions, or agent development best practices for Claude Code plugins.
 version: 0.1.0
 ---

--- a/plugins/plugin-dev/skills/command-development/SKILL.md
+++ b/plugins/plugin-dev/skills/command-development/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Command Development
+name: command-development
 description: This skill should be used when the user asks to "create a slash command", "add a command", "write a custom command", "define command arguments", "use command frontmatter", "organize commands", "create command with file references", "interactive command", "use AskUserQuestion in command", or needs guidance on slash command structure, YAML frontmatter fields, dynamic arguments, bash execution in commands, user interaction patterns, or command development best practices for Claude Code.
 version: 0.2.0
 ---

--- a/plugins/plugin-dev/skills/hook-development/SKILL.md
+++ b/plugins/plugin-dev/skills/hook-development/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Hook Development
+name: hook-development
 description: This skill should be used when the user asks to "create a hook", "add a PreToolUse/PostToolUse/Stop hook", "validate tool use", "implement prompt-based hooks", "use ${CLAUDE_PLUGIN_ROOT}", "set up event-driven automation", "block dangerous commands", or mentions hook events (PreToolUse, PostToolUse, Stop, SubagentStop, SessionStart, SessionEnd, UserPromptSubmit, PreCompact, Notification). Provides comprehensive guidance for creating and implementing Claude Code plugin hooks with focus on advanced prompt-based hooks API.
 version: 0.1.0
 ---

--- a/plugins/plugin-dev/skills/mcp-integration/SKILL.md
+++ b/plugins/plugin-dev/skills/mcp-integration/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: MCP Integration
+name: mcp-integration
 description: This skill should be used when the user asks to "add MCP server", "integrate MCP", "configure MCP in plugin", "use .mcp.json", "set up Model Context Protocol", "connect external service", mentions "${CLAUDE_PLUGIN_ROOT} with MCP", or discusses MCP server types (SSE, stdio, HTTP, WebSocket). Provides comprehensive guidance for integrating Model Context Protocol servers into Claude Code plugins for external tool and service integration.
 version: 0.1.0
 ---

--- a/plugins/plugin-dev/skills/plugin-settings/SKILL.md
+++ b/plugins/plugin-dev/skills/plugin-settings/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Plugin Settings
+name: plugin-settings
 description: This skill should be used when the user asks about "plugin settings", "store plugin configuration", "user-configurable plugin", ".local.md files", "plugin state files", "read YAML frontmatter", "per-project plugin settings", or wants to make plugin behavior configurable. Documents the .claude/plugin-name.local.md pattern for storing plugin-specific configuration with YAML frontmatter and markdown content.
 version: 0.1.0
 ---

--- a/plugins/plugin-dev/skills/plugin-structure/SKILL.md
+++ b/plugins/plugin-dev/skills/plugin-structure/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Plugin Structure
+name: plugin-structure
 description: This skill should be used when the user asks to "create a plugin", "scaffold a plugin", "understand plugin structure", "organize plugin components", "set up plugin.json", "use ${CLAUDE_PLUGIN_ROOT}", "add commands/agents/skills/hooks", "configure auto-discovery", or needs guidance on plugin directory layout, manifest configuration, component organization, file naming conventions, or Claude Code plugin architecture best practices.
 version: 0.1.0
 ---

--- a/plugins/plugin-dev/skills/skill-development/SKILL.md
+++ b/plugins/plugin-dev/skills/skill-development/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Skill Development
+name: skill-development
 description: This skill should be used when the user wants to "create a skill", "add a skill to plugin", "write a new skill", "improve skill description", "organize skill content", or needs guidance on skill structure, progressive disclosure, or skill development best practices for Claude Code plugins.
 version: 0.1.0
 ---


### PR DESCRIPTION
## What

Eight bundled skills declare a title-cased `name` containing spaces:

| file | current `name:` |
| --- | --- |
| `plugins/hookify/skills/writing-rules/SKILL.md` | `Writing Hookify Rules` |
| `plugins/plugin-dev/skills/agent-development/SKILL.md` | `Agent Development` |
| `plugins/plugin-dev/skills/command-development/SKILL.md` | `Command Development` |
| `plugins/plugin-dev/skills/hook-development/SKILL.md` | `Hook Development` |
| `plugins/plugin-dev/skills/mcp-integration/SKILL.md` | `MCP Integration` |
| `plugins/plugin-dev/skills/plugin-settings/SKILL.md` | `Plugin Settings` |
| `plugins/plugin-dev/skills/plugin-structure/SKILL.md` | `Plugin Structure` |
| `plugins/plugin-dev/skills/skill-development/SKILL.md` | `Skill Development` |

## Why it matters

The Agent Skills specification constrains the `name` field:

> The required `name` field:
> * Must be 1-64 characters
> * **May only contain unicode lowercase alphanumeric characters (`a-z`, `0-9`) and hyphens (`-`)**
> * Must not start or end with a hyphen (`-`)
> * Must not contain consecutive hyphens (`--`)
> * **Must match the parent directory name**
>
> — <https://agentskills.io/specification#name-field>

The spec lists `name: PDF-Processing  # uppercase not allowed` as an explicit invalid example. All eight skills above violate both the charset rule and the directory-match rule, so `skills-ref validate` rejects each one.

## The repo already uses the correct convention

The two skills outside `plugin-dev`/`hookify` are conformant:

```yaml
name: claude-opus-4-5-migration   # plugins/claude-opus-4-5-migration/skills/claude-opus-4-5-migration/
name: frontend-design             # plugins/frontend-design/skills/frontend-design/
```

This PR brings the other eight in line with them.

## Scope

Only the frontmatter `name` field changes — 8 files, one line each. The prose headings in `plugins/plugin-dev/README.md` and the `#` titles inside each `SKILL.md` keep their human-readable capitalization, since neither is a skill identifier.

---

Found with [AgentCompass](https://github.com/YoavLax/agent-compass), an offline static analyzer for AI-agent repo readiness. Each finding was verified by hand against the spec before opening.