### PR TITLE
fix(plugin-dev): parse block scalar agent descriptions

### DIFF
--- a/plugins/plugin-dev/skills/agent-development/scripts/validate-agent.sh
+++ b/plugins/plugin-dev/skills/agent-development/scripts/validate-agent.sh
@@ -88,7 +88,47 @@ else
 fi
 
 # Check description field
-DESCRIPTION=$(echo "$FRONTMATTER" | grep '^description:' | sed 's/description: *//')
+# Descriptions may use YAML block scalars (`|` or `>`), so include their
+# indented content instead of treating the scalar marker as the description.
+# The checks below intentionally preserve line breaks; they only validate
+# description length and trigger examples, not YAML serialization semantics.
+DESCRIPTION=$(printf '%s\n' "$FRONTMATTER" | awk '
+  function scalar_header(line) {
+    return line ~ /^description:[[:space:]]*[|>]([1-9][+-]?|[+-]?[1-9]?)[[:space:]]*(#.*)?$/
+  }
+  function scalar_indent(line,    prefix) {
+    prefix = line
+    sub(/[^[:space:]].*$/, "", prefix)
+    return length(prefix)
+  }
+  scalar_header($0) {
+    in_description_block = 1
+    next
+  }
+  in_description_block {
+    if ($0 !~ /^[[:space:]]*$/ && $0 !~ /^[[:space:]]/) {
+      in_description_block = 0
+    } else {
+      lines[++line_count] = $0
+      indent = scalar_indent($0)
+      if ($0 !~ /^[[:space:]]*$/ && (min_indent == 0 || indent < min_indent))
+        min_indent = indent
+      next
+    }
+  }
+  /^description:[[:space:]]*/ {
+    sub(/^description:[[:space:]]*/, "")
+    print
+  }
+  END {
+    for (i = 1; i <= line_count; i++) {
+      line = lines[i]
+      if (min_indent > 0)
+        line = substr(line, min_indent + 1)
+      print line
+    }
+  }
+')
 
 if [ -z "$DESCRIPTION" ]; then
   echo "❌ Missing required field: description"


### PR DESCRIPTION
## Summary

Fixes the remaining YAML block-scalar parsing defect from #83803. `validate-agent.sh` now measures multiline `description: |` / `description: >` values from their indented content instead of treating the scalar marker as the entire description.

## Problem

Agent descriptions using YAML block scalars were previously parsed as the literal `|` or `>` marker. This produced a one-character description length and caused valid plugin-dev agent files to receive incorrect validation warnings.

## Changes

- Parse literal and folded block scalar headers, including chomping/indentation indicators and inline comments.
- Remove the scalar content's common indentation before applying existing length and `<example>` checks.
- Preserve the existing plain-line description behavior.
- The validator intentionally preserves line breaks; it validates length and trigger examples rather than implementing YAML serialization semantics.

Fixes #83803.

## Verification

- `bash -n plugins/plugin-dev/skills/agent-development/scripts/validate-agent.sh`
- Direct validation of plain and block-scalar fixtures with `|`, `|-`, `>`, `>-`, inline comments, varied indentation, and explicit indentation indicators.
- `git diff --check`

## Scope

This PR addresses only block-scalar description extraction. The separate warning-counter/`errexit` fix is handled by #84427.
