### PR TITLE
plugins: add entroly-context for budget-aware context management

### DIFF
--- a/plugins/entroly-context/.claude-plugin/plugin.json
+++ b/plugins/entroly-context/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "entroly-context",
+  "version": "1.0.0",
+  "description": "Budget-aware context management for Claude Code sessions. Uses Entroly to select evidence under an explicit token budget, keep omitted content byte-exactly recoverable, and emit auditable Context Receipts.",
+  "author": {
+    "name": "juyterman1000",
+    "url": "https://github.com/juyterman1000"
+  },
+  "homepage": "https://github.com/juyterman1000/entroly"
+}

--- a/plugins/entroly-context/.mcp.json
+++ b/plugins/entroly-context/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "entroly": {
+      "command": "python",
+      "args": ["-m", "entroly"],
+      "env": {
+        "ENTROLY_BUDGET": "8000",
+        "ENTROLY_LOG_LEVEL": "warn"
+      }
+    }
+  }
+}

--- a/plugins/entroly-context/README.md
+++ b/plugins/entroly-context/README.md
@@ -1,0 +1,75 @@
+# entroly-context
+
+Budget-aware context management plugin for Claude Code. Uses [Entroly](https://github.com/juyterman1000/entroly) to select evidence under an explicit token budget, keep omitted content byte-exactly recoverable, and emit auditable Context Receipts.
+
+## What it does
+
+When working with large codebases that exceed Claude's context window, this plugin provides:
+
+- **Budget-aware selection**: Picks the most relevant code fragments under an explicit token limit using BM25 scoring and dependency-graph analysis
+- **Exact recovery**: Any omitted content stays content-addressed and byte-recoverable via CCR handles — nothing is permanently lost
+- **Context Receipts**: Auditable record of what was included, excluded, and why
+- **Local verification**: `entroly verify-claims` validates all operations locally, no API key needed
+
+## Prerequisites
+
+```bash
+pip install entroly
+```
+
+Requires Python 3.10+ and Entroly v1.0.76+. No API key needed — all operations run locally.
+
+## Verification
+
+Run this to confirm the plugin works (no API key, no network calls):
+
+```bash
+entroly verify-claims
+```
+
+Expected output: **12/12 checks passed** (SDK import, local indexing, context optimization, exact recovery, engine mode).
+
+## Usage
+
+Once installed, the MCP server provides three tools:
+
+| Tool | Description |
+|------|-------------|
+| `entroly_select` | Select evidence fragments under a token budget |
+| `entroly_recover` | Recover omitted content by CCR handle |
+| `entroly_receipt` | Get the Context Receipt audit trail |
+
+Example in a Claude Code session:
+
+```
+> /entroly-context select "How does authentication work?" --budget 4096
+Selected 17 fragments (3,877 tokens) from 140 indexed files
+Top files: lib.rs, auth.py, config.json
+```
+
+## Honest limitations
+
+- Savings are **workload-dependent** — small repos that fit in the context window pass through unchanged
+- Compression can reduce answer quality on some tasks (SQuAD: 80% → 72% at 43.8% savings)
+- `entroly simulate` gives local token estimates, not provider billing guarantees
+- Full limitations: [docs/limitations.md](https://github.com/juyterman1000/entroly/blob/main/docs/limitations.md)
+
+## Plugin structure
+
+```
+entroly-context/
+├── .claude-plugin/
+│   └── plugin.json          # Plugin metadata
+├── skills/
+│   └── entroly-context-management.md  # Skill definition
+├── .mcp.json                # MCP server configuration
+└── README.md                # This file
+```
+
+## License
+
+Apache-2.0
+
+## Disclosure
+
+This plugin is maintained by the Entroly project maintainer.

--- a/plugins/entroly-context/skills/entroly-context-management.md
+++ b/plugins/entroly-context/skills/entroly-context-management.md
@@ -1,0 +1,40 @@
+---
+name: entroly-context-management
+description: Budget-aware context selection and verification for Claude Code sessions
+---
+
+# Entroly Context Management
+
+When working with large codebases, use Entroly to manage context budget:
+
+## When to use
+
+- The codebase has more files than fit in the context window
+- The user asks about cost optimization or token budget
+- Multiple files need to be selected for a task
+
+## How to use
+
+Entroly provides these MCP tools:
+
+- `entroly_select`: Select evidence fragments under a token budget
+  - Input: query (string), budget (int, default 8000)
+  - Output: selected fragments with relevance scores
+  
+- `entroly_recover`: Recover omitted content by CCR handle
+  - Input: handle (string, e.g. "ccr:811e14e88963b07f71a564a1")
+  - Output: exact original content
+
+- `entroly_receipt`: Get the Context Receipt showing what was included/excluded
+  - Output: audit trail of selection decisions
+
+## Limitations
+
+- Savings are workload-dependent — small repos may see no improvement
+- Compression can reduce answer quality on some tasks
+- `entroly simulate` gives local estimates, not billing guarantees
+- SQuAD benchmark: accuracy drops 80% → 72% at 43.8% savings
+
+## Setup
+
+Requires `pip install entroly` (v1.0.76+). No API key needed for local operations.


### PR DESCRIPTION
## plugins: add entroly-context for budget-aware context management

Adds a new community plugin that provides budget-aware context selection for Claude Code sessions using [Entroly](https://github.com/juyterman1000/entroly).

### What it does

When codebases exceed the context window, this plugin provides three MCP tools:

| Tool | Purpose |
|------|---------|
| `entroly_select` | Select relevant code fragments under an explicit token budget |
| `entroly_recover` | Recover any omitted content by CCR handle (byte-exact) |
| `entroly_receipt` | Get an auditable Context Receipt of selection decisions |

### How it works
- BM25 + dependency-graph scoring to rank fragments by relevance
- Content-addressed handles (CCR) keep omitted content recoverable — nothing permanently lost
- Context Receipts show what was included/excluded and why

### Evidence (reproducible, no API key)
```
pip install entroly && entroly verify-claims
```
Result: **12/12 checks passed** — SDK import, local indexing (160 files, 717k tokens), context optimization (6.1ms), exact byte recovery, engine mode (no API key).

### Honest limitations
- Savings are workload-dependent — small repos pass through unchanged
- Compression can reduce answer quality (SQuAD: 80% to 72% at 43.8% savings)
- `entroly simulate` gives local estimates, not billing guarantees
- Full limitations: https://github.com/juyterman1000/entroly/blob/main/docs/limitations.md

### Plugin structure
```
plugins/entroly-context/
  .claude-plugin/plugin.json    # Plugin metadata
  skills/entroly-context-management.md  # Skill definition
  .mcp.json                     # MCP server config (stdio entrypoint)
  README.md                     # Documentation
```

### Checklist
- [x] Standard plugin structure (.claude-plugin/plugin.json, skills/, .mcp.json, README.md)
- [x] Comprehensive README with setup, usage, and limitations
- [x] No unverified percentage claims
- [x] Apache-2.0 licensed

Disclosure: I maintain Entroly.
