### PR TITLE
fix(security-guidance): skip XSS warnings in docs

### DIFF
--- a/plugins/security-guidance/hooks/patterns.py
+++ b/plugins/security-guidance/hooks/patterns.py
@@ -94,6 +94,7 @@ Only use exec() if you absolutely need shell features and the input is guarantee
     },
     {
         "ruleName": "new_function_injection",
+        "path_filter": lambda p: not p.endswith(_DOC_EXTS),
         "substrings": ["new Function"],
         "reminder": "\u26a0\ufe0f Security Warning: Using new Function() with string interpolation is a CODE INJECTION vulnerability. If any variable is concatenated or interpolated into the function body string, an attacker controlling that variable can execute arbitrary code. Use safe alternatives: for property access use obj[key] or array.reduce((o, k) => o[k], root); for computation use a safe expression parser. NEVER interpolate untrusted strings into new Function() bodies.",
     },
@@ -107,16 +108,19 @@ Only use exec() if you absolutely need shell features and the input is guarantee
     },
     {
         "ruleName": "react_dangerously_set_html",
+        "path_filter": lambda p: not p.endswith(_DOC_EXTS),
         "substrings": ["dangerouslySetInnerHTML"],
         "reminder": "⚠️ Security Warning: dangerouslySetInnerHTML can lead to XSS vulnerabilities if used with untrusted content. Ensure all content is properly sanitized using an HTML sanitizer library like DOMPurify, or use safe alternatives.",
     },
     {
         "ruleName": "document_write_xss",
+        "path_filter": lambda p: not p.endswith(_DOC_EXTS),
         "substrings": ["document.write"],
         "reminder": "⚠️ Security Warning: document.write() can be exploited for XSS attacks and has performance issues. Use DOM manipulation methods like createElement() and appendChild() instead.",
     },
     {
         "ruleName": "innerHTML_xss",
+        "path_filter": lambda p: not p.endswith(_DOC_EXTS),
         "substrings": [".innerHTML =", ".innerHTML="],
         "reminder": "⚠️ Security Warning: Setting innerHTML with untrusted content can lead to XSS vulnerabilities. Use textContent for plain text or safe DOM methods for HTML content. If you need HTML support, consider using an HTML sanitizer library such as DOMPurify.",
     },

--- a/plugins/security-guidance/tests/test_doc_path_filters.py
+++ b/plugins/security-guidance/tests/test_doc_path_filters.py
@@ -1,0 +1,64 @@
+"""Regression tests for documentation path filters on substring rules."""
+
+import sys
+import unittest
+from pathlib import Path
+
+
+HOOKS_DIR = Path(__file__).resolve().parents[1] / "hooks"
+sys.path.insert(0, str(HOOKS_DIR))
+
+from patterns import _DOC_EXTS  # noqa: E402
+from security_reminder_hook import check_patterns  # noqa: E402
+
+
+XSS_FAMILY_CASES = (
+    ("new_function_injection", "const fn = new Function(body);", "app.js"),
+    (
+        "react_dangerously_set_html",
+        "return <div dangerouslySetInnerHTML={{ __html: content }} />;",
+        "Component.jsx",
+    ),
+    ("document_write_xss", "document.write(userInput);", "legacy.ts"),
+    ("innerHTML_xss", "element.innerHTML = userInput;", "render.tsx"),
+)
+
+
+def matched_rule_names(path, content):
+    return {rule_name for rule_name, _ in check_patterns(path, content)}
+
+
+class DocumentationPathFilterTests(unittest.TestCase):
+    def test_xss_family_rules_ignore_all_documentation_extensions(self):
+        for rule_name, content, _ in XSS_FAMILY_CASES:
+            for extension in _DOC_EXTS:
+                with self.subTest(rule=rule_name, extension=extension):
+                    matches = matched_rule_names(f"docs/security-guide{extension}", content)
+                    self.assertNotIn(rule_name, matches)
+
+    def test_xss_family_rules_still_match_executable_source(self):
+        for rule_name, content, source_path in XSS_FAMILY_CASES:
+            with self.subTest(rule=rule_name, path=source_path):
+                self.assertIn(rule_name, matched_rule_names(source_path, content))
+
+    def test_only_a_terminal_documentation_extension_is_filtered(self):
+        for rule_name, content, _ in XSS_FAMILY_CASES:
+            with self.subTest(rule=rule_name):
+                self.assertNotIn(
+                    rule_name, matched_rule_names("example.js.md", content)
+                )
+                self.assertIn(
+                    rule_name, matched_rule_names("example.md.js", content)
+                )
+
+    def test_existing_eval_filter_remains_the_control(self):
+        self.assertNotIn(
+            "eval_injection", matched_rule_names("guide.md", "eval(input)")
+        )
+        self.assertIn(
+            "eval_injection", matched_rule_names("app.js", "eval(input)")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- reuse the existing `_DOC_EXTS` path filter for four XSS-family substring rules
- suppress warnings when those patterns are mentioned in documentation or prose
- preserve the existing warnings and rule IDs for executable source files
- add regression coverage for all documentation extensions and suffix ordering

Fixes #83851

## Implementation

This applies the same `path_filter` already used by `eval_injection` to:

- `new_function_injection`
- `react_dangerously_set_html`
- `document_write_xss`
- `innerHTML_xss`

The matcher, reminder text, rule IDs, `_DOC_EXTS` definition, and behavior for
non-documentation paths are unchanged.

## Test plan

- `python3 -m unittest discover -s plugins/security-guidance/tests -p 'test_*.py' -v`
  - covers all 4 target rules across all 7 `_DOC_EXTS` values
  - confirms terminal suffix behavior (`example.js.md` vs. `example.md.js`)
  - confirms all 4 rules still match executable source
  - confirms the existing `eval_injection` filter remains unchanged
- manually invoked the current `security_reminder_hook.py` with `PostToolUse` events
  - 20/20 `Write` and `Edit` documentation/source events behave as expected
- changed Python files compile successfully
- plugin manifest and hook configuration JSON parse successfully
- `git diff --check`
