### PR TITLE
docs: fix stale doc links and README drift in plugins and examples

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -32,7 +32,7 @@ body:
     attributes:
       label: Documentation Location
       description: Where did you encounter this issue? Provide a URL if possible
-      placeholder: "e.g., https://docs.anthropic.com/en/docs/claude-code/getting-started"
+      placeholder: "e.g., https://code.claude.com/docs/en/getting-started"
     validations:
       required: false
       

--- a/examples/hooks/bash_command_validator_example.py
+++ b/examples/hooks/bash_command_validator_example.py
@@ -6,7 +6,7 @@ This hook runs as a PreToolUse hook for the Bash tool.
 It validates bash commands against a set of rules before execution.
 In this case it changes grep calls to using rg.
 
-Read more about hooks here: https://docs.anthropic.com/en/docs/claude-code/hooks
+Read more about hooks here: https://code.claude.com/docs/en/hooks
 
 Make sure to change your path to your actual script.
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -6,7 +6,7 @@ This directory contains some official Claude Code plugins that extend functional
 
 Claude Code plugins are extensions that enhance Claude Code with custom slash commands, specialized agents, hooks, and MCP servers. Plugins can be shared across projects and teams, providing consistent tooling and workflows.
 
-Learn more in the [official plugins documentation](https://docs.claude.com/en/docs/claude-code/plugins).
+Learn more in the [official plugins documentation](https://code.claude.com/docs/en/plugins).
 
 ## Plugins in This Directory
 
@@ -14,7 +14,7 @@ Learn more in the [official plugins documentation](https://docs.claude.com/en/do
 |------|-------------|----------|
 | [agent-sdk-dev](./agent-sdk-dev/) | Development kit for working with the Claude Agent SDK | **Command:** `/new-sdk-app` - Interactive setup for new Agent SDK projects<br>**Agents:** `agent-sdk-verifier-py`, `agent-sdk-verifier-ts` - Validate SDK applications against best practices |
 | [claude-opus-4-5-migration](./claude-opus-4-5-migration/) | Migrate code and prompts from Sonnet 4.x and Opus 4.1 to Opus 4.5 | **Skill:** `claude-opus-4-5-migration` - Automated migration of model strings, beta headers, and prompt adjustments |
-| [code-review](./code-review/) | Automated PR code review using multiple specialized agents with confidence-based scoring to filter false positives | **Command:** `/code-review` - Automated PR review workflow<br>**Agents:** 5 parallel Sonnet agents for CLAUDE.md compliance, bug detection, historical context, PR history, and code comments |
+| [code-review](./code-review/) | Automated PR code review using multiple specialized agents with confidence-based scoring to filter false positives | **Command:** `/code-review` - Automated PR review workflow<br>**Agents:** 4 parallel review agents (2 Sonnet for CLAUDE.md compliance, 2 Opus for bugs) plus a sonnet summary agent and validation subagents |
 | [commit-commands](./commit-commands/) | Git workflow automation for committing, pushing, and creating pull requests | **Commands:** `/commit`, `/commit-push-pr`, `/clean_gone` - Streamlined git operations |
 | [explanatory-output-style](./explanatory-output-style/) | Adds educational insights about implementation choices and codebase patterns (mimics the deprecated Explanatory output style) | **Hook:** SessionStart - Injects educational context at the start of each session |
 | [feature-dev](./feature-dev/) | Comprehensive feature development workflow with a structured 7-phase approach | **Command:** `/feature-dev` - Guided feature development workflow<br>**Agents:** `code-explorer`, `code-architect`, `code-reviewer` - For codebase analysis, architecture design, and quality review |

--- a/plugins/agent-sdk-dev/README.md
+++ b/plugins/agent-sdk-dev/README.md
@@ -165,10 +165,10 @@ This plugin is included in the Claude Code repository. To use it:
 
 ## Resources
 
-- [Agent SDK Overview](https://docs.claude.com/en/api/agent-sdk/overview)
-- [TypeScript SDK Reference](https://docs.claude.com/en/api/agent-sdk/typescript)
-- [Python SDK Reference](https://docs.claude.com/en/api/agent-sdk/python)
-- [Agent SDK Examples](https://docs.claude.com/en/api/agent-sdk/examples)
+- [Agent SDK Overview](https://code.claude.com/docs/en/agent-sdk/overview)
+- [TypeScript SDK Reference](https://code.claude.com/docs/en/agent-sdk/typescript)
+- [Python SDK Reference](https://code.claude.com/docs/en/agent-sdk/python)
+- [Agent SDK Examples](https://code.claude.com/docs/en/agent-sdk/examples)
 
 ## Troubleshooting
 

--- a/plugins/claude-opus-4-5-migration/README.md
+++ b/plugins/claude-opus-4-5-migration/README.md
@@ -14,7 +14,7 @@ This skill updates your code and prompts to be compatible with Opus 4.5. It auto
 
 ## Learn More
 
-Refer to our [prompting guide](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-4-best-practices) for best practices on prompting Claude models.
+Refer to our [prompting guide](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices) for best practices on prompting Claude models.
 
 ## Authors
 

--- a/scripts/issue-lifecycle.ts
+++ b/scripts/issue-lifecycle.ts
@@ -5,7 +5,7 @@ export const lifecycle = [
     label: "invalid",
     days: 3,
     reason: "this doesn't appear to be about Claude Code",
-    nudge: "This doesn't appear to be about [Claude Code](https://github.com/anthropics/claude-code). For general Anthropic support, visit [support.anthropic.com](https://support.anthropic.com).",
+    nudge: "This doesn't appear to be about [Claude Code](https://github.com/anthropics/claude-code). For general Anthropic support, visit [support.claude.com](https://support.claude.com).",
   },
   {
     label: "needs-repro",


### PR DESCRIPTION
Small docs-only cleanup; every change verified against live redirects and the referenced plugin files.

- `examples/hooks/bash_command_validator_example.py`: docs.anthropic.com hooks link -> code.claude.com/docs/en/hooks (old URL only redirects)
- `plugins/README.md`: plugins doc link -> code.claude.com/docs/en/plugins; code-review row now matches commands/code-review.md (1 sonnet summary agent + 4 parallel review agents: 2 Sonnet CLAUDE.md, 2 Opus bug, plus validation subagents — not "5 parallel Sonnet agents")
- `plugins/claude-opus-4-5-migration/README.md`: prompting guide renamed claude-4-best-practices -> claude-prompting-best-practices
- `plugins/agent-sdk-dev/README.md`: docs.claude.com Agent SDK links -> code.claude.com equivalents (examples page included)
- `.github/ISSUE_TEMPLATE/documentation.yml`: placeholder example URL -> current docs domain
- `scripts/issue-lifecycle.ts`: support.anthropic.com -> support.claude.com

Reviewed twice (Claude + Codex at xhigh); Codex flagged the examples link target, corrected to /docs/en/agent-sdk/examples which resolves 200.