### PR TITLE
docs: point remaining stale doc links at code.claude.com

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,11 +4,11 @@ contact_links:
     url: https://anthropic.com/discord
     about: Get help, ask questions, and chat with other Claude Code users
   - name: 📖 Documentation
-    url: https://docs.claude.com/en/docs/claude-code
+    url: https://code.claude.com/docs/en
     about: Read the official documentation and guides
   - name: 🎓 Getting Started Guide
-    url: https://docs.claude.com/en/docs/claude-code/quickstart
+    url: https://code.claude.com/docs/en/quickstart
     about: New to Claude Code? Start here
   - name: 🔧 Troubleshooting Guide
-    url: https://docs.claude.com/en/docs/claude-code/troubleshooting
+    url: https://code.claude.com/docs/en/troubleshooting
     about: Common issues and how to fix them

--- a/plugins/agent-sdk-dev/agents/agent-sdk-verifier-py.md
+++ b/plugins/agent-sdk-dev/agents/agent-sdk-verifier-py.md
@@ -88,7 +88,7 @@ Your verification should prioritize SDK functionality and best practices over ge
 
 2. **Check SDK Documentation Adherence**:
 
-   - Use WebFetch to reference the official Python SDK docs: https://docs.claude.com/en/api/agent-sdk/python
+   - Use WebFetch to reference the official Python SDK docs: https://code.claude.com/docs/en/agent-sdk/python
    - Compare the implementation against official patterns and recommendations
    - Note any deviations from documented best practices
 

--- a/plugins/agent-sdk-dev/agents/agent-sdk-verifier-ts.md
+++ b/plugins/agent-sdk-dev/agents/agent-sdk-verifier-ts.md
@@ -94,7 +94,7 @@ Your verification should prioritize SDK functionality and best practices over ge
 
 2. **Check SDK Documentation Adherence**:
 
-   - Use WebFetch to reference the official TypeScript SDK docs: https://docs.claude.com/en/api/agent-sdk/typescript
+   - Use WebFetch to reference the official TypeScript SDK docs: https://code.claude.com/docs/en/agent-sdk/typescript
    - Compare the implementation against official patterns and recommendations
    - Note any deviations from documented best practices
 

--- a/plugins/agent-sdk-dev/commands/new-sdk-app.md
+++ b/plugins/agent-sdk-dev/commands/new-sdk-app.md
@@ -9,10 +9,10 @@ You are tasked with helping the user create a new Claude Agent SDK application. 
 
 Before starting, review the official documentation to ensure you provide accurate and up-to-date guidance. Use WebFetch to read these pages:
 
-1. **Start with the overview**: https://docs.claude.com/en/api/agent-sdk/overview
+1. **Start with the overview**: https://code.claude.com/docs/en/agent-sdk/overview
 2. **Based on the user's language choice, read the appropriate SDK reference**:
-   - TypeScript: https://docs.claude.com/en/api/agent-sdk/typescript
-   - Python: https://docs.claude.com/en/api/agent-sdk/python
+   - TypeScript: https://code.claude.com/docs/en/agent-sdk/typescript
+   - Python: https://code.claude.com/docs/en/agent-sdk/python
 3. **Read relevant guides mentioned in the overview** such as:
    - Streaming vs Single Mode
    - Permissions
@@ -147,8 +147,8 @@ Once setup is complete and verified, provide the user with:
 
 2. **Useful resources**:
 
-   - Link to TypeScript SDK reference: https://docs.claude.com/en/api/agent-sdk/typescript
-   - Link to Python SDK reference: https://docs.claude.com/en/api/agent-sdk/python
+   - Link to TypeScript SDK reference: https://code.claude.com/docs/en/agent-sdk/typescript
+   - Link to Python SDK reference: https://code.claude.com/docs/en/agent-sdk/python
    - Explain key concepts: system prompts, permissions, tools, MCP servers
 
 3. **Common next steps**:

--- a/plugins/explanatory-output-style/README.md
+++ b/plugins/explanatory-output-style/README.md
@@ -57,7 +57,7 @@ CLAUDE.md, but it is more flexible and allows for distribution through plugins.
 
 Note: Output styles that involve tasks besides software development, are better
 expressed as
-[subagents](https://docs.claude.com/en/docs/claude-code/sub-agents), not as
+[subagents](https://code.claude.com/docs/en/sub-agents), not as
 SessionStart hooks. Subagents change the system prompt while SessionStart hooks
 add to the default system prompt.
 
@@ -68,5 +68,5 @@ add to the default system prompt.
 - Update the plugin - create a local copy of this plugin to personalize this
   plugin
   - Hint: Ask Claude to read
-    https://docs.claude.com/en/docs/claude-code/plugins.md and set it up for
+    https://code.claude.com/docs/en/plugins.md and set it up for
     you!

--- a/plugins/learning-output-style/README.md
+++ b/plugins/learning-output-style/README.md
@@ -86,7 +86,7 @@ This SessionStart hook pattern is roughly equivalent to CLAUDE.md, but it is mor
 - Disable the plugin - keep the code installed on your device
 - Uninstall the plugin - remove the code from your device
 - Update the plugin - create a local copy of this plugin to personalize it
-  - Hint: Ask Claude to read https://docs.claude.com/en/docs/claude-code/plugins.md and set it up for you!
+  - Hint: Ask Claude to read https://code.claude.com/docs/en/plugins.md and set it up for you!
 
 ## Philosophy
 

--- a/plugins/plugin-dev/skills/hook-development/SKILL.md
+++ b/plugins/plugin-dev/skills/hook-development/SKILL.md
@@ -690,7 +690,7 @@ Development tools in `scripts/`:
 
 ### External Resources
 
-- **Official Docs**: https://docs.claude.com/en/docs/claude-code/hooks
+- **Official Docs**: https://code.claude.com/docs/en/hooks
 - **Examples**: See security-guidance plugin in marketplace
 - **Testing**: Use `claude --debug` for detailed logs
 - **Validation**: Use `jq` to validate hook JSON output

--- a/plugins/plugin-dev/skills/mcp-integration/SKILL.md
+++ b/plugins/plugin-dev/skills/mcp-integration/SKILL.md
@@ -533,7 +533,7 @@ Working examples in `examples/`:
 ### External Resources
 
 - **Official MCP Docs**: https://modelcontextprotocol.io/
-- **Claude Code MCP Docs**: https://docs.claude.com/en/docs/claude-code/mcp
+- **Claude Code MCP Docs**: https://code.claude.com/docs/en/mcp
 - **MCP SDK**: @modelcontextprotocol/sdk
 - **Testing**: Use `claude --debug` and `/mcp` command
 


### PR DESCRIPTION
Follow-up cleanup to my other branch (fix-stale-doc-links); zero file overlap between the two.

Swaps the remaining old-domain doc links (docs.claude.com, which only redirects) for their canonical code.claude.com targets across plugins, plugin skills/agents/commands, and the issue-template contact links:

- plugins/learning-output-style + explanatory-output-style READMEs
- plugins/plugin-dev skills (mcp-integration, hook-development)
- plugins/agent-sdk-dev command + verifier agents (overview/typescript/python refs)
- .github/ISSUE_TEMPLATE/config.yml contact links

Every replacement verified live: 200 and no further redirect, destination matches the old link's intent (quickstart -> quickstart, troubleshooting -> troubleshooting, sub-agents -> sub-agents, etc.). CHANGELOG left untouched (historical). Reviewed twice (Claude + Codex at xhigh): CLEAN.