### PR TITLE
Fix duplicated word in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4760,7 +4760,7 @@
 
 ## 1.0.124
 
-- Set `CLAUDE_BASH_NO_LOGIN` environment variable to 1 or true to to skip login shell for BashTool
+- Set `CLAUDE_BASH_NO_LOGIN` environment variable to 1 or true to skip login shell for BashTool
 - Fix Bedrock and Vertex environment variables evaluating all strings as truthy
 - No longer inform Claude of the list of allowed tools when permission is denied
 - Fixed security vulnerability in Bash tool permission checks


### PR DESCRIPTION
## Summary
- Fixes a duplicated word ("to to") in the CHANGELOG.md entry for `CLAUDE_BASH_NO_LOGIN` (version 1.0.124).

## Test plan
- N/A — documentation-only typo fix.