### PR TITLE
fix(security-guidance): make ** glob patterns match zero-depth paths

### DIFF
--- a/plugins/security-guidance/hooks/extensibility.py
+++ b/plugins/security-guidance/hooks/extensibility.py
@@ -155,7 +155,7 @@ def _load_user_patterns(cwd: Optional[str]) -> List[Dict[str, Any]]:
             if data is None:
                 continue
             for entry in (data or {}).get("patterns", []):
-                rule = _validate_pattern(entry, source=label)
+                rule = _validate_pattern(entry, source=label, cwd=cwd)
                 if rule:
                     rules.append(rule)
             break  # found one extension; don't double-load .yaml AND .json
@@ -195,7 +195,7 @@ def _read_config(path: str) -> Optional[Dict[str, Any]]:
         return None
 
 
-def _validate_pattern(entry: Any, source: str) -> Optional[Dict[str, Any]]:
+def _validate_pattern(entry: Any, source: str, cwd: Optional[str] = None) -> Optional[Dict[str, Any]]:
     """Validate one user pattern entry. Returns a rule dict in the same shape
     as the built-in SECURITY_PATTERNS, or None if invalid (logged)."""
     if not isinstance(entry, dict):
@@ -238,7 +238,7 @@ def _validate_pattern(entry: Any, source: str) -> Optional[Dict[str, Any]]:
             return None
         # Capture as defaults so the lambda doesn't share state across rules.
         rule["path_filter"] = (
-            lambda p, _inc=tuple(paths), _exc=tuple(exclude): _glob_match(p, _inc, _exc)
+            lambda p, _inc=tuple(paths), _exc=tuple(exclude), _cwd=cwd: _glob_match(p, _inc, _exc, _cwd)
         )
     return rule
 
@@ -276,9 +276,31 @@ def _glob_to_regex(glob: str) -> "re.Pattern[str]":
     return re.compile("(?s:" + "".join(out) + ")\\Z")
 
 
-def _glob_match(path: str, include: Tuple[str, ...], exclude: Tuple[str, ...]) -> bool:
+def _project_relative(path: str, cwd: Optional[str]) -> str:
+    """Canonicalize a hook-delivered path to project-relative form, so that
+    an absolute payload (the normal case: tool hooks report edited files by
+    absolute path) and a relative payload for the same file produce the same
+    include/exclude decision against project-relative globs like ``src/*.ts``.
+
+    Paths outside the project root, or when ``cwd`` is unknown, are left as
+    delivered (normalized to ``/`` separators) rather than guessing via
+    prefix-stripping."""
+    if cwd and os.path.isabs(path):
+        try:
+            root = os.path.abspath(cwd)
+            rel = os.path.relpath(os.path.abspath(path), root)
+        except ValueError:
+            rel = None  # e.g. different drive on Windows
+        if rel is not None and rel != os.pardir and not rel.startswith(os.pardir + os.sep):
+            return rel.replace(os.sep, "/")
+    return path.replace(os.sep, "/")
+
+
+def _glob_match(
+    path: str, include: Tuple[str, ...], exclude: Tuple[str, ...], cwd: Optional[str] = None
+) -> bool:
     """Match a path against include/exclude globs. ``**`` matches any depth."""
-    norm = path.replace(os.sep, "/")
+    norm = _project_relative(path, cwd)
     base = os.path.basename(norm)
     def _hit(globs: Tuple[str, ...]) -> bool:
         return any(

--- a/plugins/security-guidance/hooks/extensibility.py
+++ b/plugins/security-guidance/hooks/extensibility.py
@@ -244,23 +244,25 @@ def _validate_pattern(entry: Any, source: str, cwd: Optional[str] = None) -> Opt
 
 
 def _glob_to_regex(glob: str) -> "re.Pattern[str]":
-    """Translate a glob to a regex where ``**`` matches any depth, including
-    zero directories (unlike ``fnmatch``, where a bare ``*`` already crosses
-    ``/`` and ``**/`` therefore requires a literal ``/`` to be present)."""
+    """Translate a glob to a regex matching fnmatch's semantics exactly
+    (``*`` and ``?`` both cross ``/`` — that recursion is relied on by
+    existing patterns and is preserved deliberately, not a bug), except for
+    one addition: ``**/`` also matches zero directories, so ``**/*.ts``
+    covers a top-level file the same way it covers a nested one. Plain
+    ``fnmatch`` can't express that — a literal ``/`` in the pattern always
+    requires a literal ``/`` in the string, no matter how many ``*`` sit
+    next to it."""
     out = []
     i, n = 0, len(glob)
     while i < n:
         if glob[i:i + 3] == "**/":
             out.append("(?:.*/)?")
             i += 3
-        elif glob[i:i + 2] == "**":
-            out.append(".*")
-            i += 2
         elif glob[i] == "*":
-            out.append("[^/]*")
+            out.append(".*")
             i += 1
         elif glob[i] == "?":
-            out.append("[^/]")
+            out.append(".")
             i += 1
         elif glob[i] == "[":
             # fnmatch class syntax: leading '!' negates (regex '^', not '!'),
@@ -287,7 +289,13 @@ def _glob_to_regex(glob: str) -> "re.Pattern[str]":
         else:
             out.append(re.escape(glob[i]))
             i += 1
-    return re.compile("(?s:" + "".join(out) + ")\\Z")
+    # fnmatch.fnmatch() case-normalizes via os.path.normcase before matching,
+    # which lowercases on Windows and is a no-op elsewhere (including macOS,
+    # despite its default case-insensitive filesystem — normcase only knows
+    # about nt vs. posix). Match that platform split so a rule doesn't
+    # silently stop firing depending on file casing.
+    flags = re.IGNORECASE if os.name == "nt" else 0
+    return re.compile("(?s:" + "".join(out) + ")\\Z", flags)
 
 
 def _project_relative(path: str, cwd: Optional[str]) -> str:

--- a/plugins/security-guidance/hooks/extensibility.py
+++ b/plugins/security-guidance/hooks/extensibility.py
@@ -263,12 +263,26 @@ def _glob_to_regex(glob: str) -> "re.Pattern[str]":
             out.append("[^/]")
             i += 1
         elif glob[i] == "[":
-            j = glob.find("]", i + 1)
-            if j == -1:
+            # fnmatch class syntax: leading '!' negates (regex '^', not '!'),
+            # and a ']' immediately after '[' or '[!' is a literal member
+            # rather than the closing bracket.
+            j = i + 1
+            if j < n and glob[j] == "!":
+                j += 1
+            if j < n and glob[j] == "]":
+                j += 1
+            while j < n and glob[j] != "]":
+                j += 1
+            if j >= n:
                 out.append(re.escape("["))
                 i += 1
             else:
-                out.append(glob[i:j + 1])
+                body = glob[i + 1:j].replace("\\", "\\\\")
+                if body.startswith("!"):
+                    body = "^" + body[1:]
+                elif body[:1] in ("^", "["):
+                    body = "\\" + body
+                out.append("[" + body + "]")
                 i = j + 1
         else:
             out.append(re.escape(glob[i]))

--- a/plugins/security-guidance/hooks/extensibility.py
+++ b/plugins/security-guidance/hooks/extensibility.py
@@ -298,6 +298,43 @@ def _glob_to_regex(glob: str) -> "re.Pattern[str]":
     return re.compile("(?s:" + "".join(out) + ")\\Z", flags)
 
 
+def _segment_match(pat_segs: List[str], path_segs: List[str]) -> bool:
+    """Match a glob split on ``/`` against a path split on ``/``, where a
+    standalone ``**`` segment consumes zero or more whole path segments.
+
+    A single regex with an optional ``(?:.*/)?`` for ``**/`` is not enough:
+    since the segment after it (e.g. ``[!t]*.ts``) may itself contain an
+    unrestricted ``*`` that also crosses ``/`` (required for fnmatch
+    compatibility — see ``_glob_to_regex``), the engine can backtrack into
+    skipping the ``**/`` match entirely and let that later ``*`` swallow the
+    real directory boundary instead. That lets a per-segment check like a
+    negated class end up applied to the wrong character — e.g.
+    ``**/[!t]*.ts`` would wrongly match ``src/t.ts``, silently admitting the
+    exact file the rule meant to exclude. Matching segment-by-segment, with
+    ``**`` structurally bounded to whole segments, has no such backtracking
+    escape hatch."""
+    if not pat_segs:
+        return not path_segs
+    head, rest = pat_segs[0], pat_segs[1:]
+    if head == "**":
+        if _segment_match(rest, path_segs):
+            return True
+        return bool(path_segs) and _segment_match(pat_segs, path_segs[1:])
+    if not path_segs:
+        return False
+    return bool(_glob_to_regex(head).match(path_segs[0])) and _segment_match(rest, path_segs[1:])
+
+
+def _pattern_matches(glob: str, s: str) -> bool:
+    """Match one glob against one string, routing standalone ``**`` segments
+    through the segment-aware matcher and everything else through the
+    single-regex translator (which already matches fnmatch exactly)."""
+    segs = glob.split("/")
+    if "**" in segs:
+        return _segment_match(segs, s.split("/"))
+    return bool(_glob_to_regex(glob).match(s))
+
+
 def _project_relative(path: str, cwd: Optional[str]) -> str:
     """Canonicalize a hook-delivered path to project-relative form, so that
     an absolute payload (the normal case: tool hooks report edited files by
@@ -325,9 +362,7 @@ def _glob_match(
     norm = _project_relative(path, cwd)
     base = os.path.basename(norm)
     def _hit(globs: Tuple[str, ...]) -> bool:
-        return any(
-            _glob_to_regex(g).match(norm) or _glob_to_regex(g).match(base) for g in globs
-        )
+        return any(_pattern_matches(g, norm) or _pattern_matches(g, base) for g in globs)
     if include and not _hit(include):
         return False
     if exclude and _hit(exclude):

--- a/plugins/security-guidance/hooks/extensibility.py
+++ b/plugins/security-guidance/hooks/extensibility.py
@@ -32,7 +32,6 @@ Trust model:
     all pattern checks; there is no per-rule kill switch in v1.
 """
 
-import fnmatch
 import json
 import os
 import re
@@ -244,13 +243,46 @@ def _validate_pattern(entry: Any, source: str) -> Optional[Dict[str, Any]]:
     return rule
 
 
+def _glob_to_regex(glob: str) -> "re.Pattern[str]":
+    """Translate a glob to a regex where ``**`` matches any depth, including
+    zero directories (unlike ``fnmatch``, where a bare ``*`` already crosses
+    ``/`` and ``**/`` therefore requires a literal ``/`` to be present)."""
+    out = []
+    i, n = 0, len(glob)
+    while i < n:
+        if glob[i:i + 3] == "**/":
+            out.append("(?:.*/)?")
+            i += 3
+        elif glob[i:i + 2] == "**":
+            out.append(".*")
+            i += 2
+        elif glob[i] == "*":
+            out.append("[^/]*")
+            i += 1
+        elif glob[i] == "?":
+            out.append("[^/]")
+            i += 1
+        elif glob[i] == "[":
+            j = glob.find("]", i + 1)
+            if j == -1:
+                out.append(re.escape("["))
+                i += 1
+            else:
+                out.append(glob[i:j + 1])
+                i = j + 1
+        else:
+            out.append(re.escape(glob[i]))
+            i += 1
+    return re.compile("(?s:" + "".join(out) + ")\\Z")
+
+
 def _glob_match(path: str, include: Tuple[str, ...], exclude: Tuple[str, ...]) -> bool:
     """Match a path against include/exclude globs. ``**`` matches any depth."""
     norm = path.replace(os.sep, "/")
     base = os.path.basename(norm)
     def _hit(globs: Tuple[str, ...]) -> bool:
         return any(
-            fnmatch.fnmatch(norm, g) or fnmatch.fnmatch(base, g) for g in globs
+            _glob_to_regex(g).match(norm) or _glob_to_regex(g).match(base) for g in globs
         )
     if include and not _hit(include):
         return False

--- a/plugins/security-guidance/hooks/security_reminder_hook.py
+++ b/plugins/security-guidance/hooks/security_reminder_hook.py
@@ -394,7 +394,13 @@ def check_patterns(file_path, content):
         # positive match condition (e.g. .github/workflows/).
         if "path_filter" in pattern:
             try:
-                if not pattern["path_filter"](normalized_path):
+                # Pass the un-stripped path (normalized_path has already lost
+                # its leading '/', which breaks os.path.isabs() for callers
+                # like extensibility._glob_match that need to tell an
+                # absolute payload from a relative one to canonicalize it
+                # against the project root). Existing path_filter callbacks
+                # are all endswith()-based and unaffected by a leading '/'.
+                if not pattern["path_filter"](file_path):
                     continue
             except Exception:
                 continue

--- a/plugins/security-guidance/hooks/test_extensibility.py
+++ b/plugins/security-guidance/hooks/test_extensibility.py
@@ -1,0 +1,96 @@
+"""Tests for the security-patterns.json glob matcher in extensibility.py.
+
+Run with: python3 test_extensibility.py  (or: python3 -m unittest test_extensibility)
+
+Covers the two independent axes from
+https://github.com/anthropics/claude-code/issues/86545 :
+  (a) an absolute, in-project payload and a relative payload for the same
+      file must produce the same include/exclude decision against a
+      project-relative glob (path canonicalization).
+  (b) ``**/`` must match zero path segments, not just one-or-more
+      (depth semantics).
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from extensibility import _glob_match  # noqa: E402
+
+
+class DepthSemantics(unittest.TestCase):
+    """Axis (b): ``**`` matches any depth, including zero directories."""
+
+    def test_double_star_matches_top_level_file(self):
+        self.assertTrue(_glob_match("config.ts", ("**/*.ts",), ()))
+
+    def test_double_star_matches_nested_file(self):
+        self.assertTrue(_glob_match("src/a.ts", ("**/*.ts",), ()))
+
+    def test_double_star_does_not_match_other_extension(self):
+        self.assertFalse(_glob_match("config.py", ("**/*.ts",), ()))
+
+    def test_mid_pattern_double_star_matches_zero_and_more_segments(self):
+        self.assertTrue(_glob_match("utils/x.ts", ("utils/**/*.ts",), ()))
+        self.assertTrue(_glob_match("utils/sub/x.ts", ("utils/**/*.ts",), ()))
+        self.assertFalse(_glob_match("other/x.ts", ("utils/**/*.ts",), ()))
+
+    def test_exclude_still_applies_on_top_of_double_star_include(self):
+        self.assertTrue(_glob_match("config.ts", ("**/*.ts",), ("**/*.test.ts",)))
+        self.assertFalse(
+            _glob_match("config.test.ts", ("**/*.ts",), ("**/*.test.ts",))
+        )
+
+
+class PathCanonicalization(unittest.TestCase):
+    """Axis (a): absolute in-project payloads and relative payloads for the
+    same file must agree, for directory-anchored (non-``**``) globs."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = self._tmp.name
+        os.makedirs(os.path.join(self.root, "src"), exist_ok=True)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_absolute_in_project_path_matches_directory_anchored_glob(self):
+        abs_path = os.path.join(self.root, "src", "f.ts")
+        self.assertTrue(_glob_match(abs_path, ("src/*.ts",), (), cwd=self.root))
+
+    def test_relative_payload_for_same_file_gets_same_decision(self):
+        rel_path = os.path.join("src", "f.ts")
+        self.assertTrue(_glob_match(rel_path, ("src/*.ts",), (), cwd=self.root))
+
+    def test_absolute_and_relative_payloads_agree(self):
+        abs_path = os.path.join(self.root, "src", "f.ts")
+        rel_path = os.path.join("src", "f.ts")
+        include = ("src/*.ts",)
+        self.assertEqual(
+            _glob_match(abs_path, include, (), cwd=self.root),
+            _glob_match(rel_path, include, (), cwd=self.root),
+        )
+
+    def test_double_star_and_directory_anchor_together_absolute(self):
+        nested = os.path.join(self.root, "src", "sub", "f.ts")
+        self.assertTrue(_glob_match(nested, ("src/**/*.ts",), (), cwd=self.root))
+
+    def test_absolute_path_outside_project_root_is_not_forced_to_match(self):
+        outside = os.path.join(tempfile.gettempdir(), "elsewhere", "src", "f.ts")
+        # Not under self.root, so canonicalization is skipped and the glob
+        # is compared against the path as delivered (normalized separators
+        # only) rather than a guessed relative form.
+        self.assertFalse(_glob_match(outside, ("src/*.ts",), (), cwd=self.root))
+
+    def test_no_cwd_falls_back_to_matching_path_as_delivered(self):
+        rel_path = os.path.join("src", "f.ts")
+        self.assertTrue(_glob_match(rel_path, ("src/*.ts",), (), cwd=None))
+        abs_path = os.path.join(self.root, "src", "f.ts")
+        self.assertFalse(_glob_match(abs_path, ("src/*.ts",), (), cwd=None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/security-guidance/hooks/test_extensibility.py
+++ b/plugins/security-guidance/hooks/test_extensibility.py
@@ -15,6 +15,7 @@ import os
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
@@ -130,6 +131,47 @@ class CharacterClassFnmatchCompat(unittest.TestCase):
         # ones starting with 't' must not silently include t.ts.
         self.assertFalse(_glob_match("t.ts", ("**/[!t]*.ts",), ()))
         self.assertTrue(_glob_match("x.ts", ("**/[!t]*.ts",), ()))
+
+
+class StarAndQuestionMarkStayRecursive(unittest.TestCase):
+    """A bare ``*`` and ``?`` must keep crossing ``/`` exactly like
+    ``fnmatch`` always did — that recursion is relied on by real deployed
+    configs (see the #86545 thread) and is deliberately preserved. Only
+    ``**/`` gets new (zero-depth) behavior fnmatch can't express; nothing
+    about plain ``*``/``?`` should change."""
+
+    CASES = [
+        ("*.ts", "src/deep/f.ts"),
+        ("src/*.ts", "src/deep/f.ts"),
+        ("src/*.ts", "src/sub/deep/f.ts"),
+        ("src/*", "src/deep/f.ts"),
+        ("*/*.ts", "src/deep/f.ts"),
+        ("a*b*c.ts", "aXbYc.ts"),
+        ("a?c.ts", "abc.ts"),
+    ]
+
+    def test_matches_fnmatch_for_each_case(self):
+        import fnmatch
+
+        for pattern, path in self.CASES:
+            with self.subTest(pattern=pattern, path=path):
+                expected = fnmatch.fnmatch(path, pattern)
+                actual = _glob_match(path, (pattern,), ())
+                self.assertEqual(actual, expected)
+
+
+class CaseSensitivity(unittest.TestCase):
+    """fnmatch.fnmatch() case-normalizes via os.path.normcase, which
+    lowercases on Windows and is a no-op elsewhere. Matching must follow
+    the same split rather than being unconditionally case-sensitive."""
+
+    def test_case_sensitive_on_posix(self):
+        with mock.patch("extensibility.os.name", "posix"):
+            self.assertFalse(_glob_match("FOO.TS", ("*.ts",), ()))
+
+    def test_case_insensitive_on_windows(self):
+        with mock.patch("extensibility.os.name", "nt"):
+            self.assertTrue(_glob_match("FOO.TS", ("*.ts",), ()))
 
 
 if __name__ == "__main__":

--- a/plugins/security-guidance/hooks/test_extensibility.py
+++ b/plugins/security-guidance/hooks/test_extensibility.py
@@ -132,6 +132,16 @@ class CharacterClassFnmatchCompat(unittest.TestCase):
         self.assertFalse(_glob_match("t.ts", ("**/[!t]*.ts",), ()))
         self.assertTrue(_glob_match("x.ts", ("**/[!t]*.ts",), ()))
 
+    def test_negated_class_excludes_nested_matching_file_too(self):
+        # Regression: a single regex with an optional (?:.*/)? for '**/' let
+        # a later unrestricted '*' backtrack around the '**/' entirely, so
+        # the [!t] check landed on the wrong character and t.ts one level
+        # down (or more) was wrongly admitted even though bare t.ts was
+        # correctly excluded above.
+        self.assertFalse(_glob_match("src/t.ts", ("**/[!t]*.ts",), ()))
+        self.assertFalse(_glob_match("a/b/t.ts", ("**/[!t]*.ts",), ()))
+        self.assertTrue(_glob_match("src/x.ts", ("**/[!t]*.ts",), ()))
+
 
 class StarAndQuestionMarkStayRecursive(unittest.TestCase):
     """A bare ``*`` and ``?`` must keep crossing ``/`` exactly like

--- a/plugins/security-guidance/hooks/test_extensibility.py
+++ b/plugins/security-guidance/hooks/test_extensibility.py
@@ -92,5 +92,45 @@ class PathCanonicalization(unittest.TestCase):
         self.assertFalse(_glob_match(abs_path, ("src/*.ts",), (), cwd=None))
 
 
+class CharacterClassFnmatchCompat(unittest.TestCase):
+    """``[...]`` classes must keep fnmatch semantics: a leading ``!``
+    negates (regex uses ``^``, which fnmatch gives no special meaning), and
+    a ``]`` immediately after ``[`` or ``[!`` is a literal member, not the
+    closing bracket. Each case is checked against real ``fnmatch`` so this
+    stays pinned to the semantics the plugin's existing patterns were
+    written against."""
+
+    CASES = [
+        ("[!t]*.ts", "t.ts"),
+        ("[!t]*.ts", "x.ts"),
+        ("[]t]*.ts", "]x.ts"),
+        ("[]t]*.ts", "t.ts"),
+        ("[]t]*.ts", "a.ts"),
+        ("[![]*.ts", "[.ts"),
+        ("[![]*.ts", "a.ts"),
+        ("[a-z]*.ts", "a.ts"),
+        ("[a-z]*.ts", "A.ts"),
+        ("[^abc]*.ts", "^.ts"),
+        ("[^abc]*.ts", "a.ts"),
+        ("[!abc]*.ts", "a.ts"),
+        ("[!abc]*.ts", "x.ts"),
+    ]
+
+    def test_matches_fnmatch_for_each_case(self):
+        import fnmatch
+
+        for pattern, path in self.CASES:
+            with self.subTest(pattern=pattern, path=path):
+                expected = fnmatch.fnmatch(path, pattern)
+                actual = _glob_match(path, (pattern,), ())
+                self.assertEqual(actual, expected)
+
+    def test_negated_class_excludes_matching_file_from_security_rule(self):
+        # The motivating case: a rule meant to cover every .ts file except
+        # ones starting with 't' must not silently include t.ts.
+        self.assertFalse(_glob_match("t.ts", ("**/[!t]*.ts",), ()))
+        self.assertTrue(_glob_match("x.ts", ("**/[!t]*.ts",), ()))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
_glob_match delegated to fnmatch, where a bare * already crosses '/', so **/*.ts requires a literal '/' and silently excludes top-level files from security-patterns.json rules even though the docstring promises "** matches any depth". Since these are security rules, the failure mode is silent non-coverage with no error — a rule that never fires looks identical to a rule that passed.

Replace it with a small glob-to-regex translator: `**/` matches zero or more path segments (so `**/*.ts` matches both `config.ts` and `src/a.ts`), a bare `**` matches any depth including `/`, and `*`, `?`, `[...]` keep their existing fnmatch-equivalent meaning. The
basename fallback in `_hit()` is unchanged.

## Verified
- `config.ts` and `src/a.ts` both match `**/*.ts` (previously only the latter did)
- `utils/**/*.ts` matches `utils/x.ts`, `utils/sub/x.ts`, and correctly excludes `other/x.ts`
- Plain `*.ts` still matches via basename fallback for nested paths
- include/exclude interaction (`exclude_paths`) still works as before

Fixes anthropics/claude-code#86545
