### PR TITLE
ralph-wiggum: use disable-model-invocation so the model can't self-invoke /ralph-loop

### DIFF
--- a/plugins/ralph-wiggum/commands/cancel-ralph.md
+++ b/plugins/ralph-wiggum/commands/cancel-ralph.md
@@ -1,7 +1,7 @@
 ---
 description: "Cancel active Ralph Wiggum loop"
 allowed-tools: ["Bash(test -f .claude/ralph-loop.local.md:*)", "Bash(rm .claude/ralph-loop.local.md)", "Read(.claude/ralph-loop.local.md)"]
-hide-from-slash-command-tool: "true"
+disable-model-invocation: true
 ---
 
 # Cancel Ralph

--- a/plugins/ralph-wiggum/commands/ralph-loop.md
+++ b/plugins/ralph-wiggum/commands/ralph-loop.md
@@ -2,7 +2,7 @@
 description: "Start Ralph Wiggum loop in current session"
 argument-hint: "PROMPT [--max-iterations N] [--completion-promise TEXT]"
 allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh:*)"]
-hide-from-slash-command-tool: "true"
+disable-model-invocation: true
 ---
 
 # Ralph Loop Command


### PR DESCRIPTION
The ralph-wiggum plugin's `/ralph-loop` and `/cancel-ralph` commands set `hide-from-slash-command-tool: "true"` in their frontmatter. That key isn't a supported frontmatter field, so it does nothing — Claude can still invoke `/ralph-loop` on its own and start a loop without being asked (reproduced on 2.1.233).

This swaps it for the documented `disable-model-invocation: true`, which actually prevents the model from calling these commands (https://code.claude.com/docs/en/skills#control-who-invokes-a-skill). Users can still run them manually.

Fixes #79138