### PR TITLE
mods: telemetry's types path is ./-relative like the other manifest paths

### DIFF
--- a/mods/telemetry/.claude-plugin/plugin.json
+++ b/mods/telemetry/.claude-plugin/plugin.json
@@ -5,5 +5,5 @@
   "author": {
     "name": "Anthropic"
   },
-  "types": "types/index.d.ts"
+  "types": "./types/index.d.ts"
 }


### PR DESCRIPTION
Paths in `plugin.json` are `./`-relative; the telemetry mod's `types` entry added in #93912 was the one exception, and the manifest schema for `types` refuses a bare relative path. One-line fix: `"types": "./types/index.d.ts"`.
